### PR TITLE
Fix wallet_provisioner payload for the current Circle wallets API

### DIFF
--- a/backend/archimedes/marketplace/wallet_provisioner.py
+++ b/backend/archimedes/marketplace/wallet_provisioner.py
@@ -53,6 +53,39 @@ def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
     return base64.b64encode(ciphertext).decode()
 
 
+async def _resolve_wallet_set_id(session: aiohttp.ClientSession, api_key: str) -> str:
+    """Resolve the Circle ``walletSetId`` new wallets are provisioned under.
+
+    ``WALLET_SET_ID`` env override takes precedence — when set, this returns
+    immediately and makes no network call at all. Otherwise it lists the
+    account's wallet sets via ``GET /v1/w3s/walletSets`` and uses the first
+    one. Never invents an ID: an account with zero wallet sets fails loudly
+    instead of silently provisioning against a made-up value.
+
+    Raises:
+        RuntimeError: If the listing call fails or the account has no
+            wallet sets.
+    """
+    env_override = os.getenv("WALLET_SET_ID", "")
+    if env_override:
+        return env_override
+
+    async with session.get(
+        f"{CIRCLE_API_BASE}/walletSets",
+        headers={"Authorization": f"Bearer {api_key}"},
+    ) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Failed to list Circle wallet sets: {resp.status}")
+        body = await resp.json()
+        wallet_sets = body.get("data", {}).get("walletSets", [])
+        if not wallet_sets:
+            raise RuntimeError(
+                "No Circle wallet sets exist on this account — create one in "
+                "the Circle console or set WALLET_SET_ID to pin a specific one"
+            )
+        return wallet_sets[0]["id"]
+
+
 async def _create_circle_wallet(ref_value: str, ref_purpose: str) -> tuple[str, str]:
     """Shared Circle DCW creation flow used by both subscriber and publisher
     provisioning.  Fetches the RSA public key, encrypts the entity secret, and
@@ -89,12 +122,19 @@ async def _create_circle_wallet(ref_value: str, ref_purpose: str) -> tuple[str, 
 
         ciphertext = _encrypt_entity_secret(entity_secret, public_key)
 
-        # 2. Create the wallet with a deterministic idempotency key derived from the ref.
+        # 2. Resolve the walletSetId every wallet must be created under.
+        wallet_set_id = await _resolve_wallet_set_id(session, api_key)
+
+        # 3. Create the wallet with a deterministic idempotency key derived from the ref.
         #    Retries for the same ref_value reuse the same key → Circle returns the
         #    existing wallet (409) instead of provisioning a duplicate.
+        #    NOTE: Circle's current API requires `blockchains` as an ARRAY
+        #    (not a singular `blockchain` string) and a non-empty `walletSetId`
+        #    — both 400 otherwise (#1325).
         payload = {
             "idempotencyKey": str(uuid.uuid5(uuid.NAMESPACE_URL, f"archimedes-wallet:{ref_value}")),
-            "blockchain": CIRCLE_BLOCKCHAIN,
+            "blockchains": [CIRCLE_BLOCKCHAIN],
+            "walletSetId": wallet_set_id,
             "metadata": [
                 {"name": "ref", "value": ref_value},
                 {"name": "purpose", "value": ref_purpose},
@@ -112,8 +152,11 @@ async def _create_circle_wallet(ref_value: str, ref_purpose: str) -> tuple[str, 
         ) as resp:
             body = await resp.json()
             if resp.status == 201:
-                wallet_id: str = body["data"]["wallet"]["id"]
-                wallet_address: str = body["data"]["wallet"]["address"]
+                # The 201 body nests the created wallet(s) as a LIST under
+                # data.wallets, not a single object under data.wallet (#1325).
+                wallet = body["data"]["wallets"][0]
+                wallet_id: str = wallet["id"]
+                wallet_address: str = wallet["address"]
                 logger.info(
                     "Created Circle wallet %s for ref=%s (address=%s)",
                     wallet_id,

--- a/backend/archimedes/marketplace/wallet_provisioner.py
+++ b/backend/archimedes/marketplace/wallet_provisioner.py
@@ -56,7 +56,7 @@ def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
 async def _resolve_wallet_set_id(session: aiohttp.ClientSession, api_key: str) -> str:
     """Resolve the Circle ``walletSetId`` new wallets are provisioned under.
 
-    ``WALLET_SET_ID`` env override takes precedence — when set, this returns
+    ``MARKETPLACE_WALLET_SET_ID`` env override takes precedence — when set, this returns
     immediately and makes no network call at all. Otherwise it lists the
     account's wallet sets via ``GET /v1/w3s/walletSets`` and uses the first
     one. Never invents an ID: an account with zero wallet sets fails loudly
