### PR TITLE
[frontend] WCAG 2.2 residuals: public --text-4 contrast, Library aria-controls, dead subnav CSS

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -204,23 +204,30 @@ html {
 	scroll-behavior: smooth;
 	overflow-x: hidden;
 	/* The document is the scroll container and .topbar (the APP shell's bar
-     only — see the .public-site override below) is sticky over it at a
-     fixed 56px on every breakpoint. Without this, Shift+Tab backwards up a
-     long page parks the newly focused control under the blurred bar and its
-     focus ring becomes unreadable (2.4.11 Focus Not Obscured). 56px bar +
-     3px outline + 3px offset = 62, rounded to 64. */
-	scroll-padding-top: 64px;
+     only — see the .public-site override below) is sticky over it. Without
+     this, Shift+Tab backwards up a long page parks the newly focused control
+     under the blurred bar and its focus ring becomes unreadable (2.4.11
+     Focus Not Obscured). `.topbar`'s own rule below says 56px, but `.topbar`
+     only ever renders inside `.app-site` (Layout.jsx nests it under
+     `.shell.app-site`), and `.app-site .topbar` (higher specificity, no
+     media query, so it always wins) overrides that to 64px — that is the
+     height that actually renders, not 56 (#1318 residual: the original
+     64px value here was derived from the un-overridden 56px). 64px bar +
+     3px outline + 3px offset (.app-site :focus-visible) = 70, rounded up
+     to 72. */
+	scroll-padding-top: 72px;
 }
-/* .public-header (public shell) is taller than .topbar and its
-   :focus-visible ring uses a wider offset, so the 64px clearance above is
-   short here by up to 15px — a focused control on Architecture/Landing
-   could still park under the blurred public header (2.4.11, #1318 residual:
-   the base 64px value was verified against .topbar only, never against
-   .public-header). .public-site is not itself the scroll container (the
-   document/html is, per the comment above), so the override has to target
-   html, reached via :has() since .public-site is a descendant, not an
-   ancestor, of it. 72px bar (66px on the ≤560px breakpoint) + 3px outline +
-   4px offset = 79, rounded up to 80. */
+/* .public-header (public shell) is taller than the app topbar's real 64px
+   (see the comment above) and its :focus-visible ring uses a wider offset,
+   so even the corrected clearance above would be short here — a focused
+   control on Architecture/Landing could still park under the blurred
+   public header (2.4.11, #1318 residual: the base value was verified
+   against .app-site .topbar only, never against .public-header).
+   .public-site is not itself the scroll container (the document/html is,
+   per the comment above), so the override has to target html, reached via
+   :has() since .public-site is a descendant, not an ancestor, of it. 72px
+   bar (66px on the ≤560px breakpoint) + 3px outline + 4px offset = 79,
+   rounded up to 80. */
 html:has(.public-site) {
 	scroll-padding-top: 80px;
 }
