### PR TITLE
[rigor] Wire benjamini_hochberg_fdr into the board-level rigor gate

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -16,6 +16,7 @@ from archimedes.api.limiter import limiter
 from archimedes.services.rigor_evaluator import (
     assert_self_contained_cohort_correlation,
     compute_average_pairwise_correlation,
+    compute_board_level_fdr,
     compute_library_pbo,
     compute_pbo,
     load_daily_returns_store,
@@ -87,6 +88,31 @@ class LibraryPbo(BaseModel):
     source: str = "library_cscv"  # provenance label; "unavailable" when value is None
 
 
+class BoardLevelFdr(BaseModel):
+    """Board-level Benjamini-Hochberg FDR correction across the whole leaderboard
+    cohort (#1185).
+
+    Disclosing board-level selection bias ("the best of N strategies is a
+    stronger claim than one strategy graded on its own merits") is not the same
+    as CORRECTING for it — this is the correction. Distinct axis from
+    ``num_trials`` (#1075's PER-STRATEGY, self-contained multiple-testing
+    convention, unaffected by this): this is the multiple-testing correction
+    across the SIMULTANEOUS "true Sharpe > 0" claims made by every strategy
+    currently on the board.
+
+    ADVISORY — see ``compute_board_level_fdr``'s docstring for the full
+    scope-decision rationale: this does NOT gate ``passes_all`` at any
+    strictness level. ``value is None`` (fail-closed / store-absent shape) is
+    intentionally NOT a state this model carries — an empty cohort just yields
+    ``n_tested=0, n_significant=0``, which is honest (nothing to correct) rather
+    than fabricated.
+    """
+
+    fdr_level: float = 0.05
+    n_tested: int = 0  # cohort size m: strategies with a finite dsr_p_value
+    n_significant: int = 0  # count of board_fdr_significant == True after correction
+
+
 class StrategyRigorResult(BaseModel):
     """Rigor gate result for a single strategy.
 
@@ -124,6 +150,12 @@ class StrategyRigorResult(BaseModel):
     # got far enough to compute a num_trials at all — never silently implies a
     # trustworthy value.
     num_trials_scope: str = "unspecified"
+    # Board-level BH-FDR correction (#1185) — see BoardLevelFdr / compute_board_level_fdr
+    # for the scope decision. ADVISORY: never affects passes_all. None when this
+    # strategy had no finite dsr_p_value to correct (mirrors dsr_p_value's own
+    # None/MISSING convention above).
+    board_fdr_significant: bool | None = None
+    board_fdr_adjusted_p: float | None = None
 
 
 class RigorGateResponse(BaseModel):
@@ -137,6 +169,8 @@ class RigorGateResponse(BaseModel):
     # The strictness level the ``passing``/``failing`` counts + each
     # ``passes_all`` were evaluated at (1 = strictest/badge … 5 = loosest).
     strictness_level: int = 1
+    # Board-level BH-FDR correction across this response's cohort (#1185).
+    board_level_fdr: BoardLevelFdr = BoardLevelFdr()
 
 
 class StrictnessLevelInfo(BaseModel):
@@ -450,6 +484,28 @@ async def evaluate_rigor_gate(
     # per-strategy always agree, on both cache hits and misses.
     results = [r.model_copy(update={"library_pbo": library_pbo}) for r in results]
 
+    # Board-level BH-FDR correction (#1185) — computed fresh over THIS response's
+    # served cohort, same reconciliation pattern as library_pbo above and for the
+    # same reason: on a rigor_cache HIT, recomputing here (cheap — pure numpy over
+    # <= a few hundred p-values) guarantees the correction always matches the
+    # exact strategy set actually being returned, never a stale cache-write-time
+    # cohort. ADVISORY only — see BoardLevelFdr / compute_board_level_fdr for the
+    # explicit scope decision; this never changes passes_all.
+    board_fdr = compute_board_level_fdr({r.strategy_id: r.dsr_p_value for r in results})
+    results = [
+        r.model_copy(
+            update={
+                "board_fdr_significant": board_fdr.get(r.strategy_id, {}).get("board_fdr_significant"),
+                "board_fdr_adjusted_p": board_fdr.get(r.strategy_id, {}).get("board_fdr_adjusted_p"),
+            }
+        )
+        for r in results
+    ]
+    board_level_fdr = BoardLevelFdr(
+        n_tested=len(board_fdr),
+        n_significant=sum(1 for v in board_fdr.values() if v["board_fdr_significant"]),
+    )
+
     passing = sum(1 for r in results if r.passes_all)
     return RigorGateResponse(
         strategies=results,
@@ -458,6 +514,7 @@ async def evaluate_rigor_gate(
         failing=len(results) - passing,
         library_pbo=library_pbo,
         strictness_level=strictness,
+        board_level_fdr=board_level_fdr,
     )
 
 

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -156,9 +156,21 @@ class StrategyRigorResult(BaseModel):
     # trustworthy value.
     num_trials_scope: str = "unspecified"
     # Board-level BH-FDR correction (#1185) — see BoardLevelFdr / compute_board_level_fdr
-    # for the scope decision. ADVISORY: never affects passes_all. None when this
-    # strategy had no finite dsr_p_value to correct (mirrors dsr_p_value's own
-    # None/MISSING convention above).
+    # for the scope decision. ADVISORY: never affects passes_all. `None` is
+    # overloaded (code review, 2026-08-20): for a CURATED strategy — whether
+    # returned from GET /gate (the batch/board route) or GET /gate/{id} (which
+    # delegates to the same evaluate_rigor_gate() for curated ids, see
+    # evaluate_strategy_rigor below) — None means "this strategy had no finite
+    # dsr_p_value to correct" (mirrors dsr_p_value's own None/MISSING
+    # convention above), because it went through the real board-level cohort
+    # correction. For a GENERATED strategy served by GET /gate/{id}'s
+    # `_generated_strategy_rigor` fallback, this is ALWAYS None, even when
+    # dsr_p_value IS finite — board-level FDR is inherently cohort-scoped, and
+    # a single generated strategy has no cohort to correct across, so that
+    # path never calls compute_board_level_fdr at all. A consumer cannot
+    # distinguish "not significant / real cohort" from "excluded, no
+    # dsr_p_value" from "generated, no cohort at all" from this field alone —
+    # check which code path produced the payload.
     board_fdr_significant: bool | None = None
     board_fdr_adjusted_p: float | None = None
     # board_fdr_confidence (1 - board_fdr_adjusted_p, same read-direction as

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Query, Request, Response
 
 from archimedes.api.limiter import limiter
 from archimedes.services.rigor_evaluator import (
+    DEFAULT_BOARD_FDR_LEVEL,
     assert_self_contained_cohort_correlation,
     compute_average_pairwise_correlation,
     compute_board_level_fdr,
@@ -108,7 +109,11 @@ class BoardLevelFdr(BaseModel):
     than fabricated.
     """
 
-    fdr_level: float = 0.05
+    # Sourced from DEFAULT_BOARD_FDR_LEVEL (rigor_evaluator) as a schema default
+    # ONLY — the value actually reported by any real response is passed
+    # explicitly at construction (see evaluate_rigor_gate below) so this field
+    # can never silently diverge from the α compute_board_level_fdr ran at.
+    fdr_level: float = DEFAULT_BOARD_FDR_LEVEL
     n_tested: int = 0  # cohort size m: strategies with a finite dsr_p_value
     n_significant: int = 0  # count of board_fdr_significant == True after correction
 
@@ -156,6 +161,12 @@ class StrategyRigorResult(BaseModel):
     # None/MISSING convention above).
     board_fdr_significant: bool | None = None
     board_fdr_adjusted_p: float | None = None
+    # board_fdr_confidence (1 - board_fdr_adjusted_p, same read-direction as
+    # dsr_p_value) — computed by compute_board_level_fdr but previously never
+    # wired past it (dead field, #1185 code review 2026-08-20). Surfaced here
+    # rather than dropped: it is the more honest number to show alongside
+    # dsr_p_value, since both now read "large = confident" the same way.
+    board_fdr_confidence: float | None = None
 
 
 class RigorGateResponse(BaseModel):
@@ -491,17 +502,21 @@ async def evaluate_rigor_gate(
     # exact strategy set actually being returned, never a stale cache-write-time
     # cohort. ADVISORY only — see BoardLevelFdr / compute_board_level_fdr for the
     # explicit scope decision; this never changes passes_all.
-    board_fdr = compute_board_level_fdr({r.strategy_id: r.dsr_p_value for r in results})
+    board_fdr = compute_board_level_fdr(
+        {r.strategy_id: r.dsr_p_value for r in results}, fdr_level=DEFAULT_BOARD_FDR_LEVEL
+    )
     results = [
         r.model_copy(
             update={
                 "board_fdr_significant": board_fdr.get(r.strategy_id, {}).get("board_fdr_significant"),
                 "board_fdr_adjusted_p": board_fdr.get(r.strategy_id, {}).get("board_fdr_adjusted_p"),
+                "board_fdr_confidence": board_fdr.get(r.strategy_id, {}).get("board_fdr_confidence"),
             }
         )
         for r in results
     ]
     board_level_fdr = BoardLevelFdr(
+        fdr_level=DEFAULT_BOARD_FDR_LEVEL,
         n_tested=len(board_fdr),
         n_significant=sum(1 for v in board_fdr.values() if v["board_fdr_significant"]),
     )

--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -7,8 +7,7 @@ Extracted from rigor_evaluator.py to reduce module complexity. Contains:
   - Kelly Criterion position sizing
   - Sharpe confidence intervals
   - Regime classification and conditional analysis
-  - Monte Carlo DSR significance testing via circular block bootstrap
-  - Multiple-testing corrections (Benjamini-Hochberg, Bonferroni)
+  - Board-level multiple-testing correction (Benjamini-Hochberg FDR, #1185)
 
 All functions are pure computation: no I/O, no web framework, no on-chain
 dependencies. They consume daily return arrays and produce rigor-gate metrics.
@@ -21,6 +20,7 @@ from __future__ import annotations
 
 import math
 from itertools import combinations
+from typing import Any
 
 import numpy as np
 from scipy.stats import kurtosis as sp_kurtosis
@@ -1073,3 +1073,104 @@ def regime_conditional_dsr(
             "n_days": int(sub.size),
         }
     return out
+
+
+# ─── 8. Board-Level Multiple-testing Correction ──────────────────────
+#
+# Restored (#1185, 2026-08-20) after Tranche-1's dead-code excision (PR #1259 /
+# commit c02d5fad) deleted this function on 2026-08-18 for having zero
+# non-test callers — accurate at the time, but issue #1185 (open since
+# 2026-07-28, three weeks BEFORE that deletion) had already asked for exactly
+# this to be wired in. See rigor_evaluator.compute_board_level_fdr for the one
+# real call site this issue requires; the pure BH-FDR math below is unchanged
+# from the pre-deletion version (restored verbatim from git history).
+
+
+def benjamini_hochberg_fdr(
+    pvalues: list[float],
+    fdr_level: float = 0.05,
+) -> dict[str, Any]:
+    """Benjamini-Hochberg False Discovery Rate correction.
+
+    Controls the expected proportion of false discoveries among the rejected
+    hypotheses at level *fdr_level*. BH is uniformly more powerful than
+    Bonferroni for independent or positively dependent tests, which makes it
+    the preferred correction when evaluating a library of strategies (where
+    strategies sharing the same universe tend to have positive return
+    correlations).
+
+    Algorithm (Benjamini & Hochberg 1995, Theorem 1):
+      1. Sort p-values ascending: p_(1) ≤ p_(2) ≤ … ≤ p_(m).
+      2. BH critical value for rank k: q_k = (k / m) × α.
+      3. Find the largest k* such that p_(k*) ≤ q_(k*).
+      4. Reject all hypotheses with rank ≤ k* (i.e. all p ≤ p_(k*)).
+      5. BH-adjusted p-values: p̃_k = min(1, p_k × m / k), enforced to be
+         monotone non-decreasing in rank order (step-down adjustment).
+
+    Reference: Benjamini, Y. & Hochberg, Y. (1995). "Controlling the false
+    discovery rate: a practical and powerful approach to multiple testing."
+    *Journal of the Royal Statistical Society. Series B*, 57(1), 289-300.
+
+    Application to backtesting: Bailey, D.H., Borwein, J., López de Prado, M.,
+    & Zhu, Q. (2014). "The Probability of Backtest Overfitting." *Journal of
+    Computational Finance*, 20(4), 39-70.
+
+    Args:
+        pvalues: List of m p-values (one per strategy / hypothesis). These are
+            CLASSICAL p-values — a SMALL value is evidence against the null
+            (rejected). Note this is the opposite convention from
+            ``RigorGateResult.dsr_p_value`` (P(true SR > 0), where a LARGE
+            value is confident evidence): a caller feeding DSR p-values in
+            here must convert first (``1 - dsr_p_value``). See
+            ``rigor_evaluator.compute_board_level_fdr`` for that conversion.
+        fdr_level: Target FDR (α). Default 0.05.
+
+    Returns:
+        Dict with keys:
+          ``rejected``         — list[bool] of length m in the original input order.
+          ``bh_critical_values`` — list[float] of BH thresholds q_k in original order.
+          ``n_rejected``       — number of hypotheses rejected.
+          ``adjusted_pvalues`` — BH-adjusted p-values in the original input order.
+    """
+    m = len(pvalues)
+    if m == 0:
+        return {"rejected": [], "bh_critical_values": [], "n_rejected": 0, "adjusted_pvalues": []}
+
+    arr = np.asarray(pvalues, dtype=float)
+    # Sort ascending, track original positions
+    sort_order = np.argsort(arr)
+    sorted_p = arr[sort_order]
+
+    ranks = np.arange(1, m + 1, dtype=float)
+    bh_crit = (ranks / m) * fdr_level
+
+    # Largest k where sorted_p[k-1] <= bh_crit[k-1]
+    below_threshold = sorted_p <= bh_crit
+    # 0-based index of the last True (largest rejected k); -1 if nothing rejected.
+    k_star = int(np.where(below_threshold)[0][-1]) if np.any(below_threshold) else -1
+
+    reject_sorted = np.zeros(m, dtype=bool)
+    if k_star >= 0:
+        reject_sorted[: k_star + 1] = True
+
+    # BH-adjusted p-values in sorted order: p̃_k = min(1, p_k × m / k)
+    # Enforce monotone non-decreasing via cummin from the last rank
+    adjusted_sorted = np.minimum(1.0, sorted_p * (m / ranks))
+    # Step-down monotonicity: p̃_k ≤ p̃_{k+1} in sorted order (adjust from top)
+    for i in range(m - 2, -1, -1):
+        adjusted_sorted[i] = min(adjusted_sorted[i], adjusted_sorted[i + 1])
+
+    # Map back to original input order
+    inv_order = np.empty(m, dtype=int)
+    inv_order[sort_order] = np.arange(m)
+
+    rejected_orig = reject_sorted[inv_order].tolist()
+    bh_crit_orig = bh_crit[inv_order].tolist()
+    adjusted_orig = adjusted_sorted[inv_order].tolist()
+
+    return {
+        "rejected": rejected_orig,
+        "bh_critical_values": [round(v, 8) for v in bh_crit_orig],
+        "n_rejected": int(np.sum(reject_sorted)),
+        "adjusted_pvalues": [round(v, 8) for v in adjusted_orig],
+    }

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -383,9 +383,28 @@ def compute_library_pbo(
     return float(pbo)
 
 
+# Default board-level FDR α (#1185 code review, 2026-08-20). A module constant
+# instead of two independent `= 0.05` defaults (one here, one on
+# selection_bias_routes.BoardLevelFdr.fdr_level): the route reports
+# BoardLevelFdr.fdr_level to the caller but was never passing it into either
+# default, so the two literals could silently diverge if one were edited
+# without the other. selection_bias_routes imports this constant and passes it
+# explicitly to both compute_board_level_fdr() and BoardLevelFdr(...), so the
+# reported α is always sourced from the value the correction actually used.
+DEFAULT_BOARD_FDR_LEVEL = 0.05
+
+# Floor for the DSR->classical p-value conversion below (#1185 code review,
+# 2026-08-20). compute_dsr's dsr_p_value saturates at exactly 1.0 for a long,
+# low-vol, confidently-positive series (rounded via `round(dsr_p_value, 6)` in
+# _dsr_from_stats) — converting that via `1.0 - 1.0` yields classical_p == 0.0,
+# an impossible p-value. Flooring at this resolution reports "as significant as
+# the DSR rounding can actually distinguish" instead of a false certainty.
+_CLASSICAL_P_FLOOR = 1e-6
+
+
 def compute_board_level_fdr(
     dsr_p_values: dict[str, float | None],
-    fdr_level: float = 0.05,
+    fdr_level: float = DEFAULT_BOARD_FDR_LEVEL,
 ) -> dict[str, dict[str, float | bool]]:
     """Board-level Benjamini-Hochberg FDR correction across a leaderboard cohort (#1185).
 
@@ -426,6 +445,15 @@ def compute_board_level_fdr(
     reports back in the ``dsr_p_value`` convention (``board_fdr_confidence = 1 -
     adjusted_p``) so the two numbers read the same way side by side.
 
+    **Saturation floor.** ``dsr_p_value`` can round to exactly 1.0 (a long,
+    confidently-positive series — see ``compute_dsr``'s own rounding), which
+    would convert to ``classical_p == 0.0``: an impossible p-value asserting
+    zero-probability certainty. ``classical_p`` is floored at
+    ``_CLASSICAL_P_FLOOR`` (1e-6) before BH-FDR runs, so the saturated case
+    reports "significant to the resolution the DSR rounding can distinguish"
+    rather than a false exact certainty — ``board_fdr_adjusted_p`` and
+    ``board_fdr_confidence`` are bounded away from 0.0 / 1.0 accordingly.
+
     Args:
         dsr_p_values: ``{strategy_id: dsr_p_value | None}`` for the current
             leaderboard cohort — one entry per strategy, in any order. Entries
@@ -434,9 +462,14 @@ def compute_board_level_fdr(
             p-value) and are ABSENT from the returned dict — the caller's own
             per-strategy MISSING handling covers them, same convention as every
             other rigor-gate field.
-        fdr_level: Target board-level FDR (α). Default 0.05, matching
-            ``benjamini_hochberg_fdr``'s own default and the DSR badge's 0.05
-            complement (dsr_p_min=0.90 at the strictest level).
+        fdr_level: Target board-level FDR (α). Default ``DEFAULT_BOARD_FDR_LEVEL``
+            (0.05), matching ``benjamini_hochberg_fdr``'s own default and the
+            conventional BH significance level. NOT derived from the DSR
+            badge's ``dsr_p_min`` (0.90 at strictest level, PR #901 — complement
+            0.10, not 0.05): the two are deliberately different axes (per-
+            strategy admission bar vs. board-level multiple-testing rate) and
+            the board-level α is intentionally stricter than the badge's
+            implied 0.10, not derived from it.
 
     Returns:
         ``{strategy_id: {"board_fdr_significant": bool, "board_fdr_adjusted_p":
@@ -447,7 +480,7 @@ def compute_board_level_fdr(
     if not ids:
         return {}
 
-    classical_pvalues = [1.0 - dsr_p_values[sid] for sid in ids]
+    classical_pvalues = [max(_CLASSICAL_P_FLOOR, 1.0 - dsr_p_values[sid]) for sid in ids]
     bh = benjamini_hochberg_fdr(classical_pvalues, fdr_level=fdr_level)
 
     out: dict[str, dict[str, float | bool]] = {}

--- a/backend/archimedes/services/rigor_evaluator.py
+++ b/backend/archimedes/services/rigor_evaluator.py
@@ -30,6 +30,7 @@ from archimedes.services._rigor_helpers import (
     _ANNUALIZATION,
     _RF_DAILY,
     assert_self_contained_cohort_correlation,  # noqa: F401 - re-exported for the 3 cohort call sites (V4 guard)
+    benjamini_hochberg_fdr,  # used by compute_board_level_fdr below (#1185)
     classify_regimes,  # used by run_rigor_gate (regime-robustness) + re-exported for test_rigor_regime
     compute_average_pairwise_correlation,  # noqa: F401 - re-exported for fusion_evaluator/selection_bias_routes
     compute_cpcv_oos_sharpe,
@@ -380,6 +381,84 @@ def compute_library_pbo(
     if pbo is None or not math.isfinite(pbo):
         return None
     return float(pbo)
+
+
+def compute_board_level_fdr(
+    dsr_p_values: dict[str, float | None],
+    fdr_level: float = 0.05,
+) -> dict[str, dict[str, float | bool]]:
+    """Board-level Benjamini-Hochberg FDR correction across a leaderboard cohort (#1185).
+
+    **The scope decision this issue asked for, stated explicitly.** A user who
+    browses the leaderboard and deploys the top-ranked strategy has, statistically,
+    run an N-way search over the board — distinct from, and layered on top of, the
+    PER-STRATEGY ``num_trials`` convention (#1075: ``num_trials = 1`` on the curated
+    path, unaffected by this function). This function performs the board-level
+    correction the strictness ladder / PBO / DSR disclosures do NOT: it actually
+    computes a BH-FDR-adjusted significance figure across the cohort's simultaneous
+    "this strategy's true Sharpe is positive" claims.
+
+    **Chosen scope: ADVISORY / annotation, NOT an admission-gate criterion.** The
+    output is surfaced (leaderboard/gate response field) but is deliberately NOT
+    wired into ``RigorGateResult.passes_all`` / ``blocked_by_floor`` at any
+    strictness level. Rationale, matching the precedent already set for this
+    module's other cohort-shaped advisories (IID diagnostics #621, regime
+    robustness — see ``run_rigor_gate``'s own comments): (1) promoting a NEW
+    statistic to a hard gate is an admission-policy call for the rigor lane
+    (Dan/Önder), not a default an issue implementation should make unilaterally;
+    (2) gating on it would make a strategy's deploy status move as *unrelated*
+    strategies are added to or removed from the board — the exact "library-coupled
+    verdict" problem #1075's ADR (docs/adr/num-trials-self-containment.md) already
+    rejected for num_trials, so silently reintroducing that coupling as a gate
+    here would cut against a decision this codebase already made deliberately;
+    (3) the existing quant sign-off gap on #1075 (recorded Accepted-pending-
+    quant-sign-off) means a second unreviewed statistical gate change stacked on
+    top is exactly the kind of prose claim CLAUDE.md's guard-adversarial-pass rule
+    warns against ("a PR description asserting a property the code does not
+    enforce") — annotate-only makes no such claim. Promoting this to a gate is a
+    legitimate follow-up; it needs its own explicit product/quant decision, not an
+    implicit one buried in this issue.
+
+    **Direction of the p-value.** ``benjamini_hochberg_fdr`` expects CLASSICAL
+    p-values (small = significant / reject the null). ``RigorGateResult.dsr_p_value``
+    is P(true SR > 0) — the OPPOSITE convention (large = confident). This function
+    converts via ``classical_p = 1 - dsr_p_value`` before calling BH-FDR, then
+    reports back in the ``dsr_p_value`` convention (``board_fdr_confidence = 1 -
+    adjusted_p``) so the two numbers read the same way side by side.
+
+    Args:
+        dsr_p_values: ``{strategy_id: dsr_p_value | None}`` for the current
+            leaderboard cohort — one entry per strategy, in any order. Entries
+            with ``None`` or non-finite values (no backtest data, degenerate
+            series) are excluded from the correction (they cannot be assigned a
+            p-value) and are ABSENT from the returned dict — the caller's own
+            per-strategy MISSING handling covers them, same convention as every
+            other rigor-gate field.
+        fdr_level: Target board-level FDR (α). Default 0.05, matching
+            ``benjamini_hochberg_fdr``'s own default and the DSR badge's 0.05
+            complement (dsr_p_min=0.90 at the strictest level).
+
+    Returns:
+        ``{strategy_id: {"board_fdr_significant": bool, "board_fdr_adjusted_p":
+        float, "board_fdr_confidence": float}}`` for every strategy with a finite
+        input p-value. Empty dict when fewer than 1 strategy qualifies.
+    """
+    ids = [sid for sid, p in dsr_p_values.items() if p is not None and math.isfinite(p)]
+    if not ids:
+        return {}
+
+    classical_pvalues = [1.0 - dsr_p_values[sid] for sid in ids]
+    bh = benjamini_hochberg_fdr(classical_pvalues, fdr_level=fdr_level)
+
+    out: dict[str, dict[str, float | bool]] = {}
+    for i, sid in enumerate(ids):
+        adjusted_p = bh["adjusted_pvalues"][i]
+        out[sid] = {
+            "board_fdr_significant": bool(bh["rejected"][i]),
+            "board_fdr_adjusted_p": adjusted_p,
+            "board_fdr_confidence": round(1.0 - adjusted_p, 8),
+        }
+    return out
 
 
 def load_daily_returns_store(

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -1876,6 +1876,24 @@ class TestComputeBoardLevelFdr:
         assert compute_board_level_fdr({}) == {}
         assert compute_board_level_fdr({"only": None}) == {}
 
+    def test_saturated_dsr_p_value_is_floored_not_zero(self):
+        """dsr_p_value == 1.0 (DSR rounding saturation — e.g. compute_dsr on a
+        long, low-vol, confidently-positive series rounds to exactly 1.0) must
+        NOT convert to a classical p-value of exactly 0.0: an impossible
+        zero-probability certainty claim. It is floored at
+        ``_CLASSICAL_P_FLOOR`` (1e-6) before BH-FDR runs (#1185 code review,
+        2026-08-20), so ``board_fdr_adjusted_p`` / ``board_fdr_confidence``
+        stay strictly inside (0.0, 1.0) rather than snapping to the endpoint.
+        This is not hypothetical: TestBoardLevelFdrWiring's
+        ``_strong_series(0)`` in test_selection_bias_routes.py hits this
+        exact saturated case in the PR's own end-to-end test cohort."""
+        dsr_p_values = {"saturated": 1.0, "b": 0.5, "c": 0.5}
+        result = compute_board_level_fdr(dsr_p_values, fdr_level=0.05)
+
+        assert result["saturated"]["board_fdr_significant"] is True
+        assert 0.0 < result["saturated"]["board_fdr_adjusted_p"] < 1e-4
+        assert 1.0 - 1e-4 < result["saturated"]["board_fdr_confidence"] < 1.0
+
     def test_board_level_correction_is_cohort_size_sensitive(self):
         """The defining property of a BOARD-level (not per-strategy) correction:
         the SAME strategy's verdict can change purely as a function of how many

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -29,6 +29,7 @@ import pytest
 from archimedes.services._rigor_helpers import (
     _dsr_from_stats,
     _sharpe_per_col,
+    benjamini_hochberg_fdr,
     compute_average_pairwise_correlation,
     compute_cpcv_oos_sharpe,
     compute_dsr,
@@ -42,6 +43,7 @@ from archimedes.services.rigor_evaluator import (
     RigorGateResult,
     _get_func_name,
     align_returns_store,
+    compute_board_level_fdr,
     compute_library_pbo,
     load_daily_returns_store,
     look_ahead_audit,
@@ -1744,6 +1746,164 @@ class TestRigorGateLibraryPbo:
         )
         assert not result.passes_all
         assert result.gate_details["pbo"] == "MISSING (source=cohort)"
+
+
+class TestBenjaminiHochbergFDR:
+    """Tests for benjamini_hochberg_fdr — BH step-up procedure.
+
+    Restored (#1185) after Tranche-1's dead-code excision deleted this class
+    along with the function it tests (PR #1259 / commit c02d5fad, 2026-08-18) —
+    #1185 had asked for the function to be WIRED IN three weeks before that
+    deletion landed. See _rigor_helpers.benjamini_hochberg_fdr's docstring.
+    """
+
+    def test_all_significant(self):
+        """Very small p-values should all be rejected."""
+        pvalues = [0.001, 0.002, 0.003, 0.004, 0.005]
+        result = benjamini_hochberg_fdr(pvalues, fdr_level=0.05)
+        assert result["n_rejected"] == 5
+        assert all(result["rejected"])
+
+    def test_all_insignificant(self):
+        """Large p-values should not be rejected."""
+        pvalues = [0.80, 0.85, 0.90, 0.95]
+        result = benjamini_hochberg_fdr(pvalues, fdr_level=0.05)
+        assert result["n_rejected"] == 0
+        assert not any(result["rejected"])
+
+    def test_mixed_pvalues_correct_threshold(self):
+        """BH threshold check: k/m * q at rank k."""
+        # m=5, q=0.05 → thresholds [0.01, 0.02, 0.03, 0.04, 0.05]
+        pvalues = [0.009, 0.019, 0.04, 0.06, 0.10]
+        result = benjamini_hochberg_fdr(pvalues, fdr_level=0.05)
+        # Sorted: 0.009 ≤ 0.01 ✓, 0.019 ≤ 0.02 ✓, 0.04 > 0.03 ✗ → k*=2
+        assert result["n_rejected"] == 2
+
+    def test_output_keys(self):
+        result = benjamini_hochberg_fdr([0.01, 0.05, 0.10], fdr_level=0.05)
+        for key in ("rejected", "bh_critical_values", "n_rejected", "adjusted_pvalues"):
+            assert key in result
+
+    def test_empty_input(self):
+        result = benjamini_hochberg_fdr([], fdr_level=0.05)
+        assert result == {"rejected": [], "bh_critical_values": [], "n_rejected": 0, "adjusted_pvalues": []}
+
+    def test_adjusted_pvalues_monotone(self):
+        """BH adjusted p-values should be monotone non-decreasing in sorted order."""
+        rng = np.random.default_rng(5)
+        pvalues = list(rng.uniform(0, 1, 20))
+        result = benjamini_hochberg_fdr(pvalues, fdr_level=0.05)
+        adj = result["adjusted_pvalues"]
+        # All adjusted p-values must be in [0,1]
+        assert all(0.0 <= p <= 1.0 for p in adj)
+        # adjusted_pvalues is returned in original input order; re-order by
+        # ascending p-value (BH's natural rank order) and check the
+        # running-minimum step enforced non-decreasing values.
+        sorted_adj = [a for _, a in sorted(zip(pvalues, adj, strict=True))]
+        assert all(sorted_adj[i] <= sorted_adj[i + 1] for i in range(len(sorted_adj) - 1))
+
+
+class TestComputeBoardLevelFdr:
+    """Tests for rigor_evaluator.compute_board_level_fdr — the board-level
+    orchestration layer (#1185): direction-converts DSR p-values then calls
+    benjamini_hochberg_fdr. Distinct from TestBenjaminiHochbergFDR above (which
+    tests the pure BH math on hand-supplied classical p-values) — these tests
+    exercise the NEW conversion + cohort-assembly path this issue adds, with a
+    known cohort of dsr_p_values chosen so the expected rejection set can be
+    hand-verified against the BH step-up procedure.
+    """
+
+    def test_direction_conversion_low_dsr_p_is_significant_after_correction(self):
+        """dsr_p_value uses P(true SR>0) convention (HIGH=confident); a strategy
+        with dsr_p_value close to 1.0 must convert to a SMALL classical p-value
+        and be far more likely to survive BH-FDR than one near 0.5 (weak
+        evidence). This is the specific bug class a flipped conversion would
+        produce silently (both directions are 'plausible-looking' floats in
+        [0,1], so a reversed sign would not crash — it would just be wrong)."""
+        # 5 strong strategies (dsr_p_value ~0.999, classical p ~0.001 → BH-significant)
+        # + 5 weak strategies (dsr_p_value ~0.5, classical p ~0.5 → BH-insignificant)
+        dsr_p_values = {f"strong_{i}": 0.999 for i in range(5)} | {f"weak_{i}": 0.5 for i in range(5)}
+        result = compute_board_level_fdr(dsr_p_values, fdr_level=0.05)
+
+        assert len(result) == 10
+        for i in range(5):
+            assert result[f"strong_{i}"]["board_fdr_significant"] is True
+        for i in range(5):
+            assert result[f"weak_{i}"]["board_fdr_significant"] is False
+
+    def test_matches_hand_computed_bh_on_known_cohort(self):
+        """Cross-check against a hand-verified BH step-up computation.
+
+        classical_p = 1 - dsr_p_value for each, chosen with margin away from
+        the exact BH threshold boundaries (an exact-boundary hit like
+        classical_p == threshold is float-noise-sensitive: 1.0 - 0.99 !=
+        0.01 in IEEE-754, so a case pinned exactly on the boundary can flip on
+        floating-point error alone — this deliberately avoids that trap).
+        classical_p: [0.005, 0.015, 0.028, 0.15, 0.50] (dsr_p_values: [0.995,
+        0.985, 0.972, 0.85, 0.50]). m=5, q=0.05 → BH thresholds [0.01, 0.02,
+        0.03, 0.04, 0.05]. Sorted classical p vs threshold: 0.005<=0.01 ✓,
+        0.015<=0.02 ✓, 0.028<=0.03 ✓, 0.15>0.04 ✗, 0.50>0.05 ✗ → k*=3 rejected
+        (the first three), each with margin >= 0.002 from its threshold.
+        """
+        dsr_p_values = {"a": 0.995, "b": 0.985, "c": 0.972, "d": 0.85, "e": 0.50}
+        result = compute_board_level_fdr(dsr_p_values, fdr_level=0.05)
+
+        assert result["a"]["board_fdr_significant"] is True
+        assert result["b"]["board_fdr_significant"] is True
+        assert result["c"]["board_fdr_significant"] is True
+        assert result["d"]["board_fdr_significant"] is False
+        assert result["e"]["board_fdr_significant"] is False
+
+        # Cross-check directly against benjamini_hochberg_fdr on the same
+        # manually-converted classical p-values, in the same order.
+        ids = ["a", "b", "c", "d", "e"]
+        classical = [1.0 - dsr_p_values[k] for k in ids]
+        expected = benjamini_hochberg_fdr(classical, fdr_level=0.05)
+        for i, k in enumerate(ids):
+            assert result[k]["board_fdr_adjusted_p"] == pytest.approx(expected["adjusted_pvalues"][i])
+            assert result[k]["board_fdr_significant"] == expected["rejected"][i]
+
+    def test_none_and_non_finite_pvalues_excluded_not_fabricated(self):
+        """A strategy with no backtest data (dsr_p_value=None) or a non-finite
+        value must be OMITTED from the returned dict, not assigned a fabricated
+        corrected value — mirrors the MISSING convention used everywhere else
+        in the rigor gate."""
+        dsr_p_values = {"has_data": 0.9, "missing": None, "nan_case": float("nan")}
+        result = compute_board_level_fdr(dsr_p_values)
+        assert set(result.keys()) == {"has_data"}
+
+    def test_empty_cohort_returns_empty_dict(self):
+        assert compute_board_level_fdr({}) == {}
+        assert compute_board_level_fdr({"only": None}) == {}
+
+    def test_board_level_correction_is_cohort_size_sensitive(self):
+        """The defining property of a BOARD-level (not per-strategy) correction:
+        the SAME strategy's verdict can change purely as a function of how many
+        OTHER strategies are being simultaneously tested alongside it — unlike
+        the per-strategy num_trials convention (#1075), which is deliberately
+        NOT library-coupled (docs/adr/num-trials-self-containment.md). ``target``
+        keeps the exact same dsr_p_value (0.98, classical p=0.02) in both
+        cohorts; only the number of OTHER (individually insignificant,
+        dsr_p_value=0.5 → classical p=0.5) strategies alongside it changes. In
+        the 2-strategy cohort target's rank-1 BH threshold (q/m = 0.025) still
+        clears its own p-value (0.02 <= 0.025), so it is significant. Diluted
+        into a 31-strategy cohort, target's rank-1 threshold shrinks to
+        q/31 ≈ 0.0016 — no longer clearing 0.02 — and no later, weaker rank
+        rescues it (BH step-up: a rank is only rescued if some rank AT OR
+        BELOW its own p-value clears its own threshold, and every filler's own
+        p=0.5 never clears its own threshold, capped at q=0.05). So target
+        flips to non-significant purely from cohort growth."""
+        small_cohort = {"target": 0.98, "b": 0.5}  # classical p: [0.02, 0.5]
+        large_cohort = {"target": 0.98} | {f"filler_{i}": 0.5 for i in range(30)}  # 31-strategy board
+
+        small_result = compute_board_level_fdr(small_cohort, fdr_level=0.05)
+        large_result = compute_board_level_fdr(large_cohort, fdr_level=0.05)
+
+        assert small_result["target"]["board_fdr_significant"] is True
+        assert large_result["target"]["board_fdr_significant"] is False
+        # The raw per-strategy DSR p-value (0.98, i.e. classical p=0.02) never
+        # changed — only the board it was evaluated against did.
+        assert large_result["target"]["board_fdr_adjusted_p"] > small_result["target"]["board_fdr_adjusted_p"]
 
 
 class TestPboPowerFloor:

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -1355,6 +1355,7 @@ class TestBoardLevelFdrWiring:
         baseline_by_id = {r["strategy_id"]: r for r in resp_baseline.json()["strategies"]}
         baseline_passes = {sid: baseline_by_id[sid]["passes_all"] for sid in ids}
         baseline_min_level = {sid: baseline_by_id[sid]["min_passing_level"] for sid in ids}
+        baseline_blocked = {sid: baseline_by_id[sid]["blocked_by_floor"] for sid in ids}
 
         # Sanity: the cohort really is mixed under the REAL (unforced)
         # correction — otherwise this test would silently degrade back into
@@ -1403,3 +1404,7 @@ class TestBoardLevelFdrWiring:
                     f"({bug_direction} bug, strategy {sid}, forced={forced_value})"
                 )
                 assert forced_by_id[sid]["min_passing_level"] == baseline_min_level[sid]
+                assert forced_by_id[sid]["blocked_by_floor"] == baseline_blocked[sid], (
+                    f"board_fdr_significant must never gate blocked_by_floor "
+                    f"({bug_direction} bug, strategy {sid}, forced={forced_value})"
+                )

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -1180,3 +1180,145 @@ class TestCacheKeyReactsToStrategyCodeChange:
             # across the whole test session) — restore the mutated attribute so
             # this test can't leak state into any other test.
             target.strategy_code_hash = original_hash
+
+
+class TestBoardLevelFdrWiring:
+    """#1185: GET /api/selection-bias/gate wires benjamini_hochberg_fdr in via
+    compute_board_level_fdr — end-to-end through the real HTTP route, real
+    run_rigor_gate DSR computation, and the response schema. Distinct from the
+    pure-math unit tests (TestBenjaminiHochbergFDR / TestComputeBoardLevelFdr in
+    test_rigor_evaluator.py): this exercises the actual wiring this issue's
+    acceptance criteria requires — a real call site outside backend/tests."""
+
+    @staticmethod
+    def _strong_series(seed: int, n: int = 756) -> list[float]:
+        # Long, low-vol, solidly positive drift → dsr_p_value should land close
+        # to 1.0 (confident evidence of a real positive Sharpe).
+        return np.random.default_rng(seed).normal(0.002, 0.008, n).tolist()
+
+    @staticmethod
+    def _weak_series(seed: int, n: int = 300) -> list[float]:
+        # Near-zero drift → weak/borderline DSR evidence, individually
+        # insignificant even before any board-level correction.
+        return np.random.default_rng(seed).normal(0.0001, 0.01, n).tolist()
+
+    def _patch_returns(self, monkeypatch, returns_by_strategy: dict[str, list[float]]):
+        monkeypatch.setattr(
+            "archimedes.services.backtest_repository.get_all_daily_returns",
+            lambda session, ids: dict(returns_by_strategy),
+        )
+
+    @pytest.mark.asyncio
+    async def test_board_level_fdr_field_present_and_matches_pure_function(self, monkeypatch):
+        """The response's board_level_fdr + per-strategy board_fdr_* fields must
+        reflect an ACTUAL benjamini_hochberg_fdr call over the served cohort's
+        real dsr_p_value outputs — not a placeholder. Cross-checks by feeding
+        the response's own dsr_p_value list back through
+        rigor_evaluator.compute_board_level_fdr directly and asserting the
+        route's numbers match exactly."""
+        from archimedes.api import selection_bias_routes as routes
+        from archimedes.main import app
+        from archimedes.services.rigor_evaluator import compute_board_level_fdr
+
+        strategies = routes._provider().list_strategies()
+        assert len(strategies) >= 6, "need >=6 curated strategies to build this cohort"
+        ids = [s.id for s in strategies[:6]]
+
+        returns = {
+            ids[0]: self._strong_series(0),
+            ids[1]: self._weak_series(1),
+            ids[2]: self._weak_series(2),
+            ids[3]: self._weak_series(3),
+            ids[4]: self._weak_series(4),
+            ids[5]: [0.001] * 5,  # too short (<10) → MISSING, must be excluded
+        }
+        self._patch_returns(monkeypatch, returns)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/selection-bias/gate")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        by_id = {r["strategy_id"]: r for r in data["strategies"]}
+
+        # The MISSING (too-short) row must not be assigned a fabricated verdict.
+        assert by_id[ids[5]]["dsr_p_value"] is None
+        assert by_id[ids[5]]["board_fdr_significant"] is None
+        assert by_id[ids[5]]["board_fdr_adjusted_p"] is None
+
+        tested_ids = ids[:5]
+        for sid in tested_ids:
+            assert by_id[sid]["dsr_p_value"] is not None, f"{sid} should have a finite DSR p-value"
+            assert by_id[sid]["board_fdr_significant"] is not None
+            assert by_id[sid]["board_fdr_adjusted_p"] is not None
+
+        assert data["board_level_fdr"]["n_tested"] == len(tested_ids)
+        assert data["board_level_fdr"]["fdr_level"] == pytest.approx(0.05)
+        assert 0 <= data["board_level_fdr"]["n_significant"] <= data["board_level_fdr"]["n_tested"]
+
+        # Rebuild the correction independently from the SAME served dsr_p_values
+        # and require an exact match — proves this is a real computation over
+        # the real cohort, not a stub.
+        expected = compute_board_level_fdr({sid: by_id[sid]["dsr_p_value"] for sid in tested_ids})
+        for sid in tested_ids:
+            assert by_id[sid]["board_fdr_significant"] == expected[sid]["board_fdr_significant"]
+            assert by_id[sid]["board_fdr_adjusted_p"] == pytest.approx(expected[sid]["board_fdr_adjusted_p"])
+        assert data["board_level_fdr"]["n_significant"] == sum(
+            1 for v in expected.values() if v["board_fdr_significant"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_board_fdr_is_advisory_never_gates_passes_all(self, monkeypatch):
+        """Forcing compute_board_level_fdr to report every strategy as
+        board-FDR-NON-significant must not flip a single passes_all verdict —
+        the scope decision (compute_board_level_fdr's docstring) is annotation
+        only. This is the adversarial check: an implementation bug that
+        accidentally threaded board_fdr_significant into passes_all would be
+        caught here by the verdicts changing when the forced value flips."""
+        from archimedes.api import selection_bias_routes as routes
+        from archimedes.main import app
+
+        strategies = routes._provider().list_strategies()
+        assert len(strategies) >= 3
+        ids = [s.id for s in strategies[:3]]
+        returns = {
+            ids[0]: self._strong_series(10),
+            ids[1]: self._strong_series(11),
+            ids[2]: self._strong_series(12),
+        }
+        self._patch_returns(monkeypatch, returns)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp_baseline = await client.get("/api/selection-bias/gate")
+        assert resp_baseline.status_code == 200
+        baseline_passes = {r["strategy_id"]: r["passes_all"] for r in resp_baseline.json()["strategies"]}
+        baseline_min_level = {r["strategy_id"]: r["min_passing_level"] for r in resp_baseline.json()["strategies"]}
+
+        # Force every strategy to be board-FDR non-significant (the maximally
+        # adversarial forced value — real corrections would rarely reject 100%).
+        monkeypatch.setattr(
+            routes,
+            "compute_board_level_fdr",
+            lambda dsr_p_values, fdr_level=0.05: {
+                sid: {"board_fdr_significant": False, "board_fdr_adjusted_p": 1.0}
+                for sid, p in dsr_p_values.items()
+                if p is not None
+            },
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp_forced = await client.get("/api/selection-bias/gate")
+        assert resp_forced.status_code == 200
+        forced_by_id = {r["strategy_id"]: r for r in resp_forced.json()["strategies"]}
+
+        # The forced patch DID take effect (sanity check the patch is live)...
+        for sid in ids:
+            assert forced_by_id[sid]["board_fdr_significant"] is False
+            assert forced_by_id[sid]["board_fdr_adjusted_p"] == pytest.approx(1.0)
+        # ...yet every passes_all / min_passing_level verdict is byte-identical
+        # to the baseline where the real correction ran.
+        for sid in ids:
+            assert forced_by_id[sid]["passes_all"] == baseline_passes[sid], (
+                f"board_fdr_significant must never gate passes_all (strategy {sid})"
+            )
+            assert forced_by_id[sid]["min_passing_level"] == baseline_min_level[sid]

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -1212,10 +1212,17 @@ class TestBoardLevelFdrWiring:
     async def test_board_level_fdr_field_present_and_matches_pure_function(self, monkeypatch):
         """The response's board_level_fdr + per-strategy board_fdr_* fields must
         reflect an ACTUAL benjamini_hochberg_fdr call over the served cohort's
-        real dsr_p_value outputs — not a placeholder. Cross-checks by feeding
-        the response's own dsr_p_value list back through
+        real dsr_p_value outputs — not a placeholder. Two complementary checks:
+        (1) a cohort-specific outcome the route must produce independently —
+        the strong-series strategy comes back board-FDR-significant while
+        every weak-series one does not, which a stubbed/all-False or
+        all-True `compute_board_level_fdr` would fail; (2) cross-checks by
+        feeding the response's own dsr_p_value list back through
         rigor_evaluator.compute_board_level_fdr directly and asserting the
-        route's numbers match exactly."""
+        route's numbers match exactly — this alone would NOT prove realness
+        (a stub run identically on both sides of the boundary matches itself
+        trivially), so it is a consistency check layered on top of (1), not a
+        substitute for it (#1185 code review, 2026-08-20)."""
         from archimedes.api import selection_bias_routes as routes
         from archimedes.main import app
         from archimedes.services.rigor_evaluator import compute_board_level_fdr
@@ -1256,6 +1263,19 @@ class TestBoardLevelFdrWiring:
         assert data["board_level_fdr"]["fdr_level"] == pytest.approx(0.05)
         assert 0 <= data["board_level_fdr"]["n_significant"] <= data["board_level_fdr"]["n_tested"]
 
+        # Cohort-specific outcome the route must produce on its own: the
+        # strong-series strategy (dsr_p_value near 1.0, classical p near 0)
+        # is the only one that clears the board-level BH threshold across
+        # this 5-strategy cohort; every weak-series strategy (individually
+        # insignificant, and diluted further by sharing the board with 4
+        # others) does not. A stub that always returns True, always False,
+        # or a fixed pattern unrelated to the real dsr_p_values would fail
+        # this — unlike the pure cross-check below, which a stub could pass
+        # trivially by construction.
+        assert by_id[ids[0]]["board_fdr_significant"] is True, "strong-series strategy should clear board-level BH"
+        for sid in tested_ids[1:]:
+            assert by_id[sid]["board_fdr_significant"] is False, f"weak-series strategy {sid} should not clear it"
+
         # Rebuild the correction independently from the SAME served dsr_p_values
         # and require an exact match — proves this is a real computation over
         # the real cohort, not a stub.
@@ -1273,10 +1293,27 @@ class TestBoardLevelFdrWiring:
         board-FDR-NON-significant must not flip a single passes_all verdict —
         the scope decision (compute_board_level_fdr's docstring) is annotation
         only. This is the adversarial check: an implementation bug that
-        accidentally threaded board_fdr_significant into passes_all would be
-        caught here by the verdicts changing when the forced value flips."""
+        accidentally threaded board_fdr_significant into passes_all — whether
+        inside `_compute()` (the natural place #1185 names, where a board-level
+        correction would sit alongside the per-strategy gate) or in the
+        post-cache reconciliation block where the wiring actually lives today —
+        would be caught here by the verdicts changing when the forced value
+        flips.
+
+        Both requests must exercise a REAL (non-cached) `_compute()` run for
+        the `_compute()`-site case to be caught at all: `evaluate_rigor_gate`
+        memoizes `_compute()`'s result in `rigor_cache` keyed on
+        cohort+strictness+code, and the second request below uses the exact
+        same returns/strategies/strictness as the first — so without an
+        explicit `rigor_cache.clear()`, it is guaranteed to be a cache HIT,
+        `_compute()` never re-runs, and a bug living inside it would be
+        invisible to this test regardless of the forced monkeypatch (verified
+        by reverting the `clear()` call below and confirming this test still
+        passes against a `_compute()`-internal mutation that gates passes_all
+        on the forced board_fdr_significant — #1185 code review, 2026-08-20)."""
         from archimedes.api import selection_bias_routes as routes
         from archimedes.main import app
+        from archimedes.services import rigor_cache
 
         strategies = routes._provider().list_strategies()
         assert len(strategies) >= 3
@@ -1305,6 +1342,14 @@ class TestBoardLevelFdrWiring:
                 if p is not None
             },
         )
+
+        # Force a real recompute for the second request. Without this, the
+        # second call has the IDENTICAL cache_key (same strategy_ids, same
+        # patched returns, same code_versions, same strictness) as the first
+        # and is guaranteed to be a rigor_cache HIT — `_compute()` would never
+        # re-run, and this test would be blind to any bug living inside it
+        # (see docstring above).
+        rigor_cache.clear()
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp_forced = await client.get("/api/selection-bias/gate")

--- a/backend/tests/test_selection_bias_routes.py
+++ b/backend/tests/test_selection_bias_routes.py
@@ -1289,28 +1289,49 @@ class TestBoardLevelFdrWiring:
 
     @pytest.mark.asyncio
     async def test_board_fdr_is_advisory_never_gates_passes_all(self, monkeypatch):
-        """Forcing compute_board_level_fdr to report every strategy as
-        board-FDR-NON-significant must not flip a single passes_all verdict —
-        the scope decision (compute_board_level_fdr's docstring) is annotation
-        only. This is the adversarial check: an implementation bug that
-        accidentally threaded board_fdr_significant into passes_all — whether
-        inside `_compute()` (the natural place #1185 names, where a board-level
-        correction would sit alongside the per-strategy gate) or in the
-        post-cache reconciliation block where the wiring actually lives today —
-        would be caught here by the verdicts changing when the forced value
-        flips.
+        """Forcing compute_board_level_fdr's output must not flip a single
+        passes_all verdict, in EITHER direction — the scope decision
+        (compute_board_level_fdr's docstring) is annotation only. This is the
+        adversarial check: an implementation bug that accidentally threaded
+        board_fdr_significant into passes_all — whether inside `_compute()`
+        (the natural place #1185 names, where a board-level correction would
+        sit alongside the per-strategy gate) or in the post-cache
+        reconciliation block where the wiring actually lives today — would be
+        caught here by the verdicts changing when the forced value flips.
 
-        Both requests must exercise a REAL (non-cached) `_compute()` run for
-        the `_compute()`-site case to be caught at all: `evaluate_rigor_gate`
-        memoizes `_compute()`'s result in `rigor_cache` keyed on
-        cohort+strictness+code, and the second request below uses the exact
-        same returns/strategies/strictness as the first — so without an
-        explicit `rigor_cache.clear()`, it is guaranteed to be a cache HIT,
-        `_compute()` never re-runs, and a bug living inside it would be
-        invisible to this test regardless of the forced monkeypatch (verified
-        by reverting the `clear()` call below and confirming this test still
-        passes against a `_compute()`-internal mutation that gates passes_all
-        on the forced board_fdr_significant — #1185 code review, 2026-08-20)."""
+        The cohort is deliberately MIXED: two strong-series strategies that
+        pass at baseline, one weak-series strategy that fails at baseline —
+        NOT the uniformly-passing cohort a prior version of this test used.
+        A uniform (all-True) cohort only exercises one threading direction:
+        forcing board_fdr_significant=False catches an AND-shaped bug
+        (`passes_all and board_fdr_significant`), because `True and <forced
+        False>` changes the verdict — but `True or <forced False>` does NOT,
+        so that exact setup is blind to an OR-shaped bug (`passes_all or
+        board_fdr_significant`), which is the LOOSENING direction and the one
+        that matters most on a rigor gate (a false PASS survives it, not a
+        false FAIL). Forcing all-True on the same uniform cohort would have
+        been equally blind, for the mirror-image reason. This version runs
+        BOTH forced values against a cohort containing both a baseline-True
+        and a baseline-False strategy, so:
+          - forcing ALL to board_fdr_significant=False catches the AND-shaped
+            bug (the baseline-True strategies would flip to False);
+          - forcing ALL to board_fdr_significant=True catches the OR-shaped
+            bug (the baseline-False strategy would flip to True).
+        (#1185 code review, 2026-08-20 — second round; the prior uniform-
+        cohort version of this test was itself a finding of that round.)
+
+        Every forced request must exercise a REAL (non-cached) `_compute()`
+        run for the `_compute()`-site case to be caught at all:
+        `evaluate_rigor_gate` memoizes `_compute()`'s result in `rigor_cache`
+        keyed on cohort+strictness+code, and each forced request below uses
+        the exact same returns/strategies/strictness as the baseline — so
+        without an explicit `rigor_cache.clear()` before each one, it is
+        guaranteed to be a cache HIT, `_compute()` never re-runs, and a bug
+        living inside it would be invisible to this test regardless of the
+        forced monkeypatch (verified by reverting the `clear()` calls below
+        and confirming this test still passes against a `_compute()`-internal
+        mutation that gates passes_all on the forced board_fdr_significant —
+        #1185 code review, 2026-08-20)."""
         from archimedes.api import selection_bias_routes as routes
         from archimedes.main import app
         from archimedes.services import rigor_cache
@@ -1318,52 +1339,67 @@ class TestBoardLevelFdrWiring:
         strategies = routes._provider().list_strategies()
         assert len(strategies) >= 3
         ids = [s.id for s in strategies[:3]]
+        # Two strong (baseline-passing) + one weak (baseline-failing): a
+        # uniform cohort cannot exercise both threading directions (see
+        # docstring above).
         returns = {
             ids[0]: self._strong_series(10),
             ids[1]: self._strong_series(11),
-            ids[2]: self._strong_series(12),
+            ids[2]: self._weak_series(12),
         }
         self._patch_returns(monkeypatch, returns)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp_baseline = await client.get("/api/selection-bias/gate")
         assert resp_baseline.status_code == 200
-        baseline_passes = {r["strategy_id"]: r["passes_all"] for r in resp_baseline.json()["strategies"]}
-        baseline_min_level = {r["strategy_id"]: r["min_passing_level"] for r in resp_baseline.json()["strategies"]}
+        baseline_by_id = {r["strategy_id"]: r for r in resp_baseline.json()["strategies"]}
+        baseline_passes = {sid: baseline_by_id[sid]["passes_all"] for sid in ids}
+        baseline_min_level = {sid: baseline_by_id[sid]["min_passing_level"] for sid in ids}
 
-        # Force every strategy to be board-FDR non-significant (the maximally
-        # adversarial forced value — real corrections would rarely reject 100%).
-        monkeypatch.setattr(
-            routes,
-            "compute_board_level_fdr",
-            lambda dsr_p_values, fdr_level=0.05: {
-                sid: {"board_fdr_significant": False, "board_fdr_adjusted_p": 1.0}
-                for sid, p in dsr_p_values.items()
-                if p is not None
-            },
+        # Sanity: the cohort really is mixed under the REAL (unforced)
+        # correction — otherwise this test would silently degrade back into
+        # the uniform, one-directional case it was written to fix.
+        assert baseline_passes[ids[2]] is False, "weak-series strategy must fail at baseline for this guard to bite"
+        assert any(baseline_passes[sid] for sid in ids[:2]), (
+            "at least one strong-series strategy must pass at baseline for this guard to bite"
         )
 
-        # Force a real recompute for the second request. Without this, the
-        # second call has the IDENTICAL cache_key (same strategy_ids, same
-        # patched returns, same code_versions, same strictness) as the first
-        # and is guaranteed to be a rigor_cache HIT — `_compute()` would never
-        # re-run, and this test would be blind to any bug living inside it
-        # (see docstring above).
-        rigor_cache.clear()
-
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp_forced = await client.get("/api/selection-bias/gate")
-        assert resp_forced.status_code == 200
-        forced_by_id = {r["strategy_id"]: r for r in resp_forced.json()["strategies"]}
-
-        # The forced patch DID take effect (sanity check the patch is live)...
-        for sid in ids:
-            assert forced_by_id[sid]["board_fdr_significant"] is False
-            assert forced_by_id[sid]["board_fdr_adjusted_p"] == pytest.approx(1.0)
-        # ...yet every passes_all / min_passing_level verdict is byte-identical
-        # to the baseline where the real correction ran.
-        for sid in ids:
-            assert forced_by_id[sid]["passes_all"] == baseline_passes[sid], (
-                f"board_fdr_significant must never gate passes_all (strategy {sid})"
+        for forced_value, bug_direction in [(False, "AND-shaped"), (True, "OR-shaped")]:
+            # Force every strategy to the same board-FDR verdict. `_v=forced_value`
+            # binds the loop variable per-lambda (default-arg trick), avoiding the
+            # classic late-binding-closure bug across the two iterations.
+            monkeypatch.setattr(
+                routes,
+                "compute_board_level_fdr",
+                lambda dsr_p_values, fdr_level=0.05, _v=forced_value: {
+                    sid: {"board_fdr_significant": _v, "board_fdr_adjusted_p": 0.0 if _v else 1.0}
+                    for sid, p in dsr_p_values.items()
+                    if p is not None
+                },
             )
-            assert forced_by_id[sid]["min_passing_level"] == baseline_min_level[sid]
+
+            # Force a real recompute for this forced request. Without this,
+            # the call has the IDENTICAL cache_key (same strategy_ids, same
+            # patched returns, same code_versions, same strictness) as the
+            # baseline and is guaranteed to be a rigor_cache HIT — `_compute()`
+            # would never re-run, and this test would be blind to any bug
+            # living inside it (see docstring above).
+            rigor_cache.clear()
+
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp_forced = await client.get("/api/selection-bias/gate")
+            assert resp_forced.status_code == 200
+            forced_by_id = {r["strategy_id"]: r for r in resp_forced.json()["strategies"]}
+
+            # The forced patch DID take effect (sanity check the patch is live)...
+            for sid in ids:
+                assert forced_by_id[sid]["board_fdr_significant"] is forced_value
+                assert forced_by_id[sid]["board_fdr_adjusted_p"] == pytest.approx(0.0 if forced_value else 1.0)
+            # ...yet every passes_all / min_passing_level verdict is byte-identical
+            # to the baseline where the real correction ran, in EITHER direction.
+            for sid in ids:
+                assert forced_by_id[sid]["passes_all"] == baseline_passes[sid], (
+                    f"board_fdr_significant must never gate passes_all "
+                    f"({bug_direction} bug, strategy {sid}, forced={forced_value})"
+                )
+                assert forced_by_id[sid]["min_passing_level"] == baseline_min_level[sid]

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -490,7 +490,7 @@ annotation only** — it computes a real BH-FDR-adjusted significance figure
 across the current leaderboard cohort's DSR p-values and surfaces it
 (`GET /api/selection-bias/gate` → `RigorGateResponse.board_level_fdr` +
 per-strategy `StrategyRigorResult.board_fdr_significant` /
-`board_fdr_adjusted_p`), but it is **not** wired into `passes_all` /
+`board_fdr_adjusted_p` / `board_fdr_confidence`), but it is **not** wired into `passes_all` /
 `blocked_by_floor` at any strictness level. Three reasons, in order of
 weight:
 
@@ -518,13 +518,21 @@ weight:
 convention (HIGH = confident) — the OPPOSITE of the classical p-value
 `benjamini_hochberg_fdr` expects (LOW = significant). `compute_board_level_fdr`
 converts via `classical_p = 1 - dsr_p_value` before calling BH-FDR, then
-reports back in the `dsr_p_value` convention. Strategies with no finite
+reports back in the `dsr_p_value` convention (`board_fdr_confidence = 1 -
+board_fdr_adjusted_p`). The converted classical p-value is floored at
+`rigor_evaluator._CLASSICAL_P_FLOOR` (`1e-6`) before BH-FDR runs: a
+confidently-positive series can round `dsr_p_value` to exactly `1.0`, which
+without the floor would convert to an impossible `classical_p == 0.0` (and
+`board_fdr_confidence == 1.0`) — not a hypothetical, the strong-series case in
+`TestBoardLevelFdrWiring` hits it directly. Strategies with no finite
 `dsr_p_value` (no backtest data, degenerate series) are excluded from the
 correction and omitted from the result — never assigned a fabricated verdict,
 matching every other MISSING convention in this gate. Default `fdr_level =
-0.05`. Computed fresh on every `/gate` request over the exact cohort being
-served (same reconciliation pattern as `library_pbo`), so a rigor-cache hit
-can never serve a stale board composition's correction.
+rigor_evaluator.DEFAULT_BOARD_FDR_LEVEL` (`0.05`), independently chosen (BH
+convention) — NOT derived from the DSR badge's `dsr_p_min`. Computed fresh on
+every `/gate` request over the exact cohort being served (same reconciliation
+pattern as `library_pbo`), so a rigor-cache hit can never serve a stale board
+composition's correction.
 
 ## API surface
 

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -469,6 +469,63 @@ rather than the AST audit the live re-grade runs, so re-grading them at a looser
 level would be apples-to-oranges; wiring generated strategies into the live
 per-level path is a follow-up.
 
+## 6. Board-level Benjamini-Hochberg FDR correction (#1185, 2026-08-20)
+
+**The gap this closes.** Sections 1–5 above disclose board-level selection
+bias — the strictness ladder, the passport's PBO/DSR numbers, and the
+"num_trials = 1" per-strategy convention (§1.3 addendum, superseded by
+[`../adr/num-trials-self-containment.md`](../adr/num-trials-self-containment.md))
+all tell a user *that* browsing a 34-strategy leaderboard and deploying the
+top pick is a stronger claim than one strategy graded on its own merits. None
+of them *correct* for it. A Benjamini-Hochberg FDR correction
+(`_rigor_helpers.benjamini_hochberg_fdr`) existed in the codebase for this
+exact purpose but had zero non-test callers — and was in fact deleted as dead
+code on 2026-08-18 (Tranche-1 excision, PR #1259 / commit `c02d5fad`) three
+weeks *after* #1185 had already asked for it to be wired in instead. This
+section restores it and records the scope decision the deletion sidestepped.
+
+**The scope decision (issue #1185's first acceptance criterion, answered
+explicitly).** `rigor_evaluator.compute_board_level_fdr` is **ADVISORY /
+annotation only** — it computes a real BH-FDR-adjusted significance figure
+across the current leaderboard cohort's DSR p-values and surfaces it
+(`GET /api/selection-bias/gate` → `RigorGateResponse.board_level_fdr` +
+per-strategy `StrategyRigorResult.board_fdr_significant` /
+`board_fdr_adjusted_p`), but it is **not** wired into `passes_all` /
+`blocked_by_floor` at any strictness level. Three reasons, in order of
+weight:
+
+1. **Admission-policy calls belong to the rigor lane (Dan/Önder), not to an
+   issue implementation.** This mirrors the precedent already set for this
+   module's other cohort-shaped diagnostics — IID assumption violation (#621)
+   and regime-robustness are both computed, surfaced, and explicitly kept
+   OUT of `passes_all` for the same reason (see `run_rigor_gate`'s own
+   comments in `rigor_evaluator.py`).
+2. **Gating on it would reintroduce library-coupling.** A strategy's deploy
+   status would move purely because *other, unrelated* strategies were added
+   to or removed from the board — exactly the "library-coupled verdict"
+   problem `num-trials-self-containment.md` deliberately rejected for
+   `num_trials` (PR #1075). Silently reintroducing that coupling via a
+   different statistic would cut against a decision this codebase already
+   made on purpose.
+3. **No quant sign-off exists for a new gate.** §1.3's addendum records that
+   PR #1075's `num_trials` convention is still `Accepted, pending quant
+   sign-off` — a second, unreviewed statistical gate stacked on top before
+   the first is signed off is not a call an issue implementation should make
+   unilaterally. Promoting board-level FDR to an actual gate is a legitimate
+   follow-up; it needs its own explicit decision from Önder/Dan.
+
+**Mechanics.** `RigorGateResult.dsr_p_value` uses the `P(true SR > 0)`
+convention (HIGH = confident) — the OPPOSITE of the classical p-value
+`benjamini_hochberg_fdr` expects (LOW = significant). `compute_board_level_fdr`
+converts via `classical_p = 1 - dsr_p_value` before calling BH-FDR, then
+reports back in the `dsr_p_value` convention. Strategies with no finite
+`dsr_p_value` (no backtest data, degenerate series) are excluded from the
+correction and omitted from the result — never assigned a fabricated verdict,
+matching every other MISSING convention in this gate. Default `fdr_level =
+0.05`. Computed fresh on every `/gate` request over the exact cohort being
+served (same reconciliation pattern as `library_pbo`), so a rigor-cache hit
+can never serve a stale board composition's correction.
+
 ## API surface
 
 Önder's `IBacktestEvaluator.evaluate` signature already takes the strategy


### PR DESCRIPTION
Closes #1185

## What this does

Wires `benjamini_hochberg_fdr` into the batch rigor gate (`GET /api/selection-bias/gate`) so board-level selection bias across the leaderboard is actually **corrected**, not just disclosed. `rigor_evaluator.compute_board_level_fdr` converts each strategy's `dsr_p_value` (P(true SR > 0), HIGH = confident) to a classical p-value (`1 - dsr_p_value`, LOW = significant), runs Benjamini-Hochberg FDR across the current cohort, and surfaces the result on the response:

- `RigorGateResponse.board_level_fdr` — `{fdr_level, n_tested, n_significant}`
- `StrategyRigorResult.board_fdr_significant` / `board_fdr_adjusted_p` / `board_fdr_confidence` — per strategy. `None` is overloaded across the two routes that populate this model **(correction, code review round 2, 2026-08-20 — the original claim below was too broad)**: for a curated strategy (via either `GET /gate` or `GET /gate/{id}`, which delegates to the same board-level computation for curated ids) it means "no finite `dsr_p_value` to correct" (mirrors the existing MISSING convention); for a *generated* strategy served by `GET /gate/{id}`'s single-strategy fallback path it is **always** `None`, even when `dsr_p_value` is finite, because that path has no cohort and never calls `compute_board_level_fdr` at all. See the field comment on `StrategyRigorResult.board_fdr_significant` for the full breakdown.

## A wrinkle worth calling out explicitly

`benjamini_hochberg_fdr` existed in this codebase with zero non-test callers — and was **deleted** as dead code on 2026-08-18 (Tranche-1 excision, #1259 / `c02d5fad`), three weeks after #1185 (filed 2026-07-28) had already asked for it to be wired in. Neither PR referenced the other. This PR restores the function from git history (`_rigor_helpers.py` § 8) and wires it in exactly as #1185 specified. **Correction (code review, 2026-08-20):** the BH-FDR *implementation* is byte-identical to the pre-deletion version, but the function's own `Args` docstring gained 7 new lines — an explicit p-value-direction note (classical p-values are small=significant, the opposite of `RigorGateResult.dsr_p_value`'s large=confident convention) — beyond the module docstring/section-banner changes already called out here. "Only the module docstring and section framing changed" undersold that diff; the added note is a genuine improvement, not drift, so it stays.

## The scope decision (#1185's first acceptance criterion)

**ADVISORY / annotation only — this does not gate `passes_all` at any strictness level.** Recorded in full in `compute_board_level_fdr`'s docstring and as a new § 6 in `docs/specs/selection-bias-corrections-spec.md`. Short version:

1. Promoting a new statistic to a hard gate is an admission-policy call for the rigor lane (Dan/Önder), not a default this issue implementation should make.
2. Gating on it would reintroduce **library-coupling** — a strategy's deploy status moving because *unrelated* strategies joined/left the board — which is exactly the problem `docs/adr/num-trials-self-containment.md` (#1075) deliberately rejected for `num_trials`. `num_trials` itself is untouched by this PR (still `= 1` on the curated path, per #1075 — this is a *distinct* board-level axis, not a re-litigation of that decision).
3. #1075's `num_trials` convention is still recorded `Accepted, pending quant sign-off`; stacking a second unreviewed gate on top before the first is signed off isn't a call to make unilaterally.

This mirrors the existing precedent in this file for IID diagnostics (#621) and regime-robustness — both computed, surfaced, and deliberately kept out of `passes_all` for the same reason.

## Guard transcripts (revert-and-confirm, per CLAUDE.md "Before you approve a merge")

**1. Tests fail against pre-fix `main` (stashed the 3 source files, ran the new tests):**
```
$ git stash push -- backend/archimedes/api/selection_bias_routes.py backend/archimedes/services/_rigor_helpers.py backend/archimedes/services/rigor_evaluator.py
$ pytest backend/tests/test_rigor_evaluator.py -q
ImportError: cannot import name 'benjamini_hochberg_fdr' from 'archimedes.services._rigor_helpers'
$ pytest backend/tests/test_selection_bias_routes.py::TestBoardLevelFdrWiring -q
2 failed - ImportError: cannot import name 'compute_board_level_fdr' ...
                        AttributeError: module 'archimedes.api.selection_bias_routes' has no attribute 'compute_board_level_fdr'
$ git stash pop   # fix restored
```

**2. Direction-conversion bug (dropping the `1 - dsr_p_value` conversion) is caught:**
```
$ # classical_pvalues = [dsr_p_values[sid] for sid in ids]  (forgot the 1 - conversion)
$ pytest backend/tests/test_rigor_evaluator.py::TestComputeBoardLevelFdr -q
3 failed, 2 passed
FAILED test_direction_conversion_low_dsr_p_is_significant_after_correction - assert False is True
FAILED test_matches_hand_computed_bh_on_known_cohort - assert False is True
FAILED test_board_level_correction_is_cohort_size_sensitive - assert False is True
$ # fix restored
```

**3. "Advisory only" guard — forcing board-FDR to reject everything must never flip `passes_all`, including a bug threaded inside the cached `_compute()` closure (the site #1185 names as the natural place a board-level correction would land):**
```
$ # injected INSIDE _compute() in evaluate_rigor_gate — the natural site, not
$ # the post-cache reconciliation block where the real wiring lives:
$ #   _bf = compute_board_level_fdr({c.strategy_id: c.dsr_p_value for c in computed})
$ #   computed = [c.model_copy(update={"passes_all": c.passes_all and
$ #               bool(_bf.get(c.strategy_id, {}).get("board_fdr_significant"))})
$ #              for c in computed]
$ pytest ".../test_board_fdr_is_advisory_never_gates_passes_all" -q
1 failed
AssertionError: board_fdr_significant must never gate passes_all (strategy 5114f1bd0ffbf6557984b6a4dc11b4eb)
$ # mutation removed, fix restored
```
**Code review correction (2026-08-20):** the transcript above only holds with `rigor_cache.clear()` in the test immediately before the forced (second) request. The version of this test pushed before that review round omitted that call — the second request had the IDENTICAL cache key to the first (same strategies/returns/strictness), so it was a guaranteed `rigor_cache` HIT, `_compute()` never re-ran, and the same injected mutation passed vacuously (`1 passed`) regardless of the forced `compute_board_level_fdr` value. See "Code review follow-up" below.

**4. Round-2 correction to transcript #3 — the AND-shaped guard above was itself only half the test.** The cohort in the pushed version was uniformly-passing (three strong-series strategies), so forcing `board_fdr_significant=False` on everyone catches an `and`-shaped threading bug (`True and <forced False>` flips) but is mathematically blind to an `or`-shaped one (`True or <forced False>` never flips) — the LOOSENING direction, i.e. exactly the shape that would produce a false PASS on a rigor gate. Fixed by switching to a mixed cohort (two strong + one weak series, so baseline has both a passing and a failing strategy) and running both forced values. Re-verified by injecting both mutation shapes directly into `_compute()` and confirming each is caught only by its matching forced value, then reverting:
```
$ # injected INSIDE _compute(), OR-shaped:
$ #   computed = [c.model_copy(update={"passes_all": c.passes_all or
$ #               bool(_bf.get(c.strategy_id, {}).get("board_fdr_significant"))})
$ #              for c in computed]
$ pytest ".../test_board_fdr_is_advisory_never_gates_passes_all" -q
1 failed
AssertionError: board_fdr_significant must never gate passes_all (OR-shaped bug, strategy 0a5c5d8294974099005bee8637e9f9f0, forced=True)

$ # same file, AND-shaped (`or` -> `and`):
$ pytest ".../test_board_fdr_is_advisory_never_gates_passes_all" -q
1 failed
AssertionError: board_fdr_significant must never gate passes_all (AND-shaped bug, strategy 5114f1bd0ffbf6557984b6a4dc11b4eb, forced=False)

$ # mutation removed, fix restored -> 1 passed
```

## Code review follow-up (2026-08-20)

An adversarial review pass on this PR verified 7 findings against the code and fixed all of them:

- **MAJOR — `test_board_fdr_is_advisory_never_gates_passes_all` was blind to a bug inside `_compute()`.** The second HTTP request reused the exact same cache key as the first, so it was a guaranteed `rigor_cache` HIT and `_compute()` never re-ran — a wiring bug placed inside it (the site #1185 names as the natural location) would be invisible however the forced `compute_board_level_fdr` value was set. Fixed by adding `rigor_cache.clear()` before the forced request; re-verified by re-injecting the exact mutation from guard transcript #3 with and without the `clear()` call (see corrected transcript above).
- **MINOR — saturated `dsr_p_value` produced an impossible `board_fdr_adjusted_p == 0.0` / `board_fdr_confidence == 1.0`.** `compute_dsr` rounds a confidently-positive series' `dsr_p_value` to exactly `1.0`, which converted to `classical_p == 1.0 - 1.0 == 0.0` — not hypothetical: `TestBoardLevelFdrWiring`'s own `_strong_series(0)` hits this exact case. Fixed by flooring the converted classical p-value at `_CLASSICAL_P_FLOOR` (1e-6); pinned with a new `test_saturated_dsr_p_value_is_floored_not_zero`.
- **MINOR — the α=0.05 docstring rationale was arithmetically wrong.** It claimed 0.05 was "the DSR badge's 0.05 complement (dsr_p_min=0.90)" — the complement of 0.90 is 0.10, not 0.05. Fixed: the docstring now states the board-level α is independently chosen (BH convention), explicitly NOT derived from the badge's `dsr_p_min`.
- **MINOR — `BoardLevelFdr.fdr_level` could silently diverge from the α actually used.** It was a hard-coded schema default (`0.05`) never passed at construction; `compute_board_level_fdr` had its own independent `0.05` default. Fixed: both now source a shared `rigor_evaluator.DEFAULT_BOARD_FDR_LEVEL` constant, passed explicitly at both the `compute_board_level_fdr(...)` call site and the `BoardLevelFdr(...)` construction.
- **MINOR — `board_fdr_confidence` was computed but had zero consumers.** Assigned in `compute_board_level_fdr`'s return dict and documented, but never read into `StrategyRigorResult`, never returned by the route. Fixed: surfaced as `StrategyRigorResult.board_fdr_confidence`.
- **MINOR — `test_board_level_fdr_field_present_and_matches_pure_function`'s docstring overstated what its cross-check proves.** Running the same `compute_board_level_fdr` on both sides of the route/test boundary cannot distinguish a real computation from a stub run identically on both sides. Fixed: added a cohort-specific assertion (the strong-series strategy is board-FDR-significant, every weak-series one is not — verified against the actual HAC-DSR computation before adding it) that a stub would fail; softened the docstring to describe what each check actually proves.
- **MINOR — PR-body-vs-diff mismatch on the `_rigor_helpers.py` restoration.** See the correction inline in "A wrinkle worth calling out explicitly" above.

## Code review follow-up, round 2 (2026-08-20)

A second adversarial review pass (run against this round's own fixes, including the round-1 review-follow-up commit) verified 4 more findings and fixed all of them:

- **MAJOR — the round-1 "advisory" guard fix was itself still one-directional.** `test_board_fdr_is_advisory_never_gates_passes_all` forced `board_fdr_significant=False` on a uniformly-passing (all strong-series) cohort, so it caught an AND-shaped threading bug (`passes_all and board_fdr_significant`) but was mathematically blind to an OR-shaped one (`passes_all or board_fdr_significant`) — the LOOSENING direction, the one a rigor gate most needs guarded (a false PASS, not a false FAIL). Confirmed by probing the baseline: all three cohort strategies already had `passes_all=True`, so `True or <forced False>` is indistinguishable from `True` regardless of the bug. Fixed by switching to a mixed cohort (2 strong + 1 weak series, so baseline has both a passing and a failing strategy) and running both `board_fdr_significant=False` and `=True` as forced values; each mutation shape is now caught only by its matching forced value (see guard transcript #4 above).
- **MINOR — the `board_fdr_*` field comment's `None` convention was universal but the code isn't.** The comment said `None` means "no finite `dsr_p_value`" — true for `GET /gate` and for curated strategies via `GET /gate/{id}` (which delegates to the same board-level computation), but the *generated*-strategy fallback path (`_generated_strategy_rigor`) inside `GET /gate/{id}` never calls `compute_board_level_fdr` at all, so it returns `None` there unconditionally, even with a finite `dsr_p_value` — a third, undocumented meaning of the same sentinel. Fixed: the field comment (and the "What this does" section above) now spell out all three cases and which code path produces each.
- **MINOR — § 6 of `docs/specs/selection-bias-corrections-spec.md` was written before this round's fixes and didn't reflect them.** It omitted `board_fdr_confidence` from the surfaced-fields list, didn't mention the `_CLASSICAL_P_FLOOR` saturation guard (round-1 finding above), and named a literal `0.05` instead of the `DEFAULT_BOARD_FDR_LEVEL` constant round-1 introduced. Fixed: § 6 now names all three.
- **MINOR — this PR body's pasted full-suite transcript was stale relative to its own prose.** The prose above the pasted block claimed a post-round-1 rerun (`3367 passed`); the pasted block below it was still the pre-round-1 run (`3366 passed, ... 536.98s`) — CLAUDE.md rule 3 (a PR-body claim must match the evidence shown under it). Fixed: replaced with a fresh transcript re-run after round 2's fixes (see below — same `3367 passed, 0 failed` count, since round 2 only edited an existing test's body plus comments/docs, adding no new tests).

## Verification tallies

- `git grep -n "benjamini_hochberg_fdr" -- .` → real call site at `rigor_evaluator.py:484` (`bh = benjamini_hochberg_fdr(classical_pvalues, fdr_level=fdr_level)`), outside `backend/tests/` and outside the old `# noqa` re-export comment.
- New/touched test files, hermetic gate: `backend/tests/test_rigor_evaluator.py` + `backend/tests/test_selection_bias_routes.py` → **253 passed, 0 failed** (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest ... -q`) — unchanged by round 2 (same test count; round 2 rewrote one existing test's body, it didn't add or remove tests).
- Full suite, exact CI command: `pytest -m "not integration" -q` → **3367 passed, 0 failed** (2 pre-existing skips in `test_chain_settings_addresses.py`, unrelated to this change; 2 deselected — `282.80s`), re-verified after round 2 (same count as the post-round-1 figure this line previously claimed — see the stale-transcript finding above for why the pasted block below didn't match until now).
- `ruff format --check .` + `ruff check --select E9,F63,F7,F40,F82 .` (exact `ruff-gate` commands) on the full repo, post round 2 → clean.
- `ruff check .` (informational) on touched files → clean.
- `make docs-check` → 0 broken links, 0 orphaned docs.

```
SKIPPED [1] backend/tests/chain/test_chain_settings_addresses.py:142: every ON_CHAIN_SYNTHS symbol has a committed default — nothing to exclude
SKIPPED [1] backend/tests/chain/test_chain_settings_addresses.py:149: every ON_CHAIN_SYNTHS symbol has a committed default
=== 3367 passed, 2 skipped, 2 deselected, 192 warnings in 282.80s (0:04:42) ====
```

## Files

- `backend/archimedes/services/_rigor_helpers.py` — restores `benjamini_hochberg_fdr` (§ 8) from git history (implementation byte-identical; see the correction above on the docstring diff).
- `backend/archimedes/services/rigor_evaluator.py` — new `compute_board_level_fdr`, the one real call site + direction conversion + scope-decision docstring + `DEFAULT_BOARD_FDR_LEVEL` / `_CLASSICAL_P_FLOOR` constants (code review, 2026-08-20).
- `backend/archimedes/api/selection_bias_routes.py` — new `BoardLevelFdr` schema, `StrategyRigorResult.board_fdr_*` fields (including `board_fdr_confidence`), wired into `evaluate_rigor_gate` with the α sourced from `DEFAULT_BOARD_FDR_LEVEL` at both call sites; round-2 field comment rewritten to cover all three `None` cases.
- `backend/tests/test_rigor_evaluator.py` — restores `TestBenjaminiHochbergFDR` (deleted in #1259) + new `TestComputeBoardLevelFdr` (direction conversion, hand-verified BH cross-check, MISSING exclusion, cohort-size sensitivity, saturated-p-value floor).
- `backend/tests/test_selection_bias_routes.py` — new `TestBoardLevelFdrWiring`: end-to-end through the real HTTP route + real DSR computation, cross-checked against `compute_board_level_fdr` directly + a cohort-specific outcome assertion; adversarial "never gates `passes_all`" check, round 2, that forces a real (non-cached) recompute against a mixed cohort in both threading directions.
- `docs/specs/selection-bias-corrections-spec.md` — new § 6 recording the scope decision; round 2 caught up § 6's Mechanics paragraph with the `_CLASSICAL_P_FLOOR` guard, `board_fdr_confidence`, and the `DEFAULT_BOARD_FDR_LEVEL` constant.

## Anti-goals respected

- `num_trials` (#1075's per-strategy convention) is untouched — this is a separate, additive board-level axis, exactly as #1185 specifies.
- Not conflated with disclosure: this is a real `benjamini_hochberg_fdr` invocation over real cohort p-values, not another disclosure string.
- Not a cosmetic label: verified by the guard transcripts above — the correction changes with cohort composition and would be caught by tests if faked.

