### PR TITLE
[infra] Deploy queue-not-cancel: superseded runs coalesce instead of starving prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,12 @@ concurrency:
   # split into a cancellable build phase + queued deploy phase: separate
   # concurrency groups would let run B's migrate interleave into run A's
   # migrate→deploy window, deploying older code against a newer schema.
+  #
+  # Caveat for incident response: a MANUAL workflow_dispatch (e.g. a rollback)
+  # shares this group, so during a merge burst it queues behind the in-flight
+  # run and may replace a pending one. If a rollback must jump the line,
+  # cancel the in-progress/pending runs in the Actions UI first, then
+  # dispatch.
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,18 @@ on:
 
 concurrency:
   group: deploy-production
-  cancel-in-progress: true
+  # QUEUE, never cancel (#1346). With cancel-in-progress: true, every merge to
+  # main killed the in-flight run: under a merge cadence faster than the ~13-min
+  # build no deploy ever completed (prod ran a stale image while main carried
+  # fixes), and a cancel landing in the verify tail AFTER the image deployed
+  # left "red run + healthy prod" — a failed-deploy false alarm. With false,
+  # the running deploy completes untouched and GitHub keeps at most ONE pending
+  # run per group (a newer push replaces the older pending run), so bursts
+  # coalesce to latest with strict old-before-new ordering. Deliberately NOT
+  # split into a cancellable build phase + queued deploy phase: separate
+  # concurrency groups would let run B's migrate interleave into run A's
+  # migrate→deploy window, deploying older code against a newer schema.
+  cancel-in-progress: false
 
 permissions:
   id-token: write   # Required for OIDC token request


### PR DESCRIPTION
## Problem

`deploy.yml` runs with `concurrency: cancel-in-progress: true`. Two failure modes observed on 2026-08-20 (full evidence in #1346 and on #1309):

1. **Starvation**: under a merge cadence faster than the ~13-minute build, every run is cancelled by the next push — no deploy completes. Five consecutive runs cancelled between 07:36 and 07:57Z while `main` carried an active production fix (#1337) that could not reach the live service. `git merge-base --is-ancestor <fix-sha> <deployed-sha>` stayed false throughout.
2. **Verify-tail false alarms**: the cancel can land AFTER the image deployed, during the run's verification tail — production healthy on the new image while the run shows `cancelled`, indistinguishable from a failed deploy.

## Fix (#1346 AC1, exactly as the issue specifies)

`cancel-in-progress: false` on the `deploy-production` group. The running deploy completes untouched; GitHub keeps at most **one** pending run per group (a newer push replaces the older *pending* run), so merge bursts queue-and-collapse to the latest commit with strict old-before-new ordering — the issue's stated "right shape". Worst case, the newest merge lands one full run (~13 min) behind the in-flight one.

Deliberately **not** a cancellable-build-phase + queued-deploy-phase split: separate job-level concurrency groups would let run B's `migrate` interleave into run A's migrate→deploy window, deploying older code against a newer schema. The single queued group keeps migrate+deploy atomic per run. A documented caveat covers manual `workflow_dispatch` rollbacks (they share the group and queue behind a burst; the escape hatch is cancelling pending runs in the UI first).

## Scope against #1346's acceptance criteria

- **AC1** — this PR (the issue's exact YAML; `grep -n -A3 "concurrency:" .github/workflows/deploy.yml` now shows `cancel-in-progress: false`).
- **AC2 (drift observability — alarm when production trails `main` by more than one deploy)** — NOT in this PR; it is a separate observability build and stays tracked on the open issue.
- **AC3 (demonstration)** — the failing half is already on the record: the issue's own run table (five consecutive cancelled runs, 32345584819 et al.) is the current config failing the check. The passing half — a merge burst where the in-flight run completes and the queue drains to the latest — can only be produced by `deploy.yml` running from `main`, so it will be demonstrated on the first post-merge burst and posted to #1346 with run links before the issue closes.

**Addresses #1346 (AC1).** No closing keyword — the issue stays open for AC2 and the AC3 post-merge demonstration.

## Verification

- `yaml.safe_load` parses the edited workflow cleanly.
- Queue semantics are GitHub Actions' documented behavior for `cancel-in-progress: false` (in-progress runs complete; at most one pending run per group, newest wins).

Observed while here, not touched (separate concern): the top-level `EC2_INSTANCE_ID` env constant points at a terminated instance and is referenced only by comments — dead constant, candidate for a cleanup pass.