@@ -66,7 +66,7 @@ async def _resolve_wallet_set_id(session: aiohttp.ClientSession, api_key: str) -
         RuntimeError: If the listing call fails or the account has no
             wallet sets.
     """
-    env_override = os.getenv("WALLET_SET_ID", "")
+    env_override = os.getenv("MARKETPLACE_WALLET_SET_ID", "")
     if env_override:
         return env_override
 
@@ -81,7 +81,7 @@ async def _resolve_wallet_set_id(session: aiohttp.ClientSession, api_key: str) -
         if not wallet_sets:
             raise RuntimeError(
                 "No Circle wallet sets exist on this account — create one in "
-                "the Circle console or set WALLET_SET_ID to pin a specific one"
+                "the Circle console or set MARKETPLACE_WALLET_SET_ID to pin a specific one"
             )
         return wallet_sets[0]["id"]
 

--- a/backend/tests/marketplace/test_wallet_provisioner.py
+++ b/backend/tests/marketplace/test_wallet_provisioner.py
@@ -91,10 +91,17 @@ def _pubkey_route(pem: str):
     return ("GET", "config/entity/publicKey"), _FakeResp(200, {"data": {"publicKey": pem}})
 
 
+def _walletset_route(wallet_set_id="ws-default-1"):
+    """The GET /v1/w3s/walletSets route used when WALLET_SET_ID is unset."""
+    return ("GET", "walletSets"), _FakeResp(200, {"data": {"walletSets": [{"id": wallet_set_id}]}})
+
+
 def _created_route(wallet_id="w-created-1", address="0xWa11e70000000000000000000000000000000001"):
+    # The real 201 body nests the created wallet(s) as a LIST under
+    # data.wallets — not a single object under data.wallet.
     return (
         ("POST", "developer/wallets"),
-        _FakeResp(201, {"data": {"wallet": {"id": wallet_id, "address": address}}}),
+        _FakeResp(201, {"data": {"wallets": [{"id": wallet_id, "address": address}]}}),
     )
 
 
@@ -102,7 +109,7 @@ class TestCreateCircleWallet:
     @pytest.mark.asyncio
     async def test_happy_path_creates_wallet_and_really_encrypts_the_entity_secret(self, monkeypatch, rsa_keypair):
         key, pem = rsa_keypair
-        session = _FakeSession(dict([_pubkey_route(pem), _created_route()]))
+        session = _FakeSession(dict([_pubkey_route(pem), _walletset_route(), _created_route()]))
         _install(monkeypatch, session)
 
         wallet_id, address = await wp.provision_subscriber_wallet("0xsubid")
@@ -110,7 +117,8 @@ class TestCreateCircleWallet:
         assert (wallet_id, address) == ("w-created-1", "0xWa11e70000000000000000000000000000000001")
         assert len(session.posts) == 1
         payload = session.posts[0]
-        assert payload["blockchain"] == wp.CIRCLE_BLOCKCHAIN
+        assert payload["blockchains"] == [wp.CIRCLE_BLOCKCHAIN]
+        assert payload["walletSetId"] == "ws-default-1"
         assert {"name": "ref", "value": "sub:0xsubid"} in payload["metadata"]
         # THE load-bearing assertion: decrypt the posted ciphertext with the
         # test private key and require the original entity secret back. A
@@ -128,7 +136,7 @@ class TestCreateCircleWallet:
         reuse the SAME key (so Circle returns the existing wallet), and a
         different ref must get a different key (so wallets never collide)."""
         _, pem = rsa_keypair
-        session = _FakeSession(dict([_pubkey_route(pem), _created_route()]))
+        session = _FakeSession(dict([_pubkey_route(pem), _walletset_route(), _created_route()]))
         _install(monkeypatch, session)
 
         await wp.provision_subscriber_wallet("0xsame")
