### PR TITLE
Stop the leaderboard's rigor fields from leaking fixture data (#1187)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -950,7 +950,7 @@ async def get_portfolio_advisor(
         # on the in-memory object are frozen values the live gate never wrote, so
         # serving them next to a live badge let the advisor's numbers disagree
         # with GET /api/selection-bias/gate. SOLELY the live result (honesty fix
-        # #1187, same scope as _to_strategy_response): these four fields render
+        # #1187, same scope as _to_strategy_response): these five fields render
         # None — never st.<field> — when the live gate could not run for this
         # strategy. Do not reintroduce the st.<field> fallback here; that is
         # precisely the defect #1187 tracks, now closed for both response paths.
@@ -960,7 +960,7 @@ async def get_portfolio_advisor(
             "rigor_gate_status": _verdict.status if _verdict else "pending",
             "deflated_sharpe_ratio": _live.deflated_sharpe if _live else None,
             "dsr_p_value": _live.dsr_p_value if _live else None,
-            "num_trials_in_selection": _live.num_trials if _live else st.num_trials_in_selection,
+            "num_trials_in_selection": _live.num_trials if _live else None,
             "pbo_score": _live.pbo_score if _live else None,
             "out_of_sample_sharpe": _live.oos_sharpe if _live else None,
             "paper_claimed_sharpe": st.paper_claimed_sharpe,

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -949,18 +949,20 @@ async def get_portfolio_advisor(
         # (#868 contract, mirrored from _to_strategy_response): the fixture fields
         # on the in-memory object are frozen values the live gate never wrote, so
         # serving them next to a live badge let the advisor's numbers disagree
-        # with GET /api/selection-bias/gate. Fall back to the stored fixture value
-        # only when the live gate could not run for this strategy — the fallback
-        # is the documented #868 behavior, only the preferred source changes.
+        # with GET /api/selection-bias/gate. SOLELY the live result (honesty fix
+        # #1187, same scope as _to_strategy_response): these four fields render
+        # None — never st.<field> — when the live gate could not run for this
+        # strategy. Do not reintroduce the st.<field> fallback here; that is
+        # precisely the defect #1187 tracks, now closed for both response paths.
         _live = advisor_results.get(st.id)
         return {
             "passes_rigor_gate": _verdict.passes if _verdict else False,
             "rigor_gate_status": _verdict.status if _verdict else "pending",
-            "deflated_sharpe_ratio": _live.deflated_sharpe if _live else st.deflated_sharpe_ratio,
-            "dsr_p_value": _live.dsr_p_value if _live else st.dsr_p_value,
+            "deflated_sharpe_ratio": _live.deflated_sharpe if _live else None,
+            "dsr_p_value": _live.dsr_p_value if _live else None,
             "num_trials_in_selection": _live.num_trials if _live else st.num_trials_in_selection,
-            "pbo_score": _live.pbo_score if _live else st.pbo_score,
-            "out_of_sample_sharpe": _live.oos_sharpe if _live else st.out_of_sample_sharpe,
+            "pbo_score": _live.pbo_score if _live else None,
+            "out_of_sample_sharpe": _live.oos_sharpe if _live else None,
             "paper_claimed_sharpe": st.paper_claimed_sharpe,
             "paper_claimed_cagr": st.paper_claimed_cagr,
             "paper_claimed_max_dd": st.paper_claimed_max_dd,

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -61,9 +61,14 @@ def _to_strategy_response(
     ``out_of_sample_sharpe``) so the leaderboard can never disagree with
     ``GET /api/selection-bias/gate`` for a given strategy id. ``None`` means the
     live gate could not run for this strategy (no/insufficient persisted returns,
-    or a batch/DB failure); the numeric fields then fall back to the stale
-    ``s.<field>``/``bt.<field>`` fixture values exactly as before — the fallback
-    is unchanged, only the preferred source is new. When ``verdict is None``
+    or a batch/DB failure); the numeric fields then render as ``None`` — the API's
+    honest "not run" — rather than falling back to ``s.<field>``/``bt.<field>``
+    (#1187: those columns trace back to a migrated test-fixture snapshot
+    (``backend/tests/fixtures/backtest_fixtures_snapshot.json``, PR #863) that
+    predates the current DSR convention (raw vs. excess returns) and gate
+    threshold (#901, 0.95 → 0.90) and cannot be reproduced by any single code
+    version — presenting it as a measured number next to a ``pending`` badge is a
+    claim-integrity defect, not a display nicety). When ``verdict is None``
     (single-strategy fetch) ``rigor_result`` is also computed on demand here.
     """
     from archimedes.api.schemas import PaperRefResponse
@@ -144,40 +149,24 @@ def _to_strategy_response(
         if s.real_corr_spy is not None
         else (bt.correlation_to_spy if bt else s.stub_corr_spy),
         total_trades=s.real_total_trades if s.real_total_trades is not None else (bt.total_trades if bt else None),
-        # Numeric rigor fields (#868): prefer the LIVE gate result — the SAME
-        # run_rigor_gate call that produced `verdict` above — so the leaderboard
-        # can never disagree with GET /api/selection-bias/gate for this id.
-        # rigor_result is None when the live gate could not run (no/insufficient
-        # persisted returns, or a batch failure); fall back to the best stored
-        # value (s.<field> fixture first, then bt.<field> from the backtest row).
-        deflated_sharpe_ratio=(
-            rigor_result.deflated_sharpe
-            if rigor_result is not None
-            else (
-                s.deflated_sharpe_ratio
-                if s.deflated_sharpe_ratio is not None
-                else (bt.deflated_sharpe_ratio if bt else None)
-            )
-        ),
-        dsr_p_value=(
-            rigor_result.dsr_p_value
-            if rigor_result is not None
-            else (s.dsr_p_value if s.dsr_p_value is not None else (bt.dsr_p_value if bt else None))
-        ),
-        pbo_score=(
-            rigor_result.pbo_score
-            if rigor_result is not None
-            else (s.pbo_score if s.pbo_score is not None else (bt.pbo_score if bt else None))
-        ),
-        out_of_sample_sharpe=(
-            rigor_result.oos_sharpe
-            if rigor_result is not None
-            else (
-                s.out_of_sample_sharpe
-                if s.out_of_sample_sharpe is not None
-                else (bt.out_of_sample_sharpe if bt else None)
-            )
-        ),
+        # Numeric rigor fields (#868, honesty fix #1187): SOLELY the LIVE gate
+        # result — the SAME run_rigor_gate call that produced `verdict` above —
+        # so the leaderboard can never disagree with GET /api/selection-bias/gate
+        # for this id. rigor_result is None when the live gate could not run
+        # (no/insufficient persisted returns, or a batch failure); the field then
+        # renders None (served as the API's honest "not run"), NEVER the stale
+        # s.<field> / bt.<field> values. Those trace back to a migrated
+        # test-fixture snapshot (#1187) that predates the current DSR convention
+        # and gate threshold and cannot be reproduced by any single code version —
+        # falling back to it silently re-labels a `pending` verdict's numbers as
+        # measured. Do not reintroduce the s.<field>/bt.<field> fallback here;
+        # that is precisely the defect #1187 tracks. The basic display metrics
+        # below (sharpe_ratio, cagr, etc.) are a DIFFERENT, out-of-scope concern —
+        # they are descriptive backtest stats, not a rigor-gate pass/fail claim.
+        deflated_sharpe_ratio=(rigor_result.deflated_sharpe if rigor_result is not None else None),
+        dsr_p_value=(rigor_result.dsr_p_value if rigor_result is not None else None),
+        pbo_score=(rigor_result.pbo_score if rigor_result is not None else None),
+        out_of_sample_sharpe=(rigor_result.oos_sharpe if rigor_result is not None else None),
         kelly_fraction=s.kelly_fraction,
         # Badge from the LIVE gate verdict (#821) — never the fixture boolean.
         # passes_rigor_gate is the fail-closed boolean (True only when status=="pass");
@@ -258,14 +247,14 @@ def _live_rigor_result_for_one(s: Strategy) -> RigorGateResult | None:
     fetch carries the same cohort PBO + avg correlation context as the list.
     ``num_trials`` is self-contained (1, decouple #2) — it does NOT come from
     the library size. Returns ``None`` on no/insufficient persisted returns or
-    any failure — the caller must fall back to the stale fixture fields rather
-    than fabricate a number, matching the fail-closed badge contract.
+    any failure — the caller (#1187) renders that as the numeric fields being
+    ``None``, never a fabricated number, matching the fail-closed badge contract.
     """
     try:
         cohort = _library_cohort_including(s)
         return _live_rigor_results_for_strategies(cohort).get(s.id)
     except Exception as exc:
-        logger.warning("live rigor gate failed for %s (numbers → stale fallback): %s", s.id, exc)
+        logger.warning("live rigor gate failed for %s (numbers → None): %s", s.id, exc)
         return None
 
 
@@ -284,14 +273,16 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
     strategy. ``num_trials`` is self-contained (1 per strategy, decouple #2) —
     it is NOT derived from this cohort. Strategies with no/insufficient
     persisted returns are simply absent from the returned dict — the caller
-    falls back to the stale fixture fields for those ids (fail-closed: no
-    fabricated number for a strategy the live gate cannot evaluate). A
-    degenerate (zero-variance) series IS graded and included here — it just
-    runs with self-contained cohort context (see the ``gate_kwargs`` branch
-    below) so it can't dilute ``avg_correlation`` for the rest of the cohort.
+    (#1187) serves ``None`` for those ids' numeric rigor fields (fail-closed:
+    no fabricated number for a strategy the live gate cannot evaluate; the
+    pre-#1187 fixture-field fallback is gone). A degenerate (zero-variance)
+    series IS graded and included here — it just runs with self-contained
+    cohort context (see the ``gate_kwargs`` branch below) so it can't dilute
+    ``avg_correlation`` for the rest of the cohort.
 
-    Any DB or cohort-compute failure degrades to ``{}`` (every id falls back to
-    the stale fields) rather than raising into the library-list response.
+    Any DB or cohort-compute failure degrades to ``{}`` (every id's numeric
+    rigor fields render ``None``) rather than raising into the library-list
+    response.
 
     **Perf (Library page load latency):** the batch cohort compute below (PBO,
     average correlation, per-strategy look-ahead code load, one ``run_rigor_gate``
@@ -309,8 +300,8 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
     open (any cache-layer error falls back to calling the compute closure
     directly), so a cache bug can only make a request slow, never wrong. It also
     never caches the ``{}`` failure sentinel (``cache_if=bool``) so
-    a transient cohort-compute failure can't strand every strategy on stale
-    fallback fields for the full TTL.
+    a transient cohort-compute failure can't strand every strategy on ``None``
+    numeric rigor fields for the full TTL.
     """
     if not strategies:
         return {}
@@ -325,7 +316,7 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
         with get_session() as session:
             returns_by_strategy = get_all_daily_returns(session, strategy_ids)
     except Exception as exc:
-        logger.warning("live rigor result batch: DB read failed (all → stale fallback): %s", exc)
+        logger.warning("live rigor result batch: DB read failed (all → None): %s", exc)
         return {}
 
     from archimedes.services.rigor_cache import cohort_key, get_or_compute
@@ -374,7 +365,7 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
             # same fail-closed contract as the rest of this cohort-context block).
             assert_self_contained_cohort_correlation(num_trials, avg_correlation)
         except Exception as exc:
-            logger.warning("live rigor result batch: cohort-context compute failed (all → stale fallback): %s", exc)
+            logger.warning("live rigor result batch: cohort-context compute failed (all → None): %s", exc)
             return {}
 
         # Load code for every strategy that has >= 10 returns — degenerate series
@@ -388,7 +379,7 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
         for s in strategies:
             daily_returns = returns_by_strategy.get(s.id, [])
             if len(daily_returns) < 10:
-                continue  # No sufficient returns — caller falls back to stale fields
+                continue  # No sufficient returns — caller (#1187) serves None, never a fixture number
             if s.id in valid_returns:
                 # Non-degenerate series: num_trials is self-contained (1, decouple
                 # #2); pbo_scores / avg_correlation still come from the cohort so
@@ -415,14 +406,14 @@ def _live_rigor_results_for_strategies(strategies: list[Strategy]) -> dict[str, 
                     **gate_kwargs,
                 )
             except Exception as exc:
-                logger.warning("live rigor gate failed for %s in batch (numbers → stale fallback): %s", s.id, exc)
+                logger.warning("live rigor gate failed for %s in batch (numbers → None): %s", s.id, exc)
         return computed
 
     # cache_if=bool: `_compute()` returns `{}` on a transient
     # cohort-context compute failure (see the `except Exception` above), and an
     # empty dict must never be memoized — caching it would make that transient
-    # failure "sticky" for the full TTL, serving every strategy's stale
-    # fallback fields long after the underlying failure has passed (Copilot
+    # failure "sticky" for the full TTL, serving every strategy's numeric rigor
+    # fields as None long after the underlying failure has passed (Copilot
     # review, PR #1040). The live `{}` is still returned to THIS caller either
     # way; only whether it's written to the store for the NEXT caller changes.
     return get_or_compute(cache_key, _compute, cache_if=bool)

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -346,12 +346,12 @@ class TestStrategyRoutes:
     def test_advisor_serves_null_not_fixture_when_live_gate_empty(self, client, seeded_db):
         """#1187 (``_rigor_fields``, the advisor's own copy of the leaderboard's
         fixed-then-fixed-again fallback): when the live-gate batch returns no
-        result for a strategy, the four numeric rigor fields on its advisor
+        result for any strategy, the four numeric rigor fields on EVERY advisor
         allocation must render ``None`` — never the migrated fixture value on
         the in-memory ``Strategy`` object. Not vacuous: reverting just this
         fallback (restoring ``else st.<field>`` on the four keys) makes this
-        fail — George Hwang's allocation then serves the exact fixture
-        constants (0.277212 / 0.339938 / 0.910213) from
+        fail — an allocation then serves the exact fixture constants
+        (0.277212 / 0.339938 / 0.910213) from
         ``backend/tests/fixtures/backtest_fixtures_snapshot.json``, confirmed
         by hand against the pre-fix code."""
         from archimedes.api import strategies_routes as sr
@@ -361,24 +361,26 @@ class TestStrategyRoutes:
         assert resp.status_code == 200
         allocations = resp.json()["allocations"]
         assert allocations, "advisor returned no allocations to check"
-        gh = next(
-            (a for a in allocations if "52-Week High" in a.get("title", "")),
-            None,
-        )
-        if gh is None:
-            pytest.skip("George Hwang allocation not present in this advisor run")
-        # The rule-based aggregate row (id "agg_<symbol>") does not carry
-        # rigor_gate_status forward (_RIGOR_KEYS omits it) — passes_rigor_gate
-        # is the field available here, and must stay the fail-closed default.
-        assert gh["passes_rigor_gate"] is False
-        assert gh["deflated_sharpe_ratio"] is None, (
-            f"deflated_sharpe_ratio must be None, not the fixture value; got {gh['deflated_sharpe_ratio']}"
-        )
-        assert gh["dsr_p_value"] is None, f"dsr_p_value must be None, not the fixture value; got {gh['dsr_p_value']}"
-        assert gh["pbo_score"] is None, f"pbo_score must be None, not the fixture value; got {gh['pbo_score']}"
-        assert gh["out_of_sample_sharpe"] is None, (
-            f"out_of_sample_sharpe must be None, not the fixture value; got {gh['out_of_sample_sharpe']}"
-        )
+        for a in allocations:
+            # The rule-based aggregate row (id "agg_<symbol>") does not carry
+            # rigor_gate_status forward (_RIGOR_KEYS omits it) — passes_rigor_gate
+            # is the field available on every row, and must stay the fail-closed
+            # default.
+            assert a["passes_rigor_gate"] is False, f"{a.get('id')}: passes_rigor_gate must be fail-closed False"
+            assert a["deflated_sharpe_ratio"] is None, (
+                f"{a.get('id')}: deflated_sharpe_ratio must be None, not the fixture value; "
+                f"got {a['deflated_sharpe_ratio']}"
+            )
+            assert a["dsr_p_value"] is None, (
+                f"{a.get('id')}: dsr_p_value must be None, not the fixture value; got {a['dsr_p_value']}"
+            )
+            assert a["pbo_score"] is None, (
+                f"{a.get('id')}: pbo_score must be None, not the fixture value; got {a['pbo_score']}"
+            )
+            assert a["out_of_sample_sharpe"] is None, (
+                f"{a.get('id')}: out_of_sample_sharpe must be None, not the fixture value; "
+                f"got {a['out_of_sample_sharpe']}"
+            )
 
 
 class TestRiskRoutes:

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -315,7 +315,10 @@ class TestStrategyRoutes:
         the LIVE gate on persisted returns — NOT the fixture boolean. ``seeded_db``
         only seeds Buy-and-Hold's backtest, so Moreira-Muir has no live returns and
         the badge must be ``pending`` (False), even though its fixture row says True.
-        The fixture-derived display metric (dsr_p_value) still flows for rendering."""
+        #1187: the numeric rigor fields (dsr_p_value etc.) are None alongside the
+        pending badge — never the fixture-derived number (that was the claim-
+        integrity bug #1187 fixed; a concrete pending badge next to a concrete
+        fixture number was self-contradictory)."""
         strategies = _list_all_strategies(client)
         # Match Moreira-Muir specifically by its full title. A bare "Volatility"
         # substring also matches Ang-Hodrick's "The Cross-Section of Volatility
@@ -329,6 +332,16 @@ class TestStrategyRoutes:
         # No live returns for this strategy → pending, NOT a fixture True/False.
         assert mm["rigor_gate_status"] == "pending"
         assert mm["passes_rigor_gate"] is False, "fixture boolean must NOT drive the live badge (#821)"
+        # #1187: pending must mean pending — no fixture-sourced number rendered
+        # as if it were measured.
+        assert mm["dsr_p_value"] is None, f"dsr_p_value must be None when pending (#1187); got {mm['dsr_p_value']}"
+        assert mm["pbo_score"] is None, f"pbo_score must be None when pending (#1187); got {mm['pbo_score']}"
+        assert mm["deflated_sharpe_ratio"] is None, (
+            f"deflated_sharpe_ratio must be None when pending (#1187); got {mm['deflated_sharpe_ratio']}"
+        )
+        assert mm["out_of_sample_sharpe"] is None, (
+            f"out_of_sample_sharpe must be None when pending (#1187); got {mm['out_of_sample_sharpe']}"
+        )
 
 
 class TestRiskRoutes:

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -343,6 +343,43 @@ class TestStrategyRoutes:
             f"out_of_sample_sharpe must be None when pending (#1187); got {mm['out_of_sample_sharpe']}"
         )
 
+    def test_advisor_serves_null_not_fixture_when_live_gate_empty(self, client, seeded_db):
+        """#1187 (``_rigor_fields``, the advisor's own copy of the leaderboard's
+        fixed-then-fixed-again fallback): when the live-gate batch returns no
+        result for a strategy, the four numeric rigor fields on its advisor
+        allocation must render ``None`` — never the migrated fixture value on
+        the in-memory ``Strategy`` object. Not vacuous: reverting just this
+        fallback (restoring ``else st.<field>`` on the four keys) makes this
+        fail — George Hwang's allocation then serves the exact fixture
+        constants (0.277212 / 0.339938 / 0.910213) from
+        ``backend/tests/fixtures/backtest_fixtures_snapshot.json``, confirmed
+        by hand against the pre-fix code."""
+        from archimedes.api import strategies_routes as sr
+
+        with patch.object(sr, "_live_rigor_results_for_strategies", return_value={}):
+            resp = client.get("/api/strategies/advisor?risk_profile=moderate")
+        assert resp.status_code == 200
+        allocations = resp.json()["allocations"]
+        assert allocations, "advisor returned no allocations to check"
+        gh = next(
+            (a for a in allocations if "52-Week High" in a.get("title", "")),
+            None,
+        )
+        if gh is None:
+            pytest.skip("George Hwang allocation not present in this advisor run")
+        # The rule-based aggregate row (id "agg_<symbol>") does not carry
+        # rigor_gate_status forward (_RIGOR_KEYS omits it) — passes_rigor_gate
+        # is the field available here, and must stay the fail-closed default.
+        assert gh["passes_rigor_gate"] is False
+        assert gh["deflated_sharpe_ratio"] is None, (
+            f"deflated_sharpe_ratio must be None, not the fixture value; got {gh['deflated_sharpe_ratio']}"
+        )
+        assert gh["dsr_p_value"] is None, f"dsr_p_value must be None, not the fixture value; got {gh['dsr_p_value']}"
+        assert gh["pbo_score"] is None, f"pbo_score must be None, not the fixture value; got {gh['pbo_score']}"
+        assert gh["out_of_sample_sharpe"] is None, (
+            f"out_of_sample_sharpe must be None, not the fixture value; got {gh['out_of_sample_sharpe']}"
+        )
+
 
 class TestRiskRoutes:
     def test_risk_profiles(self, client):

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -827,6 +827,60 @@ def test_to_strategy_response_serves_null_not_fixture_without_live_rigor_result(
     )
 
 
+def test_to_strategy_response_serves_null_not_bt_fixture_without_live_rigor_result(monkeypatch):
+    """#1187 adversarial gap (found in re-review): the sibling test above only
+    guards the ``s.<field>`` half of the removed fallback chain — ``bt`` is
+    always ``None`` there (a bare ``Strategy`` against an empty tmp DB), so a
+    partial revert that restored ONLY ``(bt.<field> if bt else None)`` would
+    pass every existing guard. This test persists the ``bt`` half: a
+    ``BacktestResult`` carrying non-None rigor numbers is what
+    ``strategy_provider().get_backtest_result`` returns for this strategy id,
+    while ``s.<field>`` stays ``None`` and ``rigor_result`` stays ``None``
+    (live gate could not run). Adversarial check: reintroducing
+    ``(bt.deflated_sharpe_ratio if bt else None)`` (etc.) on any of the four
+    keys makes this fail — it would observe 0.283312 / 0.611531 / 0.373116 /
+    0.930283 (the same real fixture values as the sibling test) instead of
+    ``None``.
+    """
+    from archimedes.api.strategies_routes import _to_strategy_response, strategy_provider
+    from archimedes.models.backtest import BacktestResult
+    from archimedes.models.strategy import Strategy
+    from archimedes.services.live_rigor_gate import RigorGateVerdict
+
+    s = Strategy(id="test-1187-bt-stub")  # s.<field> defaults None — bt half only
+    bt = BacktestResult(
+        strategy_id=s.id,
+        sharpe_ratio=1.0,
+        sortino_ratio=1.0,
+        max_drawdown=0.1,
+        cagr=0.1,
+        calmar_ratio=1.0,
+        win_rate=0.5,
+        profit_factor=1.5,
+        total_trades=10,
+        avg_holding_period_days=5.0,
+        correlation_to_spy=0.5,
+        correlation_to_btc=0.0,
+        deflated_sharpe_ratio=0.283312,
+        dsr_p_value=0.611531,
+        pbo_score=0.373116,
+        out_of_sample_sharpe=0.930283,
+    )
+    monkeypatch.setattr(strategy_provider(), "get_backtest_result", lambda strategy_id: bt)
+
+    resp = _to_strategy_response(s, verdict=RigorGateVerdict.pending(), rigor_result=None)
+
+    assert resp.rigor_gate_status == "pending"
+    assert resp.deflated_sharpe_ratio is None, (
+        f"deflated_sharpe_ratio must be None, not the bt fixture value; got {resp.deflated_sharpe_ratio}"
+    )
+    assert resp.dsr_p_value is None, f"dsr_p_value must be None, not the bt fixture value; got {resp.dsr_p_value}"
+    assert resp.pbo_score is None, f"pbo_score must be None, not the bt fixture value; got {resp.pbo_score}"
+    assert resp.out_of_sample_sharpe is None, (
+        f"out_of_sample_sharpe must be None, not the bt fixture value; got {resp.out_of_sample_sharpe}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_leaderboard_serves_null_not_fixture_without_real_returns(monkeypatch):
     """End-to-end companion to the unit test above, over the REAL curated

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -780,13 +780,80 @@ async def test_leaderboard_never_disagrees_with_selection_bias_gate_route(monkey
     assert checked >= 1, "no shared ids resolved between the two routes — fixture setup is broken"
 
 
+def test_to_strategy_response_serves_null_not_fixture_without_live_rigor_result():
+    """#1187 (claim-integrity): when the live rigor gate could not run
+    (``rigor_result is None`` — insufficient/no persisted returns, or a batch
+    failure), the four numeric rigor fields must serve ``None`` — the honest
+    "not run" — NEVER the strategy's stored ``s.<field>`` values. Those columns
+    trace back to a migrated test-fixture snapshot
+    (``backend/tests/fixtures/backtest_fixtures_snapshot.json``, PR #863) that
+    predates the current DSR convention and gate threshold (#901) and cannot be
+    reproduced by any single code version — presenting one as measured next to
+    a ``pending`` badge is exactly the defect #1187 tracks.
+
+    Direct unit call (no HTTP, no DB seeding needed): construct a ``Strategy``
+    carrying non-None values for all four fields — mirroring exactly what the
+    real migrated fixture rows look like — and confirm none of them leak
+    through when the live gate result is unavailable. Adversarial check: with
+    the pre-#1187 fallback chain restored (``s.<field> if s.<field> is not None
+    else (bt.<field> if bt else None)``), this test fails — it would observe
+    0.283312 / 0.611531 / 0.373116 / 0.930283 instead of ``None``.
+    """
+    from archimedes.api.strategies_routes import _to_strategy_response
+    from archimedes.models.strategy import Strategy
+    from archimedes.services.live_rigor_gate import RigorGateVerdict
+
+    # Values lifted from the real migrated fixture (faber_2007_sma200_timing in
+    # backend/tests/fixtures/backtest_fixtures_snapshot.json) so this test fails
+    # exactly the way the live #1187 bug did, not against an arbitrary sentinel.
+    s = Strategy(
+        id="test-1187-fixture-stub",
+        deflated_sharpe_ratio=0.283312,
+        dsr_p_value=0.611531,
+        pbo_score=0.373116,
+        out_of_sample_sharpe=0.930283,
+    )
+
+    resp = _to_strategy_response(s, verdict=RigorGateVerdict.pending(), rigor_result=None)
+
+    assert resp.rigor_gate_status == "pending"
+    assert resp.deflated_sharpe_ratio is None, (
+        f"deflated_sharpe_ratio must be None, not the fixture value; got {resp.deflated_sharpe_ratio}"
+    )
+    assert resp.dsr_p_value is None, f"dsr_p_value must be None, not the fixture value; got {resp.dsr_p_value}"
+    assert resp.pbo_score is None, f"pbo_score must be None, not the fixture value; got {resp.pbo_score}"
+    assert resp.out_of_sample_sharpe is None, (
+        f"out_of_sample_sharpe must be None, not the fixture value; got {resp.out_of_sample_sharpe}"
+    )
+
+
 @pytest.mark.asyncio
-async def test_leaderboard_falls_back_to_stale_fields_without_real_returns(monkeypatch):
-    """A strategy with NO persisted returns still serves numeric fields from the
-    pre-existing fallback chain (stub/None) — rigor_result is None in that case,
-    so _to_strategy_response's fallback branch (unchanged by #868) is exercised,
-    not a crash or a fabricated number."""
+async def test_leaderboard_serves_null_not_fixture_without_real_returns(monkeypatch):
+    """End-to-end companion to the unit test above, over the REAL curated
+    library with the REAL migrated fixture data seeded into the DB (#863's
+    ``strategy_backtest_fixtures`` table — the exact source the issue names) —
+    not a synthetic Strategy. With NO persisted daily returns for anyone,
+    ``GET /api/strategies/`` must still serve every strategy's numeric rigor
+    fields as ``None`` and its badge as ``pending``, never the seeded fixture
+    number. Seeding the fixture table (mirroring ``test_api_routes.py``'s
+    ``_use_tmp_db``) is what makes this a real regression guard rather than
+    a vacuous one: against pre-#1187 code every strategy here has a non-None
+    ``s.deflated_sharpe_ratio`` fixture value available to leak through."""
+    import json
+    from pathlib import Path
+
+    from archimedes.api._route_helpers import strategy_provider
+    from archimedes.db import get_session
     from archimedes.main import app
+    from archimedes.models.backtest_fixtures_store import FIXTURE_FIELDS, StrategyBacktestFixture
+
+    snapshot_path = Path(__file__).parent / "fixtures" / "backtest_fixtures_snapshot.json"
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    with get_session() as session:
+        for stem, rec in snapshot.items():
+            session.merge(StrategyBacktestFixture(stem=stem, **{field: rec[field] for field in FIXTURE_FIELDS}))
+        session.commit()
+    strategy_provider.cache_clear()
 
     monkeypatch.setattr(
         "archimedes.services.backtest_repository.get_all_daily_returns",
@@ -798,10 +865,26 @@ async def test_leaderboard_falls_back_to_stale_fields_without_real_returns(monke
     assert resp.status_code == 200
     served = resp.json()["strategies"]
     assert served
-    # No assertion on the specific fallback values (those come from whatever
-    # fixtures/stubs the curated library happens to carry) — the point is the
-    # route does not 500 and does not fabricate a rigor_result-sourced number
-    # when the live gate could not run.
+    # Sanity: the seeded fixture data actually landed on the in-memory Strategy
+    # objects (else this test would vacuously pass regardless of the fix, the
+    # exact trap CLAUDE.md's guard-adversarial-pass rule warns about).
+    strategies = strategy_provider().list_strategies()
+    assert any(s.deflated_sharpe_ratio is not None for s in strategies), (
+        "fixture seed did not reach strategy_provider() — this test would pass vacuously regardless of the #1187 fix"
+    )
+    for s in served:
+        assert s["rigor_gate_status"] == "pending", (
+            f"{s['id']}: expected pending badge with no persisted returns, got {s['rigor_gate_status']}"
+        )
+        assert s["deflated_sharpe_ratio"] is None, (
+            f"{s['id']}: deflated_sharpe_ratio must be None (not the seeded fixture number) when the "
+            f"live gate could not run; got {s['deflated_sharpe_ratio']}"
+        )
+        assert s["dsr_p_value"] is None, f"{s['id']}: dsr_p_value must be None; got {s['dsr_p_value']}"
+        assert s["pbo_score"] is None, f"{s['id']}: pbo_score must be None; got {s['pbo_score']}"
+        assert s["out_of_sample_sharpe"] is None, (
+            f"{s['id']}: out_of_sample_sharpe must be None; got {s['out_of_sample_sharpe']}"
+        )
 
 
 @pytest.mark.asyncio

--- a/docs/architectural-principles.md
+++ b/docs/architectural-principles.md
@@ -181,7 +181,7 @@ Three instances of the same failure were found in one week:
 | Instance | Mechanism | Cost |
 |---|---|---|
 | SSM credentials | `load_ssm_secrets()` catches the IAM denial and boots degraded by design | Marketplace publish never worked in production. 19 days, silent, no alarm. |
-| Leaderboard fixture fallback | Numeric fields fall back to migrated fixture columns when live compute is unavailable | Fabricated statistics presented as measured, on the flagship public page |
+| Leaderboard fixture fallback | Numeric fields fall back to migrated fixture columns when live compute is unavailable | Fabricated statistics presented as measured, on the flagship public page (fixed [#1187](https://github.com/a-apin/archimedes/issues/1187): the four rigor numeric fields now render `None` — not a fixture number — whenever the live gate could not run) |
 | T-bill / Maillard rows | Persisted return series bound to the wrong asset | The top-ranked strategy graded the null benchmark's returns |
 
 Note what the three have in common: each one was a *deliberate* design choice at the time,


### PR DESCRIPTION
Refs #1187

> **Post-review update (2026-08-20):** an adversarial re-review of this PR found the
> fallback the issue names was only half-removed (the advisor route's own copy of it
> was untouched) and that one of the three regression guards below could pass against
> a partial revert. Both are fixed on this branch — see "Post-review fixes" below —
> and `Closes` was downgraded to `Refs` because AC 4 is still genuinely open. Original
> PR description follows, unedited except for this note and the checklist below it.

## What

`_to_strategy_response` in `backend/archimedes/api/strategies_routes.py` served the
leaderboard's four numeric rigor fields — `deflated_sharpe_ratio`, `dsr_p_value`,
`pbo_score`, `out_of_sample_sharpe` — from a fallback chain (`s.<field>` then
`bt.<field>`) whenever the live rigor gate could not run (insufficient/no persisted
returns, or a batch failure). `s.<field>` traces back to a migration from
`backend/tests/fixtures/backtest_fixtures_snapshot.json` (#863) that predates the
current DSR convention (raw vs. excess returns) and gate threshold (#901, 0.95 →
0.90) and cannot be reproduced by any single code version. `bt.<field>` is a prior
engine-computed snapshot with the same staleness problem. Both fallbacks presented a
concrete number next to a `pending` badge — self-contradictory, and a claim-integrity
defect on the flagship public leaderboard.

**Fix:** both fallbacks are removed for these four fields only. They are now solely
the live `run_rigor_gate` result; `None` (served as the API's honest "not run") when
it could not run. No other field is touched — the fixture-backed *display* metrics
(`sharpe_ratio`, `cagr`, `max_drawdown`, etc.) are a separate, out-of-scope concern:
they are descriptive backtest stats, not a rigor-gate pass/fail claim, and the issue
does not name them.

Also updated the stale docstrings/log messages around the removed fallback (they
described "falls back to stale fixture fields", which is no longer true), and marked
the "Leaderboard fixture fallback" row in `docs/architectural-principles.md`'s
fail-soft table as fixed.

## Post-review fixes (2026-08-20)

An adversarial reviewer checked the "fixed" claim against the code (not just the
diff) and the regression guards against partial reverts, and found two real gaps:

1. **The identical fallback survived in `_rigor_fields`** (the *other* place these
   four fields are served — `GET /api/strategies/advisor`, the portfolio advisor,
   reading from the same fixture-hydrated `Strategy` objects). The original "Fix"
   section above only ever described `_to_strategy_response` (the leaderboard); the
   advisor route's copy of the same `else st.<field>` chain on the same four keys was
   untouched, so the "fixed #1187" doc claim was true for the leaderboard but false
   for the advisor. **Fixed:** the same one-line-per-field change applied to
   `_rigor_fields` — `deflated_sharpe_ratio` / `dsr_p_value` / `pbo_score` /
   `out_of_sample_sharpe` now render `None`, never `st.<field>`, when the live batch
   (`advisor_results`) has no entry for the strategy. **Second review pass (same
   day):** `num_trials_in_selection` carried the identical `else st.num_trials_in_
   selection` fixture fallback in the same function and was missed by the first
   pass — it isn't one of the four fields the issue names and isn't itself a
   rigor-*pass/fail* claim the way DSR/PBO/OOS-Sharpe are, but it's the same defect
   class this PR exists to remove, so leaving it was inconsistent. Nulled it
   alongside the other four. Verified safe to null: the rule-based-aggregate merge
   (`_RIGOR_KEYS` in the same file) already treats a missing/`None` value as
   "nothing to merge" (`if new is None: continue`), and the sole frontend reader,
   `StrategyPassport.jsx:654`, already guards `s.num_trials_in_selection != null`
   before using it — so nulling it has no unguarded consumer. New guard: `test_api_
   routes.py::TestStrategyRoutes::test_advisor_serves_null_not_fixture_when_live_gate_
   empty` — patches the live batch to `{}` and asserts every advisor allocation
   returned (not one named allocation with a skip-if-absent, which the same review
   pass flagged as a silent no-op risk) serves `None` on all four numeric fields and
   fail-closed `False` on `passes_rigor_gate`. Confirmed adversarially: reverting just
   the `_rigor_fields` half (restoring `else st.<field>` on `deflated_sharpe_ratio`)
   makes this new test fail — `agg_USD/TRY: deflated_sharpe_ratio must be None, not
   the fixture value; got 0.545957`; the three original guards are silent on this
   path (they only ever hit `_to_strategy_response`), which is exactly how the gap
   survived the first pass.
2. **Only the `s.<field>` half of the removed fallback was regression-covered — the
   `bt.<field>` half was not.** All three original guards construct scenarios where
   `bt` (the persisted `BacktestResult` row) is `None`, so a partial revert that
   restored *only* `(bt.<field> if bt else None)` on the four keys passes all three
   unchanged. New guard: `test_strategies_routes.py::test_to_strategy_response_serves_
   null_not_bt_fixture_without_live_rigor_result` — stubs `strategy_provider().get_
   backtest_result` to return a `BacktestResult` carrying the four fixture values with
   `s.<field>` left `None`, and asserts `_to_strategy_response(..., rigor_result=None)`
   still serves `None` on all four. Confirmed adversarially: reintroducing
   `(bt.<field> if bt else None)` on the four keys in `_to_strategy_response` makes
   this new test fail (got 0.283312 / 0.611531 / 0.373116 / 0.930283 — same fixture
   row as guard #1 below) while the two pre-existing guards that exercise this
   function stay green.

Neither gap involved reintroducing the fallback in the *currently-fixed* code path —
both were coverage gaps (a second, unfixed copy of the bug; a regression test that
couldn't detect one specific revert shape), not code regressions.

## Acceptance criteria (from the issue)

- [x] A strategy with insufficient persisted returns renders honest `None` (the
  frontend already renders `null` as `—`/omits it — see `ui/src/components/
  Leaderboard.jsx`'s `fmt()`), never a fixture-derived number presented as measured.
- [x] `GET /api/leaderboard` returns no value sourced from
  `backtest_fixtures_snapshot.json` or its migrated columns, for these four fields —
  the leaderboard's curated cohort is built through this exact function
  (`leaderboard_routes.py::_curated_cohort_responses` → `_to_strategy_response`). As
  of the post-review fixes above, the same is now also true of `GET /api/strategies/
  advisor` (`_rigor_fields`) — the only other place these four fields are served.
  Scoped to these four fields deliberately: the issue's "no value sourced from ...
  its migrated columns" is broader than the four rigor fields — the fixture-backed
  *display* metrics (`sharpe_ratio`, `cagr`, `max_drawdown`, etc., 24 of the 28
  `FIXTURE_FIELDS` columns) are untouched by design (see "What" above) and remain
  fixture-sourced on both routes. That is a separate, disclosed scope decision, not
  an oversight — but it means this checkbox covers the rigor-gate numbers, not every
  fixture-migrated value on these public rows.
- [x] Tests assert insufficient daily returns yields a null verdict, not a fallback
  number (five guards now — three original plus the two post-review additions above;
  see Guard transcripts).
- [ ] Re-running the `pbo_score` bucketing shown in the issue against the live prod
  API — this requires prod data and can't be exercised from a hermetic test
  environment. Structurally guaranteed by the fix though: once a strategy's
  `pbo_score` is `None` instead of a fixture constant, it cannot contribute to any
  bucket in that histogram at all (buckets are built from present values), so the
  fixture-constant clustering the issue found is now categorically impossible for
  not-yet-live-graded strategies. **Dan: re-run `GET /api/leaderboard` post-deploy,
  bucket by `pbo_score` to confirm live, and close #1187 by hand** — this PR now
  references it (`Refs`) rather than auto-closing it, since this item is still open
  and the display-metrics scope note above is worth Dan's explicit sign-off before
  the issue is considered fully resolved.

## Anti-goals honored

- Fixture file untouched — still used by tests (`backend/tests/fixtures/
  backtest_fixtures_snapshot.json`, `strategy_backtest_fixtures` DB table).
- No replacement default fabricated — `None` all the way through.
- Rigor gate itself untouched — `run_rigor_gate`, thresholds, and DSR convention are
  unchanged; only what happens when it *can't run* changed.

## Guard transcripts (CLAUDE.md "Before you approve a merge" rule 4)

All five guards were run against the pre-fix / partially-fixed code (isolated via a
scoped `git stash` / hand-revert of only `strategies_routes.py`) and confirmed to
fail with the exact leaked fixture values, before being run green against the fix.

**1. Direct unit test** (`test_to_strategy_response_serves_null_not_fixture_without_live_rigor_result`)
— constructs a `Strategy` with the real `faber_2007_sma200_timing` fixture values and
calls `_to_strategy_response` with `rigor_result=None`:

```
FAILED (pre-fix): AssertionError: deflated_sharpe_ratio must be None, not the fixture
value; got 0.283312
PASSED (post-fix)
```

**2. End-to-end test** (`test_leaderboard_serves_null_not_fixture_without_real_returns`)
— seeds the real `strategy_backtest_fixtures` table from the real snapshot file (so
the guard isn't vacuous), mocks `get_all_daily_returns` to return no data for anyone,
hits `GET /api/strategies/?limit=100`:

```
FAILED (pre-fix): AssertionError: 8e089dec88a36dc3c5657996c75a41ba: deflated_sharpe_ratio
must be None (not the seeded fixture number) when the live gate could not run; got
-0.123211
PASSED (post-fix)
```

**3. Strengthened existing test** (`test_rigor_gate_badge_is_live_not_fixture_for_tier1`)
— Moreira-Muir has no live returns in `seeded_db`, so its badge is `pending`; added
assertions that the four numeric fields are also `None` there:

```
FAILED (pre-fix): AssertionError: dsr_p_value must be None when pending (#1187); got
0.994567
PASSED (post-fix)
```

**4. (post-review) `_rigor_fields` guard** (`test_advisor_serves_null_not_fixture_when_live_gate_empty`)
— patches `_live_rigor_results_for_strategies` to `{}` and checks every advisor
allocation returned (broadened from a single named allocation with a skip-if-absent
in a later review pass — see item 1 above):

```
FAILED (pre-fix, `_rigor_fields` else-branch restored on deflated_sharpe_ratio):
AssertionError: agg_USD/TRY: deflated_sharpe_ratio must be None, not the fixture
value; got 0.545957
PASSED (post-fix)
```

**5. (post-review) `bt.<field>` half guard** (`test_to_strategy_response_serves_null_not_bt_fixture_without_live_rigor_result`)
— stubs `get_backtest_result` to return a `BacktestResult` carrying the four fixture
values, `s.<field>` left `None`:

```
FAILED (bt.<field> fallback reintroduced in _to_strategy_response):
AssertionError: deflated_sharpe_ratio must be None, not the bt fixture value; got 0.283312
PASSED (current code — no bt.<field> fallback exists)
```

## Verification tallies

- `backend/tests/test_strategies_routes.py`: 29 passed (was 28; +1 post-review guard)
- `backend/tests/test_api_routes.py`: 36 passed (was 35; +1 post-review guard)
- Adjacent leaderboard/passport/selection-bias/rigor files (`test_leaderboard.py`,
  `test_leaderboard_single_user_scope.py`, `test_passport_honesty.py`,
  `test_unify_curated_generated.py`, `test_selection_bias_routes.py`,
  `test_selection_bias_generated_gate.py`, `test_dsr_parity.py`,
  `test_gate_equivalence.py`, `test_rigor_strictness.py`, `test_rigor_cache.py`,
  `test_rigor_regime.py`): 202 passed
- Full unit suite from repo root, `pytest -m "not integration" -q`: **3356 passed
  (was 3354; +2 post-review guards), 2 skipped (pre-existing, unrelated), 2
  deselected, 0 failed**
- `ruff format --check` + `ruff check --select E9,F63,F7,F40` on all touched Python
  files: clean
- `make docs-check`: 0 broken links, 0 orphaned docs

No UI files touched — `ui/` build/lint not applicable to this change.

