### PR TITLE
[data][rigor] Reject impossible Explore pct changes; median group headline; crypto vol annualization (#1322)

### DIFF
--- a/backend/archimedes/api/explore_schemas.py
+++ b/backend/archimedes/api/explore_schemas.py
@@ -41,6 +41,15 @@ class AssetExploreItem(BaseModel):
         default_factory=dict,
         description="Per-metric plain-English copy keyed by field name",
     )
+    rejected_fields: list[str] = Field(
+        default_factory=list,
+        description="Field names (e.g. 'change_24h_pct', 'realized_vol_30d') whose computed "
+        "value was actively suppressed as arithmetically implausible (#1322 — a bad tick / "
+        "decimal-placement error in the upstream feed), distinct from a field that is null "
+        "because there isn't enough history yet. The honest-absence mechanism this item's "
+        "is_stale/price_source already carry is about the displayed *price*; this discloses "
+        "suppression of a *derived* stat on an otherwise fresh, correctly-sourced price.",
+    )
 
 
 class ExploreAssetsResponse(BaseModel):

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -75,9 +75,14 @@ _HISTORY_FETCH_BUDGET_SECONDS = 45.0
 # explosive ratio that passes every other check — e.g. sJUP's prior close of
 # 0.0003166165 produced a reported "+1483.08% 24h" move. 100%/day is already
 # an extremely generous bound (no major asset has ever moved >100% in a
-# single day without a corporate-action-style event); it scales with
-# sqrt(n) for multi-day windows so legitimate large cumulative moves in
-# volatile assets over a week/month aren't rejected.
+# single day without a corporate-action-style event); multi-day windows
+# compound this per-day bound rather than scaling it by sqrt(n) — sqrt(n)
+# models how a *volatility* (a standard deviation) grows with time and does
+# not apply to a point-to-point *cumulative simple return*, which compounds
+# multiplicatively. A sqrt(n)-scaled bound is both mathematically wrong for
+# this quantity and too tight in practice: at n=30 it allows only ±548%,
+# which would reject a real (if extreme) 10x month in a volatile crypto
+# name. See `_pct_change` for the compounding formula.
 _MAX_PLAUSIBLE_DAILY_PCT = 100.0
 
 # Trading-day conventions differ by asset class (#1322). Equities/ETFs/FX