@@ -162,6 +170,7 @@ class TestCreateCircleWallet:
         session = _FakeSession(
             {
                 ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("GET", "walletSets"): _FakeResp(200, {"data": {"walletSets": [{"id": "ws-default-1"}]}}),
                 ("POST", "developer/wallets"): _FakeResp(409, {"code": "conflict"}),
                 ("GET", "developer/wallets"): listing,
             }
@@ -179,6 +188,7 @@ class TestCreateCircleWallet:
         session = _FakeSession(
             {
                 ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("GET", "walletSets"): _FakeResp(200, {"data": {"walletSets": [{"id": "ws-default-1"}]}}),
                 ("POST", "developer/wallets"): _FakeResp(409, {"code": "conflict"}),
                 ("GET", "developer/wallets"): _FakeResp(200, {"data": {"wallets": []}}),
             }
@@ -194,6 +204,7 @@ class TestCreateCircleWallet:
         session = _FakeSession(
             {
                 ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("GET", "walletSets"): _FakeResp(200, {"data": {"walletSets": [{"id": "ws-default-1"}]}}),
                 ("POST", "developer/wallets"): _FakeResp(500, {"error": "boom"}),
             }
         )
@@ -201,6 +212,54 @@ class TestCreateCircleWallet:
 
         with pytest.raises(RuntimeError, match="500"):
             await wp.provision_subscriber_wallet("0xerr")
+
+    @pytest.mark.asyncio
+    async def test_request_shape_is_blockchains_array_with_wallet_set_id(self, monkeypatch, rsa_keypair):
+        """Pins the #1325 request shape against a mocked transport. The
+        pre-fix payload (singular `blockchain`, no `walletSetId`) is exactly
+        what Circle 400s with 'blockchains field may not be empty' /
+        'walletSetId field may not be empty' — this assertion must fail
+        against that payload (verified by reverting the fix locally per the
+        house guard-demo rule) and pass against the fixed one."""
+        _, pem = rsa_keypair
+        session = _FakeSession(dict([_pubkey_route(pem), _walletset_route("ws-shape-check"), _created_route()]))
+        _install(monkeypatch, session)
+
+        await wp.provision_subscriber_wallet("0xshape")
+
+        payload = session.posts[0]
+        assert payload["blockchains"] == [wp.CIRCLE_BLOCKCHAIN]
+        assert isinstance(payload["blockchains"], list), "blockchains must be an array, not a bare string"
+        assert payload["walletSetId"] == "ws-shape-check"
+        assert payload["walletSetId"], "walletSetId must be non-empty"
+        assert "blockchain" not in payload, "the old singular `blockchain` key must be gone"
+
+    @pytest.mark.asyncio
+    async def test_response_parses_first_entry_of_data_wallets(self, monkeypatch, rsa_keypair):
+        """Pins response parsing at data.wallets[0] (a LIST), not data.wallet
+        (a single object). Two wallets in the list proves index [0] is used
+        deliberately, not just tolerated because len==1."""
+        _, pem = rsa_keypair
+        multi_wallet_route = (
+            ("POST", "developer/wallets"),
+            _FakeResp(
+                201,
+                {
+                    "data": {
+                        "wallets": [
+                            {"id": "w-first", "address": "0xFirst00000000000000000000000000000001"},
+                            {"id": "w-second", "address": "0xSecond0000000000000000000000000000002"},
+                        ]
+                    }
+                },
+            ),
+        )
+        session = _FakeSession(dict([_pubkey_route(pem), _walletset_route(), multi_wallet_route]))
+        _install(monkeypatch, session)
+
+        wallet_id, address = await wp.provision_subscriber_wallet("0xmulti")
+
+        assert (wallet_id, address) == ("w-first", "0xFirst00000000000000000000000000000001")
 
     @pytest.mark.asyncio
     async def test_missing_credentials_fail_before_any_network(self, monkeypatch):
@@ -213,6 +272,59 @@ class TestCreateCircleWallet:
 
         with pytest.raises(RuntimeError, match="credentials not configured"):
             await wp.provision_subscriber_wallet("0xnocreds")
+
+
+class TestWalletSetIdResolution:
+    @pytest.mark.asyncio
+    async def test_wallet_set_id_env_override_skips_the_walletsets_get(self, monkeypatch, rsa_keypair):
+        """WALLET_SET_ID takes precedence and must short-circuit before any
+        GET /v1/w3s/walletSets call — deliberately no walletSets route is
+        registered, so if the code fell through to the GET anyway the fake
+        session's unrouted-request assertion would fail this test."""
+        _, pem = rsa_keypair
+        session = _FakeSession(dict([_pubkey_route(pem), _created_route()]))
+        _install(monkeypatch, session)
+        monkeypatch.setenv("WALLET_SET_ID", "ws-from-env")
+
+        wallet_id, address = await wp.provision_subscriber_wallet("0xenvoverride")
+
+        assert (wallet_id, address) == ("w-created-1", "0xWa11e70000000000000000000000000000000001")
+        assert session.posts[0]["walletSetId"] == "ws-from-env"
+
+    @pytest.mark.asyncio
+    async def test_no_wallet_sets_on_account_raises_loudly_and_never_invents_one(self, monkeypatch, rsa_keypair):
+        """Zero wallet sets on the account, no env override: must raise
+        loudly and must NEVER fall back to inventing/guessing an ID by
+        attempting the POST anyway."""
+        _, pem = rsa_keypair
+        session = _FakeSession(
+            {
+                ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("GET", "walletSets"): _FakeResp(200, {"data": {"walletSets": []}}),
+            }
+        )
+        _install(monkeypatch, session)
+
+        with pytest.raises(RuntimeError, match="No Circle wallet sets"):
+            await wp.provision_subscriber_wallet("0xnowalletsets")
+
+        assert session.posts == [], "must never attempt wallet creation without a resolved walletSetId"
+
+    @pytest.mark.asyncio
+    async def test_no_wallet_sets_listing_failure_raises(self, monkeypatch, rsa_keypair):
+        _, pem = rsa_keypair
+        session = _FakeSession(
+            {
+                ("GET", "config/entity/publicKey"): _FakeResp(200, {"data": {"publicKey": pem}}),
+                ("GET", "walletSets"): _FakeResp(503, {"error": "unavailable"}),
+            }
+        )
+        _install(monkeypatch, session)
+
+        with pytest.raises(RuntimeError, match="Failed to list Circle wallet sets: 503"):
+            await wp.provision_subscriber_wallet("0xlistfail")
+
+        assert session.posts == []
 
 
 class TestFindWalletByRef:

--- a/backend/tests/marketplace/test_wallet_provisioner.py
+++ b/backend/tests/marketplace/test_wallet_provisioner.py
@@ -92,7 +92,7 @@ def _pubkey_route(pem: str):
 
 
 def _walletset_route(wallet_set_id="ws-default-1"):
-    """The GET /v1/w3s/walletSets route used when WALLET_SET_ID is unset."""
+    """The GET /v1/w3s/walletSets route used when MARKETPLACE_WALLET_SET_ID is unset."""
     return ("GET", "walletSets"), _FakeResp(200, {"data": {"walletSets": [{"id": wallet_set_id}]}})
 
 
@@ -277,14 +277,14 @@ class TestCreateCircleWallet:
 class TestWalletSetIdResolution:
     @pytest.mark.asyncio
     async def test_wallet_set_id_env_override_skips_the_walletsets_get(self, monkeypatch, rsa_keypair):
-        """WALLET_SET_ID takes precedence and must short-circuit before any
+        """MARKETPLACE_WALLET_SET_ID takes precedence and must short-circuit before any
         GET /v1/w3s/walletSets call — deliberately no walletSets route is
         registered, so if the code fell through to the GET anyway the fake
         session's unrouted-request assertion would fail this test."""
         _, pem = rsa_keypair
         session = _FakeSession(dict([_pubkey_route(pem), _created_route()]))
         _install(monkeypatch, session)
-        monkeypatch.setenv("WALLET_SET_ID", "ws-from-env")
+        monkeypatch.setenv("MARKETPLACE_WALLET_SET_ID", "ws-from-env")
 
         wallet_id, address = await wp.provision_subscriber_wallet("0xenvoverride")
 


### PR DESCRIPTION
Closes #1325. Found live while provisioning the platform wallet: `_create_circle_wallet` posted `{"blockchain": ...}` with no `walletSetId` — the current `POST /v1/w3s/developer/wallets` 400s both. Never fired in prod because `PAYMENTS_DRY_RUN=true` keeps provisioning dormant; must land before the flip on the marketplace rail.

**Fix** (matching the payload shape proven against the live API):
- `blockchains` as an array (`[CIRCLE_BLOCKCHAIN]`);
- `walletSetId` resolved via `MARKETPLACE_WALLET_SET_ID` env override (no network call when set) else `GET /v1/w3s/walletSets` first set — an account with zero wallet sets fails LOUDLY, never invents an id;
- 201 parsing from `data.wallets[0]` (the body nests a list, not `data.wallet`);
- entity-secret encryption flow untouched.

**Tests** (5 new, extending the existing mocked-transport style; 14/14 total): request shape pinned (array + walletSetId present), `data.wallets[0]` parsing, env-override-skips-GET, loud no-wallet-sets error, listing-failure error. Guard demo per house rule: the PRE-FIX payload demonstrated failing the request-shape assertion (reverted in place, run, restored — recorded in the build log).

**Verification**: built + adversarially verified in a two-stage workflow (independent api-shape lens: no findings — probed empty-walletSets silent-proceed, env-override leakage, residual singular reads; all clean), then personally vetted and re-run post-rebase to 0-behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7

**Naming note (review):** the override is `MARKETPLACE_WALLET_SET_ID`, not `WALLET_SET_ID` — the latter already exists in `.env.example`'s Circle deployer/signer block with a different meaning, and a box setting it for that context would have silently steered marketplace provisioning into the wrong wallet set. Grep confirms zero consumers of the new name elsewhere.