@@ -3688,15 +3695,23 @@ button:where(.tag) {
 	--text-3: #8da098;
 	/* Architecture's loading / error / "live number unavailable" copy is drawn
      in --text-4 (Architecture.jsx :86, :382, :514, :872, :901, :1054, :1084),
-     so it has to clear 4.5:1 on every surface it could paint against, not
-     just the ones call sites happen to use today — same standard already
-     applied to --chart-label above. #7d9189 (the #1319 fix) was 4.74:1 on
-     --surface-2 (#10252d) but only 3.94:1 on the lighter --surface-3
-     (#17343d) — flagged as a residual in #1318. #8b9f97 clears both:
-     5.67:1 on --surface-2, 4.71:1 on --surface-3, 6.31:1 on the glass card
-     (--surface-3 is the binding constraint). No current call site actually
-     paints --text-4 on --surface-3 inside .public-site — grepped clean —
-     so this raises the floor defensively rather than fixing a live defect. */
+     so it has to clear 4.5:1 on every surface it could actually paint
+     against — same standard already applied to --chart-label above.
+     #7d9189 (the #1319 fix) was 4.74:1 on --surface-2 (#10252d) but only
+     3.94:1 on the lighter --surface-3 (#17343d) — flagged as a residual in
+     #1318. #8b9f97 clears --surface-1 through --surface-3 (6.23:1, 5.67:1,
+     4.70:1 — --surface-3 is the binding constraint of the three) and the
+     glass card (6.31:1).
+     It does NOT clear --surface-4 (#21434a, 3.82:1), and deliberately isn't
+     raised to cover it: every `background: var(--surface-4)` rule
+     (.token-pill-select .cs-trigger:hover, .info-box code, .chat-count,
+     .timeline::before, ...) belongs to app-shell-only components that
+     Landing.jsx / Architecture.jsx never render, so --text-4 painted on
+     --surface-4 inside .public-site cannot actually happen — grepped
+     clean. No current call site pairs --text-4 with --surface-1/2/3 either
+     — this raises the floor defensively for those three, the same
+     standard already applied to --chart-label, rather than fixing a
+     rendered defect. */
 	--text-4: #8b9f97;
 	--accent-rgb: 217, 168, 92;
 	--accent: var(--public-bronze);

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -3703,15 +3703,13 @@ button:where(.tag) {
      4.70:1 — --surface-3 is the binding constraint of the three) and the
      glass card (6.31:1).
      It does NOT clear --surface-4 (#21434a, 3.82:1), and deliberately isn't
-     raised to cover it: every `background: var(--surface-4)` rule
-     (.token-pill-select .cs-trigger:hover, .info-box code, .chat-count,
-     .timeline::before, ...) belongs to app-shell-only components that
-     Landing.jsx / Architecture.jsx never render, so --text-4 painted on
-     --surface-4 inside .public-site cannot actually happen — grepped
-     clean. No current call site pairs --text-4 with --surface-1/2/3 either
-     — this raises the floor defensively for those three, the same
-     standard already applied to --chart-label, rather than fixing a
-     rendered defect. */
+     raised to cover it: the surface-4 backgrounds that can render inside
+     .public-site are chrome-only (::-webkit-scrollbar-thumb) and carry no
+     text; the shell's children are Landing, Architecture and the 404 page,
+     none of which pairs --text-4 with --surface-4. No current call site
+     pairs --text-4 with --surface-1/2/3 either — this raises the floor
+     defensively for those three, the same standard already applied to
+     --chart-label, rather than fixing a rendered defect. */
 	--text-4: #8b9f97;
 	--accent-rgb: 217, 168, 92;
 	--accent: var(--public-bronze);

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -430,55 +430,6 @@ h4,
 	margin: 0 auto;
 }
 
-/* --- Section subnav (Explore) --- */
-.explore-subnav {
-	position: sticky;
-	top: 56px;
-	z-index: 40;
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-	padding: 10px 0;
-	margin-bottom: var(--space-5);
-	background: var(--topbar-bg);
-	backdrop-filter: blur(16px) saturate(1.2);
-	-webkit-backdrop-filter: blur(16px) saturate(1.2);
-	border-bottom: 1px solid var(--glass-border);
-}
-.explore-subnav-btn {
-	display: inline-flex;
-	align-items: center;
-	padding: 6px 12px;
-	font-size: 0.78rem;
-	font-weight: 500;
-	color: var(--text-3);
-	background: var(--glass);
-	border: 1px solid var(--glass-border);
-	border-radius: var(--radius-sm);
-	text-decoration: none;
-	transition:
-		color 0.15s,
-		background 0.15s,
-		border-color 0.15s;
-}
-.explore-subnav-btn:hover {
-	color: var(--text-1);
-	background: var(--glass-hover);
-	border-color: var(--accent-muted);
-}
-.scroll-anchor {
-	scroll-margin-top: 120px;
-}
-
-@media (max-width: 900px) {
-	.explore-subnav {
-		top: 0;
-	}
-	.scroll-anchor {
-		scroll-margin-top: 16px;
-	}
-}
-
 /* --- Sidebar --- */
 .sidebar-brand {
 	display: flex;
@@ -3723,9 +3674,16 @@ button:where(.tag) {
 	--text-3: #8da098;
 	/* Architecture's loading / error / "live number unavailable" copy is drawn
      in --text-4 (Architecture.jsx :86, :382, :514, :872, :901, :1054, :1084),
-     so it has to clear 4.5:1: #7d9189 is 4.74:1 on --surface-2 (#10252d) and
-     5.28:1 on the glass card, where #657a73 was 3.46 / 3.86:1. */
-	--text-4: #7d9189;
+     so it has to clear 4.5:1 on every surface it could paint against, not
+     just the ones call sites happen to use today — same standard already
+     applied to --chart-label above. #7d9189 (the #1319 fix) was 4.74:1 on
+     --surface-2 (#10252d) but only 3.94:1 on the lighter --surface-3
+     (#17343d) — flagged as a residual in #1318. #8b9f97 clears both:
+     5.67:1 on --surface-2, 4.71:1 on --surface-3, 6.31:1 on the glass card
+     (--surface-3 is the binding constraint). No current call site actually
+     paints --text-4 on --surface-3 inside .public-site — grepped clean —
+     so this raises the floor defensively rather than fixing a live defect. */
+	--text-4: #8b9f97;
 	--accent-rgb: 217, 168, 92;
 	--accent: var(--public-bronze);
 	--accent-hover: #e4ba78;

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -203,12 +203,26 @@ html {
 	-moz-osx-font-smoothing: grayscale;
 	scroll-behavior: smooth;
 	overflow-x: hidden;
-	/* The document is the scroll container and .topbar is sticky over it at a
+	/* The document is the scroll container and .topbar (the APP shell's bar
+     only — see the .public-site override below) is sticky over it at a
      fixed 56px on every breakpoint. Without this, Shift+Tab backwards up a
      long page parks the newly focused control under the blurred bar and its
      focus ring becomes unreadable (2.4.11 Focus Not Obscured). 56px bar +
      3px outline + 3px offset = 62, rounded to 64. */
 	scroll-padding-top: 64px;
+}
+/* .public-header (public shell) is taller than .topbar and its
+   :focus-visible ring uses a wider offset, so the 64px clearance above is
+   short here by up to 15px — a focused control on Architecture/Landing
+   could still park under the blurred public header (2.4.11, #1318 residual:
+   the base 64px value was verified against .topbar only, never against
+   .public-header). .public-site is not itself the scroll container (the
+   document/html is, per the comment above), so the override has to target
+   html, reached via :has() since .public-site is a descendant, not an
+   ancestor, of it. 72px bar (66px on the ≤560px breakpoint) + 3px outline +
+   4px offset = 79, rounded up to 80. */
+html:has(.public-site) {
+	scroll-padding-top: 80px;
 }
 body {
 	font-family: var(--sans);

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -180,12 +180,17 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
               "Open Passport", the exports, the source links or the DSR/PBO
               numbers, which live only in the expanded row (2.1.1 / 4.1.2).
               The row keeps its onClick as a mouse convenience; the button
-              stops propagation so one activation is one toggle. */}
+              stops propagation so one activation is one toggle.
+              aria-controls is conditional on `open` (same pattern as
+              CustomSelect's listbox): the <tr id={detailId}> below only
+              exists in the DOM while open, so an unconditional aria-controls
+              pointed at a nonexistent id on every collapsed row — a #1318
+              residual of the #1311/#1319 pass. */}
           <button
             type="button"
             className="lib-row-toggle"
             aria-expanded={open}
-            aria-controls={detailId}
+            aria-controls={open ? detailId : undefined}
             onClick={(e) => { e.stopPropagation(); setOpen(o => !o) }}
           >
             <span aria-hidden="true" className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3 h-3 mr-1.5 text-[var(--text-4)] flex-shrink-0 inline-block`} />

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -54,8 +54,9 @@ test("base and public palettes keep muted text above the 4.5:1 floor", () => {
 		css,
 		/:root\[data-theme="light"\]\s*\{[\s\S]*?--accent-rgb:\s*138,\s*95,\s*10;/,
 	);
-	// Public --text-4 was #657a73 = 3.46:1 on the slate card.
-	assert.match(css, /\.public-site\s*\{[\s\S]*?--text-4:\s*#7d9189;/);
+	// Public --text-4 was #657a73 = 3.46:1 on the slate card, then #7d9189
+	// (3.94:1 on the lighter --surface-3, a #1318 residual).
+	assert.match(css, /\.public-site\s*\{[\s\S]*?--text-4:\s*#8b9f97;/);
 	// --text-4 is a border/decoration token on the base palette (it is #3f3f46
 	// there = 1.73:1) and must never be used as text on the auth screen.
 	assert.doesNotMatch(authPage, /text-\[var\(--text-4\)\]/);

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -260,9 +260,14 @@ test("sticky topbar cannot cover a focused control", () => {
 		nestedCssBlock(media560, "\\.public-header__inner"),
 		"min-height",
 	);
+	// `.public-header__inner`'s min-height is not the whole sticky bar: the
+	// outer `.public-header` adds its own border-bottom below it, which also
+	// occupies rendered height a scrolled-to control can hide under.
+	const publicHeaderBorder = numPx(cssBlock(css, "\\.public-header"), "border-bottom");
 	const publicFocus = cssBlock(css, "\\.public-site :focus-visible");
 	const publicRequired =
 		Math.max(publicHeaderHeight, publicHeaderHeight560) +
+		publicHeaderBorder +
 		numPx(publicFocus, "outline") +
 		numPx(publicFocus, "outline-offset");
 	const publicScrollPad = numPx(

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -225,7 +225,11 @@ test("row-level click targets expose a real control", () => {
 	// the desktop table row was the only disclosure and it had no role, no tab
 	// stop and no aria-expanded.
 	assert.match(strategies, /className="lib-row-toggle"[\s\S]{0,120}aria-expanded=\{open\}/);
-	assert.match(strategies, /aria-controls=\{detailId\}/);
+	// aria-controls must be conditional: <tr id={detailId}> only exists in the
+	// DOM while open, so an unconditional aria-controls pointed at a
+	// nonexistent id on every collapsed row (4.1.2, #1318).
+	assert.match(strategies, /aria-controls=\{open \? detailId : undefined\}/);
+	assert.doesNotMatch(strategies, /aria-controls=\{detailId\}/);
 	assert.match(strategies, /className="lib-row-detail" id=\{detailId\}/);
 	// Corpus catalog: clicking the row was the only way into a paper.
 	assert.match(

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -14,6 +14,55 @@ import test from "node:test";
 
 const src = (p) => readFileSync(new URL(`../src/${p}`, import.meta.url), "utf8");
 
+// ── WCAG contrast helpers ───────────────────────────────────────────────
+//
+// A regex pinning a literal foreground hex only guards that one side of the
+// pair — the background it is measured against can drift (a token edit
+// elsewhere in the same block) with the guard still green, because nothing
+// ever computes the ratio. These resolve `--token: var(--other-token)`
+// indirection inside one CSS block and compute the real WCAG 2.x relative
+// luminance / contrast ratio, so the 4.5:1 floor is enforced against
+// whatever the current tokens actually are, not a snapshot of them.
+
+function cssBlock(cssText, selector) {
+	const re = new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`);
+	const m = cssText.match(re);
+	assert.ok(m, `CSS block not found: ${selector}`);
+	return m[1];
+}
+
+function tokenValue(block, name) {
+	const re = new RegExp(`--${name}:\\s*([^;]+);`);
+	const m = block.match(re);
+	assert.ok(m, `token not found in block: --${name}`);
+	return m[1].trim();
+}
+
+function resolveHex(block, rawValue) {
+	const varRef = rawValue.match(/^var\(--([\w-]+)\)$/);
+	if (varRef) return resolveHex(block, tokenValue(block, varRef[1]));
+	assert.match(rawValue, /^#[0-9a-fA-F]{3,6}$/, `not a hex literal: ${rawValue}`);
+	return rawValue;
+}
+
+function relativeLuminance(hex) {
+	const h = hex.replace("#", "");
+	const full = h.length === 3 ? [...h].map((c) => c + c).join("") : h;
+	const n = Number.parseInt(full, 16);
+	const [r, g, b] = [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((v) => {
+		const s = v / 255;
+		return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+	});
+	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(hexA, hexB) {
+	const [lo, hi] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort(
+		(a, b) => a - b,
+	);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
 const css = src("App.css");
 const app = src("App.jsx");
 const authPage = src("components/AuthPage.jsx");
@@ -55,8 +104,22 @@ test("base and public palettes keep muted text above the 4.5:1 floor", () => {
 		/:root\[data-theme="light"\]\s*\{[\s\S]*?--accent-rgb:\s*138,\s*95,\s*10;/,
 	);
 	// Public --text-4 was #657a73 = 3.46:1 on the slate card, then #7d9189
-	// (3.94:1 on the lighter --surface-3, a #1318 residual).
-	assert.match(css, /\.public-site\s*\{[\s\S]*?--text-4:\s*#8b9f97;/);
+	// (3.94:1 on the lighter --surface-3, a #1318 residual). Pinning the
+	// foreground literal alone only guards that one side of the pair — the
+	// background (--surface-2 / --surface-3) can drift with the guard still
+	// green unless the ratio is actually computed, so this resolves both
+	// tokens out of the live .public-site block and checks the real WCAG
+	// contrast rather than trusting a snapshot value.
+	const publicBlock = cssBlock(css, "\\.public-site");
+	const publicText4 = resolveHex(publicBlock, tokenValue(publicBlock, "text-4"));
+	for (const surfaceName of ["surface-2", "surface-3"]) {
+		const surfaceHex = resolveHex(publicBlock, tokenValue(publicBlock, surfaceName));
+		const ratio = contrastRatio(publicText4, surfaceHex);
+		assert.ok(
+			ratio >= 4.5,
+			`--text-4 (${publicText4}) on --${surfaceName} (${surfaceHex}) is ${ratio.toFixed(2)}:1, below the 4.5:1 floor`,
+		);
+	}
 	// --text-4 is a border/decoration token on the base palette (it is #3f3f46
 	// there = 1.73:1) and must never be used as text on the auth screen.
 	assert.doesNotMatch(authPage, /text-\[var\(--text-4\)\]/);
@@ -141,6 +204,15 @@ test("no rule strips the focus indicator from a control", () => {
 test("sticky topbar cannot cover a focused control", () => {
 	// 56px bar + 3px outline + 3px offset.
 	assert.match(css, /^html \{[^}]*scroll-padding-top: 64px;/m);
+	// .public-header is taller (72px, 66px ≤560px) with a wider focus-ring
+	// offset (4px) than .topbar, so the 64px clearance above is short by up
+	// to 15px there. .public-site is not the scroll container — html is —
+	// so the override has to reach html via :has(), not sit on .public-site
+	// itself. 72 + 3 + 4 = 79, rounded up to 80 (#1318 residual).
+	assert.match(
+		css,
+		/html:has\(\.public-site\)\s*\{\s*scroll-padding-top: 80px;/,
+	);
 });
 
 test("corpus category labels wrap instead of clipping under zoom", () => {

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -45,6 +45,28 @@ function resolveHex(block, rawValue) {
 	return rawValue;
 }
 
+// A regex pinning `scroll-padding-top: 80px` only guards that one side of
+// the clearance pair too — the header height / focus-ring geometry it was
+// derived from can drift with the guard still green unless the relationship
+// is actually computed. These pull a raw px number off a declaration and,
+// for a rule nested one level inside another block (e.g. inside a @media
+// query), off a block whose own closing brace carries that block's indent
+// rather than sitting at column 0.
+
+function numPx(block, prop) {
+	const re = new RegExp(`\\b${prop}:\\s*(\\d+(?:\\.\\d+)?)px`);
+	const m = block.match(re);
+	assert.ok(m, `property not found in block: ${prop}`);
+	return Number(m[1]);
+}
+
+function nestedCssBlock(blockText, selector) {
+	const re = new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\t\\}`);
+	const m = blockText.match(re);
+	assert.ok(m, `nested CSS block not found: ${selector}`);
+	return m[1];
+}
+
 function relativeLuminance(hex) {
 	const h = hex.replace("#", "");
 	const full = h.length === 3 ? [...h].map((c) => c + c).join("") : h;
@@ -202,16 +224,55 @@ test("no rule strips the focus indicator from a control", () => {
 // ── 2.4.11 Focus Not Obscured / 1.4.4 Resize Text ─────────────────────────
 
 test("sticky topbar cannot cover a focused control", () => {
-	// 56px bar + 3px outline + 3px offset.
-	assert.match(css, /^html \{[^}]*scroll-padding-top: 64px;/m);
-	// .public-header is taller (72px, 66px ≤560px) with a wider focus-ring
-	// offset (4px) than .topbar, so the 64px clearance above is short by up
-	// to 15px there. .public-site is not the scroll container — html is —
-	// so the override has to reach html via :has(), not sit on .public-site
-	// itself. 72 + 3 + 4 = 79, rounded up to 80 (#1318 residual).
-	assert.match(
-		css,
-		/html:has\(\.public-site\)\s*\{\s*scroll-padding-top: 80px;/,
+	// Pinning the scroll-padding-top literal alone only guards that one side
+	// of the clearance pair — the sticky bar's height and the focus ring's
+	// outline width / offset can drift out from under it with the guard
+	// still green. This resolves both sides out of the live CSS for each
+	// shell and asserts scroll-padding-top actually clears
+	// height + outline + outline-offset, the same static-parse approach the
+	// contrast test above uses.
+
+	// App shell: `.topbar`'s own rule below says 56px, but `.topbar` only
+	// ever renders inside `.app-site` (Layout.jsx nests it under
+	// `.shell.app-site`), and `.app-site .topbar` — higher specificity, not
+	// scoped to any breakpoint — overrides that to 64px. That is the height
+	// that actually renders, so it's what has to be measured, not the bare
+	// rule's 56px.
+	const appTopbarHeight = numPx(cssBlock(css, "\\.app-site \\.topbar"), "height");
+	const appFocus = cssBlock(css, "\\.app-site :focus-visible");
+	const appRequired =
+		appTopbarHeight + numPx(appFocus, "outline") + numPx(appFocus, "outline-offset");
+	const baseScrollPad = numPx(cssBlock(css, "html"), "scroll-padding-top");
+	assert.ok(
+		baseScrollPad >= appRequired,
+		`scroll-padding-top (${baseScrollPad}px) does not clear .app-site .topbar: ` +
+			`${appTopbarHeight}px height + focus ring needs ${appRequired}px`,
+	);
+
+	// Public shell: `.public-header__inner` is taller than the app topbar
+	// (72px, 66px on the ≤560px breakpoint) with a wider :focus-visible
+	// offset (4px) than `.app-site`'s (3px). `.public-site` is not the
+	// scroll container — html is — so the override has to reach html via
+	// :has(), not sit on .public-site itself (#1318 residual).
+	const publicHeaderHeight = numPx(cssBlock(css, "\\.public-header__inner"), "min-height");
+	const media560 = cssBlock(css, "@media \\(max-width: 560px\\)");
+	const publicHeaderHeight560 = numPx(
+		nestedCssBlock(media560, "\\.public-header__inner"),
+		"min-height",
+	);
+	const publicFocus = cssBlock(css, "\\.public-site :focus-visible");
+	const publicRequired =
+		Math.max(publicHeaderHeight, publicHeaderHeight560) +
+		numPx(publicFocus, "outline") +
+		numPx(publicFocus, "outline-offset");
+	const publicScrollPad = numPx(
+		cssBlock(css, "html:has\\(\\.public-site\\)"),
+		"scroll-padding-top",
+	);
+	assert.ok(
+		publicScrollPad >= publicRequired,
+		`html:has(.public-site) scroll-padding-top (${publicScrollPad}px) does not clear ` +
+			`.public-header__inner: needs ${publicRequired}px`,
 	);
 });
 


### PR DESCRIPTION
## Summary

Fixes the mechanical subset of #1318's WCAG 2.2 AA residuals — the findings that are pure token/attribute corrections, not the ones that require per-call-site design judgment or human-operated screen-reader/reflow testing (see "Not in this PR" below).

**Correction (2026-08-20, adversarial re-review):** the original version of this PR body overclaimed on 2.4.11 ("not reproducible on current `main`", "there is no rendered sticky bar left to obscure a focused control") and mislabeled a test transcript as the "full suite" when it was one file. Both are fixed below — see the 2.4.11 bullet and the Guards section.

**Correction (2026-08-20, second adversarial pass):** two more findings against that same round of fixes. (1) The new `sticky topbar cannot cover a focused control` guard pinned `scroll-padding-top: 80px` as a literal without computing it against `.public-header__inner`'s height — and the pre-existing base half of the same guard had the identical defect, pinned against a `.topbar` height (56px) that turns out to be wrong: `.topbar` only ever renders inside `.app-site`, and `.app-site .topbar` (higher specificity, no media query) overrides it to 64px everywhere, which the original 64px `scroll-padding-top` never accounted for — a real, currently-shipping 2.4.11 shortfall (needs 70px, had 64). Both halves of the guard are now computed instead of pinned, and the base value is corrected 64px → 72px. (2) The `--text-4` comment's "clear 4.5:1 on every surface it could paint against" was false as written — `.public-site` declares four surfaces and `#8b9f97` is only 3.82:1 on `--surface-4` (#21434a), below the floor. Not a rendered defect (nothing that paints `background: var(--surface-4)` renders inside `.public-site`'s DOM), so the comment is corrected to say precisely which three surfaces are in scope and why `--surface-4` is excluded, rather than claiming universal coverage. Also fixes a rounding error: the binding `--surface-3` ratio is 4.7046, i.e. **4.70:1**, not the 4.71:1 stated below and in the original comment.

## What changed

- **1.4.3 (Contrast, Minimum)** — `.public-site`'s `--text-4` (`#7d9189`, set by #1319) is 4.74:1 on `--surface-2` but only 3.94:1 on the lighter `--surface-3` — the #1318 finding. Raised to `#8b9f97`: 5.67:1 on `--surface-2`, **4.70:1** on `--surface-3`, 6.31:1 on the glass card. It does **not** clear `--surface-4` (#21434a, 3.82:1) and is deliberately not raised further to do so — the `background: var(--surface-4)` rules that can render inside `.public-site` are chrome-only (`::-webkit-scrollbar-thumb`, an unscoped global) and carry no text, so the text-on-surface-4 combination cannot actually occur; the App.css comment now says this precisely instead of claiming coverage of "every surface" (third adversarial pass narrowed it again — the earlier "app-shell-only" absolute was itself false for the scrollbar chrome). I grepped the tree first — no current call site actually paints `--text-4` on `--surface-1/2/3` inside `.public-site` (only `Architecture.jsx` and `Landing.jsx` render inside that shell, and neither pairs the two), so this raises the floor defensively, the same standard already applied to `--chart-label`, rather than fixing a rendered defect.
- **2.4.11 (Focus Not Obscured)** — the `.explore-subnav` / `.explore-subnav-btn` / `.scroll-anchor` rules the #1318 finding named are dead code with zero call sites anywhere in `src/` (`git blame`: added for a `Marketplace.jsx` page in `501714d7`, that file was deleted by a later UI rewrite — `4410924f` — and the sticky-subnav pattern was never ported to today's `Explore.jsx`). Removed the orphaned CSS so a future audit doesn't rediscover the same false trail. **That part held up; the disposition around it did not, twice.** First: the named class being dead does not mean nothing can obscure a focused control — `scroll-padding-top: 64px` on `html` (App.css:206-218) was sized for `.topbar` alone and is the *only* `scroll-padding` in the tree, so it silently governed the public shell too; `.public-header` is taller (72px, 66px on the ≤560px breakpoint) with a wider `:focus-visible` offset (4px) plus `.public-header`'s own 1px `border-bottom`, so the required clearance is 72+1+3+4 = 80px (the border term was added by the third adversarial pass; the guard computes it rather than pinning). Fixed with a shell-scoped override — `html:has(.public-site) { scroll-padding-top: 80px; }` (`.public-site` is a descendant of the scroll container, not the scroller itself, so the override has to reach `html` via `:has()` rather than sit on `.public-site` directly). Second (caught on the second adversarial pass): the base value's own derivation — "56px bar + 3px outline + 3px offset = 62, rounded to 64" — assumed `.topbar` renders at its own rule's 56px, but `.topbar` only ever renders inside `.app-site` (`Layout.jsx` nests it under `.shell.app-site`), and `.app-site .topbar` (App.css, higher specificity, not scoped to any breakpoint) overrides the height to 64px unconditionally — that's what actually renders. 64px bar + 3px outline + 3px offset = 70, more than the 64px the base rule provided: up to 6px of a keyboard-focused control could park under the blurred app-shell topbar. Corrected to `scroll-padding-top: 72px`. Both halves are now guarded by a computed check rather than a literal pin (see Guards).
- **4.1.2 (Name, Role, Value)** — Library's row-disclosure `<button>` set `aria-controls` to the expanded row's id unconditionally, but `<tr id={detailId}>` only exists in the DOM while the row is open — every *collapsed* row referenced a nonexistent id. Made it conditional on `open`, the same pattern `CustomSelect` already uses for its listbox (`aria-controls={open ? listboxId : undefined}`).

## Not in this PR (left open on #1318)

- **1.4.3, ~175 `--text-4`-as-body-text call sites** (base-palette portalled modals 1.7–1.8:1, `.app-site` raised cards 3.9:1) — the issue is explicit this needs **per-call-site triage to `--text-3`, not a token bump**: each site has to be judged on whether it's genuinely decorative or real body text before moving it, which is a design read, not a mechanical fix. Left for a scoped follow-up.
- **Formal conformance evaluation** — screen-reader pass (VoiceOver/NVDA), 200%/400% reflow, text-spacing override, motion review, automated axe/Lighthouse against the live app. None of this can be honestly claimed from a source-diff session; it needs a human operating real assistive tech and a live browser. No conformance claim is made by this PR.

## Guards

`ui/test/a11y.test.js` updated in place (no new file — extends the #1319 guard suite):

- `base and public palettes keep muted text above the 4.5:1 floor` — the public-palette half no longer pins `--text-4` as a literal hex (a regex on one side of a contrast pair passes even when the *background* token drifts underneath it — confirmed by mutating `.public-site`'s `--surface-3` to `#3d7a8c`, which drops the ratio to 1.72:1 while the old literal-pin guard stayed green). It now resolves `--text-4` / `--surface-2` / `--surface-3` out of the live `.public-site` block (following `var()` indirection) and computes the actual WCAG contrast ratio, asserting ≥ 4.5:1 against both surfaces. (`--surface-4` is intentionally out of this loop — see the 1.4.3 bullet above for why.)
- `sticky topbar cannot cover a focused control` — no longer pins either `scroll-padding-top` literal. It now pulls `.app-site .topbar`'s real height and `.app-site :focus-visible`'s outline/offset out of the live CSS and asserts the base `html` value clears `height + outline + offset`, and separately pulls `.public-header__inner`'s `min-height` (both breakpoints) and `.public-site :focus-visible`'s outline/offset and asserts `html:has(.public-site)` clears that pair — the same static-parse approach (`cssBlock`/`tokenValue`/`resolveHex`) the contrast guard above uses.
- `row-level click targets expose a real control` — re-pinned to the conditional `aria-controls={open ? detailId : undefined}` and now asserts the old unconditional form is **absent**.

All four mutation demonstrations below are `node --test test/a11y.test.js` alone (24 cases in this file):

```
# App.css + Strategies.jsx both reverted to their pre-#1348 state (parent of 13c970bc):
ℹ pass 21
ℹ fail 3
  ✖ base and public palettes keep muted text above the 4.5:1 floor
  ✖ sticky topbar cannot cover a focused control
  ✖ row-level click targets expose a real control

# Strategies.jsx alone reverted (isolated demonstration for the aria-controls guard):
ℹ pass 23
ℹ fail 1
  ✖ row-level click targets expose a real control

# Adversarial mutation of .public-site's --surface-3 (#17343d → #3d7a8c, 1.72:1 with --text-4)
# against the OLD literal-pin guard (i.e. before this correction): stayed green (24/24) —
# this is what motivated replacing it with a computed check. Against the NEW
# computed-contrast guard, same mutation:
ℹ pass 23
ℹ fail 1
  ✖ base and public palettes keep muted text above the 4.5:1 floor

# Second pass — .public-header__inner min-height 72px → 120px (the exact mutation from
# the adversarial finding), against the now-computed topbar guard:
ℹ pass 23
ℹ fail 1
  ✖ sticky topbar cannot cover a focused control
  AssertionError: html:has(.public-site) scroll-padding-top (80px) does not clear
  .public-header__inner: needs 127px

# Second pass — .app-site .topbar height 64px → 100px, against the now-computed guard:
ℹ pass 23
ℹ fail 1
  ✖ sticky topbar cannot cover a focused control
  AssertionError: scroll-padding-top (72px) does not clear .app-site .topbar:
  100px height + focus ring needs 106px

# Second pass — reverting only the base value to the original (wrong) 64px, current
# .app-site .topbar (64px) and focus-ring tokens unchanged, against the now-computed guard
# (this is the guard catching the actual pre-existing shortfall, not a synthetic mutation):
ℹ pass 23
ℹ fail 1
  ✖ sticky topbar cannot cover a focused control
  AssertionError: scroll-padding-top (64px) does not clear .app-site .topbar:
  64px height + focus ring needs 70px
```

## Verification (this branch)

```
ui: node --test               90/90 passed
ui: node --test test/a11y.test.js   24/24 passed
ui: npm run lint              clean
ui: npm run build             clean
grep -rn "explore-subnav\|scroll-anchor" ui/src/ ui/test/   → 0 (dead code confirmed gone)
grep -n "4.71" ui/src/App.css ui/test/a11y.test.js          → 0 (rounding error fixed)
```

No backend or Python files touched, so the backend suite / ruff gates don't apply to this diff.

Refs #1318

