### PR TITLE
[api] Fix 500 on GET /api/strategies/{id} for strategies with no linked paper

### DIFF
--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -183,8 +183,8 @@ class StrategyResponse(BaseModel):
     status: str  # "candidate" | "validated" | "live" | "retired" | "rejected"
 
     # Legacy scalar fields (populated from papers[0] for backwards compat)
-    paper_arxiv_id: str = ""
-    paper_title: str = ""
+    paper_arxiv_id: str | None = None
+    paper_title: str | None = None
     paper_authors: list[str] = []
     paper_venue: str | None = None
     paper_year: int | None = None

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -810,3 +810,45 @@ async def test_list_route_grades_full_library_regardless_of_pagination(monkeypat
     assert len(seen_cohorts) == 3
     for cohort in seen_cohorts:
         assert cohort == full_library
+
+
+# ── GET /api/strategies/{id} must not 500 for a strategy with no linked
+# paper (#1342) ──────────────────────────────────────────────────────────
+#
+# Curated strategies always have papers[0], so the legacy scalar fields
+# (paper_arxiv_id / paper_title) never went through the None branch for
+# them. GENERATED strategies (fusion/architect, ingested straight into
+# strategy_passports with no paper_refs) do: _passport_to_strategy_response
+# passes ``first.arxiv_id if first else None`` into a field declared
+# ``str = ""``, which pydantic 2.x rejects — turning a genuine "no paper"
+# into an HTTP 500 instead of a null field.
+
+
+@pytest.mark.asyncio
+async def test_single_strategy_endpoint_200s_with_no_linked_paper():
+    """A generated (passport) strategy with zero linked papers must serve
+    200 with paper_arxiv_id/paper_title == None, not 500."""
+    from archimedes.db import get_session
+    from archimedes.main import app
+    from archimedes.models.strategy import StrategyPassport
+    from archimedes.services.passport_loader import ingest_passport
+
+    strategy_id = "test-1342-no-linked-paper"
+    passport = StrategyPassport(
+        id=strategy_id,
+        papers=[],
+        methodology_summary="A strategy with no linked paper (e.g. a fresh generation).",
+        asset_universe=["SPY"],
+    )
+    with get_session() as session:
+        ingest_passport(session, passport, generation_method="fusion")
+        session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{strategy_id}")
+
+    assert resp.status_code == 200, resp.text
+    served = resp.json()
+    assert served["paper_arxiv_id"] is None
+    assert served["paper_title"] is None
+    assert served["papers"] == []


### PR DESCRIPTION
## Summary

`GET /api/strategies/{id}` returned HTTP 500 for any strategy with no linked paper.

`StrategyResponse` (`backend/archimedes/api/schemas.py:186-187`) declared the legacy scalar
fields as `str = ""` — a default that makes the field *not required*, but does not make it
accept `None`. `_passport_to_strategy_response` (`backend/archimedes/api/strategies_routes.py:1731-1732`)
passes `None` for both when a strategy has zero linked papers:

```python
paper_arxiv_id=first.arxiv_id if first else None,
paper_title=first_title or None,
```

pydantic 2.x rejects the `None` against a bare `str` field, and FastAPI turns the
`ValidationError` into a 500. This bites GENERATED strategies specifically — curated
strategies always have `papers[0]`.

## Fix

Widen both fields to `str | None = None`, matching the sibling fields already declared
correctly four lines below (`paper_venue`, `paper_year`, `paper_doi`,
`paper_citation_count`). No route-level coercion to `""` — a strategy with no paper
genuinely has no arXiv id, and the API should say so (per the issue's anti-goal).

Verified every consumer of the widened fields:
- `_to_strategy_response` (curated path) always passes real strings from
  `models/strategy.py`'s `paper_arxiv_id`/`paper_title` properties, which return `""`
  (never `None`) when a curated strategy has no paper — behavior there is unchanged.
- UI (`ui/src/components/Strategies.jsx`, `StrategyPassport.jsx`, `QuantLab.jsx`,
  `CreateVaultModal.jsx`, `PublishStrategyTable.jsx`, etc.) reads both fields exclusively
  through `||`/truthy checks (`s.paper_title || ...`, `s.paper_arxiv_id && (...)`), so a
  `null` renders identically to how `""` did.

## Regression test

`backend/tests/test_strategies_routes.py::test_single_strategy_endpoint_200s_with_no_linked_paper`
ingests a `StrategyPassport` with `papers=[]` via `ingest_passport(..., generation_method="fusion")`
into the tmp-sqlite DB, hits `GET /api/strategies/{id}` through `httpx.ASGITransport`, and
asserts `200` with `paper_arxiv_id is None` / `paper_title is None`.

## Mutation-proof

Reverted the schema fix only (`str | None = None` -> `str = ""`) and re-ran the new test —
it fails with the exact `ValidationError` from the issue report:

```
backend/archimedes/api/strategies_routes.py:1997: in get_strategy
    return _passport_to_strategy_response(record, session=session)
backend/archimedes/api/strategies_routes.py:1728: in _passport_to_strategy_response
    return StrategyResponse(
E   pydantic_core._pydantic_core.ValidationError: 2 validation errors for StrategyResponse
E   paper_arxiv_id
E     Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
E   paper_title
E     Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
FAILED backend/tests/test_strategies_routes.py::test_single_strategy_endpoint_200s_with_no_linked_paper
1 failed, 27 deselected in 4.70s
```

Restored the fix — back to green:

```
backend/tests/test_strategies_routes.py .............................  [100%]
28 passed, 1 warning in 8.75s
```

## Test evidence

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_strategies_routes.py -q
28 passed, 1 warning in 8.75s

pytest -m "not integration"   (repo root, full unit suite)
3378 passed, 2 skipped, 2 deselected, 190 warnings in 293.26s
```

`ruff format --check` / `ruff check` on both touched files: clean.

Closes #1342
