### PR TITLE
Retire the leaderboard banner's interpreter-divergence clause — F2/F3 are live

### DIFF
--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -175,18 +175,17 @@ export default function Leaderboard() {
             re-run landed fresh rows for every curated strategy (verified
             against prod 2026-08-19 — backtest_results max created_at
             2026-08-20 03:28 UTC; zero curated strategies stale). The
-            backtest/live interpreter divergence is retired only in part:
-            F1/F4–F10 are fixed, but F2 (stateless entry-AND-NOT-exit live vs
-            the backtest's position FSM) and F3 (rebalance cadence never read
-            live) are prepared and HELD for the live-money go-ahead — and
-            exit + rebalance_frequency are REQUIRED DSL fields, so every
-            generated strategy carries them. The own view ALSO still holds
-            July-era rows for older generated strategies (21 ids at the time
-            of verification) that predate the corrections and refresh on
-            their next cycle. Hence the narrower banner below, scoped to the
-            own view and carrying BOTH residuals; curated rows are
-            reference-only backtests, all verified fresh, where neither
-            residual makes a claim. */}
+            backtest/live interpreter divergence is fully retired as of
+            2026-08-20: F1/F4–F10 landed earlier, and F2 (live position FSM)
+            + F3 (rebalance cadence) landed via PR #1320 — parity-pinned
+            per-bar in test_interpreter_parity.py — and were verified running
+            on the redeployed agent runner, so the old divergence clause here
+            was removed (its claim became false). The ONE remaining residual:
+            the own view still holds July-era rows for older generated
+            strategies that predate the corrections and refresh on their next
+            cycle — hence the single-caveat banner below, scoped to the own
+            view; curated rows are reference-only backtests, all verified
+            fresh. */}
         {isOwn && (
           <div
             role="status"
@@ -200,12 +199,9 @@ export default function Leaderboard() {
               color: 'var(--text-2)',
             }}
           >
-            <strong style={{ color: 'var(--warning, #b45309)' }}>Two caveats on your figures.</strong>{' '}
+            <strong style={{ color: 'var(--warning, #b45309)' }}>One caveat on your figures.</strong>{' '}
             Older strategies may still show numbers computed before the August engine corrections —
-            they refresh on their next backtest cycle. And live execution currently interprets
-            entry/exit state and rebalance cadence differently than the backtest does, so a strategy
-            run live may not behave exactly as its figures describe; a fix is prepared and awaiting
-            live-trading sign-off.
+            they refresh on their next backtest cycle.
           </div>
         )}
         {engine?.disclaimer && (

--- a/ui/test/app-visuals.test.js
+++ b/ui/test/app-visuals.test.js
@@ -143,16 +143,20 @@ const leaderboard = readFileSync(
 	"utf8",
 );
 
-test("leaderboard caveat banner is own-scope-gated and carries both residuals (#1306)", () => {
+test("leaderboard caveat banner is own-scope-gated with only the refresh residual (#1306, F2/F3 landed)", () => {
 	// The broad unconditional banner ("known to be incorrect") is retired for
 	// the curated view, whose freshness was verified against prod.
 	assert.doesNotMatch(leaderboard, /known to be incorrect/);
 	// The remaining banner renders ONLY under isOwn — the gate expression must
 	// immediately precede the banner's status div.
 	assert.match(leaderboard, /\{isOwn && \(\s*<div\s*\n?\s*role="status"/);
-	// Both residuals, by their load-bearing phrases: pre-correction rows that
-	// refresh later, and the held backtest/live interpreter divergence.
+	// The one remaining residual: pre-correction rows that refresh later.
 	assert.match(leaderboard, /before the August engine corrections/);
-	assert.match(leaderboard, /entry\/exit state and rebalance cadence/);
-	assert.match(leaderboard, /awaiting\s*\n?\s*live-trading sign-off/);
+	// The interpreter-divergence clause is RETIRED (F2/F3 landed via #1320,
+	// parity-pinned, verified on the redeployed runner) — its claim would now
+	// be false, so it must not reappear in the rendered banner text. (The
+	// comment block documenting the retirement legitimately mentions the
+	// fixes, so pin the banner's own load-bearing phrases, not the comment.)
+	assert.doesNotMatch(leaderboard, /live execution currently interprets/);
+	assert.doesNotMatch(leaderboard, /awaiting\s*\n?\s*live-trading sign-off/);
 });


### PR DESCRIPTION
Completes the #1306 sequence exactly as its wording planned: the own-view banner's second clause claimed live execution interprets entry/exit state and rebalance cadence differently than the backtest. That claim became false today:

- F2 (live position FSM) + F3 (cadence gate) merged via #1320, parity-pinned per-bar in `test_interpreter_parity.py`;
- the agent runner is verified RUNNING that code: revived from its 13-day SSM outage (reboot + the #1335 dash/pipefail fix), redeployed on image `f64b864c` (deploy-runners run 32345942723, green), first tick clean — zero window-age warnings, zero F2/F3-related errors.

Keeping the clause past this point would be the dishonest state — the same standard that kept it until now. The banner retains its one remaining true caveat (pre-correction July-era rows that refresh on their next backtest cycle), now labeled "One caveat."

**Test**: the static pin flips — the retired phrases are asserted ABSENT from the banner, the refresh caveat and `isOwn` gating still pinned. Mutation-proven: re-adding a divergence sentence fails the suite (89 pass, 1 fail); restored. UI 90/90, eslint clean.

Related found-work from the same verification chain: #1341 (oracle deviation band deadlocks after an outage — prices frozen at Aug-7 values pending `forceSetPrice` or a staleness-aware band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7