### PR TITLE
[chain] Reconcile dangling reveals — an executed trade's reasoning can become verifiable again

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -16,6 +16,10 @@ Env:
     AGENT_USDC_FLOOR        — minimum USDC allocation, 0.0–1.0 (default: 0.20)
     AGENT_LEASE_TTL_MS      — exactly-once lease TTL (default: 180000 = 3min)
     AGENT_LEASE_RENEW_S     — lease renewal interval (default: 50s, ~ttl/3)
+    REVEAL_RECONCILE_MAX_ATTEMPTS  — retries before a dangling commitment goes
+                              TERMINAL (default: 3)
+    REVEAL_RECONCILE_SCAN_LIMIT    — newest traces scanned per tick (default: 200)
+    REVEAL_RECONCILE_MAX_PER_TICK  — reveals retried per tick (default: 5)
 
 Exactly-once (#1043): this runner is a funds-adjacent singleton whose
 rebalance is NOT idempotent (it issues absolute swap amounts, not deltas) —
@@ -78,6 +82,41 @@ INTERVAL = int(os.getenv("AGENT_INTERVAL_SECONDS", "300"))
 DRY_RUN = os.getenv("AGENT_DRY_RUN", "false").lower() == "true"
 EXPLICIT_VAULTS = os.getenv("AGENT_VAULT_ADDRESSES", "")
 USDC_FLOOR = float(os.getenv("AGENT_USDC_FLOOR", "0.20"))
+
+# ─── Reveal reconciliation (#1276, audit G9) ─────────────────────────
+#
+# A tick that trades and commits but then FAILS to reveal (revert, RPC outage,
+# lease lost during the claimedExecutionTime wait) leaves a DANGLING COMMITMENT:
+# the money moved, the reasoning is persisted, the commit is anchored — but
+# nothing on-chain ever proves the reasoning preceded the trade. Pre-#1276 no
+# later tick ever came back for it, so that trade's reasoning was permanently
+# unverifiable.
+#
+# A later retry is legitimate — not a fabrication — because
+# ReasoningTraceRegistry.reveal() imposes NO upper window. Its five guards are:
+#   revealBlock == 0 (unrevealed) | msg.sender == committer |
+#   block.number > commitBlock | block.timestamp >= claimedExecutionTime |
+#   keccak256(fullTraceContent) == contentHash
+# Every one is monotone-satisfiable later: the block/timestamp bounds are LOWER
+# bounds only, and the content bound is over immutable persisted bytes. So the
+# same reveal that failed at T is still accepted at T+n — verified against
+# contracts/src/ReasoningTraceRegistry.sol, not assumed.
+#
+# The two guards that CANNOT be satisfied later are the reason "terminal" exists
+# as a state: a rotated signer key (msg.sender != committer) and canonical bytes
+# that no longer re-derive to the committed hash are permanent, and so is having
+# no on-chain commitment id at all (a pre-v1.5 publishTrace anchor). Those must
+# surface as a countable, alertable state — never as a silent retry loop.
+REVEAL_RECONCILE_MAX_ATTEMPTS = int(os.getenv("REVEAL_RECONCILE_MAX_ATTEMPTS", "3"))
+REVEAL_RECONCILE_SCAN_LIMIT = int(os.getenv("REVEAL_RECONCILE_SCAN_LIMIT", "200"))
+REVEAL_RECONCILE_MAX_PER_TICK = int(os.getenv("REVEAL_RECONCILE_MAX_PER_TICK", "5"))
+
+_RECONCILE_PENDING = "pending"  # retried, failed, eligible for another attempt
+_RECONCILE_TERMINAL = "terminal"  # given up on — LOUD, countable, never retried
+_RECONCILE_DONE = "reconciled"  # a retry landed the reveal on-chain
+_RECONCILE_FROM_CHAIN = "reconciled_from_chain"  # reveal was already on-chain; DB caught up
+# Any state other than "pending" (and absent) closes the record to further scans.
+_RECONCILE_CLOSED_STATES = frozenset({_RECONCILE_TERMINAL, _RECONCILE_DONE, _RECONCILE_FROM_CHAIN})
 
 # Exactly-once lease (#1043)
 RUNNER_NAME = "agent_runner"
@@ -176,6 +215,78 @@ def _paper_hashes_from_signals(all_signals: list[StrategySignals]) -> list[str]:
     return build_consulted_hashes(papers)
 
 
+def _needs_reveal_reconciliation(record: dict) -> bool:
+    """True iff a persisted trace is a dangling commitment awaiting a reveal retry.
+
+    The exact shape (#1276): ``commit_tx_hash IS NOT NULL AND reveal_tx_hash IS
+    NULL AND trade_tx_hash IS NOT NULL`` — a trade that really executed, whose
+    reasoning was really committed, whose reveal never landed.
+
+    Everything else must NOT match, and each exclusion is load-bearing:
+      - no ``trade_tx_hash``  → nothing executed (a SKIP trace, a lease-not-held
+        cycle, a dry run). There is no money-moved asymmetry to repair, and the
+        commitment is simply unused.
+      - ``reveal_tx_hash`` present → already revealed. Retrying would revert
+        "Already revealed" and burn gas for nothing.
+      - no ``commit_tx_hash`` → nothing was ever anchored, so there is no
+        commitment to reveal against.
+      - a CLOSED ``reveal_reconcile_state`` → already resolved or already given
+        up on. This is what makes "terminal" terminal: without it the bounded
+        retry counter would still be re-scanned forever.
+    """
+    if not isinstance(record, dict):
+        return False  # a corrupt store entry is not a reconciliation candidate
+    if record.get("reveal_reconcile_state") in _RECONCILE_CLOSED_STATES:
+        return False
+    return bool(record.get("commit_tx_hash")) and bool(record.get("trade_tx_hash")) and not record.get("reveal_tx_hash")
+
+
+def _rebuild_committed_trace(record: dict) -> ReasoningTrace:
+    """Re-derive the EXACT committed trace object from its persisted record.
+
+    Mirrors ``GET /traces/{id}/canonical``: every ``_HASH_FIELDS`` member is
+    restored from persistence and nothing else is, because ``canonical_json()``
+    is computed over exactly those fields and the contract recomputes
+    ``keccak256(fullTraceContent)`` against the committed hash.
+
+    ``timestamp`` is deliberately left as the persisted ISO STRING rather than
+    re-parsed to a datetime: ``canonical_json()`` only ``isoformat()``s
+    datetimes, so passing the string through reproduces the committed bytes
+    exactly and side-steps any parse/format round-trip difference — which would
+    surface as an on-chain "Hash mismatch" revert (#903).
+    """
+    return ReasoningTrace(
+        id=record["id"],
+        vault_address=record["vault_address"],
+        decision_type=DecisionType(record["decision_type"]),
+        trigger=record["trigger"],
+        timestamp=record["timestamp"],
+        market_context=record.get("market_context", {}),
+        portfolio_before=record.get("portfolio_before", {}),
+        portfolio_after=record.get("portfolio_after", {}),
+        reasoning=record.get("reasoning", ""),
+        confidence=record.get("confidence", 0.0),
+        trades_executed=record.get("trades_executed", []),
+        strategies_referenced=record.get("strategies_referenced", []),
+        consulted_paper_hashes=record.get("consulted_paper_hashes", []),
+    )
+
+
+def _norm_hash(value: str | None) -> str:
+    """Normalize a hex hash for comparison (0x-prefix and case are not content)."""
+    return (value or "").removeprefix("0x").lower()
+
+
+def _is_already_revealed_error(exc: Exception) -> bool:
+    """True when a reveal failure is the contract saying "Already revealed".
+
+    That revert is not a failure at all — it means the reveal DID land and only
+    our off-chain write of it was lost, so it routes to the reconcile-from-chain
+    backfill instead of consuming a retry attempt.
+    """
+    return "already revealed" in str(exc).lower()
+
+
 class StrategyRunner:
     """Paper-strategy-driven portfolio runner.
 
@@ -243,6 +354,18 @@ class StrategyRunner:
         logger.info("═══ Strategy tick %s ═══", tick_id)
 
         try:
+            # 0. Reveal reconciliation (#1276). Runs FIRST, under the same lease
+            # this tick holds, and strictly BEFORE any new commit work: a
+            # dangling commitment from an earlier tick is an already-executed
+            # trade whose reasoning is not yet provable, which outranks a trade
+            # that has not happened yet. Its own try/except is belt-and-braces
+            # on top of the pass's internal guards — repairing yesterday's trace
+            # must never be able to stop today's rebalance.
+            try:
+                await self._reconcile_dangling_reveals(tick_id)
+            except Exception:
+                logger.exception("[tick %s] Reveal reconciliation pass FAILED — continuing with the tick", tick_id)
+
             # 1. Load strategies
             strategies = self.provider.list_strategies()
             if not strategies:
@@ -1563,6 +1686,15 @@ class StrategyRunner:
                 "reveal_block_number": reveal_block,
                 "trade_tx_hash": tx_hashes[0] if tx_hashes else None,
                 "trade_block_number": trade_block,
+                # Reveal-reconciliation raw material (#1276). The registry's
+                # own trace id and the committed claimedExecutionTime are what a
+                # later tick needs to retry a failed reveal — without the id
+                # there is no reveal(traceId, …) to make, and the dangling
+                # commitment is unrecoverable. Persisted on EVERY reveal
+                # attempt, success or failure, precisely because the failure is
+                # the case that needs them.
+                "onchain_trace_id": trace_id,
+                "claimed_execution_time": claimed_execution_time,
                 "temporal_binding_source": "chain" if trace_id is not None else "none",
                 "temporal_binding_valid": (
                     trace_id is not None
@@ -1575,6 +1707,313 @@ class StrategyRunner:
             await self.state.save_trace(off_chain_data)
         except Exception as e:
             logger.error("[tick %s] REVEAL Redis save FAILED: %s", tick_id, e)
+
+    # ─── Reveal reconciliation (#1276, audit G9) ───────────────────
+
+    async def _reconcile_dangling_reveals(self, tick_id: str) -> None:
+        """Retry the reveal for commitments whose trade executed but never revealed.
+
+        The repair pass for the failure mode #1275 pins: ``_reveal_trace``
+        degrades honestly (loud ERROR, never-fabricated verification, dangling
+        commit preserved) but is per-tick terminal on its own. This is what
+        comes back for those records on a later tick.
+
+        Ordering and safety properties, all deliberate:
+          - runs at tick start, BEFORE new commit work, under the SAME lease
+            (``_lease_ok``) the tick already holds — and re-checks it between
+            records, because a lease lost mid-pass must stop the writes;
+          - honours ``AGENT_DRY_RUN`` exactly as ``_reveal_trace`` does: a dry
+            run performs NO chain interaction at all, so reconciliation can
+            never become a back door around it;
+          - checks the chain BEFORE transacting, so a reveal that landed but
+            whose DB write was lost is backfilled rather than re-sent;
+          - bounded: every real failure consumes one of
+            ``REVEAL_RECONCILE_MAX_ATTEMPTS``, after which the record goes
+            TERMINAL with a loud ERROR. Terminal is a state, not a deletion —
+            the honest unverified trace stays exactly as #1275 persisted it.
+        """
+        if DRY_RUN:
+            logger.debug("[tick %s] DRY RUN — skipping reveal reconciliation (no chain reads, no writes)", tick_id)
+            return
+
+        if not self._lease_ok:
+            logger.error(
+                "[tick %s] LEASE NOT HELD — skipping reveal reconciliation this cycle "
+                "(fail-closed; dangling commitments keep until the lease is re-acquired)",
+                tick_id,
+            )
+            return
+
+        try:
+            records = await self.state.list_recent_traces(REVEAL_RECONCILE_SCAN_LIMIT)
+        except Exception as e:
+            logger.error("[tick %s] Reveal reconciliation scan FAILED: %s", tick_id, e)
+            return
+
+        dangling = [r for r in (records or []) if _needs_reveal_reconciliation(r)]
+        if not dangling:
+            return
+
+        logger.warning(
+            "[tick %s] Reveal reconciliation: %d dangling commitment(s) with an executed trade — "
+            "retrying up to %d this tick",
+            tick_id,
+            len(dangling),
+            REVEAL_RECONCILE_MAX_PER_TICK,
+        )
+
+        for record in dangling[:REVEAL_RECONCILE_MAX_PER_TICK]:
+            if not self._lease_ok:
+                logger.error(
+                    "[tick %s] LEASE LOST mid-reconciliation — stopping (fail-closed)",
+                    tick_id,
+                )
+                return
+            try:
+                await self._reconcile_one_reveal(record, tick_id)
+            except Exception:
+                # One malformed record must never take the pass — or the tick — down.
+                logger.exception(
+                    "[tick %s] Reveal reconciliation errored for trace %s — continuing",
+                    tick_id,
+                    record.get("id"),
+                )
+
+    async def _reconcile_one_reveal(self, record: dict, tick_id: str) -> None:
+        """Reconcile a single dangling commitment (see ``_reconcile_dangling_reveals``)."""
+        trace_uuid = record.get("id")
+
+        # The registry is 1-indexed (trace 0 is the empty sentinel), so 0, a
+        # non-integer, or an absent id all mean the same thing: nothing to reveal.
+        try:
+            onchain_id = int(record["onchain_trace_id"])
+        except (KeyError, TypeError, ValueError):
+            onchain_id = 0
+
+        # ── Permanently unrevealable #1: no on-chain commitment to reveal ──
+        if onchain_id <= 0:
+            await self._reconcile_terminal(
+                record,
+                tick_id,
+                "no on-chain commitment id — the anchor was a publishTrace fallback "
+                "(pre-v1.5 registry, #588) or predates commit-reveal persistence, so "
+                "there is no commit() commitment for reveal() to consume",
+            )
+            return
+
+        # ── Permanently unrevealable #2: the bytes no longer re-derive ──
+        try:
+            trace = _rebuild_committed_trace(record)
+        except (KeyError, ValueError, TypeError) as e:
+            await self._reconcile_terminal(
+                record,
+                tick_id,
+                f"persisted record cannot be rebuilt into its committed trace ({e!r}) — "
+                "the canonical bytes reveal() must submit are unrecoverable",
+            )
+            return
+        rebuilt_hash = trace.compute_hash()
+        if _norm_hash(rebuilt_hash) != _norm_hash(record.get("trace_hash")):
+            await self._reconcile_terminal(
+                record,
+                tick_id,
+                f"canonical bytes no longer re-derive to the committed hash "
+                f"(rebuilt {_norm_hash(rebuilt_hash)[:16]} != committed "
+                f"{_norm_hash(record.get('trace_hash'))[:16]}) — reveal() would revert 'Hash mismatch'",
+            )
+            return
+
+        # ── Chain first: did the reveal actually land and only our write get lost? ──
+        commitment = await trace_publisher.get_commitment(onchain_id)
+        if commitment is not None and commitment.get("revealed"):
+            await self._backfill_reveal_from_chain(record, commitment, onchain_id, tick_id)
+            return
+        if commitment is None:
+            # Unreadable ≠ absent (see TracePublisher.get_commitment): treat as a
+            # retryable failure so the attempt cap still bounds it.
+            await self._reconcile_failure(
+                record, tick_id, "on-chain commitment unreadable (registry read failed, or no such commitment)"
+            )
+            return
+
+        # The contract's one LOWER bound we can predict: reveal before
+        # claimedExecutionTime reverts. Not a failed attempt — the window simply
+        # has not opened yet — so it must not consume a retry.
+        claimed = int(commitment.get("claimed_execution_time") or 0)
+        now_ts = int(datetime.now(UTC).timestamp())
+        if claimed > now_ts:
+            logger.info(
+                "[tick %s] Reveal reconciliation: trace %s still inside its claimedExecutionTime "
+                "window (%ds left) — leaving pending, no attempt consumed",
+                tick_id,
+                trace_uuid,
+                claimed - now_ts,
+            )
+            return
+
+        # ── The retry itself, from the persisted canonical bytes ──
+        # storage_pointer is NOT part of the hash binding, so a missing CID can
+        # never block verification: reuse the pinned one when we have it,
+        # otherwise reveal hash-only rather than failing the reconciliation.
+        storage_pointer = record.get("ipfs_cid") or ""
+        try:
+            reveal_tx, reveal_block = await trace_publisher.reveal(onchain_id, trace, storage_pointer=storage_pointer)
+        except Exception as e:
+            if _is_already_revealed_error(e):
+                fresh = await trace_publisher.get_commitment(onchain_id)
+                if fresh is not None and fresh.get("revealed"):
+                    await self._backfill_reveal_from_chain(record, fresh, onchain_id, tick_id)
+                    return
+            await self._reconcile_failure(record, tick_id, f"reveal raised: {e}")
+            return
+
+        if not reveal_tx:
+            await self._reconcile_failure(record, tick_id, "reveal returned no tx hash")
+            return
+
+        self._apply_verified_reveal(record, reveal_tx, reveal_block)
+        record["reveal_reconcile_state"] = _RECONCILE_DONE
+        record["reveal_reconcile_resolved_at"] = datetime.now(UTC).isoformat()
+        logger.info(
+            "[tick %s] REVEAL RECONCILED: trace %s (vault %s) revealed on retry %d — tx=%s block=%s, "
+            "temporal_binding_valid=%s",
+            tick_id,
+            trace_uuid,
+            (record.get("vault_address") or "")[:10],
+            int(record.get("reveal_reconcile_attempts") or 0) + 1,
+            reveal_tx[:16],
+            reveal_block,
+            record.get("temporal_binding_valid"),
+        )
+        await self._persist_reconciled(record, tick_id)
+
+    async def _backfill_reveal_from_chain(self, record: dict, commitment: dict, onchain_id: int, tick_id: str) -> None:
+        """Record a reveal that is already on-chain but missing from our store.
+
+        Restart-safety (#1276 constraint 5): the reveal tx can land and the
+        process die before persisting it. The registry's ``revealBlock`` is set
+        inside ``reveal()`` after its own hash check, so it is honest proof of
+        verification — stronger, not weaker, than the tx hash we normally key
+        ``is_verified`` off. The tx hash itself is recovered from the indexed
+        ``TraceRevealed`` log when the node still serves it; when it does not,
+        ``reveal_tx_hash`` stays None rather than being invented, and the
+        ``reveal_source`` field says where the claim came from.
+        """
+        reveal_block = commitment.get("reveal_block")
+        reveal_tx = await trace_publisher.find_reveal_tx(onchain_id, reveal_block)
+
+        self._apply_verified_reveal(record, reveal_tx, reveal_block)
+        record["reveal_reconcile_state"] = _RECONCILE_FROM_CHAIN
+        record["reveal_reconcile_resolved_at"] = datetime.now(UTC).isoformat()
+        record["reveal_source"] = "chain_commitment"
+        if commitment.get("storage_pointer"):
+            record["ipfs_cid"] = commitment["storage_pointer"]
+
+        logger.warning(
+            "[tick %s] REVEAL RECONCILED FROM CHAIN: trace %s (vault %s) was already revealed on-chain "
+            "at block %s (tx=%s) — no new transaction sent; the off-chain record had lost it",
+            tick_id,
+            record.get("id"),
+            (record.get("vault_address") or "")[:10],
+            reveal_block,
+            reveal_tx[:16] if reveal_tx else "unknown (log unavailable)",
+        )
+        await self._persist_reconciled(record, tick_id)
+
+    def _apply_verified_reveal(self, record: dict, reveal_tx: str | None, reveal_block: int | None) -> None:
+        """Write the reveal outcome onto the record, recomputing the binding honestly.
+
+        ``temporal_binding_valid`` is re-derived from the SAME rule
+        ``_reveal_trace`` uses — chain source, and commit < trade <= reveal —
+        never assumed from the fact that a retry succeeded.
+        """
+        record["reveal_tx_hash"] = reveal_tx
+        record["reveal_block_number"] = reveal_block
+        if reveal_tx:
+            record["arc_tx_hash"] = reveal_tx
+        record["is_verified"] = True
+
+        commit_block = record.get("commit_block_number")
+        trade_block = record.get("trade_block_number")
+        record["temporal_binding_valid"] = (
+            record.get("temporal_binding_source") == "chain"
+            and isinstance(commit_block, int)
+            and isinstance(trade_block, int)
+            and isinstance(reveal_block, int)
+            and commit_block < trade_block <= reveal_block
+        )
+
+    async def _reconcile_failure(self, record: dict, tick_id: str, reason: str) -> None:
+        """Count one failed retry; go terminal at the cap.
+
+        The verification fields are pointedly NOT touched here — a failed retry
+        leaves the #1275 honest-degradation contract exactly as it was
+        (``is_verified`` False, reveal fields None, binding invalid, dangling
+        commit preserved). Only the reconciliation bookkeeping moves.
+        """
+        attempts = int(record.get("reveal_reconcile_attempts") or 0) + 1
+        record["reveal_reconcile_attempts"] = attempts
+        record["reveal_reconcile_last_error"] = reason
+        record["reveal_reconcile_last_attempt_at"] = datetime.now(UTC).isoformat()
+
+        if attempts >= REVEAL_RECONCILE_MAX_ATTEMPTS:
+            await self._reconcile_terminal(record, tick_id, reason)
+            return
+
+        record["reveal_reconcile_state"] = _RECONCILE_PENDING
+        logger.warning(
+            "[tick %s] Reveal reconciliation attempt %d/%d FAILED for trace %s (vault %s): %s "
+            "— still unverified, will retry next tick",
+            tick_id,
+            attempts,
+            REVEAL_RECONCILE_MAX_ATTEMPTS,
+            record.get("id"),
+            (record.get("vault_address") or "")[:10],
+            reason,
+        )
+        await self._persist_reconciled(record, tick_id)
+
+    async def _reconcile_terminal(self, record: dict, tick_id: str, reason: str) -> None:
+        """Give up on a commitment — LOUDLY, and once and for all.
+
+        The failure mode this exists to prevent is an infinite silent retry
+        loop. Terminal is a STATE, not a deletion: the trace stays persisted
+        exactly as it was, honestly unverified, and becomes countable/alertable
+        via ``reveal_reconcile_state == "terminal"`` — which is also what stops
+        ``_needs_reveal_reconciliation`` from ever picking it up again.
+        """
+        record["reveal_reconcile_state"] = _RECONCILE_TERMINAL
+        record["reveal_reconcile_terminal_reason"] = reason
+        record["reveal_reconcile_terminal_at"] = datetime.now(UTC).isoformat()
+        record.setdefault("reveal_reconcile_attempts", 0)
+
+        logger.error(
+            "[tick %s] REVEAL RECONCILIATION TERMINAL — trace %s (hash %s, vault %s, commit %s) "
+            "can no longer be made on-chain-verifiable after %d attempt(s): %s. Its executed trade "
+            "%s stays honestly UNVERIFIED; this record is now countable as "
+            "reveal_reconcile_state=terminal and will not be retried again.",
+            tick_id,
+            record.get("id"),
+            _norm_hash(record.get("trace_hash"))[:16],
+            (record.get("vault_address") or "")[:10],
+            (record.get("commit_tx_hash") or "")[:16],
+            int(record.get("reveal_reconcile_attempts") or 0),
+            reason,
+            (record.get("trade_tx_hash") or "")[:16],
+        )
+        await self._persist_reconciled(record, tick_id)
+
+    async def _persist_reconciled(self, record: dict, tick_id: str) -> None:
+        """Persist a reconciliation outcome; a store failure is loud, never fatal."""
+        try:
+            await self.state.save_trace(record)
+        except Exception as e:
+            logger.error(
+                "[tick %s] Reveal reconciliation persist FAILED for trace %s: %s",
+                tick_id,
+                record.get("id"),
+                e,
+            )
 
     # ─── Reasoning trace (legacy) ──────────────────────────────────
 

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -338,6 +338,79 @@ class TracePublisher:
         trace.reveal_block_number = block_num
         return tx_hash, block_num
 
+    async def get_commitment(self, trace_id: int) -> dict | None:
+        """Read the registry's commitment record for ``trace_id``.
+
+        The authoritative answer to "did that reveal actually land?" — the
+        contract sets ``revealBlock`` inside ``reveal()`` itself, AFTER it has
+        re-hashed the submitted content and checked it against the committed
+        hash. A non-zero ``revealBlock`` is therefore proof that the content
+        was revealed AND verified on-chain, independent of whether our own
+        off-chain write of the reveal tx survived (#1276 reconciliation).
+
+        Returns None when the commitment cannot be read — either the registry
+        has no such id (``getCommitment`` reverts "No commitment" for an
+        unknown id, e.g. after a redeploy) or the RPC call failed. The caller
+        CANNOT distinguish those two from here, so an unreadable commitment
+        must be treated as "unknown, retry later", never as proof of absence.
+        """
+        if not self.supports_commit_reveal():
+            return None
+
+        registry = self.loader.trace_registry
+        try:
+            result = await registry.functions.getCommitment(int(trace_id)).call()
+        except Exception as e:
+            logger.warning(f"getCommitment({trace_id}) unreadable: {e}")
+            return None
+
+        reveal_block = int(result[6])
+        return {
+            "content_hash": result[0],
+            "committer": result[1],
+            "vault": result[2],
+            "commit_block": int(result[3]),
+            "claimed_execution_time": int(result[4]),
+            "revealed": bool(result[5]),
+            "reveal_block": reveal_block or None,
+            "storage_pointer": result[7],
+        }
+
+    async def find_reveal_tx(self, trace_id: int, reveal_block: int | None) -> str | None:
+        """Best-effort lookup of the tx hash that revealed ``trace_id``.
+
+        ``get_commitment`` proves a reveal happened and in which block, but not
+        which transaction carried it. The ``TraceRevealed`` event does, and it
+        indexes ``traceId`` — and because the block is already known the log
+        query is a single-block range, which no RPC provider rejects for size.
+
+        Returns None if the log can't be found or read. Callers must then record
+        the reveal WITHOUT a tx hash rather than inventing one: the on-chain
+        commitment is still honest proof, a fabricated hash never would be.
+        """
+        if reveal_block is None:
+            return None
+
+        registry = self.loader.trace_registry
+        try:
+            logs = await registry.events.TraceRevealed().get_logs(
+                from_block=int(reveal_block),
+                to_block=int(reveal_block),
+                argument_filters={"traceId": int(trace_id)},
+            )
+        except Exception as e:
+            logger.warning(f"TraceRevealed log lookup for trace {trace_id} @ block {reveal_block} failed: {e}")
+            return None
+
+        for entry in logs or []:
+            tx_hash = (
+                entry.get("transactionHash") if isinstance(entry, dict) else getattr(entry, "transactionHash", None)
+            )
+            if tx_hash is None:
+                continue
+            return tx_hash.hex() if isinstance(tx_hash, (bytes, bytearray)) else str(tx_hash)
+        return None
+
     async def verify(self, trace: ReasoningTrace) -> bool:
         """Verify a trace against its on-chain hash."""
         if not trace.trace_hash:

--- a/backend/archimedes/services/redis_state.py
+++ b/backend/archimedes/services/redis_state.py
@@ -448,6 +448,28 @@ class AgentStateStore:
         window = traces[offset : offset + limit]
         return window, total
 
+    async def list_recent_traces(self, limit: int = 200) -> list[dict]:
+        """Newest-first window of persisted traces, bounded AT THE INDEX.
+
+        Deliberately not ``list_traces(limit=…)``: that one loads every trace in
+        the index and only windows afterwards, which is acceptable for a
+        user-facing page but not for something the agent runs on every tick.
+        Here the ``zrevrange`` bound is applied first, so the cost is O(limit)
+        regardless of how much history has accumulated (#1276).
+        """
+        r = await self._get_redis()
+        hashes = await r.zrevrange(KEY_TRACE_INDEX, 0, max(int(limit), 1) - 1)
+
+        traces: list[dict] = []
+        for h in hashes:
+            raw = await r.get(f"{KEY_TRACE_PREFIX}{h}")
+            if not raw:
+                continue
+            data = safe_json_loads(raw, context="trace:recent")
+            if data is not None:
+                traces.append(data)
+        return traces
+
     async def get_last_trace(self, vault_address: str) -> dict | None:
         """Get the most recent trace for a specific vault."""
         traces, _ = await self.list_traces(vault_address=vault_address, limit=1)

--- a/backend/tests/services/test_redis_state.py
+++ b/backend/tests/services/test_redis_state.py
@@ -311,6 +311,30 @@ class TestTraces:
         assert window[0]["decision_type"] == "rebalance"
 
     @pytest.mark.asyncio
+    async def test_list_recent_traces_bounds_the_range_at_the_index(self) -> None:
+        """#1276: the tick's reconciliation scan must be O(limit), not O(history)
+        — the zrevrange itself carries the bound, unlike list_traces."""
+        store, fake = await _store_with_fake_redis()
+        fake.zrevrange.return_value = ["h1", "h2"]
+        fake.get = AsyncMock(side_effect=[json.dumps({"id": "t1"}), json.dumps({"id": "t2"})])
+
+        traces = await store.list_recent_traces(limit=2)
+
+        assert [t["id"] for t in traces] == ["t1", "t2"]
+        key, start, stop = fake.zrevrange.await_args.args
+        assert (key, start, stop) == (KEY_TRACE_INDEX, 0, 1)  # inclusive stop => exactly 2
+
+    @pytest.mark.asyncio
+    async def test_list_recent_traces_skips_missing_and_malformed_entries(self) -> None:
+        store, fake = await _store_with_fake_redis()
+        fake.zrevrange.return_value = ["h1", "h2", "h3"]
+        fake.get = AsyncMock(side_effect=[None, "{not json", json.dumps({"id": "t3"})])
+
+        traces = await store.list_recent_traces(limit=3)
+
+        assert [t["id"] for t in traces] == ["t3"]  # a corrupt entry never breaks the scan
+
+    @pytest.mark.asyncio
     async def test_get_last_trace_returns_first(self) -> None:
         store, fake = await _store_with_fake_redis()
         fake.zrevrange.return_value = ["h1"]

--- a/backend/tests/test_agent_runner_reveal_reconciliation.py
+++ b/backend/tests/test_agent_runner_reveal_reconciliation.py
@@ -1,0 +1,569 @@
+"""Reveal reconciliation for dangling commitments (#1276, audit G9).
+
+The repair pass for the failure mode ``TestRevealFailureAfterTradeExecuted``
+(#1275) pins: trade + commit land, the reveal does not, and the trace persists
+honestly as unverified with a dangling commit. Pre-#1276 no later tick ever came
+back for it, so that executed trade's reasoning could never become
+on-chain-verifiable.
+
+Hermetic, boundary-mocked exactly like ``test_agent_runner_commit_reveal.py`` /
+``test_agent_runner_tick.py``: chain client, executor, trace_publisher, IPFS pin,
+provider and the Redis state store are all mocked. No network, no RPC, no Redis.
+
+The dangling records under test are NOT hand-written dicts — they are produced by
+running the real ``_reveal_trace`` failure path and capturing what it persisted,
+so the scan is proven against the actual #1275 output shape rather than against a
+test author's idea of it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.agent_runner import _needs_reveal_reconciliation
+from archimedes.models.trace import DecisionType, ReasoningTrace
+
+
+def _make_trace(trace_id: str = "recon-trace-001") -> ReasoningTrace:
+    trace = ReasoningTrace(
+        id=trace_id,
+        vault_address="0x1234567890abcdef1234567890abcdef12345678",
+        decision_type=DecisionType.REBALANCE,
+        trigger="strategy_signal_drift",
+        timestamp=datetime.now(UTC),
+        market_context={"regime": "risk_on"},
+        portfolio_before={"vault": "0x12345678", "aum_usdc": 1000.0},
+        portfolio_after={"intended": True, "target_weights": {"sSPY": 0.6}},
+        reasoning="Reveal reconciliation test",
+        confidence=0.9,
+        trades_executed=[{"symbol": "sSPY", "direction": "buy", "amount": 100.0}],
+        strategies_referenced=["faber_001"],
+        consulted_paper_hashes=["0001:abc123"],
+    )
+    trace.compute_hash()
+    return trace
+
+
+@pytest.fixture()
+def runner_env():
+    """A StrategyRunner with every chain boundary mocked and the live path armed."""
+    with (
+        patch("archimedes.chain.agent_runner.chain_client"),
+        patch("archimedes.chain.agent_runner.chain_executor"),
+        patch("archimedes.chain.agent_runner.trace_publisher") as mock_tp,
+        patch("archimedes.chain.agent_runner.default_provider"),
+        patch("archimedes.chain.agent_runner.AgentStateStore"),
+        patch("archimedes.chain.agent_runner.pin_public_provenance", new=AsyncMock(return_value=(None, None))),
+        patch("archimedes.chain.agent_runner.DRY_RUN", False),
+    ):
+        from archimedes.chain.agent_runner import StrategyRunner
+
+        runner = StrategyRunner()
+        runner.state = MagicMock()
+        runner.state.save_trace = AsyncMock()
+        runner.state.list_recent_traces = AsyncMock(return_value=[])
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.get_commitment = AsyncMock(return_value=None)
+        mock_tp.find_reveal_tx = AsyncMock(return_value=None)
+        mock_tp.publish = AsyncMock(return_value=None)
+        yield runner, mock_tp
+
+
+def _dangling_record(runner, mock_tp, *, trace_id: str = "recon-trace-001") -> dict:
+    """The REAL persisted output of the #1275 reveal-failure path.
+
+    Runs ``_reveal_trace`` with a reveal that raises (RPC outage / revert) and
+    returns the dict it saved: executed trade, dangling commit, no reveal, no
+    fabricated verification.
+    """
+    mock_tp.reveal = AsyncMock(side_effect=RuntimeError("execution reverted: rpc down"))
+    asyncio.run(
+        runner._reveal_trace(
+            _make_trace(trace_id),
+            trace_id=42,
+            tick_id="t-orig",
+            tx_hashes=["0xtrade"],
+            commit_tx="0xcommit",
+            commit_block=100,
+            trade_block=101,
+            claimed_execution_time=int(datetime.now(UTC).timestamp()) - 300,
+        )
+    )
+    record = runner.state.save_trace.call_args[0][0]
+    runner.state.save_trace.reset_mock()
+    # Sanity: this really is the honest-degradation shape #1275 pins.
+    assert record["is_verified"] is False
+    assert record["reveal_tx_hash"] is None
+    assert record["trade_tx_hash"] == "0xtrade"
+    assert record["commit_tx_hash"] == "0xcommit"
+    return record
+
+
+def _run_pass(runner, records: list[dict], tick_id: str = "t-recon") -> None:
+    runner.state.list_recent_traces = AsyncMock(return_value=records)
+    asyncio.run(runner._reconcile_dangling_reveals(tick_id))
+
+
+def _saved(runner) -> dict:
+    return runner.state.save_trace.call_args[0][0]
+
+
+# ── the scan filter ───────────────────────────────────────────
+
+
+class TestScanPicksUpExactlyTheDanglingShape:
+    """commit_tx_hash NOT NULL and reveal_tx_hash NULL and trade_tx_hash NOT NULL."""
+
+    def test_matches_the_real_1275_failure_record(self, runner_env):
+        runner, mock_tp = runner_env
+        assert _needs_reveal_reconciliation(_dangling_record(runner, mock_tp)) is True
+
+    @pytest.mark.parametrize(
+        ("label", "mutate"),
+        [
+            # HOUSE-RULE guard demos: each of these MUST NOT match. They are the
+            # near-misses the filter exists to exclude, constructed by breaking
+            # exactly one leg of the real dangling record.
+            ("unrevealed_but_no_trade", lambda r: r.update(trade_tx_hash=None)),
+            ("already_revealed", lambda r: r.update(reveal_tx_hash="0xREVEALED")),
+            ("no_commit_anchored", lambda r: r.update(commit_tx_hash=None)),
+            ("already_terminal", lambda r: r.update(reveal_reconcile_state="terminal")),
+            ("already_reconciled", lambda r: r.update(reveal_reconcile_state="reconciled")),
+            ("already_reconciled_from_chain", lambda r: r.update(reveal_reconcile_state="reconciled_from_chain")),
+        ],
+    )
+    def test_near_misses_are_excluded(self, runner_env, label, mutate):
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mutate(record)
+        assert _needs_reveal_reconciliation(record) is False, label
+
+    def test_pending_state_is_still_eligible(self, runner_env):
+        """ "pending" is the retried-and-failed state — it must stay in the scan."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        record["reveal_reconcile_state"] = "pending"
+        record["reveal_reconcile_attempts"] = 1
+        assert _needs_reveal_reconciliation(record) is True
+
+    def test_pass_ignores_non_matching_records_end_to_end(self, runner_env):
+        """The guard demo, run through the real pass: a store full of near-misses
+        must produce ZERO reveal attempts and ZERO writes."""
+        runner, mock_tp = runner_env
+        base = _dangling_record(runner, mock_tp)
+
+        no_trade = dict(base, id="no-trade", trade_tx_hash=None)
+        revealed = dict(base, id="revealed", reveal_tx_hash="0xREVEALED", is_verified=True)
+        no_commit = dict(base, id="no-commit", commit_tx_hash=None)
+        terminal = dict(base, id="terminal", reveal_reconcile_state="terminal")
+
+        mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 999))
+        _run_pass(runner, [no_trade, revealed, no_commit, terminal])
+
+        mock_tp.reveal.assert_not_awaited()
+        mock_tp.get_commitment.assert_not_awaited()
+        runner.state.save_trace.assert_not_awaited()
+
+
+# ── the retry ─────────────────────────────────────────────────
+
+
+class TestSuccessfulRetry:
+    def test_backfills_reveal_and_verification_honestly(self, runner_env):
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+
+        # Commitment exists on-chain, is NOT yet revealed, window already open.
+        mock_tp.get_commitment = AsyncMock(
+            return_value={
+                "revealed": False,
+                "reveal_block": None,
+                "claimed_execution_time": int(datetime.now(UTC).timestamp()) - 300,
+                "storage_pointer": "",
+            }
+        )
+        mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 150))
+
+        _run_pass(runner, [record])
+
+        # The retry submitted the re-derived canonical bytes for the SAME on-chain id.
+        mock_tp.reveal.assert_awaited_once()
+        assert mock_tp.reveal.await_args.args[0] == 42
+        revealed_trace = mock_tp.reveal.await_args.args[1]
+        assert revealed_trace.compute_hash() == record["trace_hash"]
+
+        saved = _saved(runner)
+        assert saved["reveal_tx_hash"] == "0xRETRYREVEAL"
+        assert saved["reveal_block_number"] == 150
+        assert saved["is_verified"] is True
+        assert saved["arc_tx_hash"] == "0xRETRYREVEAL"
+        # commit(100) < trade(101) <= reveal(150), chain source → a genuine binding.
+        assert saved["temporal_binding_valid"] is True
+        assert saved["reveal_reconcile_state"] == "reconciled"
+        # …and it is closed to any further scan.
+        assert _needs_reveal_reconciliation(saved) is False
+
+    def test_binding_stays_false_when_block_ordering_does_not_hold(self, runner_env):
+        """A successful retry never asserts a binding it cannot prove: a reveal
+        block that predates the trade block is not a valid ordering."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            return_value={"revealed": False, "reveal_block": None, "claimed_execution_time": 0, "storage_pointer": ""}
+        )
+        mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 100))  # < trade_block 101
+
+        _run_pass(runner, [record])
+
+        saved = _saved(runner)
+        assert saved["is_verified"] is True  # the reveal really did land…
+        assert saved["temporal_binding_valid"] is False  # …but the ordering is not provable
+
+    def test_reuses_the_pinned_cid_as_storage_pointer(self, runner_env):
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        record["ipfs_cid"] = "bafyREUSED"
+        mock_tp.get_commitment = AsyncMock(
+            return_value={"revealed": False, "reveal_block": None, "claimed_execution_time": 0, "storage_pointer": ""}
+        )
+        mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 150))
+
+        _run_pass(runner, [record])
+
+        assert mock_tp.reveal.await_args.kwargs["storage_pointer"] == "bafyREUSED"
+
+
+class TestFailingRetry:
+    def test_increments_the_counter_and_stays_unverified(self, runner_env):
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            return_value={"revealed": False, "reveal_block": None, "claimed_execution_time": 0, "storage_pointer": ""}
+        )
+        mock_tp.reveal = AsyncMock(side_effect=RuntimeError("execution reverted: rpc down again"))
+
+        _run_pass(runner, [record])
+
+        saved = _saved(runner)
+        assert saved["reveal_reconcile_attempts"] == 1
+        assert saved["reveal_reconcile_state"] == "pending"
+        assert "rpc down again" in saved["reveal_reconcile_last_error"]
+        # The #1275 honest-degradation contract is untouched by a failed retry.
+        assert saved["is_verified"] is False
+        assert saved["reveal_tx_hash"] is None
+        assert saved["reveal_block_number"] is None
+        assert saved["temporal_binding_valid"] is False
+        assert saved["commit_tx_hash"] == "0xcommit"
+        assert saved["trade_tx_hash"] == "0xtrade"
+        # Still eligible — a bounded retry, not a give-up.
+        assert _needs_reveal_reconciliation(saved) is True
+
+    def test_reveal_returning_no_tx_counts_as_a_failure(self, runner_env):
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            return_value={"revealed": False, "reveal_block": None, "claimed_execution_time": 0, "storage_pointer": ""}
+        )
+        mock_tp.reveal = AsyncMock(return_value=(None, None))  # publisher swallowed its own error
+
+        _run_pass(runner, [record])
+
+        saved = _saved(runner)
+        assert saved["reveal_reconcile_attempts"] == 1
+        assert saved["is_verified"] is False
+
+    def test_unreadable_commitment_is_retryable_not_terminal(self, runner_env):
+        """Unreadable ≠ absent: an RPC failure must not be read as proof that
+        the commitment does not exist."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(return_value=None)
+        mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 1))
+
+        _run_pass(runner, [record])
+
+        mock_tp.reveal.assert_not_awaited()  # never transact against an unknown commitment
+        saved = _saved(runner)
+        assert saved["reveal_reconcile_attempts"] == 1
+        assert saved["reveal_reconcile_state"] == "pending"
+
+    def test_window_not_yet_open_consumes_no_attempt(self, runner_env):
+        """reveal() reverts before claimedExecutionTime — a wait, not a failure."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            return_value={
+                "revealed": False,
+                "reveal_block": None,
+                "claimed_execution_time": int(datetime.now(UTC).timestamp()) + 300,
+                "storage_pointer": "",
+            }
+        )
+        mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 1))
+
+        _run_pass(runner, [record])
+
+        mock_tp.reveal.assert_not_awaited()
+        runner.state.save_trace.assert_not_awaited()  # nothing changed, nothing burned
+        assert _needs_reveal_reconciliation(record) is True
+
+
+# ── the bound ─────────────────────────────────────────────────
+
+
+class TestTerminalCap:
+    """The failure mode this pass must not become: an infinite silent retry."""
+
+    def test_nth_failure_goes_terminal_loudly_and_is_never_retried(self, runner_env, caplog, monkeypatch):
+        runner, mock_tp = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.REVEAL_RECONCILE_MAX_ATTEMPTS", 3)
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            return_value={"revealed": False, "reveal_block": None, "claimed_execution_time": 0, "storage_pointer": ""}
+        )
+        mock_tp.reveal = AsyncMock(side_effect=RuntimeError("execution reverted: still broken"))
+
+        # Attempts 1 and 2: pending, retried each tick.
+        for expected in (1, 2):
+            _run_pass(runner, [record])
+            record = _saved(runner)
+            assert record["reveal_reconcile_attempts"] == expected
+            assert record["reveal_reconcile_state"] == "pending"
+            runner.state.save_trace.reset_mock()
+
+        # Attempt 3 (the cap): TERMINAL, loudly.
+        with caplog.at_level("ERROR"):
+            _run_pass(runner, [record])
+        record = _saved(runner)
+
+        assert "REVEAL RECONCILIATION TERMINAL" in caplog.text
+        assert record["id"] in caplog.text  # the ERROR names the trace…
+        assert "still broken" in caplog.text  # …and why it gave up
+        assert record["reveal_reconcile_state"] == "terminal"
+        assert record["reveal_reconcile_attempts"] == 3
+        assert record["reveal_reconcile_terminal_reason"]
+
+        # Terminal is a STATE, not a deletion — #1275's honest record survives.
+        assert record["is_verified"] is False
+        assert record["reveal_tx_hash"] is None
+        assert record["trade_tx_hash"] == "0xtrade"
+        assert record["commit_tx_hash"] == "0xcommit"
+        assert record["temporal_binding_valid"] is False
+
+        # HOUSE-RULE guard demo: feed the terminal record straight back in. It
+        # must be picked up by NOTHING — no scan match, no chain read, no
+        # transaction, no further write.
+        assert _needs_reveal_reconciliation(record) is False
+        mock_tp.reveal.reset_mock()
+        mock_tp.get_commitment.reset_mock()
+        runner.state.save_trace.reset_mock()
+        _run_pass(runner, [record])
+        mock_tp.reveal.assert_not_awaited()
+        mock_tp.get_commitment.assert_not_awaited()
+        runner.state.save_trace.assert_not_awaited()
+
+    # 0 is the registry's empty sentinel (traces are 1-indexed) and a
+    # non-numeric id is unusable — all three mean "no commitment to reveal".
+    @pytest.mark.parametrize("bad_id", [None, 0, "not-an-id"])
+    def test_missing_onchain_id_is_terminal_immediately(self, runner_env, caplog, bad_id):
+        """A publishTrace-fallback anchor (pre-v1.5, #588) has no commitment to
+        reveal — it is unrevealable by construction, so it must surface as a
+        countable terminal state instead of being retried forever."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        record["onchain_trace_id"] = bad_id
+        mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 1))
+
+        with caplog.at_level("ERROR"):
+            _run_pass(runner, [record])
+
+        mock_tp.reveal.assert_not_awaited()
+        saved = _saved(runner)
+        assert saved["reveal_reconcile_state"] == "terminal"
+        assert "no on-chain commitment id" in saved["reveal_reconcile_terminal_reason"]
+        assert "REVEAL RECONCILIATION TERMINAL" in caplog.text
+        assert saved["is_verified"] is False
+
+    def test_canonical_drift_is_terminal_immediately(self, runner_env, caplog):
+        """If the persisted bytes no longer re-derive to the committed hash, the
+        contract's keccak256 check can never pass — retrying only burns gas."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        record["reasoning"] = "mutated after the commit"  # a HASHED field
+        mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 1))
+
+        with caplog.at_level("ERROR"):
+            _run_pass(runner, [record])
+
+        mock_tp.reveal.assert_not_awaited()
+        saved = _saved(runner)
+        assert saved["reveal_reconcile_state"] == "terminal"
+        assert "Hash mismatch" in saved["reveal_reconcile_terminal_reason"]
+        assert "REVEAL RECONCILIATION TERMINAL" in caplog.text
+
+
+# ── restart safety ────────────────────────────────────────────
+
+
+class TestAlreadyRevealedOnChain:
+    """The reveal landed; the process died before the DB write (#1276 c.5)."""
+
+    def test_backfills_from_chain_without_a_new_transaction(self, runner_env, caplog):
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            return_value={
+                "revealed": True,
+                "reveal_block": 150,
+                "claimed_execution_time": 0,
+                "storage_pointer": "bafyONCHAIN",
+            }
+        )
+        mock_tp.find_reveal_tx = AsyncMock(return_value="0xONCHAINREVEAL")
+        mock_tp.reveal = AsyncMock(return_value=("0xSHOULDNOTHAPPEN", 999))
+
+        with caplog.at_level("WARNING"):
+            _run_pass(runner, [record])
+
+        mock_tp.reveal.assert_not_awaited()  # no second reveal — that would revert
+        saved = _saved(runner)
+        assert saved["reveal_tx_hash"] == "0xONCHAINREVEAL"
+        assert saved["reveal_block_number"] == 150
+        assert saved["is_verified"] is True
+        assert saved["temporal_binding_valid"] is True
+        assert saved["ipfs_cid"] == "bafyONCHAIN"
+        assert saved["reveal_reconcile_state"] == "reconciled_from_chain"
+        assert saved["reveal_source"] == "chain_commitment"
+        assert "RECONCILED FROM CHAIN" in caplog.text
+        assert _needs_reveal_reconciliation(saved) is False
+
+    def test_no_recoverable_tx_hash_is_recorded_honestly_not_invented(self, runner_env):
+        """When the TraceRevealed log can't be served, the on-chain commitment is
+        still proof — but the tx hash is left None rather than fabricated."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            return_value={"revealed": True, "reveal_block": 150, "claimed_execution_time": 0, "storage_pointer": ""}
+        )
+        mock_tp.find_reveal_tx = AsyncMock(return_value=None)
+        mock_tp.reveal = AsyncMock(return_value=("0xSHOULDNOTHAPPEN", 999))
+
+        _run_pass(runner, [record])
+
+        saved = _saved(runner)
+        assert saved["reveal_tx_hash"] is None
+        assert saved["reveal_block_number"] == 150
+        assert saved["is_verified"] is True
+        assert saved["reveal_source"] == "chain_commitment"
+
+    def test_already_revealed_revert_routes_to_the_chain_backfill(self, runner_env):
+        """The race: the commitment reads unrevealed, then our own in-flight tx
+        (or another attempt) lands first and reveal() reverts "Already revealed".
+        That is a success, not a retry."""
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.get_commitment = AsyncMock(
+            side_effect=[
+                {"revealed": False, "reveal_block": None, "claimed_execution_time": 0, "storage_pointer": ""},
+                {"revealed": True, "reveal_block": 151, "claimed_execution_time": 0, "storage_pointer": ""},
+            ]
+        )
+        mock_tp.find_reveal_tx = AsyncMock(return_value="0xRACEREVEAL")
+        mock_tp.reveal = AsyncMock(side_effect=RuntimeError("execution reverted: Already revealed"))
+
+        _run_pass(runner, [record])
+
+        saved = _saved(runner)
+        assert saved["reveal_reconcile_state"] == "reconciled_from_chain"
+        assert saved["reveal_tx_hash"] == "0xRACEREVEAL"
+        assert saved["reveal_block_number"] == 151
+        assert saved["is_verified"] is True
+        assert saved.get("reveal_reconcile_attempts", 0) == 0  # not counted as a failure
+
+
+# ── the gates ─────────────────────────────────────────────────
+
+
+class TestDryRunAndLeaseGates:
+    def test_dry_run_does_not_transact_or_even_scan(self, runner_env, monkeypatch):
+        """AGENT_DRY_RUN is honoured exactly as ``_reveal_trace`` honours it —
+        reconciliation must never become a dry-run bypass to the chain."""
+        runner, mock_tp = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.DRY_RUN", True)
+        record = _dangling_record(runner, mock_tp)
+        mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 1))
+
+        _run_pass(runner, [record])
+
+        mock_tp.reveal.assert_not_awaited()
+        mock_tp.get_commitment.assert_not_awaited()
+        runner.state.save_trace.assert_not_awaited()
+        runner.state.list_recent_traces.assert_not_awaited()
+
+    def test_lease_not_held_skips_the_pass(self, runner_env, caplog):
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
+        runner.lease = MagicMock(is_valid=False)
+        mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 1))
+
+        with caplog.at_level("ERROR"):
+            _run_pass(runner, [record])
+
+        assert "LEASE NOT HELD" in caplog.text
+        mock_tp.reveal.assert_not_awaited()
+        runner.state.save_trace.assert_not_awaited()
+
+    def test_scan_failure_is_loud_and_never_kills_the_tick(self, runner_env, caplog):
+        runner, _ = runner_env
+        runner.state.list_recent_traces = AsyncMock(side_effect=RuntimeError("redis down"))
+
+        with caplog.at_level("ERROR"):
+            asyncio.run(runner._reconcile_dangling_reveals("t-recon"))
+
+        assert "Reveal reconciliation scan FAILED" in caplog.text
+
+    def test_per_tick_batch_is_bounded(self, runner_env, monkeypatch):
+        runner, mock_tp = runner_env
+        monkeypatch.setattr("archimedes.chain.agent_runner.REVEAL_RECONCILE_MAX_PER_TICK", 2)
+        # Five genuinely distinct dangling records (the id is a HASHED field, so
+        # they must be built through the real path, not copied and relabelled).
+        records = [_dangling_record(runner, mock_tp, trace_id=f"dangling-{i}") for i in range(5)]
+        mock_tp.get_commitment = AsyncMock(
+            return_value={"revealed": False, "reveal_block": None, "claimed_execution_time": 0, "storage_pointer": ""}
+        )
+        mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 150))
+
+        _run_pass(runner, records)
+
+        assert mock_tp.reveal.await_count == 2
+
+
+class TestTickIntegration:
+    """The pass runs at tick start, before any new commit work."""
+
+    def test_tick_runs_reconciliation_first(self, runner_env):
+        runner, _ = runner_env
+        order: list[str] = []
+        runner._reconcile_dangling_reveals = AsyncMock(side_effect=lambda tick_id: order.append("reconcile"))
+        runner.provider.list_strategies = MagicMock(side_effect=lambda: order.append("strategies") or [])
+
+        asyncio.run(runner.tick())
+
+        assert order == ["reconcile", "strategies"]
+
+    def test_reconciliation_failure_does_not_abort_the_tick(self, runner_env, caplog):
+        """Repairing yesterday's trace must never stop today's rebalance."""
+        runner, _ = runner_env
+        runner._reconcile_dangling_reveals = AsyncMock(side_effect=RuntimeError("boom"))
+        reached = MagicMock(return_value=[])
+        runner.provider.list_strategies = reached
+
+        with caplog.at_level("ERROR"):
+            asyncio.run(runner.tick())  # must not raise
+
+        assert "Reveal reconciliation pass FAILED" in caplog.text
+        reached.assert_called_once()  # the tick carried on past it
+        assert "Strategy tick failed" not in caplog.text

--- a/backend/tests/test_agent_runner_tick.py
+++ b/backend/tests/test_agent_runner_tick.py
@@ -119,6 +119,10 @@ def runner_env(monkeypatch):
         state.save_trace = AsyncMock()
         state.get_last_trace = AsyncMock(return_value=None)
         state.save_last_rebalance = AsyncMock()
+        # #1276: tick step 0 scans for dangling commitments to reconcile. Empty
+        # store => the pass is a no-op, so live-mode (DRY_RUN=False) cases below
+        # exercise exactly the same commit/trade/reveal flow they always did.
+        state.list_recent_traces = AsyncMock(return_value=[])
 
         from archimedes.chain.agent_runner import StrategyRunner
 


### PR DESCRIPTION
Closes #1276 (audit G9). When trade + commit succeed but the reveal fails, the trace persisted honestly as unverified — and nothing ever retried it, so the product's core promise stayed permanently degraded for that trade. This adds a bounded reconciliation pass.

## Design (constraints ratified before build)

- **Tick step 0**, same lease, before any new commit work, wrapped so it can never abort the tick.
- **Scan predicate** is exactly the dangling shape — `commit_tx_hash AND trade_tx_hash AND NOT reveal_tx_hash`, minus closed states — with every exclusion documented as load-bearing.
- **Contract-verified, not assumed**: `ReasoningTraceRegistry.reveal()`'s guards are lower-bound/content-only (checked against the Solidity and the compiled ABI) — a later-block reveal IS accepted; the guards that can never pass later are exactly the TERMINAL reasons (no on-chain id from a publishTrace-era anchor; canonical bytes that no longer re-derive; rotated committer).
- **Chain first**: `getCommitment` read before any transaction — a reveal that landed on-chain with a lost DB write is backfilled as `reveal_source='chain_commitment'` (loud, provenanced), never re-sent; the "Already revealed" revert routes the same way. Unreadable ≠ absent: treated as a bounded retryable, never terminal.
- **Bounded**: attempt counter persisted; `REVEAL_RECONCILE_MAX_ATTEMPTS` (3) → TERMINAL with an ERROR naming trace/vault/commit/reason. Terminal is a state, never a deletion. A commitment still inside its claimedExecutionTime window waits without consuming an attempt.
- **DRY_RUN**: first line of the pass — zero reads, zero writes, zero counter movement.
- **#1275's honest-degradation contract byte-unchanged** and green.

## Verification

- 30 new tests whose dangling fixtures are produced by RUNNING the real #1275 failure path (not hand-written dicts); 105 green across the four touched suites; full CI-exact suite **3385 passed, 0 failed** (run twice by independent verifiers).
- Guard demos with counterfactuals in the commit body: near-miss records → 0 reveals (weakened filter → 3, proving the filter does the work); terminal-cap trace attempts 1,2,3→terminal, never retried (state stripped → retried, proving the cap does the work).
- Independently re-verified twice: the Solidity guards and ABI tuple/event mappings re-derived from source; the attempt cap reproduced end-to-end across ticks; and three honesty guards mutation-tested (fabricated is_verified on failure, dropped `revealed` gate before backfill, terminal-as-deletion) — each mutation caught by 3–8 existing tests.

## Known limits (deliberate, for review)

1. **Attempt-cap durability rides on Redis writes** (verifier finding): a compound failure (reveal failing AND save_trace persistently failing) retries unbounded — generic to persisted-counter designs; flagged, not fixed here.
2. **Scan window** is the newest 200 traces (env-tunable) — a dangling record can age out unseen at high tick volume; a dedicated unrevealed-index is the durable fix.
3. **Terminal isn't yet alertable** beyond the ERROR log + persisted state — no metric/API surface.
4. **No signer pre-check**: a rotated committer burns all N attempts before terminal; a cheap `commitment.committer` vs configured-address check would terminal immediately.
5. **First-deploy burst**: pre-existing dangling traces persisted without `onchain_trace_id` will terminal loudly on the first pass — honest, expected, not a new failure.

Follow-up issue for 1–4 coming alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