@@ -152,24 +157,38 @@ def _explanations_for(item: dict[str, Any], is_247: bool = False) -> dict[str, s
 # ── Stat math ─────────────────────────────────────────────────────────────
 
 
-def _pct_change(prices: list[float], n: int) -> float | None:
-    """Pct change between prices[-1] and prices[-1-n]. None if not enough data,
-    or if the result exceeds a plausible bound for a window this size (#1322):
-    a bad tick / decimal-placement error in the upstream feed can turn a tiny
-    prior close into an explosive ratio that passes every other check. An
-    honest absence beats shipping an arithmetically-impossible number — see
-    docs/architectural-principles.md § fail-soft.
+def _pct_change_with_reason(prices: list[float], n: int) -> tuple[float | None, bool]:
+    """Pct change between prices[-1] and prices[-1-n].
+
+    Returns ``(value, was_rejected)``. ``value`` is None if not enough data,
+    the prior close is zero, or the result exceeds a plausible bound for a
+    window this size (#1322): a bad tick / decimal-placement error in the
+    upstream feed can turn a tiny prior close into an explosive ratio that
+    passes every other check. An honest absence beats shipping an
+    arithmetically-impossible number — see docs/architectural-principles.md
+    § fail-soft. ``was_rejected`` is True only for the plausibility-bound
+    case (not for insufficient data / zero start), so callers can
+    distinguish "not enough history yet" from "a value was actively
+    suppressed as implausible" — see ``AssetExploreItem.rejected_fields``.
+
+    The bound compounds the single-day bound across the window rather than
+    scaling it by sqrt(n): the n-bar quantity being checked is a cumulative
+    *simple* return, which compounds multiplicatively — sqrt(n) is a
+    volatility-scaling argument that doesn't apply here, and using it made
+    the bound too tight for legitimate large multi-day moves (e.g. a real
+    10x over a month in a volatile crypto name) while still being generous
+    enough to admit the sJUP-style single-bar decimal-placement defect at
+    n=1. Compounding means only the 1-day window stays tightly bounded
+    (100%) — exactly where that defect class lives.
     """
     if not prices or len(prices) < n + 1:
-        return None
+        return None, False
     end, start = prices[-1], prices[-1 - n]
     if not start:
-        return None
+        return None, False
     pct = (end - start) / start * 100.0
-    # sqrt(n) scaling (vol scales with sqrt of time) so a legitimate large
-    # cumulative move over a week/month isn't rejected by a bound sized for
-    # a single day.
-    bound = _MAX_PLAUSIBLE_DAILY_PCT * math.sqrt(max(n, 1))
+    n_eff = max(n, 1)
+    bound = ((1.0 + _MAX_PLAUSIBLE_DAILY_PCT / 100.0) ** n_eff - 1.0) * 100.0
     if abs(pct) > bound:
         logger.warning(
             "explore: rejecting implausible %.1f%% change over %d bar(s) (bound ±%.1f%%) — "
@@ -178,8 +197,69 @@ def _pct_change(prices: list[float], n: int) -> float | None:
             n,
             bound,
         )
-        return None
-    return pct
+        return None, True
+    return pct, False
+
+
+def _pct_change(prices: list[float], n: int) -> float | None:
+    """Pct change between prices[-1] and prices[-1-n]; see
+    ``_pct_change_with_reason`` for the full contract. Thin wrapper kept for
+    callers (and the existing unit-test surface) that only need the value."""
+    return _pct_change_with_reason(prices, n)[0]
+
+
+def _realized_vol_annual_with_reason(
+    prices: list[float],
+    window: int = 30,
+    trading_days_per_year: int = _EQUITY_TRADING_DAYS_PER_YEAR,
+) -> tuple[float | None, bool]:
+    """Annualized realized vol over the most recent ``window`` bars.
+
+    Returns ``(value, was_rejected)`` — see ``_pct_change_with_reason`` for
+    why callers need both.
+
+    ``trading_days_per_year`` is the annualization factor (#1322): 252 for
+    equities/ETFs/FX (yfinance bars only on trading days), 365 for crypto
+    (yfinance bars every calendar day, no weekend/holiday gaps) — applying
+    the equity constant to a 24/7 asset understates its vol by
+    sqrt(365/252) ≈ 1.20, about 17%.
+
+    Plausibility guard (#1322): a bad tick / decimal-placement error inside
+    the window inflates one bar-to-bar return past what's physically
+    plausible even when the *endpoint-to-endpoint* ratio `_pct_change`
+    checks would pass — vol is built from every bar-to-bar step, not just
+    the two ends, so a single corrupt bar corrupts the whole estimate.
+    Dropping the bad bar and computing vol on what's left would still ship
+    a clean-looking but fabricated number (the issue's anti-goal forbids
+    exactly that shape of "fix"); the honest response is None for the
+    whole window when any single bar exceeds the same per-day plausibility
+    bound `_pct_change` uses (bar-to-bar, so no compounding — n=1 always).
+    """
+    if not prices or len(prices) < window + 1:
+        return None, False
+    tail = prices[-(window + 1) :]
+    rets = []
+    for i in range(1, len(tail)):
+        prev = tail[i - 1]
+        if not prev:
+            continue
+        ret = (tail[i] - prev) / prev
+        if abs(ret) * 100.0 > _MAX_PLAUSIBLE_DAILY_PCT:
+            logger.warning(
+                "explore: rejecting realized-vol window — bar %d/%d implied a %.1f%% "
+                "single-bar move (bound ±%.1f%%) — treating as a bad tick, not a real move",
+                i,
+                len(tail) - 1,
+                ret * 100.0,
+                _MAX_PLAUSIBLE_DAILY_PCT,
+            )
+            return None, True
+        rets.append(ret)
+    if len(rets) < 2:
+        return None, False
+    mean = sum(rets) / len(rets)
+    var = sum((r - mean) ** 2 for r in rets) / (len(rets) - 1)
+    return math.sqrt(var) * math.sqrt(trading_days_per_year), False
 
 
 def _realized_vol_annual(
@@ -187,28 +267,11 @@ def _realized_vol_annual(
     window: int = 30,
     trading_days_per_year: int = _EQUITY_TRADING_DAYS_PER_YEAR,
 ) -> float | None:
-    """Annualized realized vol over the most recent ``window`` bars.
-
-    ``trading_days_per_year`` is the annualization factor (#1322): 252 for
-    equities/ETFs/FX (yfinance bars only on trading days), 365 for crypto
-    (yfinance bars every calendar day, no weekend/holiday gaps) — applying
-    the equity constant to a 24/7 asset understates its vol by
-    sqrt(365/252) ≈ 1.20, about 17%.
-    """
-    if not prices or len(prices) < window + 1:
-        return None
-    tail = prices[-(window + 1) :]
-    rets = []
-    for i in range(1, len(tail)):
-        prev = tail[i - 1]
-        if not prev:
-            continue
-        rets.append((tail[i] - prev) / prev)
-    if len(rets) < 2:
-        return None
-    mean = sum(rets) / len(rets)
-    var = sum((r - mean) ** 2 for r in rets) / (len(rets) - 1)
-    return math.sqrt(var) * math.sqrt(trading_days_per_year)
+    """Annualized realized vol over the most recent ``window`` bars; see
+    ``_realized_vol_annual_with_reason`` for the full contract. Thin wrapper
+    kept for callers (and the existing unit-test surface) that only need the
+    value."""
+    return _realized_vol_annual_with_reason(prices, window, trading_days_per_year)[0]
 
 
 # ── Direct yfinance fetch (used by /assets/{symbol}/history) ─────────────
@@ -647,16 +710,38 @@ class AssetMarketService:
 
             # Change / vol from yfinance daily history (independent of where
             # the spot came from — both source paths benefit from these).
+            # Each `*_with_reason` call also reports whether the None came
+            # from an active plausibility rejection (#1322) vs. simply not
+            # having enough history yet; rejected_fields discloses the
+            # former on the served item rather than leaving a suppressed
+            # bad tick indistinguishable from "not fetched yet" (issue
+            # Precedent: route rejected values down an honest-absence path).
+            rejected_fields: list[str] = []
+            change_24h_pct, rej_24h = _pct_change_with_reason(hist_prices, 1) if hist_prices else (None, False)
+            change_7d_pct, rej_7d = _pct_change_with_reason(hist_prices, week_n) if hist_prices else (None, False)
+            change_30d_pct, rej_30d = _pct_change_with_reason(hist_prices, month_n) if hist_prices else (None, False)
+            realized_vol_30d, rej_vol = (
+                _realized_vol_annual_with_reason(hist_prices, 30, trading_days_per_year)
+                if hist_prices
+                else (None, False)
+            )
+            if rej_24h:
+                rejected_fields.append("change_24h_pct")
+            if rej_7d:
+                rejected_fields.append("change_7d_pct")
+            if rej_30d:
+                rejected_fields.append("change_30d_pct")
+            if rej_vol:
+                rejected_fields.append("realized_vol_30d")
+
             stat_dict: dict[str, Any] = {
                 "current_price": current_price,
-                "change_24h_pct": _pct_change(hist_prices, 1) if hist_prices else None,
-                "change_7d_pct": _pct_change(hist_prices, week_n) if hist_prices else None,
-                "change_30d_pct": _pct_change(hist_prices, month_n) if hist_prices else None,
+                "change_24h_pct": change_24h_pct,
+                "change_7d_pct": change_7d_pct,
+                "change_30d_pct": change_30d_pct,
                 "high_24h": high_24h,
                 "low_24h": low_24h,
-                "realized_vol_30d": _realized_vol_annual(hist_prices, 30, trading_days_per_year)
-                if hist_prices
-                else None,
+                "realized_vol_30d": realized_vol_30d,
             }
 
             # oracle_address is a capability marker — populated from settings
@@ -680,6 +765,7 @@ class AssetMarketService:
                     is_stale=displayed_is_stale,
                     price_source=price_source,
                     explanations=_explanations_for(stat_dict, is_247=is_247),
+                    rejected_fields=rejected_fields,
                     **stat_dict,
                 )
             )

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -70,6 +70,25 @@ _ORACLE_TOTAL_BUDGET_SECONDS = 12.0
 _HISTORY_CHUNK_SIZE = 60
 _HISTORY_FETCH_BUDGET_SECONDS = 45.0
 
+# Plausibility bound for computed pct changes (#1322). A bad tick / decimal-
+# placement error in the upstream feed (a tiny prior close) can turn into an
+# explosive ratio that passes every other check — e.g. sJUP's prior close of
+# 0.0003166165 produced a reported "+1483.08% 24h" move. 100%/day is already
+# an extremely generous bound (no major asset has ever moved >100% in a
+# single day without a corporate-action-style event); it scales with
+# sqrt(n) for multi-day windows so legitimate large cumulative moves in
+# volatile assets over a week/month aren't rejected.
+_MAX_PLAUSIBLE_DAILY_PCT = 100.0
+
+# Trading-day conventions differ by asset class (#1322). Equities/ETFs/FX
+# only print a yfinance daily bar on trading days (weekends + holidays are
+# gaps), so ~5 bars ≈ 1 calendar week and ~21 bars ≈ 1 calendar month, and
+# annualizing realized vol uses the standard 252 trading days/year. Crypto
+# trades every calendar day with no gaps, so 1 bar == 1 calendar day: 7
+# bars == 1 week, 30 bars == 1 month, and annualizing must use 365.
+_EQUITY_TRADING_DAYS_PER_YEAR = 252
+_CRYPTO_TRADING_DAYS_PER_YEAR = 365
+
 # Range param → (yfinance period, yfinance interval). Daily intervals work
 # for week / month / year ranges; 1D uses 5-minute intraday data; the longer
 # ranges (5Y / 10Y / MAX) downsample to weekly / monthly bars to keep the
@@ -94,8 +113,8 @@ _EXPLANATIONS_TEMPLATES = {
         "Percentage move in the last trading day. Positive = up. "
         "Daily moves bigger than {vol_daily_pct:.1f}% are unusual for this asset."
     ),
-    "change_7d_pct": "Percentage move over the past week (5 trading days).",
-    "change_30d_pct": "Percentage move over the past month (≈21 trading days).",
+    "change_7d_pct": "Percentage move over the past week ({week_label}).",
+    "change_30d_pct": "Percentage move over the past month ({month_label}).",
     "realized_vol_30d": (
         "How much the price wobbles. Higher = bigger swings. {vol:.2f} annualized "
         "means daily moves of ~{vol_daily_pct:.1f}% are typical."
@@ -103,15 +122,28 @@ _EXPLANATIONS_TEMPLATES = {
 }
 
 
-def _explanations_for(item: dict[str, Any]) -> dict[str, str]:
+def _explanations_for(item: dict[str, Any], is_247: bool = False) -> dict[str, str]:
+    """Plain-English copy for each metric. ``is_247`` (#1322) selects the
+    asset-class-correct trading-day convention so the copy never asserts a
+    convention the computation didn't actually use — crypto is 7/30 calendar
+    days annualized with sqrt(365); everything else is 5/21 trading days
+    annualized with sqrt(252)."""
     vol = item.get("realized_vol_30d") or 0.0
-    vol_daily_pct = (vol / math.sqrt(252)) * 100.0 if vol else 0.0
+    trading_days_per_year = _CRYPTO_TRADING_DAYS_PER_YEAR if is_247 else _EQUITY_TRADING_DAYS_PER_YEAR
+    vol_daily_pct = (vol / math.sqrt(trading_days_per_year)) * 100.0 if vol else 0.0
+    week_label = "7 calendar days" if is_247 else "5 trading days"
+    month_label = "30 calendar days" if is_247 else "≈21 trading days"
     fields = {}
     for key, template in _EXPLANATIONS_TEMPLATES.items():
         if item.get(key) is None:
             continue
         try:
-            fields[key] = template.format(vol=vol, vol_daily_pct=vol_daily_pct)
+            fields[key] = template.format(
+                vol=vol,
+                vol_daily_pct=vol_daily_pct,
+                week_label=week_label,
+                month_label=month_label,
+            )
         except (KeyError, IndexError):
             fields[key] = template
     return fields
@@ -121,17 +153,48 @@ def _explanations_for(item: dict[str, Any]) -> dict[str, str]:
 
 
 def _pct_change(prices: list[float], n: int) -> float | None:
-    """Pct change between prices[-1] and prices[-1-n]. None if not enough data."""
+    """Pct change between prices[-1] and prices[-1-n]. None if not enough data,
+    or if the result exceeds a plausible bound for a window this size (#1322):
+    a bad tick / decimal-placement error in the upstream feed can turn a tiny
+    prior close into an explosive ratio that passes every other check. An
+    honest absence beats shipping an arithmetically-impossible number — see
+    docs/architectural-principles.md § fail-soft.
+    """
     if not prices or len(prices) < n + 1:
         return None
     end, start = prices[-1], prices[-1 - n]
     if not start:
         return None
-    return (end - start) / start * 100.0
+    pct = (end - start) / start * 100.0
+    # sqrt(n) scaling (vol scales with sqrt of time) so a legitimate large
+    # cumulative move over a week/month isn't rejected by a bound sized for
+    # a single day.
+    bound = _MAX_PLAUSIBLE_DAILY_PCT * math.sqrt(max(n, 1))
+    if abs(pct) > bound:
+        logger.warning(
+            "explore: rejecting implausible %.1f%% change over %d bar(s) (bound ±%.1f%%) — "
+            "treating as a bad tick, not a real move",
+            pct,
+            n,
+            bound,
+        )
+        return None
+    return pct
 
 
-def _realized_vol_annual(prices: list[float], window: int = 30) -> float | None:
-    """Annualized realized vol over the most recent ``window`` trading days."""
+def _realized_vol_annual(
+    prices: list[float],
+    window: int = 30,
+    trading_days_per_year: int = _EQUITY_TRADING_DAYS_PER_YEAR,
+) -> float | None:
+    """Annualized realized vol over the most recent ``window`` bars.
+
+    ``trading_days_per_year`` is the annualization factor (#1322): 252 for
+    equities/ETFs/FX (yfinance bars only on trading days), 365 for crypto
+    (yfinance bars every calendar day, no weekend/holiday gaps) — applying
+    the equity constant to a 24/7 asset understates its vol by
+    sqrt(365/252) ≈ 1.20, about 17%.
+    """
     if not prices or len(prices) < window + 1:
         return None
     tail = prices[-(window + 1) :]
@@ -145,7 +208,7 @@ def _realized_vol_annual(prices: list[float], window: int = 30) -> float | None:
         return None
     mean = sum(rets) / len(rets)
     var = sum((r - mean) ** 2 for r in rets) / (len(rets) - 1)
-    return math.sqrt(var) * math.sqrt(252)
+    return math.sqrt(var) * math.sqrt(trading_days_per_year)
 
 
 # ── Direct yfinance fetch (used by /assets/{symbol}/history) ─────────────
@@ -218,6 +281,18 @@ def _explore_universe() -> list[str]:
     except Exception as exc:  # pragma: no cover — SSOT loader logs its own errors
         logger.warning("explore: universe SSOT import failed: %s", exc)
         return []
+
+
+def _is_24_7_asset_class(asset_class: str) -> bool:
+    """True for asset classes that trade every calendar day, no gaps (#1322).
+
+    Crypto is the only such class in the current universe: a yfinance daily
+    bar for e.g. BTC-USD prints every calendar day (weekends included), so
+    1 bar == 1 calendar day. Equities/ETFs/FX/bonds/commodities only trade
+    (and only get a bar) on trading days — the same string-membership test
+    the existing group-sort already uses (see ``items.sort`` below).
+    """
+    return "crypto" in (asset_class or "")
 
 
 def _ssot_display_name(synth: str, fallback: str) -> str:
@@ -559,21 +634,30 @@ class AssetMarketService:
             high_24h = None
             low_24h = None
 
+            entry = GLOBAL_ASSETS.get(synth)
+            asset_class = entry[2] if entry else "unknown"
+            real_ticker = entry[0] if entry else synth.lstrip("s")
+            # Trading-day convention is asset-class aware (#1322): crypto
+            # bars are 1-per-calendar-day (24/7 markets), everything else is
+            # 1-per-trading-day (weekends/holidays are gaps in the feed).
+            is_247 = _is_24_7_asset_class(asset_class)
+            week_n = 7 if is_247 else 5
+            month_n = 30 if is_247 else 21
+            trading_days_per_year = _CRYPTO_TRADING_DAYS_PER_YEAR if is_247 else _EQUITY_TRADING_DAYS_PER_YEAR
+
             # Change / vol from yfinance daily history (independent of where
             # the spot came from — both source paths benefit from these).
             stat_dict: dict[str, Any] = {
                 "current_price": current_price,
                 "change_24h_pct": _pct_change(hist_prices, 1) if hist_prices else None,
-                "change_7d_pct": _pct_change(hist_prices, 5) if hist_prices else None,
-                "change_30d_pct": _pct_change(hist_prices, 21) if hist_prices else None,
+                "change_7d_pct": _pct_change(hist_prices, week_n) if hist_prices else None,
+                "change_30d_pct": _pct_change(hist_prices, month_n) if hist_prices else None,
                 "high_24h": high_24h,
                 "low_24h": low_24h,
-                "realized_vol_30d": _realized_vol_annual(hist_prices, 30) if hist_prices else None,
+                "realized_vol_30d": _realized_vol_annual(hist_prices, 30, trading_days_per_year)
+                if hist_prices
+                else None,
             }
-
-            entry = GLOBAL_ASSETS.get(synth)
-            asset_class = entry[2] if entry else "unknown"
-            real_ticker = entry[0] if entry else synth.lstrip("s")
 
             # oracle_address is a capability marker — populated from settings
             # regardless of whether the oracle read succeeded (Issue #346).
@@ -595,7 +679,7 @@ class AssetMarketService:
                     last_updated=last_updated,
                     is_stale=displayed_is_stale,
                     price_source=price_source,
-                    explanations=_explanations_for(stat_dict),
+                    explanations=_explanations_for(stat_dict, is_247=is_247),
                     **stat_dict,
                 )
             )

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -178,13 +178,17 @@ def _pct_change_with_reason(prices: list[float], n: int) -> tuple[float | None, 
     """Pct change between prices[-1] and prices[-1-n].
 
     Returns ``(value, was_rejected)``. ``value`` is None if not enough data,
-    the prior close is zero, or the result exceeds a plausible bound for a
-    window this size (#1322): a bad tick / decimal-placement error in the
-    upstream feed can turn a tiny prior close into an explosive ratio that
-    passes every other check. An honest absence beats shipping an
-    arithmetically-impossible number — see docs/architectural-principles.md
-    § fail-soft. ``was_rejected`` is True only for the plausibility-bound
-    case (not for insufficient data / zero start), so callers can
+    either window endpoint (the prior close or the last close) is
+    non-positive, or the result exceeds a plausible bound for a window this
+    size (#1322): a bad tick / decimal-placement error in the upstream feed
+    can turn a tiny prior close into an explosive ratio that passes every
+    other check. An honest absence beats shipping an arithmetically-
+    impossible number — see docs/architectural-principles.md § fail-soft.
+    ``was_rejected`` is True for the plausibility-bound case AND for a
+    non-positive endpoint (a zero/negative close is a data hole, not a
+    computable return — round-3 fix, PR #1343: a zero *last* close at n=1
+    used to compute an undetected exact -100.0% "return" instead of being
+    caught here); it is False only for insufficient data, so callers can
     distinguish "not enough history yet" from "a value was actively
     suppressed as implausible" — see ``AssetExploreItem.rejected_fields``.
 
@@ -209,8 +213,21 @@ def _pct_change_with_reason(prices: list[float], n: int) -> tuple[float | None, 
     if not prices or len(prices) < n + 1:
         return None, False
     end, start = prices[-1], prices[-1 - n]
-    if not start:
-        return None, False
+    if start <= 0 or end <= 0:
+        # A non-positive price at EITHER window endpoint is a data hole, not
+        # a computable return (#1322 review, PR #1343 round-3 finding): the
+        # old `if not start` only checked the *prior* close, so a zero/
+        # negative *last* close at n=1 fell through to `pct = (end - start)
+        # / start * 100.0` and computed an exact -100.0% "return" that slid
+        # past the strict `abs(pct) > bound` check below (-100.0 is not >
+        # 100.0) and got served as a real change_24h_pct — self-contradictory
+        # next to the n>1 bar-scan and the vol path below, which already
+        # reject any non-positive bar they touch. was_rejected=True (not
+        # False) here so this is classified the same as those rejections —
+        # not lumped in with "not enough history yet" — matching the bar-
+        # scan's treatment of the identical zero one bar deeper in the
+        # window.
+        return None, True
     pct = (end - start) / start * 100.0
     if n <= 1:
         if abs(pct) > _MAX_PLAUSIBLE_DAILY_PCT:
@@ -298,8 +315,13 @@ def _realized_vol_annual_with_reason(
     step *into* it compute an exact -100% return that slipped past a
     strict ``>`` bound comparison (-100% is not > 100%) and got folded into
     the vol estimate as real data. A zero/negative close is a data hole,
-    not a return — same treatment `_pct_change_with_reason` gives a zero
-    start.
+    not a return — the same classification `_pct_change_with_reason` now
+    gives a non-positive price at either window endpoint (round-3 fix, PR
+    #1343: before it, `_pct_change_with_reason` only checked its *prior*
+    close and returned ``was_rejected=False`` for a zero — this docstring's
+    "same treatment" claim was not yet true; the n=1 endpoint check was
+    fixed to match this function's bar-scan instead of the other way
+    around).
     """
     if not prices or len(prices) < window + 1:
         return None, False

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -75,14 +75,18 @@ _HISTORY_FETCH_BUDGET_SECONDS = 45.0
 # explosive ratio that passes every other check — e.g. sJUP's prior close of
 # 0.0003166165 produced a reported "+1483.08% 24h" move. 100%/day is already
 # an extremely generous bound (no major asset has ever moved >100% in a
-# single day without a corporate-action-style event); multi-day windows
-# compound this per-day bound rather than scaling it by sqrt(n) — sqrt(n)
-# models how a *volatility* (a standard deviation) grows with time and does
-# not apply to a point-to-point *cumulative simple return*, which compounds
-# multiplicatively. A sqrt(n)-scaled bound is both mathematically wrong for
-# this quantity and too tight in practice: at n=30 it allows only ±548%,
-# which would reject a real (if extreme) 10x month in a volatile crypto
-# name. See `_pct_change` for the compounding formula.
+# single day without a corporate-action-style event). Multi-day windows
+# (n > 1) do NOT compound this into a single endpoint-ratio bound — sqrt(n)
+# scaling is mathematically wrong for a point-to-point cumulative simple
+# return (it's a volatility-scaling argument), but compounding the bound
+# itself (`(1+bound)**n - 1`) is vacuous, not just generous: ±12,700% at
+# n=7, ±107,374,182,300% at n=30 — wide enough to let the sJUP-shaped bad
+# tick straight through once it ages into the 7d/30d lookback (#1322
+# review, PR #1343 finding 5). Instead, multi-day windows are scanned
+# bar-to-bar against this same per-day bound, admitting a real 10x month
+# (many individually-plausible ~8%/day steps) while still rejecting a
+# single implausible bar anywhere in the window. See `_pct_change_with_reason`
+# for the bar-scan.
 _MAX_PLAUSIBLE_DAILY_PCT = 100.0
 
 # Trading-day conventions differ by asset class (#1322). Equities/ETFs/FX
@@ -126,6 +130,13 @@ _EXPLANATIONS_TEMPLATES = {
     ),
 }
 
+# change_24h_pct copy for when realized_vol_30d was suppressed (#1322
+# review finding 3) — the vol-guard makes this systematically more common
+# (one bad bar suppresses vol for the whole 30-session window it sits in),
+# and the vol-based "unusual" clause can't be honestly asserted from a
+# number the computation explicitly refused to produce.
+_CHANGE_24H_PCT_NO_VOL_TEMPLATE = "Percentage move in the last trading day. Positive = up."
+
 
 def _explanations_for(item: dict[str, Any], is_247: bool = False) -> dict[str, str]:
     """Plain-English copy for each metric. ``is_247`` (#1322) selects the
@@ -133,7 +144,7 @@ def _explanations_for(item: dict[str, Any], is_247: bool = False) -> dict[str, s
     convention the computation didn't actually use — crypto is 7/30 calendar
     days annualized with sqrt(365); everything else is 5/21 trading days
     annualized with sqrt(252)."""
-    vol = item.get("realized_vol_30d") or 0.0
+    vol = item.get("realized_vol_30d")
     trading_days_per_year = _CRYPTO_TRADING_DAYS_PER_YEAR if is_247 else _EQUITY_TRADING_DAYS_PER_YEAR
     vol_daily_pct = (vol / math.sqrt(trading_days_per_year)) * 100.0 if vol else 0.0
     week_label = "7 calendar days" if is_247 else "5 trading days"
@@ -141,6 +152,12 @@ def _explanations_for(item: dict[str, Any], is_247: bool = False) -> dict[str, s
     fields = {}
     for key, template in _EXPLANATIONS_TEMPLATES.items():
         if item.get(key) is None:
+            continue
+        if key == "change_24h_pct" and vol is None:
+            # realized_vol_30d was suppressed as implausible/insufficient —
+            # don't default it to a fabricated 0.0% just to fill the
+            # template; drop the vol clause instead.
+            fields[key] = _CHANGE_24H_PCT_NO_VOL_TEMPLATE
             continue
         try:
             fields[key] = template.format(
@@ -171,15 +188,23 @@ def _pct_change_with_reason(prices: list[float], n: int) -> tuple[float | None, 
     distinguish "not enough history yet" from "a value was actively
     suppressed as implausible" — see ``AssetExploreItem.rejected_fields``.
 
-    The bound compounds the single-day bound across the window rather than
-    scaling it by sqrt(n): the n-bar quantity being checked is a cumulative
-    *simple* return, which compounds multiplicatively — sqrt(n) is a
-    volatility-scaling argument that doesn't apply here, and using it made
-    the bound too tight for legitimate large multi-day moves (e.g. a real
-    10x over a month in a volatile crypto name) while still being generous
-    enough to admit the sJUP-style single-bar decimal-placement defect at
-    n=1. Compounding means only the 1-day window stays tightly bounded
-    (100%) — exactly where that defect class lives.
+    For n > 1, compounding the single-day bound onto the *endpoint* ratio
+    (e.g. `(1 + bound)**n - 1`) turns out to be vacuous rather than merely
+    generous: at n=7 it allows ±12,700%, at n=30 it allows
+    ±107,374,182,300% — wide enough to let the issue's own bad tick
+    (sJUP's +1479.20%, aged into the 7d/30d lookback) straight through
+    (#1322 review, PR #1343 finding 5). An endpoint-only check can never
+    tell "one bad tick" apart from "many small legitimate daily moves" —
+    both can produce the same huge endpoint ratio — so for n > 1 this scans
+    the window bar-to-bar instead, the same shape
+    `_realized_vol_annual_with_reason` uses: reject only if *some single
+    bar* in the window implies a move past the per-day bound. A real
+    multi-day move made of individually-plausible daily steps (e.g. a
+    genuine 10x over a month, ~8.1%/day compounded) is kept no matter how
+    large the compounded total is; a single implausible bar anywhere in the
+    window — including one that's since aged out of the 1-day window but
+    still sits inside the 7d/30d one — is not. n=1 keeps the simple
+    endpoint bound (identical to a 1-bar scan).
     """
     if not prices or len(prices) < n + 1:
         return None, False
@@ -187,17 +212,49 @@ def _pct_change_with_reason(prices: list[float], n: int) -> tuple[float | None, 
     if not start:
         return None, False
     pct = (end - start) / start * 100.0
-    n_eff = max(n, 1)
-    bound = ((1.0 + _MAX_PLAUSIBLE_DAILY_PCT / 100.0) ** n_eff - 1.0) * 100.0
-    if abs(pct) > bound:
-        logger.warning(
-            "explore: rejecting implausible %.1f%% change over %d bar(s) (bound ±%.1f%%) — "
-            "treating as a bad tick, not a real move",
-            pct,
-            n,
-            bound,
-        )
-        return None, True
+    if n <= 1:
+        if abs(pct) > _MAX_PLAUSIBLE_DAILY_PCT:
+            logger.warning(
+                "explore: rejecting implausible %.1f%% change over %d bar(s) (bound ±%.1f%%) — "
+                "treating as a bad tick, not a real move",
+                pct,
+                n,
+                _MAX_PLAUSIBLE_DAILY_PCT,
+            )
+            return None, True
+        return pct, False
+    window = prices[-(n + 1) :]
+    for i in range(1, len(window)):
+        prev, curr = window[i - 1], window[i]
+        if prev <= 0 or curr <= 0:
+            # A non-positive price inside the window is itself a data hole
+            # (#1322 review finding 4's fix, applied consistently here too)
+            # — not a computable return, and not something a legitimate
+            # multi-day move can produce.
+            logger.warning(
+                "explore: rejecting implausible %.1f%% change over %d bar(s) — bar %d/%d has a "
+                "non-positive price (prev=%.6g, curr=%.6g) — treating as a bad tick, not a real move",
+                pct,
+                n,
+                i,
+                len(window) - 1,
+                prev,
+                curr,
+            )
+            return None, True
+        bar_pct = (curr - prev) / prev * 100.0
+        if abs(bar_pct) > _MAX_PLAUSIBLE_DAILY_PCT:
+            logger.warning(
+                "explore: rejecting implausible %.1f%% change over %d bar(s) — bar %d/%d implied a "
+                "%.1f%% single-bar move (bound ±%.1f%%) — treating as a bad tick, not a real move",
+                pct,
+                n,
+                i,
+                len(window) - 1,
+                bar_pct,
+                _MAX_PLAUSIBLE_DAILY_PCT,
+            )
+            return None, True
     return pct, False
 
 
@@ -234,16 +291,33 @@ def _realized_vol_annual_with_reason(
     exactly that shape of "fix"); the honest response is None for the
     whole window when any single bar exceeds the same per-day plausibility
     bound `_pct_change` uses (bar-to-bar, so no compounding — n=1 always).
+
+    A non-positive bar inside the window (#1322 review finding 4) is
+    rejected the same way, not silently skipped: skipping only the step
+    *out of* a zero close (the old ``if not prev: continue``) still let the
+    step *into* it compute an exact -100% return that slipped past a
+    strict ``>`` bound comparison (-100% is not > 100%) and got folded into
+    the vol estimate as real data. A zero/negative close is a data hole,
+    not a return — same treatment `_pct_change_with_reason` gives a zero
+    start.
     """
     if not prices or len(prices) < window + 1:
         return None, False
     tail = prices[-(window + 1) :]
     rets = []
     for i in range(1, len(tail)):
-        prev = tail[i - 1]
-        if not prev:
-            continue
-        ret = (tail[i] - prev) / prev
+        prev, curr = tail[i - 1], tail[i]
+        if prev <= 0 or curr <= 0:
+            logger.warning(
+                "explore: rejecting realized-vol window — bar %d/%d has a non-positive "
+                "price (prev=%.6g, curr=%.6g) — treating as a bad tick, not real data",
+                i,
+                len(tail) - 1,
+                prev,
+                curr,
+            )
+            return None, True
+        ret = (curr - prev) / prev
         if abs(ret) * 100.0 > _MAX_PLAUSIBLE_DAILY_PCT:
             logger.warning(
                 "explore: rejecting realized-vol window — bar %d/%d implied a %.1f%% "

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -32,7 +32,9 @@ from archimedes.services.asset_market_service import (
     _explore_universe,
     _is_24_7_asset_class,
     _pct_change,
+    _pct_change_with_reason,
     _realized_vol_annual,
+    _realized_vol_annual_with_reason,
     _ssot_display_name,
 )
 
@@ -87,13 +89,66 @@ class TestPctChangePlausibilityGuard:
         assert _pct_change([100.0, 200.0], 1) == pytest.approx(100.0)
 
     def test_pct_change_multiday_window_tolerates_a_wider_move(self):
-        """A 21-bar window's bound is wider than a 1-bar window's (vol scales
-        with sqrt(time)) — the same cumulative move that would be rejected
-        over 1 bar is plausible compounded over 21."""
+        """A 21-bar window's bound is wider than a 1-bar window's (the daily
+        bound compounds across the window) — the same cumulative move that
+        would be rejected over 1 bar is plausible over 21."""
         prices = [10.0] * 21 + [30.0]  # +200% over 21 bars
         assert _pct_change(prices, 21) == pytest.approx(200.0)
         # But the 1-bar version of the same magnitude is still rejected.
         assert _pct_change([10.0, 30.0], 1) is None
+
+    def test_pct_change_multiday_bound_compounds_not_sqrt_scales(self):
+        """Regression for #1322 review: the multi-day bound must compound the
+        per-day bound (a legitimate large cumulative move — even a real 10x
+        over a month in a volatile crypto name — is many individually-
+        plausible daily steps), not scale it by sqrt(n). sqrt(n) applies a
+        volatility-scaling argument to a point-to-point cumulative simple
+        return, where it doesn't belong, and is strict enough to falsely
+        reject genuine moves: sqrt(30)*100% ≈ 548%, well under a real 10x
+        (+900%) month."""
+        # +900% (a real 10x) over 30 bars, each individual bar only a
+        # plausible ~8.1%/day compounded — no single bar is anywhere near
+        # the 100%/day bound, so this must NOT be rejected.
+        start = 10.0
+        end = start * 10.0  # +900%
+        daily_factor = (end / start) ** (1.0 / 30)
+        prices = [start * (daily_factor**i) for i in range(31)]
+        pct = _pct_change(prices, 30)
+        assert pct is not None, "a legitimate compounding 10x/month move must not be rejected"
+        assert pct == pytest.approx(900.0, rel=1e-6)
+
+    def test_pct_change_with_reason_distinguishes_rejection_from_no_data(self):
+        """rejected_fields (#1322 review) needs to tell "actively suppressed
+        as implausible" apart from "not enough history yet" — both surface
+        as None from `_pct_change`, but only the former is a rejection."""
+        # Implausible: was_rejected True.
+        value, was_rejected = _pct_change_with_reason([0.0003166165, 0.005], 1)
+        assert value is None
+        assert was_rejected is True
+        # Not enough data: was_rejected False.
+        value, was_rejected = _pct_change_with_reason([100.0], 1)
+        assert value is None
+        assert was_rejected is False
+        # Zero prior close: was_rejected False (a different honest-absence
+        # cause, not a plausibility rejection).
+        value, was_rejected = _pct_change_with_reason([0.0, 105.0], 1)
+        assert value is None
+        assert was_rejected is False
+        # A kept value: was_rejected False.
+        value, was_rejected = _pct_change_with_reason([100.0, 105.0], 1)
+        assert value == pytest.approx(5.0)
+        assert was_rejected is False
+
+    def test_pct_change_bound_is_1_day_tight_but_30_day_generous(self):
+        """Sanity-pins the compounding formula's shape: the 1-day bound stays
+        at the strict 100% (where the sJUP defect class lives) while the
+        30-day endpoint bound is enormously wider — verifying the fix
+        doesn't accidentally leave the multi-day guard just as tight as the
+        sqrt(n) version it replaced (sqrt(30)*100% ≈ 548% would have
+        rejected the +600% endpoint move asserted below)."""
+        assert _pct_change([100.0, 201.0], 1) is None  # just over the 1-day bound
+        prices = [10.0] * 30 + [70.0]  # +600% endpoint-to-endpoint over 30 bars
+        assert _pct_change(prices, 30) == pytest.approx(600.0)
 
 
 # ── Asset-class-aware trading-day convention (#1322) ────────────────────────
@@ -140,6 +195,69 @@ class TestAssetClassAwareAnnualization:
         prices = self._series(7)
         assert _realized_vol_annual(prices, 30) == _realized_vol_annual(prices, 30, 252)
 
+    def test_realized_vol_annual_actually_uses_the_given_param(self):
+        """Guards the exact defect class this repo's CLAUDE.md rule 4 warns
+        about: a `trading_days_per_year` param that's accepted but silently
+        ignored (the return statement hard-coded back to `sqrt(252)`).
+        Unlike `test_identical_daily_returns_annualize_differently_by_asset_class`
+        and `test_daily_vol_copy_uses_the_matching_annualization_factor`
+        (which both derive their expected value from the function's own
+        output — see PR #1343 review), this computes the expected annualized
+        vol independently from the raw bar-to-bar returns, so a mutation
+        that hard-codes sqrt(252) actually makes the assertion fail rather
+        than passing on both sides of the mutation."""
+        prices = self._series(2024)
+        tail = prices[-31:]
+        rets = [(tail[i] - tail[i - 1]) / tail[i - 1] for i in range(1, len(tail))]
+        mean = sum(rets) / len(rets)
+        var = sum((r - mean) ** 2 for r in rets) / (len(rets) - 1)
+        expected_crypto_vol = math.sqrt(var) * math.sqrt(_CRYPTO_TRADING_DAYS_PER_YEAR)
+
+        crypto_vol = _realized_vol_annual(prices, 30, _CRYPTO_TRADING_DAYS_PER_YEAR)
+        assert crypto_vol == pytest.approx(expected_crypto_vol)
+        # And it must differ from what the (wrong) hard-coded-252 mutation
+        # would produce, so this genuinely distinguishes the two.
+        wrong_if_ignored = math.sqrt(var) * math.sqrt(_EQUITY_TRADING_DAYS_PER_YEAR)
+        assert crypto_vol != pytest.approx(wrong_if_ignored)
+
+
+class TestRealizedVolPlausibilityGuard:
+    """A bad tick inside the realized-vol window must not survive as a
+    fabricated-but-plausible-looking vol number (#1322 review finding: the
+    plausibility guard was applied only to `_pct_change`, leaving
+    `_realized_vol_annual` unguarded — the same sJUP-style bad tick that
+    `_pct_change` rejects for change_24h_pct still flowed into
+    realized_vol_30d and produced an internally-impossible 'typical daily
+    move' figure via `_explanations_for`)."""
+
+    def test_realized_vol_rejects_window_containing_a_bad_tick(self):
+        """Mirrors sJUP's real prior close (0.0003166165) landing inside an
+        otherwise-normal 30-bar window: one implausible bar corrupts the
+        whole vol estimate, so the honest response is None, not a number."""
+        prices = [0.0003166165] + [0.005] * 30
+        assert _realized_vol_annual(prices, 30, _CRYPTO_TRADING_DAYS_PER_YEAR) is None
+
+    def test_realized_vol_accepts_a_window_with_no_bad_bars(self):
+        """Sanity: a normal (if volatile) window is unaffected by the guard."""
+        rng = random.Random(42)
+        prices = [100.0]
+        for _ in range(31):
+            prices.append(prices[-1] * (1 + rng.uniform(-0.05, 0.05)))
+        assert _realized_vol_annual(prices, 30, _CRYPTO_TRADING_DAYS_PER_YEAR) is not None
+
+    def test_realized_vol_with_reason_reports_rejection(self):
+        prices = [0.0003166165] + [0.005] * 30
+        value, was_rejected = _realized_vol_annual_with_reason(prices, 30, _CRYPTO_TRADING_DAYS_PER_YEAR)
+        assert value is None
+        assert was_rejected is True
+
+    def test_realized_vol_with_reason_insufficient_data_is_not_a_rejection(self):
+        """None from too little history is NOT a plausibility rejection —
+        callers (rejected_fields) must be able to tell the two apart."""
+        value, was_rejected = _realized_vol_annual_with_reason([100.0, 101.0], 30)
+        assert value is None
+        assert was_rejected is False
+
 
 class TestExplanationsAssetClassAware:
     def test_period_labels_match_asset_class(self):
@@ -164,7 +282,17 @@ class TestExplanationsAssetClassAware:
         annualized with — otherwise the copy asserts a number the
         computation didn't produce (#1322 honesty requirement: a hard-coded
         wrong-convention explanation is the same defect class as a fabricated
-        statistic)."""
+        statistic).
+
+        Scope note (PR #1343 review): this guards `_explanations_for`'s own
+        factor choice, NOT `_realized_vol_annual`'s `trading_days_per_year`
+        plumbing — `expected_daily_pct` here is derived from `crypto_vol`,
+        the same value both sides compare against, so it passes unchanged
+        even if `_realized_vol_annual` silently ignored its param and always
+        annualized with 252 (a mutation-checked demonstration lives in the
+        PR body). `test_realized_vol_annual_actually_uses_the_given_param`
+        above is what actually guards the param plumbing, by computing its
+        expectation independently."""
         rng = random.Random(7)
         prices = [100.0]
         for _ in range(31):
@@ -544,6 +672,67 @@ class TestExploreAssetsPlausibilityAndAssetClassAwareness:
         jup = next(a for a in resp.assets if a.symbol == "sJUP")
         assert jup.change_24h_pct is None  # honest absence, not +1479%
         assert jup.current_price == pytest.approx(0.005)  # price still shown
+        # #1322 review: the served item must disclose WHICH field was
+        # actively suppressed as implausible, not merely leave the field
+        # null (indistinguishable from "not enough history yet" — see the
+        # issue's Precedent section on is_stale/price_source as the honest-
+        # absence mechanism this payload already carries for the price).
+        assert jup.rejected_fields == ["change_24h_pct"]
+
+    @pytest.mark.asyncio
+    async def test_list_assets_rejected_fields_empty_when_nothing_suppressed(self):
+        """A normal series must NOT carry a spurious rejected_fields entry —
+        the disclosure mechanism must not cry wolf on legitimate data."""
+        service = AssetMarketService()
+        mock_histories = {
+            "sSPY": {
+                "close": [540.0, 545.0, 548.0],
+                "dates": ["2026-05-22", "2026-05-23", "2026-05-24"],
+            }
+        }
+
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch("archimedes.services.strategy_signal_evaluator._fetch_price_histories", return_value=mock_histories),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sSPY"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sSPY": ("SPY", "SPY", "us_equity_etf", "NYSE")},
+            ),
+        ):
+            resp = await service.list_assets()
+
+        spy = next(a for a in resp.assets if a.symbol == "sSPY")
+        assert spy.rejected_fields == []
+
+    @pytest.mark.asyncio
+    async def test_list_assets_realized_vol_rejected_field_disclosed(self):
+        """The realized_vol_30d guard (#1322 review finding: it was
+        previously unguarded) must also disclose via rejected_fields when it
+        fires, end to end through list_assets."""
+        service = AssetMarketService()
+        bad_tick_series = [0.0003166165] + [0.005] * 30
+        mock_histories = {
+            "sJUP": {
+                "close": bad_tick_series,
+                "dates": [f"d{i}" for i in range(len(bad_tick_series))],
+            }
+        }
+
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch("archimedes.services.strategy_signal_evaluator._fetch_price_histories", return_value=mock_histories),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sJUP"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sJUP": ("JUP-USD", "JUP", "crypto", "Coinbase")},
+            ),
+        ):
+            resp = await service.list_assets()
+
+        jup = next(a for a in resp.assets if a.symbol == "sJUP")
+        assert jup.realized_vol_30d is None  # no fabricated "typical daily move ~270%"
+        assert "realized_vol_30d" in jup.rejected_fields
 
     @pytest.mark.asyncio
     async def test_list_assets_period_offsets_are_asset_class_aware(self):

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -135,15 +135,33 @@ class TestPctChangePlausibilityGuard:
         value, was_rejected = _pct_change_with_reason([100.0], 1)
         assert value is None
         assert was_rejected is False
-        # Zero prior close: was_rejected False (a different honest-absence
-        # cause, not a plausibility rejection).
+        # Zero prior close: was_rejected True (round-3 fix, PR #1343 review).
+        # A non-positive endpoint is a data hole, not a computable return —
+        # the SAME classification the n>1 bar-scan and the vol path already
+        # give a non-positive bar, so this must not be a separate "no data"
+        # bucket. Pinning this as False (the pre-fix behavior) is exactly
+        # the bug: it let a zero prior close silently compute a "kept"
+        # value on the boundary case (see the negative control below for
+        # the case that actually leaked, a zero *last* close at n=1).
         value, was_rejected = _pct_change_with_reason([0.0, 105.0], 1)
         assert value is None
-        assert was_rejected is False
+        assert was_rejected is True
         # A kept value: was_rejected False.
         value, was_rejected = _pct_change_with_reason([100.0, 105.0], 1)
         assert value == pytest.approx(5.0)
         assert was_rejected is False
+        # Negative control (round-3 fix, PR #1343 review): a zero *last*
+        # close at n=1 — the exact shape that leaked. Before the fix, only
+        # `start` (the prior close) was checked; `end` (the last close)
+        # fell through to `pct = (end - start) / start * 100.0 == -100.0`,
+        # which then passed the `abs(pct) > 100.0` bound check (-100.0 is
+        # not > 100.0) and was served as a real, non-rejected change_24h_pct
+        # — self-contradictory next to the 7d/30d/vol paths, which already
+        # reject any non-positive bar they scan. Mutation check: reverting
+        # the `end <= 0` half of the endpoint guard back to checking only
+        # `start` makes this assertion fail with (-100.0, False) instead of
+        # (None, True) — see the PR body for the transcript.
+        assert _pct_change_with_reason([10.0] * 39 + [0.0], 1) == (None, True)
 
     def test_pct_change_bound_is_1_day_tight_but_30_day_generous(self):
         """Sanity-pins the guard's shape: the 1-day bound stays at the

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -89,12 +89,18 @@ class TestPctChangePlausibilityGuard:
         assert _pct_change([100.0, 200.0], 1) == pytest.approx(100.0)
 
     def test_pct_change_multiday_window_tolerates_a_wider_move(self):
-        """A 21-bar window's bound is wider than a 1-bar window's (the daily
-        bound compounds across the window) — the same cumulative move that
-        would be rejected over 1 bar is plausible over 21."""
-        prices = [10.0] * 21 + [30.0]  # +200% over 21 bars
-        assert _pct_change(prices, 21) == pytest.approx(200.0)
-        # But the 1-bar version of the same magnitude is still rejected.
+        """A large multi-day move survives when it's actually made of
+        individually-plausible daily steps (#1322 review finding 2 —
+        the guard scans bar-to-bar, not an endpoint-compounded bound, so
+        this must be a genuinely compounding series, not a flat run with
+        one terminal spike, which is the bad-tick shape the guard exists
+        to catch, not tolerate)."""
+        start = 10.0
+        end = start * 3.0  # +200% over 21 bars
+        daily_factor = (end / start) ** (1.0 / 21)
+        prices = [start * (daily_factor**i) for i in range(22)]
+        assert _pct_change(prices, 21) == pytest.approx(200.0, rel=1e-6)
+        # But the same +200% packed into a single bar is still rejected.
         assert _pct_change([10.0, 30.0], 1) is None
 
     def test_pct_change_multiday_bound_compounds_not_sqrt_scales(self):
@@ -140,15 +146,45 @@ class TestPctChangePlausibilityGuard:
         assert was_rejected is False
 
     def test_pct_change_bound_is_1_day_tight_but_30_day_generous(self):
-        """Sanity-pins the compounding formula's shape: the 1-day bound stays
-        at the strict 100% (where the sJUP defect class lives) while the
-        30-day endpoint bound is enormously wider — verifying the fix
-        doesn't accidentally leave the multi-day guard just as tight as the
-        sqrt(n) version it replaced (sqrt(30)*100% ≈ 548% would have
-        rejected the +600% endpoint move asserted below)."""
+        """Sanity-pins the guard's shape: the 1-day bound stays at the
+        strict 100% (where the sJUP defect class lives) while a genuinely
+        compounding 30-day move — every bar individually plausible — is
+        kept no matter how large the cumulative total is. (Not an endpoint-
+        compounded bound: see `test_pct_change_multiday_rejects_a_bad_bar_
+        anywhere_in_the_window` for why an endpoint-only check can't tell
+        this apart from a single bad tick.)"""
         assert _pct_change([100.0, 201.0], 1) is None  # just over the 1-day bound
-        prices = [10.0] * 30 + [70.0]  # +600% endpoint-to-endpoint over 30 bars
-        assert _pct_change(prices, 30) == pytest.approx(600.0)
+        start = 10.0
+        end = start * 7.0  # +600% over 30 bars, each bar a plausible ~6.6%/day
+        daily_factor = (end / start) ** (1.0 / 30)
+        prices = [start * (daily_factor**i) for i in range(31)]
+        assert _pct_change(prices, 30) == pytest.approx(600.0, rel=1e-6)
+
+    def test_pct_change_multiday_rejects_a_bad_bar_anywhere_in_the_window(self):
+        """Negative control (#1322 review finding 1/2): a single implausible
+        bar must still sink the whole window at n=7 and n=30, even once
+        it's aged past the 1-day lookback — an endpoint-only bound (whether
+        compounded or sqrt(n)-scaled) can't distinguish "one bad tick
+        inside an otherwise-flat run" from "many small legitimate daily
+        moves"; only a bar-to-bar scan can. Mirrors the issue's own
+        sJUP-shaped bad bar (a tiny prior close that snaps back to a normal
+        price one bar later) aged 8 bars deep into a 40-bar history, so it
+        sits inside the 7d window (n=7) and the 30d window (n=30) but has
+        already fallen out of the 1d window (n=1).
+
+        Mutation check: deleting the multi-day bar-scan — e.g. reverting to
+        `if n_eff > 1: bound = float('inf')`, or any endpoint-only bound —
+        makes both assertions below fail (value stops being None)."""
+        prices = [10.0] * 32 + [0.0003166165] + [0.005] * 7  # bad bar at index -8
+        assert len(prices) == 40
+        for n in (7, 30):
+            value, was_rejected = _pct_change_with_reason(prices, n)
+            assert value is None, f"n={n}: bad bar must not survive as a value"
+            assert was_rejected is True, f"n={n}: must be flagged as a rejection, not 'no data'"
+        # The 1-day window no longer contains the bad bar at all (it aged
+        # out 7 bars ago) — the trailing bars are all plausible 0.5%/0.005
+        # steps, so n=1 is unaffected.
+        assert _pct_change(prices, 1) == pytest.approx(0.0, abs=1e-9)
 
 
 # ── Asset-class-aware trading-day convention (#1322) ────────────────────────
@@ -258,6 +294,21 @@ class TestRealizedVolPlausibilityGuard:
         assert value is None
         assert was_rejected is False
 
+    def test_realized_vol_rejects_a_zero_bar_in_the_window(self):
+        """#1322 review finding 4: a zero close inside the window is a data
+        hole, not a real -100% return — it must not slip through and get
+        folded into the vol estimate. Before the fix, `if not prev:
+        continue` only skipped the step *out of* the zero; the step *into*
+        it computed an exact -100% return that passed the strict `>` bound
+        comparison (-100% is not > 100%) and was silently included as real
+        data. Mutation check: reverting the `prev <= 0 or curr <= 0` guard
+        back to `if not prev: continue` makes this assertion fail (value
+        stops being None)."""
+        prices = [0.005] * 20 + [0.0] + [0.005] * 10
+        value, was_rejected = _realized_vol_annual_with_reason(prices, 30, _CRYPTO_TRADING_DAYS_PER_YEAR)
+        assert value is None
+        assert was_rejected is True
+
 
 class TestExplanationsAssetClassAware:
     def test_period_labels_match_asset_class(self):
@@ -303,6 +354,25 @@ class TestExplanationsAssetClassAware:
         expl = _explanations_for({"realized_vol_30d": crypto_vol}, is_247=True)
         expected_daily_pct = (crypto_vol / math.sqrt(365)) * 100.0
         assert f"{expected_daily_pct:.1f}%" in expl["realized_vol_30d"]
+
+    def test_change_24h_copy_drops_vol_clause_when_vol_was_suppressed(self):
+        """#1322 review finding 3: when realized_vol_30d is None (suppressed
+        by the plausibility guard, or just not enough history), the
+        change_24h_pct copy must not assert a fabricated '0.0%' vol
+        threshold — a number the computation explicitly refused to
+        produce. It should read as a plain move description with no vol
+        clause at all. Mutation check: reverting `vol = item.get(...)` back
+        to `item.get(...) or 0.0` makes '0.0%' reappear in the copy."""
+        expl = _explanations_for({"change_24h_pct": 5.0, "realized_vol_30d": None}, is_247=True)
+        assert "0.0%" not in expl["change_24h_pct"]
+        assert expl["change_24h_pct"] == "Percentage move in the last trading day. Positive = up."
+
+    def test_change_24h_copy_keeps_vol_clause_when_vol_present(self):
+        """Sanity: the vol clause still renders normally when realized_vol_30d
+        is actually present, so the finding-3 fix doesn't drop it always."""
+        expl = _explanations_for({"change_24h_pct": 5.0, "realized_vol_30d": 0.5}, is_247=True)
+        assert "unusual for this asset" in expl["change_24h_pct"]
+        assert "0.0%" not in expl["change_24h_pct"]
 
 
 # ── Oracle read tests (mocked chain_client) ────────────────────────────────

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -16,6 +16,8 @@ timeout. All tests are hermetic — yfinance / chain boundaries are mocked.
 from __future__ import annotations
 
 import asyncio
+import math
+import random
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,8 +25,12 @@ import pytest
 from archimedes.api.explore_schemas import ExploreAssetsResponse
 from archimedes.services.asset_market_service import (
     _CACHE_TTL_SECONDS,
+    _CRYPTO_TRADING_DAYS_PER_YEAR,
+    _EQUITY_TRADING_DAYS_PER_YEAR,
     AssetMarketService,
+    _explanations_for,
     _explore_universe,
+    _is_24_7_asset_class,
     _pct_change,
     _realized_vol_annual,
     _ssot_display_name,
@@ -50,6 +56,125 @@ class TestStatMath:
 
     def test_realized_vol_insufficient(self):
         assert _realized_vol_annual([100, 101], 30) is None
+
+
+# ── Plausibility guard (#1322 — sJUP's +1483.08% "24h" move) ───────────────
+
+
+class TestPctChangePlausibilityGuard:
+    """An arithmetically-impossible pct change must come back None, not a
+    fabricated number — honest absence per docs/architectural-principles.md
+    § fail-soft, not a clamp/winsorize (the issue's anti-goal)."""
+
+    def test_pct_change_rejects_implausible_24h_move(self):
+        """The exact defect class from the issue: a tiny prior close (a bad
+        tick / decimal-placement error) implies a >100%/day move. This
+        mirrors sJUP's real prior close of 0.0003166165."""
+        prices = [0.0003166165, 0.005]
+        implied_pct = (0.005 - 0.0003166165) / 0.0003166165 * 100.0
+        assert implied_pct > 100.0  # sanity: this genuinely trips the bound
+        assert _pct_change(prices, 1) is None
+
+    def test_pct_change_accepts_plausible_large_move(self):
+        """A legitimate outsized daily move — well inside the bound — is NOT
+        rejected. The guard targets impossible values, not merely large
+        ones; the anti-goal forbids hiding real moves behind the guard."""
+        assert _pct_change([100.0, 180.0], 1) == pytest.approx(80.0)
+
+    def test_pct_change_exactly_at_the_bound_is_kept(self):
+        """Exactly doubling in one bar (100% for n=1) sits ON the bound and
+        is kept, not rejected — the guard is a strict '>' check."""
+        assert _pct_change([100.0, 200.0], 1) == pytest.approx(100.0)
+
+    def test_pct_change_multiday_window_tolerates_a_wider_move(self):
+        """A 21-bar window's bound is wider than a 1-bar window's (vol scales
+        with sqrt(time)) — the same cumulative move that would be rejected
+        over 1 bar is plausible compounded over 21."""
+        prices = [10.0] * 21 + [30.0]  # +200% over 21 bars
+        assert _pct_change(prices, 21) == pytest.approx(200.0)
+        # But the 1-bar version of the same magnitude is still rejected.
+        assert _pct_change([10.0, 30.0], 1) is None
+
+
+# ── Asset-class-aware trading-day convention (#1322) ────────────────────────
+
+
+class TestIs247AssetClass:
+    def test_crypto_is_24_7(self):
+        assert _is_24_7_asset_class("crypto") is True
+
+    def test_equity_etf_is_not_24_7(self):
+        assert _is_24_7_asset_class("us_equity_etf") is False
+
+    def test_empty_or_none_asset_class_is_not_24_7(self):
+        assert _is_24_7_asset_class("") is False
+        assert _is_24_7_asset_class(None) is False
+
+
+class TestAssetClassAwareAnnualization:
+    """Crypto trades 365 days/year with no weekend/holiday gaps; equities
+    trade ~252. Annualizing crypto's realized vol with the equity constant
+    understates it by sqrt(365/252) ≈ 1.20 — about 17% too low."""
+
+    def _series(self, seed: int) -> list[float]:
+        rng = random.Random(seed)
+        prices = [100.0]
+        for _ in range(31):
+            prices.append(prices[-1] * (1 + rng.uniform(-0.02, 0.02)))
+        return prices
+
+    def test_identical_daily_returns_annualize_differently_by_asset_class(self):
+        prices = self._series(1322)
+        equity_vol = _realized_vol_annual(prices, 30, _EQUITY_TRADING_DAYS_PER_YEAR)
+        crypto_vol = _realized_vol_annual(prices, 30, _CRYPTO_TRADING_DAYS_PER_YEAR)
+
+        assert equity_vol is not None
+        assert crypto_vol is not None
+        assert crypto_vol != equity_vol
+        assert crypto_vol > equity_vol
+        assert crypto_vol / equity_vol == pytest.approx(math.sqrt(365 / 252), rel=1e-9)
+
+    def test_realized_vol_annual_defaults_to_equity_252_unspecified(self):
+        """Backward-compatible default: a caller that omits
+        trading_days_per_year keeps the pre-#1322 (equity) behavior."""
+        prices = self._series(7)
+        assert _realized_vol_annual(prices, 30) == _realized_vol_annual(prices, 30, 252)
+
+
+class TestExplanationsAssetClassAware:
+    def test_period_labels_match_asset_class(self):
+        stat_dict = {
+            "current_price": 100.0,
+            "change_24h_pct": 1.0,
+            "change_7d_pct": 2.0,
+            "change_30d_pct": 3.0,
+            "realized_vol_30d": 0.4,
+        }
+        equity_expl = _explanations_for(stat_dict, is_247=False)
+        crypto_expl = _explanations_for(stat_dict, is_247=True)
+
+        assert "5 trading days" in equity_expl["change_7d_pct"]
+        assert "≈21 trading days" in equity_expl["change_30d_pct"]
+        assert "7 calendar days" in crypto_expl["change_7d_pct"]
+        assert "30 calendar days" in crypto_expl["change_30d_pct"]
+
+    def test_daily_vol_copy_uses_the_matching_annualization_factor(self):
+        """The de-annualized 'typical daily move' figure in the copy must be
+        computed with the SAME trading-day count the vol was actually
+        annualized with — otherwise the copy asserts a number the
+        computation didn't produce (#1322 honesty requirement: a hard-coded
+        wrong-convention explanation is the same defect class as a fabricated
+        statistic)."""
+        rng = random.Random(7)
+        prices = [100.0]
+        for _ in range(31):
+            prices.append(prices[-1] * (1 + rng.uniform(-0.03, 0.03)))
+        crypto_vol = _realized_vol_annual(prices, 30, _CRYPTO_TRADING_DAYS_PER_YEAR)
+        assert crypto_vol is not None
+
+        expl = _explanations_for({"realized_vol_30d": crypto_vol}, is_247=True)
+        expected_daily_pct = (crypto_vol / math.sqrt(365)) * 100.0
+        assert f"{expected_daily_pct:.1f}%" in expl["realized_vol_30d"]
 
 
 # ── Oracle read tests (mocked chain_client) ────────────────────────────────
@@ -385,6 +510,77 @@ class TestListAssets:
             assert refreshed is stale_resp
 
         assert call_count == 1  # deduplicated, not 5 separate rebuilds
+
+
+# ── End-to-end #1322 repro: impossible values never reach the API ──────────
+
+
+class TestExploreAssetsPlausibilityAndAssetClassAwareness:
+    @pytest.mark.asyncio
+    async def test_list_assets_change_24h_pct_none_for_impossible_move(self):
+        """Full repro of the issue: a corrupted history (tiny prior close,
+        mirroring sJUP's real 0.0003166165) must surface as
+        change_24h_pct=None on the served AssetExploreItem — never as a
+        fabricated triple-digit percentage. The price itself still shows."""
+        service = AssetMarketService()
+        mock_histories = {
+            "sJUP": {
+                "close": [0.0003166165, 0.005],
+                "dates": ["2026-08-19", "2026-08-20"],
+            }
+        }
+
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch("archimedes.services.strategy_signal_evaluator._fetch_price_histories", return_value=mock_histories),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sJUP"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sJUP": ("JUP-USD", "JUP", "crypto", "Coinbase")},
+            ),
+        ):
+            resp = await service.list_assets()
+
+        jup = next(a for a in resp.assets if a.symbol == "sJUP")
+        assert jup.change_24h_pct is None  # honest absence, not +1479%
+        assert jup.current_price == pytest.approx(0.005)  # price still shown
+
+    @pytest.mark.asyncio
+    async def test_list_assets_period_offsets_are_asset_class_aware(self):
+        """Same input series for a crypto symbol and an equity symbol must
+        produce DIFFERENT change_7d_pct / change_30d_pct: crypto indexes 7
+        and 30 bars back (24/7, one bar per calendar day); equity indexes 5
+        and 21 (trading days only)."""
+        service = AssetMarketService()
+        closes = [100.0 + i for i in range(35)]  # monotonic → offsets diverge
+        mock_histories = {
+            "sBTC": {"close": closes, "dates": [f"d{i}" for i in range(35)]},
+            "sSPY": {"close": closes, "dates": [f"d{i}" for i in range(35)]},
+        }
+
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch("archimedes.services.strategy_signal_evaluator._fetch_price_histories", return_value=mock_histories),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sBTC", "sSPY"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {
+                    "sBTC": ("BTC-USD", "BTC", "crypto", "Coinbase"),
+                    "sSPY": ("SPY", "SPY", "us_equity_etf", "NYSE"),
+                },
+            ),
+        ):
+            resp = await service.list_assets()
+
+        btc = next(a for a in resp.assets if a.symbol == "sBTC")
+        spy = next(a for a in resp.assets if a.symbol == "sSPY")
+        assert btc.change_7d_pct != spy.change_7d_pct
+        assert btc.change_30d_pct != spy.change_30d_pct
+        # Exact expected values pin the offsets down (7/30 vs 5/21 bars back).
+        assert btc.change_7d_pct == pytest.approx((closes[-1] - closes[-1 - 7]) / closes[-1 - 7] * 100.0)
+        assert spy.change_7d_pct == pytest.approx((closes[-1] - closes[-1 - 5]) / closes[-1 - 5] * 100.0)
+        assert btc.change_30d_pct == pytest.approx((closes[-1] - closes[-1 - 30]) / closes[-1 - 30] * 100.0)
+        assert spy.change_30d_pct == pytest.approx((closes[-1] - closes[-1 - 21]) / closes[-1 - 21] * 100.0)
 
 
 # ── Universe alignment (#759 follow-up to #842) ────────────────────────────

--- a/ui/src/components/AssetGroupModal.jsx
+++ b/ui/src/components/AssetGroupModal.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import PriceHistoryChart from './PriceHistoryChart'
 import AssetGroupIcon from './AssetGroupIcon'
 import { groupMeta } from '../assetGroups'
+import { median } from '../statUtils'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 const RANGES = ['1D', '1W', '1M', '1Y', '5Y', '10Y', 'MAX']
@@ -160,10 +161,9 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
 
   // Aggregate 24h change across the whole group (not just the capped
   // aggregate-chart subset) — cheap since it's already in the /assets payload.
-  const avgChange24h = useMemo(() => {
+  const medianChange24h = useMemo(() => {
     const vals = members.map(a => a.change_24h_pct).filter(v => v != null && !Number.isNaN(v))
-    if (vals.length === 0) return null
-    return vals.reduce((a, b) => a + b, 0) / vals.length
+    return median(vals)
   }, [members])
 
   if (!assetClass) return null
@@ -222,10 +222,10 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
         <div style={{ display: 'flex', gap: 24, alignItems: 'baseline', marginTop: 16, flexWrap: 'wrap' }}>
           <div>
             <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
-              Avg 24h change (equal-weight, {members.length} assets)
+              Median 24h change ({members.length} assets)
             </div>
-            <div className={`mono ${changeClass(avgChange24h)}`} style={{ fontSize: '1.3rem', fontWeight: 600 }}>
-              {fmtPct(avgChange24h)}
+            <div className={`mono ${changeClass(medianChange24h)}`} style={{ fontSize: '1.3rem', fontWeight: 600 }}>
+              {fmtPct(medianChange24h)}
             </div>
           </div>
         </div>

--- a/ui/src/components/AssetModal.jsx
+++ b/ui/src/components/AssetModal.jsx
@@ -22,6 +22,16 @@ function sourceLabel(price_source) {
   return 'No source available'
 }
 
+// A rejected field (#1322) is a computed value actively suppressed as
+// arithmetically implausible (a bad tick) — distinct from simply not having
+// enough history yet. Surfaced as a tooltip on the "—" so it doesn't read
+// as an unexplained gap.
+function rejectedTitle(asset, field) {
+  return asset.rejected_fields?.includes(field)
+    ? 'Suppressed: the computed value was arithmetically implausible (likely a bad tick), not a real move'
+    : undefined
+}
+
 export default function AssetModal({ asset, onClose }) {
   const [range, setRange] = useState('1M')
   const [history, setHistory] = useState([])
@@ -142,7 +152,11 @@ export default function AssetModal({ asset, onClose }) {
           </div>
           <div>
             <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>24h change</div>
-            <div className={`mono ${changeClass(asset.change_24h_pct)}`} style={{ fontSize: '1.1rem', fontWeight: 600 }}>
+            <div
+              className={`mono ${changeClass(asset.change_24h_pct)}`}
+              style={{ fontSize: '1.1rem', fontWeight: 600 }}
+              title={rejectedTitle(asset, 'change_24h_pct')}
+            >
               {fmtPct(asset.change_24h_pct)}
             </div>
           </div>
@@ -207,17 +221,21 @@ export default function AssetModal({ asset, onClose }) {
           </div>
           <div>
             <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>7d change</div>
-            <div className={`mono ${changeClass(asset.change_7d_pct)}`}>{fmtPct(asset.change_7d_pct)}</div>
+            <div className={`mono ${changeClass(asset.change_7d_pct)}`} title={rejectedTitle(asset, 'change_7d_pct')}>
+              {fmtPct(asset.change_7d_pct)}
+            </div>
           </div>
           <div>
             <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>30d change</div>
-            <div className={`mono ${changeClass(asset.change_30d_pct)}`}>{fmtPct(asset.change_30d_pct)}</div>
+            <div className={`mono ${changeClass(asset.change_30d_pct)}`} title={rejectedTitle(asset, 'change_30d_pct')}>
+              {fmtPct(asset.change_30d_pct)}
+            </div>
           </div>
           <div>
             <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
               Realized vol (30d, annualized)
             </div>
-            <div className="mono">
+            <div className="mono" title={rejectedTitle(asset, 'realized_vol_30d')}>
               {asset.realized_vol_30d != null ? asset.realized_vol_30d.toFixed(2) : '—'}
             </div>
           </div>

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -368,7 +368,15 @@ export default function Explore() {
               </div>
 
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginTop: 6 }}>
-                <span className={`mono ${changeClass(a.change_24h_pct)}`} style={{ fontSize: '0.85rem' }}>
+                <span
+                  className={`mono ${changeClass(a.change_24h_pct)}`}
+                  style={{ fontSize: '0.85rem' }}
+                  title={
+                    a.rejected_fields?.includes('change_24h_pct')
+                      ? 'Suppressed: the computed change was arithmetically implausible (likely a bad tick), not a real move'
+                      : undefined
+                  }
+                >
                   {fmtPct(a.change_24h_pct)}
                 </span>
                 <span className="caption" style={{ color: 'var(--text-4)', fontSize: '0.65rem' }}>

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -3,6 +3,7 @@ import AssetModal from './AssetModal'
 import AssetGroupModal from './AssetGroupModal'
 import AssetGroupIcon from './AssetGroupIcon'
 import { groupMeta } from '../assetGroups'
+import { median } from '../statUtils'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -213,10 +214,9 @@ export default function Explore() {
           }}
         >
           {groups.map(g => {
-            const avgChange = (() => {
+            const medianChange = (() => {
               const vals = g.members.map(a => a.change_24h_pct).filter(v => v != null && !Number.isNaN(v))
-              if (vals.length === 0) return null
-              return vals.reduce((a, b) => a + b, 0) / vals.length
+              return median(vals)
             })()
             return (
               <button
@@ -281,11 +281,11 @@ export default function Explore() {
                 </p>
 
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginTop: 12 }}>
-                  <span className={`mono ${changeClass(avgChange)}`} style={{ fontSize: '0.85rem' }}>
-                    {fmtPct(avgChange)}
+                  <span className={`mono ${changeClass(medianChange)}`} style={{ fontSize: '0.85rem' }}>
+                    {fmtPct(medianChange)}
                   </span>
                   <span className="caption" style={{ color: 'var(--text-4)', fontSize: '0.65rem' }}>
-                    avg 24h
+                    median 24h
                   </span>
                 </div>
               </button>

--- a/ui/src/statUtils.js
+++ b/ui/src/statUtils.js
@@ -1,0 +1,18 @@
+// Small shared stat helpers for display-layer aggregation (#1322).
+//
+// `median` exists because a group's "24h change" headline (Explore.jsx and
+// AssetGroupModal.jsx) used an equal-weight arithmetic mean over the group's
+// members. A single outlier — a bad tick that slips past the backend's
+// plausibility guard, or simply one real large mover in a small group —
+// drags an arithmetic mean by tens of points; the median is robust to a
+// single outlier of any magnitude, which is the property a headline stat
+// needs.
+
+/** Median of a numeric array. Returns null for an empty array. Does not
+ * mutate the input (sorts a copy). */
+export function median(nums) {
+  if (!nums || nums.length === 0) return null
+  const sorted = [...nums].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}

--- a/ui/test/stat-utils.test.js
+++ b/ui/test/stat-utils.test.js
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { median } from "../src/statUtils.js";
+
+// ── #1322: group "24h change" headline must be robust to a single outlier ──
+// A prior arithmetic-mean implementation let one bad tick (or one genuinely
+// large single mover) drag a whole group's headline by tens of points. The
+// median is robust to a single outlier of any magnitude — this is the
+// property under test, not just "median math is correct".
+
+test("median: odd-length array returns the middle value", () => {
+	assert.equal(median([3, 1, 2]), 2);
+});
+
+test("median: even-length array averages the two middle values", () => {
+	assert.equal(median([1, 2, 3, 4]), 2.5);
+});
+
+test("median: empty array returns null, not NaN or 0", () => {
+	assert.equal(median([]), null);
+});
+
+test("median: single value returns that value", () => {
+	assert.equal(median([42]), 42);
+});
+
+test("median: does not mutate its input array", () => {
+	const input = [5, 3, 1, 4, 2];
+	const copy = [...input];
+	median(input);
+	assert.deepEqual(input, copy);
+});
+
+test("median is robust to one outlier of any magnitude (the actual #1322 bug)", () => {
+	// The reported live defect: sJUP's corrupted +1483.08% sat among a crypto
+	// group whose real median 24h move was ~6.70%, but an arithmetic mean
+	// reported "+29.82% avg 24h" — the outlier moved the headline by ~23 points.
+	const realistic = [2.1, -0.8, 1.4, 3.2, -1.1, 0.6, 6.7, 4.4, -2.3, 0.2];
+	const withOutlier = [...realistic, 1483.08];
+
+	const meanOf = (nums) => nums.reduce((a, b) => a + b, 0) / nums.length;
+
+	const medianBefore = median(realistic);
+	const medianAfter = median(withOutlier);
+	const meanBefore = meanOf(realistic);
+	const meanAfter = meanOf(withOutlier);
+
+	// The median barely moves for one outlier among 11 values...
+	assert.ok(Math.abs(medianAfter - medianBefore) < 1, `median moved by ${medianAfter - medianBefore}`);
+	// ...while the mean is dragged by well over 100 points — proving *why*
+	// the median was the correct fix, not merely that it computes correctly.
+	assert.ok(meanAfter - meanBefore > 100, `mean only moved by ${meanAfter - meanBefore}`);
+});
+
+// ── Wiring: both group-headline call sites use the shared median, and the
+// arithmetic-mean pattern the issue names is fully gone from both ──────────
+
+const explorePage = readFileSync(new URL("../src/components/Explore.jsx", import.meta.url), "utf8");
+const groupModal = readFileSync(new URL("../src/components/AssetGroupModal.jsx", import.meta.url), "utf8");
+
+test("Explore.jsx group headline imports and calls the shared median, not a local mean", () => {
+	assert.match(explorePage, /import \{ median \} from '\.\.\/statUtils'/);
+	assert.match(explorePage, /median\(vals\)/);
+	assert.doesNotMatch(explorePage, /reduce\(\(a, b\) => a \+ b, 0\) \/ vals\.length/);
+});
+
+test("AssetGroupModal.jsx aggregate stat imports and calls the shared median, not a local mean", () => {
+	assert.match(groupModal, /import \{ median \} from '\.\.\/statUtils'/);
+	assert.match(groupModal, /median\(vals\)/);
+	assert.doesNotMatch(groupModal, /reduce\(\(a, b\) => a \+ b, 0\) \/ vals\.length/);
+});
+
+test("the group headline labels no longer claim 'avg' when the value is a median", () => {
+	assert.doesNotMatch(explorePage, />\s*avg 24h\s*</);
+	assert.doesNotMatch(groupModal, /Avg 24h change/);
+	assert.match(explorePage, /median 24h/);
+	assert.match(groupModal, /Median 24h change/);
+});


### PR DESCRIPTION
Closes #1322

## Summary

`GET /api/explore/assets` could ship arithmetically-impossible `change_24h_pct`
values (sJUP reported +1483.08%) whenever a bad tick / decimal-placement error
in the upstream yfinance history produced a tiny prior close, and the
period-offset / annualization math applied the equity 252-trading-day
convention to 24/7 crypto assets. The frontend then averaged the group's
`change_24h_pct` values with an arithmetic mean, so one such outlier (or one
genuinely large mover) dragged a whole asset-class card's headline by tens of
points.

**Updated after two adversarial review passes** (see "Review follow-up" and
"Review follow-up round 2" below): the plausibility guard originally covered
only `change_24h_pct`/`change_7d_pct`/`change_30d_pct` via `_pct_change` —
`realized_vol_30d` was unguarded and could still ship a fabricated "typical
daily move" figure from the same bad tick. That gap is now closed, and
rejected values are disclosed on the served item via a new `rejected_fields`
list rather than silently degrading to a bare `null`.

The multi-day bound went through **two** wrong shapes before landing on a
correct one, and it's worth being explicit about that rather than letting the
history read as "fixed on the first try": round 1 scaled the per-day bound by
`sqrt(n)` (too tight — it rejected a real 10x/month move); the round-1 fix
compounded the per-day bound onto the endpoint ratio instead
(`(1+1.0)**n - 1`), which round 2 found to be **vacuous, not just generous**
— ±12,700% at n=7, ±107,374,182,300% at n=30, wide enough to let the issue's
own bad tick through once it ages into the 7d/30d lookback. The bound is now
a **bar-to-bar scan** of the window (reject if any single bar exceeds the
per-day bound), not an endpoint-only check of either shape — see "Review
follow-up round 2" item 1.

## What changed

**Backend (`asset_market_service.py`, `explore_schemas.py`)**
- `_pct_change` rejects a computed change that exceeds a plausibility bound
  and returns `None` — an honest absence, not a fabricated number, per
  `docs/architectural-principles.md` § fail-soft. For `n=1` the bound is the
  simple 100%/day endpoint check; for `n>1` it **scans the window bar-to-bar**
  against the same per-day bound (reject if any single bar in the window
  exceeds it), the same shape `_realized_vol_annual` already used — **not**
  an endpoint-compounded bound (`(1+1.0)**n - 1`), which turned out to be
  vacuous rather than generous. See "Review follow-up round 2" item 1 for why.
- `_realized_vol_annual` now also rejects a window containing an implausible
  single-bar return (same 100%/day bound, bar-to-bar, no compounding) and
  returns `None` rather than a vol number computed partly from a bad tick —
  see "Review follow-up" item 1. A non-positive bar in the window (a zero or
  negative close — a data hole, not a real return) is now rejected the same
  way rather than silently skipped — see "Review follow-up round 2" item 4.
- Both functions have a `_with_reason` variant returning `(value,
  was_rejected)` so the service can distinguish "not enough history yet" from
  "a value was actively suppressed as implausible"; the plain functions are
  now thin wrappers, unchanged for existing callers/tests.
- New `AssetExploreItem.rejected_fields: list[str]` discloses which fields (if
  any) were suppressed on that item — see "Review follow-up" item 3.
- `_realized_vol_annual` takes a `trading_days_per_year` param; `list_assets`
  now selects **365** for crypto and **252** for everything else, and offsets
  the "7d"/"30d" windows by **calendar** days (7/30 bars) for crypto vs.
  **trading** days (5/21 bars) for everything else.
- `_explanations_for` uses the matching annualization factor so the "typical
  daily move" copy never asserts a number the computation didn't produce.
  When `realized_vol_30d` is suppressed (`None`), the `change_24h_pct` copy
  now drops its vol-based clause instead of defaulting the vol to a
  fabricated `0.0%` — see "Review follow-up round 2" item 3.
- No asset is dropped from the universe and the `281` count is unaffected —
  a rejected field becomes `None` on the same `AssetExploreItem`, the card
  still renders (issue anti-goal: don't silently drop the asset).
- No clamping/winsorizing — a rejected value is `None`, never a substituted
  plausible-looking number (issue anti-goal).

**Frontend (`Explore.jsx`, `AssetGroupModal.jsx`, `AssetModal.jsx`)**
- Group "24h change" headline (both the group-card grid and the drill-down
  modal) now uses the **median** of member `change_24h_pct`, not an
  equal-weight arithmetic mean. Extracted into a shared `ui/src/statUtils.js`
  (both call sites had reimplemented the same block). Labels changed from
  "avg 24h" / "Avg 24h change" to "median 24h" / "Median 24h change" so the
  label matches the statistic shown (issue anti-goal: fix the computation
  *and* make the label true, not just rename it).
- `Explore.jsx` card and `AssetModal.jsx` detail view now show a `title`
  tooltip on a suppressed stat ("Suppressed: the computed value was
  arithmetically implausible…") when the field appears in `rejected_fields`,
  so the "—" doesn't read as an unexplained gap.

## Acceptance criteria (from the issue)

1. **No impossible value survives to the API.**
   ```
   $ pytest backend/tests/services/test_asset_market_service.py -q
   51 passed, 0 failed
   ```
   (issue names `backend/tests/test_asset_market_service.py`; actual path is
   `backend/tests/services/test_asset_market_service.py` — no such file
   exists at the issue's literal path.) Now covers **both**
   `change_24h_pct`/`change_7d_pct`/`change_30d_pct` (via `_pct_change`) and
   `realized_vol_30d` (via `_realized_vol_annual`) — see "Review follow-up"
   item 1 for why the vol guard was added after the initial push, and "Review
   follow-up round 2" item 1 for why the multi-day case specifically needed a
   second fix before this claim was actually true (the round-1 `47 passed`
   green run was passing against a bound that admitted the issue's own bad
   tick at n=7/n=30 — no test exercised that).

2. **Group headline robust to outliers.**
   ```
   $ grep -n "reduce((a, b) => a + b, 0) / vals.length" ui/src/components/Explore.jsx
   (no match, exit 1)
   ```
   Also fixed the identical pattern in `AssetGroupModal.jsx`'s drill-down
   modal — same defect, same headline concept, one click away from the group
   card; leaving it as an arithmetic mean would have left the honesty bug
   live on the very next screen.

3. **Annualization and period offsets are asset-class aware.**
   ```
   $ grep -n "sqrt(252)" backend/archimedes/services/asset_market_service.py
   135:    annualized with sqrt(252)."""
   ```
   Only remaining match is prose in a docstring describing the equity
   convention — not applied unconditionally in the computation.
   New test: `TestAssetClassAwareAnnualization` asserts a crypto series and
   an equity series with identical daily returns produce different
   annualized vol (`crypto_vol / equity_vol == sqrt(365/252)`), plus
   `test_realized_vol_annual_actually_uses_the_given_param`, which computes
   its expected value independently of the function under test — see
   "Review follow-up" item 2 for why that independence matters.

4. **Live check after deploy** — the curl-based check in the issue targets
   the deployed site post-merge; not runnable from this branch. The fix
   applies uniformly (no per-symbol allowlist), so it should resolve the
   live sJUP case along with any other symbol susceptible to the same
   bad-tick pattern.

**Out of scope, disclosed and tracked:** the issue's Summary named three
underlying defects; defect 2 ("`24h`" is a misnomer for a 1-bar change, which
can span >24h across a weekend/holiday gap) is **not** fixed here — it isn't
covered by the issue's own machine-checkable acceptance criteria (1–4 above),
so this PR closes #1322 without it, per the issue's anti-goal against
renaming the label without fixing the computation. Filed as a standalone
follow-up: #1378.

## Guard demonstrations (mutation-checked before push)

**1. `_pct_change` plausibility bound**, guard removed:
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q
...
FAILED ...test_pct_change_rejects_implausible_24h_move
  - assert 1479.1975465586918 is None
FAILED ...test_pct_change_multiday_window_tolerates_a_wider_move
  - assert 200.0 is None
FAILED ...test_pct_change_with_reason_distinguishes_rejection_from_no_data
  - assert 1479.1975465586918 is None
FAILED ...test_pct_change_bound_is_1_day_tight_but_30_day_generous
  - assert 101.0 is None
FAILED ...test_list_assets_change_24h_pct_none_for_impossible_move
  - AssertionError: assert 1479.1975465586918 is None
5 failed, 42 passed
```
Restored → `47 passed, 0 failed`.

**2. `_realized_vol_annual` plausibility guard** (new — added in response to
review finding "an arithmetically-impossible value still survives to
`realized_vol_30d`"), guard removed:
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q \
    -k "RealizedVolPlausibility or realized_vol_rejected_field or list_assets_change_24h_pct_none_for_impossible_move"
FAILED ...test_realized_vol_rejects_window_containing_a_bad_tick
  - assert 51.59551867933937 is None
FAILED ...test_realized_vol_with_reason_reports_rejection
  - assert 51.59551867933937 is None
FAILED ...test_list_assets_realized_vol_rejected_field_disclosed
  - AssertionError: assert 51.59551867933937 is None
3 failed, 3 passed
```
Restored → `47 passed, 0 failed`. Repro: `[0.0003166165] + [0.005]*30` (a
sJUP-shaped bad tick sitting in an otherwise flat window) produced
`realized_vol_30d = 51.6`, which `_explanations_for` rendered as "typical
daily moves of ~270.1%" — impossible on its face, and on the same input the
`change_24h_pct` guard already rejects.

**3. `_pct_change` multi-day bound compounding fix** (review finding: the
original `sqrt(n)`-scaled bound applies a volatility-scaling argument to a
cumulative *simple* return, which compounds multiplicatively — `sqrt(n)` is
mathematically the wrong model and, in practice, too tight: at n=30 it only
allowed ±548%, which would reject a real 10x-in-a-month move), bound reverted
to `sqrt(n)`:
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q -k "PctChangePlausibility"
FAILED ...test_pct_change_multiday_bound_compounds_not_sqrt_scales
  - AssertionError: a legitimate compounding 10x/month move must not be rejected
    assert None is not None
FAILED ...test_pct_change_bound_is_1_day_tight_but_30_day_generous
  - assert None == 600.0 ± 6.0e-04
2 failed, 5 passed
```
Restored → `47 passed, 0 failed`.

**4. `_realized_vol_annual` ignoring its own `trading_days_per_year` param**
(this repo's exact defect class per `CLAUDE.md` § "Before you approve a
merge" rule 4 — a guard that doesn't actually reject anything): found live in
this branch's own pre-commit working state, where the return statement still
hard-coded `math.sqrt(252)` despite accepting the parameter.
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q
FAILED ...test_identical_daily_returns_annualize_differently_by_asset_class
  - assert 0.18332719904939557 != 0.18332719904939557
FAILED ...test_realized_vol_annual_actually_uses_the_given_param
  - assert 0.17183162550695083 == 0.20679939330903074 ± 2.1e-07
2 failed, 45 passed
```
Restored → `47 passed, 0 failed`.

**Review correction:** the original guard-demonstration #2 in this PR body
claimed `test_daily_vol_copy_uses_the_matching_annualization_factor` also
failed under this mutation (`2 failed, 35 passed`); it does not — that test
derives its expected value from `crypto_vol`, the same (mutated) value it's
checking, so both sides of the assertion move together and it passes
regardless of the mutation (the exact trap CLAUDE.md rule 3 names: "passing
the same literal to both sides of the boundary the bug lives on"). Its
docstring now discloses that scope explicitly, and
`test_realized_vol_annual_actually_uses_the_given_param` (new, computes its
expectation independently from raw returns) is what actually guards this.

**5. `rejected_fields` disclosure** (new — routes a suppressed value down an
honest-absence marker, per the issue's Precedent section), wiring removed
(served item always gets an empty list regardless of what was suppressed):
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q
FAILED ...test_list_assets_change_24h_pct_none_for_impossible_move
  - AssertionError: assert [] == ['change_24h_pct']
FAILED ...test_list_assets_realized_vol_rejected_field_disclosed
  - AssertionError: assert 'realized_vol_30d' in []
2 failed, 45 passed
```
Restored → `47 passed, 0 failed`.

**6. UI `median()` reverted to arithmetic mean:**
```
$ node --test test/stat-utils.test.js
✖ median is robust to one outlier of any magnitude (the actual #1322 bug)
  AssertionError: median moved by 134.69454545454545
8 pass, 1 fail
```
Restored → `9 passed, 0 failed`.

**7. Raw mean pattern reintroduced into `Explore.jsx`** (simulating a future
regression):
```
$ node --test test/stat-utils.test.js
✖ Explore.jsx group headline imports and calls the shared median, not a local mean
  AssertionError [ERR_ASSERTION]: expected /median\(vals\)/ ... actual: (source without it)
8 pass, 1 fail
```
Restored → `9 passed, 0 failed`.

## Review follow-up (adversarial pass on this PR)

Five findings came back from a review of this PR; all five led to a code or
doc change, listed here for the record:

1. **[major, fixed]** `realized_vol_30d` was unguarded — a bad tick survived
   into an "impossible typical daily move" figure even though
   `change_24h_pct` correctly rejected the same tick. Fixed: `_realized_vol_annual`
   now rejects a window containing any single bar past the same 100%/day
   bound. See guard demonstration #2.
2. **[major, fixed]** The PR body's guard-demonstration #2 transcript for
   "`_realized_vol_annual` ignores its param" was not reproducible —
   `test_daily_vol_copy_uses_the_matching_annualization_factor` cannot fail
   under that mutation because it derives its expectation from the same
   value it checks. Corrected the transcript, reattributed that test's
   docstring to what it actually guards, and added
   `test_realized_vol_annual_actually_uses_the_given_param`, which computes
   its expectation independently and does fail under the mutation.
3. **[minor, fixed]** Rejected values weren't routed down the `is_stale`/
   `price_source` honest-absence path the issue names as precedent, and this
   body originally claimed they were (they aren't — that mechanism describes
   the *price*, not a *derived stat*). Added `AssetExploreItem.rejected_fields`
   instead of overloading `is_stale`, plus a UI tooltip.
4. **[minor, disclosed]** "Closes #1322" was claimed while the issue's
   defect 2 (`"24h"` is a misnomer for a 1-bar change) was silently
   untouched. It remains out of scope for this PR (not covered by the
   issue's own acceptance criteria) but is now disclosed above and tracked
   in #1378 rather than left implicit.
5. **[minor, fixed]** The multi-day plausibility bound scaled by `sqrt(n)`
   (a volatility-scaling argument) applied to a cumulative simple return
   (which compounds multiplicatively) — mathematically the wrong model, and
   in practice too tight (rejects a real 10x/month move at n=30). Changed to
   compound the per-day bound instead. See guard demonstration #3.

## Review follow-up round 2 (second adversarial pass, on this PR's own fix)

Four findings came back from a second review — one blocker, one major, two
minor. All four led to a code and/or test change.

1. **[blocker, fixed]** The round-1 fix for the multi-day bound replaced a
   too-tight `sqrt(n)`-scaled bound with a **vacuous** one:
   `((1 + 1.0)**n - 1) * 100` is ±12,700% at n=7 and
   ±107,374,182,300% at n=30 — wide enough that the issue's own bad tick
   (sJUP's +1479.20%) shipped unchanged as `change_7d_pct`/`change_30d_pct`
   once it aged 8+/31+ bars deep into those lookback windows, while
   `rejected_fields` disclosed only `realized_vol_30d` as suppressed —
   silently shipping a +1479% "truth" next to an honest disclosure that a
   *different* field was suppressed. Nothing in the 47-test green run
   exercised this: mutating the branch to `bound = float('inf')` for `n>1`
   left the suite fully green. Fixed: for `n>1`, `_pct_change_with_reason`
   now scans the `n`-bar window bar-to-bar and rejects if any single bar
   implies a move past the same 100%/day bound — the same shape
   `_realized_vol_annual_with_reason` already used — rather than checking
   only the endpoint ratio. This still keeps a genuinely compounding large
   move (every bar individually plausible, e.g. a real 10x/month at
   ~8%/day) while actually rejecting a single bad tick anywhere in the
   window. New test:
   `test_pct_change_multiday_rejects_a_bad_bar_anywhere_in_the_window`,
   mutation-checked (fails when the bar-scan is disabled).
2. **[major, fixed]** The two existing multi-day tests didn't just fail to
   cover the blocker above — they pinned the self-contradictory behavior as
   intended: `test_pct_change_multiday_window_tolerates_a_wider_move` and
   `test_pct_change_bound_is_1_day_tight_but_30_day_generous` both used a
   flat run with a single terminal spike (`[10.0]*21 + [30.0]`,
   `[10.0]*30 + [70.0]`) — the exact bad-tick shape the guard exists to
   reject — and asserted it kept at n=21/n=30 while the identical jump was
   rejected at n=1. Rebuilt both as genuinely compounding series (every bar
   an individually-plausible daily step, via `daily_factor = (end/start) **
   (1/n)`, the pattern `test_pct_change_multiday_bound_compounds_not_sqrt_scales`
   already used) so they assert what was actually intended: "a large move
   made of plausible daily steps is kept," not "a single spike anywhere in
   the window is kept." The missing negative control (item 1's new test) was
   added alongside.
3. **[minor, fixed]** When `realized_vol_30d` is suppressed (`None`), the
   `change_24h_pct` explanation still asserted a de-annualized vol figure of
   `0.0%` — a number the computation explicitly refused to produce (`vol =
   item.get("realized_vol_30d") or 0.0` collapsed `None` to `0.0`). More
   frequent now than before this PR, since the new vol guard means one bad
   bar suppresses `realized_vol_30d` for the whole 30-session window it sits
   in. Fixed: `_explanations_for` now drops the vol-clause sentence entirely
   for `change_24h_pct` when `realized_vol_30d` is `None`, instead of
   substituting a fabricated `0.0%`. New tests:
   `test_change_24h_copy_drops_vol_clause_when_vol_was_suppressed`,
   `test_change_24h_copy_keeps_vol_clause_when_vol_present`.
4. **[minor, fixed]** The realized-vol guard handled a zero/negative close
   inconsistently with `_pct_change`, which the same file treats as an
   honest absence: `if not prev: continue` skipped only the step *out of* a
   zero bar; the step *into* it computed an exact -100% return that passed
   the strict `>` bound comparison (`100.0 > 100.0` is `False`) and was
   folded into the vol estimate as real data — `[0.005]*20 + [0.0] +
   [0.005]*10` returned a vol of `3.55` (annualized ~18.6% "typical daily
   move") instead of `None`. Fixed: a non-positive bar anywhere in the
   window (either side of the step) now rejects the whole window the same
   way an over-bound bar does. Applied the identical treatment to the new
   `_pct_change_with_reason` bar-scan (item 1) for consistency. New test:
   `test_realized_vol_rejects_a_zero_bar_in_the_window`.

**Guard demonstrations, round 2 (mutation-checked before push):**

**8.** `_pct_change` multi-day bar-scan, bound-check branch disabled:
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q -k "PctChangePlausibility"
FAILED ...test_pct_change_multiday_rejects_a_bad_bar_anywhere_in_the_window
  - AssertionError: n=7: bad bar must not survive as a value
    assert 1479.1975465586918 is None
1 failed, 7 passed
```
Restored → `51 passed, 0 failed`.

**9.** `_realized_vol_annual` non-positive-bar guard, reverted to the old
`if not prev: continue`:
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q -k "RealizedVolPlausibility"
FAILED ...test_realized_vol_rejects_a_zero_bar_in_the_window
  - assert 3.54770445451023 is None
1 failed, 4 passed
```
Restored → `51 passed, 0 failed`.

**10.** `_explanations_for` no-vol clause drop, reverted to `vol = item.get(...) or 0.0`:
```
$ python -m pytest backend/tests/services/test_asset_market_service.py -q -k "ExplanationsAssetClassAware"
FAILED ...test_change_24h_copy_drops_vol_clause_when_vol_was_suppressed
  - AssertionError: assert '0.0%' not in 'Percentage move in the last trading
    day. Positive = up. Daily moves bigger than 0.0% are unusual for this asset.'
1 failed, 3 passed
```
Restored → `51 passed, 0 failed`.

**Review correction (round 2):** item 5 of the round-1 "Review follow-up"
section below claimed the compounded-bound fix (`(1+1.0)**n - 1`) was
correct; it wasn't — see item 1 above. Left in place rather than rewritten,
per this repo's convention of disclosing corrections rather than silently
editing history.

## Verification tallies (round 2, final state, before push)

| Check | Result |
|---|---|
| `pytest backend/tests/services/test_asset_market_service.py -q` | 51 passed, 0 failed (was 47 before round 2 — 4 new tests) |
| `pytest -m "not integration" -q` (full backend unit suite) | 3380 passed, 2 skipped, 2 deselected, 0 failed |
| `cd ui && node --test` | 99 passed, 0 failed (unchanged — no frontend files touched in round 2) |
| `cd ui && npm run lint` | clean |
| `cd ui && npm run build` | succeeds |
| `ruff check` (touched .py) | all checks passed |
| `ruff format --check` (touched .py) | 2 files already formatted |

## Review follow-up round 3 (third adversarial pass, on this PR's own fix)

One major finding came back from a third review, verified directly against
this PR's head in `_pct_change_with_reason`.

1. **[major, fixed]** The n=1 endpoint path never checked the **last** close
   for non-positivity — only the prior close. `if not start: return None,
   False` only guarded `start` (`prices[-1-n]`); a non-positive **last**
   close (`end = prices[-1]`) fell through to `pct = (end - start) / start *
   100.0`, and for `prices = [10.0]*39 + [0.0]` (n=1) that computes an exact
   `-100.0` — which then passed the strict `abs(pct) > 100.0` bound check
   (`abs(-100.0) > 100.0` is `False`) and was served as a real,
   non-rejected `change_24h_pct`. The **same bar**, on the **same series**,
   already made the 7d/30d bar-scan and the realized-vol scan return
   disclosed-rejected — a self-contradictory row on the served
   `AssetExploreItem`, and `-100.0` is exactly the shape of value that feeds
   the group-median headline this PR exists to fix.

   Secondary inconsistency, same root cause: a zero exactly at the
   window-start index returned `(None, False)` (undisclosed — grouped with
   "not enough history yet") while the identical zero one bar deeper —
   already inside the n>1 bar-scan — returned `(None, True)` (disclosed).

   Fixed: `_pct_change_with_reason` now checks **both** endpoints together,
   before computing `pct`, and classifies a non-positive endpoint the same
   way the bar-scan and the vol-scan already classify a non-positive bar —
   `was_rejected=True`, not `False`:
   ```python
   if start <= 0 or end <= 0:
       return None, True
   ```
   (was: `if not start: return None, False`.)

   Updated `test_pct_change_with_reason_distinguishes_rejection_from_no_data`'s
   `_pct_change_with_reason([0.0, 105.0], 1) == (None, False)` assertion to
   the new `(None, True)` semantics, with a comment explaining the
   classification choice (a non-positive endpoint is a data hole, not a
   "no data yet" case — same bucket as the plausibility-bound and bar-scan
   rejections). Added the negative control from the exact repro:
   ```python
   assert _pct_change_with_reason([10.0] * 39 + [0.0], 1) == (None, True)
   ```
   Corrected the `_realized_vol_annual_with_reason` docstring's closing
   sentence, which claimed "the same treatment `_pct_change_with_reason`
   gives a zero start" — that claim was **not actually true** before this
   fix (`_pct_change_with_reason` returned `was_rejected=False` for a zero
   start, not `True`, so the two functions disagreed). The docstring now
   states this explicitly and notes it was the n=1 endpoint check that was
   brought into line with the vol function's bar-scan, not the reverse.

   Checked for other tests pinning the old `(None, False)` zero-start
   behavior: `test_pct_change_zero_start` (`TestStatMath`) only asserts
   `_pct_change([0, 105], 1) is None` via the plain (value-only) wrapper —
   unaffected, since the value stays `None` either way. No other test in
   the repo asserts a `was_rejected` value for a zero/negative endpoint.

**Guard demonstration, round 3 (mutation-checked before push):**

**11.** `_pct_change_with_reason` endpoint check, `end`-check reverted (only
`start <= 0` kept — the pre-fix shape):
```
$ python -m pytest backend/tests/services/test_asset_market_service.py::TestPctChangePlausibilityGuard::test_pct_change_with_reason_distinguishes_rejection_from_no_data -q
FAILURES
backend/tests/services/test_asset_market_service.py:164: in test_pct_change_with_reason_distinguishes_rejection_from_no_data
    assert _pct_change_with_reason([10.0] * 39 + [0.0], 1) == (None, True)
E   assert (-100.0, False) == (None, True)
E     At index 0 diff: -100.0 != None
1 failed, 0 passed
```
Restored → `51 passed, 0 failed` (full file).

**Reviewer's four-probe scenario, re-verified against the fix** (all four
must return disclosed-rejected on `prices = [10.0]*39 + [0.0]`):
```
n=1  -> _pct_change_with_reason(prices, 1)                          == (None, True)
n=7  -> _pct_change_with_reason(prices, 7)                          == (None, True)
n=30 -> _pct_change_with_reason(prices, 30)                         == (None, True)
vol  -> _realized_vol_annual_with_reason(prices, 30, 365)           == (None, True)
```
All four confirmed `(None, True)` on this branch.

## Verification tallies (round 3, final state, before push)

| Check | Result |
|---|---|
| `pytest backend/tests/services/test_asset_market_service.py -q` | 51 passed, 0 failed (same count as round 2 — the round-3 fix extended an existing test + added one new assertion, no new test function) |
| `pytest -m "not integration" -q` (full backend unit suite) | 3380 passed, 2 skipped, 2 deselected, 0 failed |
| `ruff format --check` (touched .py) | 2 files already formatted |

## Notes for reviewers

- This branch's worktree had uncommitted WIP from a prior session already
  applying most of the backend fix, but with the `_realized_vol_annual`
  annualization param silently ignored in the return statement (marked
  `# TEMP-MUTATION-CHECK-1322` in the stale diff) — i.e. the crypto-vol fix
  looked applied but wasn't. Fixed as part of this PR; see guard
  demonstration #4 above.
