### PR TITLE
[security] Admin-gate the per-wallet metrics endpoints

### DIFF
--- a/backend/archimedes/api/metrics_private_routes.py
+++ b/backend/archimedes/api/metrics_private_routes.py
@@ -32,6 +32,17 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException
 
 from archimedes.api.wallet_routes import require_linked_wallet
+from archimedes.models.telemetry import (
+    WalletConnectionOut,
+    WalletConnectionsResponse,
+    WalletIdentityOut,
+    WalletsResponse,
+)
+from archimedes.services.identity_metrics import (
+    count_human_wallets,
+    list_human_wallets,
+    list_wallet_connections,
+)
 from archimedes.services.user_stats import get_distinct_user_count
 
 
@@ -88,3 +99,48 @@ async def get_private_cost(wallet: str = Depends(require_platform_admin)) -> dic
         "authenticated_wallet": wallet,
         "timestamp": datetime.now(UTC).isoformat(),
     }
+
+
+@metrics_private_router.get("/wallets", response_model=WalletsResponse)
+async def get_wallets() -> WalletsResponse:
+    """Enumerate legacy verified human wallets, separate from account count.
+
+    ADMIN-ONLY, moved here from the public metrics router (#1366): this returns
+    the full per-wallet roster — wallet addresses are pseudonymous but
+    permanently linkable to on-chain activity, so an open enumeration endpoint
+    let anyone list every user of the platform and trace their chain history.
+    The public metrics surface is aggregate and PII-free BY DESIGN (module
+    docstring above); a per-identity roster belongs behind the same admin gate
+    as the rest of the ops dashboard. Anonymous → 401; verified non-admin → 403
+    (router-level dependency).
+
+    ``real_users`` field is retained for response compatibility but means wallet
+    count on this endpoint only (#1028 AC1). Fail-safe: empty list / zero on DB
+    error.
+    """
+    return WalletsResponse(
+        real_users=count_human_wallets(),
+        wallets=[WalletIdentityOut(**row) for row in list_human_wallets()],
+        timestamp=datetime.now(UTC).isoformat(),
+    )
+
+
+@metrics_private_router.get("/wallets/connections", response_model=WalletConnectionsResponse)
+async def get_wallet_connections() -> WalletConnectionsResponse:
+    """ "Which wallets connected, and when" — issue #1028 AC2.
+
+    ADMIN-ONLY, moved here from the public metrics router for the same reason
+    as ``/wallets`` above (#1366): a per-wallet first-connection ledger is
+    identity data, not aggregate traction.
+
+    ``SELECT wallet, min(occurred_at) FROM identity_events WHERE event_type =
+    'auth_verified' GROUP BY wallet`` — a query that was impossible before the
+    ledger (the SIWE-verify path used to discard the wallet into a stateless
+    cookie with no durable write). Fail-safe: an empty list on any DB error.
+    """
+    connections = list_wallet_connections()
+    return WalletConnectionsResponse(
+        count=len(connections),
+        connections=[WalletConnectionOut(**row) for row in connections],
+        timestamp=datetime.now(UTC).isoformat(),
+    )

--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -24,7 +24,7 @@ from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Literal
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 
 from archimedes.api.funnel_middleware import record_funnel
 from archimedes.api.visitor_insights import record_visitor_insight
@@ -40,6 +40,7 @@ from archimedes.models.telemetry import (
     WalletIdentityOut,
     WalletsResponse,
 )
+from archimedes.api.metrics_private_routes import require_platform_admin
 from archimedes.services.funnel_store import CLIENT_EMITTABLE_STAGES, STAGES, FunnelStore
 from archimedes.services.identity_metrics import (
     count_human_wallets,
@@ -162,9 +163,21 @@ async def get_metrics() -> MetricsResponse:
     )
 
 
-@metrics_router.get("/metrics/wallets", response_model=WalletsResponse)
+@metrics_router.get(
+    "/metrics/wallets",
+    response_model=WalletsResponse,
+    dependencies=[Depends(require_platform_admin)],
+)
 async def get_wallets() -> WalletsResponse:
     """Enumerate legacy verified human wallets, separate from account count.
+
+    ADMIN-ONLY (#1366): this returns the full per-wallet roster — wallet
+    addresses are pseudonymous but permanently linkable to on-chain activity,
+    so an open enumeration endpoint let anyone list every user of the platform
+    and trace their chain history. The public metrics surface is aggregate and
+    PII-free BY DESIGN (see metrics_private_routes' module docstring); a
+    per-identity roster belongs behind the same admin gate as the ops
+    dashboard. Anonymous → 401; verified non-admin wallet → 403.
 
     ``real_users`` field is retained for response compatibility but means wallet
     count on this endpoint only. Fail-safe: empty list / zero on DB error.
@@ -176,9 +189,16 @@ async def get_wallets() -> WalletsResponse:
     )
 
 
-@metrics_router.get("/metrics/wallets/connections", response_model=WalletConnectionsResponse)
+@metrics_router.get(
+    "/metrics/wallets/connections",
+    response_model=WalletConnectionsResponse,
+    dependencies=[Depends(require_platform_admin)],
+)
 async def get_wallet_connections() -> WalletConnectionsResponse:
     """ "Which wallets connected, and when" — issue #1028 AC2.
+
+    ADMIN-ONLY (#1366) for the same reason as ``/metrics/wallets`` above: a
+    per-wallet first-connection ledger is identity data, not aggregate traction.
 
     ``SELECT wallet, min(occurred_at) FROM identity_events WHERE event_type =
     'auth_verified' GROUP BY wallet`` — a query that was impossible before the

--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -7,10 +7,13 @@ instrument; the write side is ``api/telemetry_middleware.py`` +
 ``services/telemetry_store.py`` (live Redis counters) plus
 ``services/request_snapshot_store.py`` (the durable Postgres floor).
 
-``real_users`` now reads canonical Better Auth accounts. Legacy identity-ledger
-views remain available to enumerate verified wallets and connection events,
-and a ``source=identity`` mode on the funnel that recomputes distinct-wallet
-conversion from ``identity_events`` alone (AC3) — see
+``real_users`` now reads canonical Better Auth accounts. The identity-ledger
+roster views (per-wallet enumeration + connection events) live on the ADMIN
+router in ``metrics_private_routes.py`` (#1366 — this public router is
+aggregate and PII-free by design; no route here may carry a wallet-bearing
+response model, and a test walks the router to enforce that). The funnel keeps
+its ``source=identity`` mode, which recomputes distinct-wallet conversion from
+``identity_events`` alone (AC3) as an aggregate — see
 ``services/identity_metrics.py`` for the queries themselves.
 
 # TODO(T-observability): Phase 2 — Prometheus ``/metrics`` exposition endpoint
@@ -24,7 +27,7 @@ from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Query, Request
 
 from archimedes.api.funnel_middleware import record_funnel
 from archimedes.api.visitor_insights import record_visitor_insight
@@ -35,19 +38,9 @@ from archimedes.models.telemetry import (
     FunnelStageCount,
     MetricsResponse,
     VisitorInsightsResponse,
-    WalletConnectionOut,
-    WalletConnectionsResponse,
-    WalletIdentityOut,
-    WalletsResponse,
 )
-from archimedes.api.metrics_private_routes import require_platform_admin
 from archimedes.services.funnel_store import CLIENT_EMITTABLE_STAGES, STAGES, FunnelStore
-from archimedes.services.identity_metrics import (
-    count_human_wallets,
-    get_identity_funnel,
-    list_human_wallets,
-    list_wallet_connections,
-)
+from archimedes.services.identity_metrics import get_identity_funnel
 from archimedes.services.request_snapshot_store import get_last_snapshot_totals, record_and_get_totals
 from archimedes.services.telemetry_store import TelemetryStore
 from archimedes.services.user_stats import get_distinct_user_count
@@ -159,56 +152,6 @@ async def get_metrics() -> MetricsResponse:
         real_users=real_users,
         epoch_started_at=totals["epoch_started_at"],
         epoch_resets=(totals["epoch_count"] - 1) if totals["epoch_count"] else None,
-        timestamp=datetime.now(UTC).isoformat(),
-    )
-
-
-@metrics_router.get(
-    "/metrics/wallets",
-    response_model=WalletsResponse,
-    dependencies=[Depends(require_platform_admin)],
-)
-async def get_wallets() -> WalletsResponse:
-    """Enumerate legacy verified human wallets, separate from account count.
-
-    ADMIN-ONLY (#1366): this returns the full per-wallet roster — wallet
-    addresses are pseudonymous but permanently linkable to on-chain activity,
-    so an open enumeration endpoint let anyone list every user of the platform
-    and trace their chain history. The public metrics surface is aggregate and
-    PII-free BY DESIGN (see metrics_private_routes' module docstring); a
-    per-identity roster belongs behind the same admin gate as the ops
-    dashboard. Anonymous → 401; verified non-admin wallet → 403.
-
-    ``real_users`` field is retained for response compatibility but means wallet
-    count on this endpoint only. Fail-safe: empty list / zero on DB error.
-    """
-    return WalletsResponse(
-        real_users=count_human_wallets(),
-        wallets=[WalletIdentityOut(**row) for row in list_human_wallets()],
-        timestamp=datetime.now(UTC).isoformat(),
-    )
-
-
-@metrics_router.get(
-    "/metrics/wallets/connections",
-    response_model=WalletConnectionsResponse,
-    dependencies=[Depends(require_platform_admin)],
-)
-async def get_wallet_connections() -> WalletConnectionsResponse:
-    """ "Which wallets connected, and when" — issue #1028 AC2.
-
-    ADMIN-ONLY (#1366) for the same reason as ``/metrics/wallets`` above: a
-    per-wallet first-connection ledger is identity data, not aggregate traction.
-
-    ``SELECT wallet, min(occurred_at) FROM identity_events WHERE event_type =
-    'auth_verified' GROUP BY wallet`` — a query that was impossible before the
-    ledger (the SIWE-verify path used to discard the wallet into a stateless
-    cookie with no durable write). Fail-safe: an empty list on any DB error.
-    """
-    connections = list_wallet_connections()
-    return WalletConnectionsResponse(
-        count=len(connections),
-        connections=[WalletConnectionOut(**row) for row in connections],
         timestamp=datetime.now(UTC).isoformat(),
     )
 

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -113,7 +113,10 @@ class WalletIdentityOut(BaseModel):
     """One anchored human wallet (issue #1028 AC1)."""
 
     wallet_address: str = Field(..., description="Lowercased cryptographically verified wallet address.")
-    actor_class: str = Field(..., description="Always 'human' on this endpoint (see /api/metrics/wallets filter).")
+    actor_class: str = Field(
+        ...,
+        description="Always 'human' on this endpoint (see the /api/metrics/private/wallets filter — admin-gated since #1366).",
+    )
     first_seen_at: str = Field(..., description="ISO-8601 UTC — first time this wallet was anchored.")
     last_auth_at: str | None = Field(default=None, description="ISO-8601 UTC — most recent wallet proof.")
 

--- a/backend/tests/test_metrics_routes.py
+++ b/backend/tests/test_metrics_routes.py
@@ -145,68 +145,101 @@ async def test_metrics_survives_a_redis_reset_without_regressing():
 
 
 @pytest.mark.asyncio
-async def test_get_wallets_unauthenticated_is_401_never_a_roster():
-    """#1366 guard demo: the wallet roster must NOT be publicly enumerable.
-
-    This endpoint served the complete per-wallet user roster (addresses +
-    first/last-seen) to anonymous callers in production. The guard is shown
-    rejecting the exact request that leaked: unauthenticated GET → 401, and the
-    body must not contain a wallets list.
-    """
+async def test_old_public_wallet_roster_paths_are_gone():
+    """#1366 guard demo, part 1: the roster endpoints served the complete
+    per-wallet user list (addresses + first/last-seen) to anonymous callers in
+    production. They are not merely gated — they are OFF the public surface
+    entirely (moved to the admin router). The exact requests that leaked now
+    404 with no roster in the body."""
     from archimedes.main import app
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/metrics/wallets")
-
-    assert resp.status_code == 401
-    assert "wallets" not in resp.json()
+        for path in ("/api/metrics/wallets", "/api/metrics/wallets/connections"):
+            resp = await client.get(path)
+            assert resp.status_code == 404, path
+            body = resp.json()
+            assert "wallets" not in body and "connections" not in body
 
 
 @pytest.mark.asyncio
-async def test_get_wallet_connections_unauthenticated_is_401():
-    """#1366 guard demo: the per-wallet connection ledger is identity data."""
+async def test_no_public_metrics_route_carries_a_wallet_response_model():
+    """#1366 AC2 regression guard: no route on the public ``metrics_router`` may
+    declare a response model with a wallet-bearing field. Walks the router so
+    the SAME drift (mounting an identity roster on the anonymous traction
+    instrument) cannot recur silently."""
+    from archimedes.api.metrics_routes import metrics_router
+
+    offending: list[str] = []
+    for route in metrics_router.routes:
+        model = getattr(route, "response_model", None)
+        if model is None:
+            continue
+        for field_name in getattr(model, "model_fields", {}):
+            if "wallet" in field_name.lower():
+                offending.append(f"{route.path} -> {model.__name__}.{field_name}")
+    assert offending == [], f"public metrics routes expose wallet fields: {offending}"
+
+
+# ── The roster endpoints on their new ADMIN paths (#1366 six-case minimum:
+# both endpoints x {401 anonymous, 403 non-admin, 200 admin-shape}) ──────
+
+_ADMIN = "0xadmin000000000000000000000000000000000001"
+_NON_ADMIN = "0xnotadmin0000000000000000000000000000000002"
+
+
+def _override_linked_wallet(app, wallet):
+    from archimedes.api.wallet_routes import require_linked_wallet
+
+    app.dependency_overrides[require_linked_wallet] = lambda: wallet
+    return require_linked_wallet
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/api/metrics/private/wallets", "/api/metrics/private/wallets/connections"])
+async def test_private_roster_unauthenticated_is_401(path):
+    """#1366 guard demo, part 2: anonymous requests to the moved endpoints are
+    rejected by the router-level admin dependency before any query runs."""
     from archimedes.main import app
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/metrics/wallets/connections")
+        resp = await client.get(path)
 
     assert resp.status_code == 401
-    assert "connections" not in resp.json()
+    body = resp.json()
+    assert "wallets" not in body and "connections" not in body
 
 
 @pytest.mark.asyncio
-async def test_get_wallets_verified_non_admin_is_403(monkeypatch):
+@pytest.mark.parametrize("path", ["/api/metrics/private/wallets", "/api/metrics/private/wallets/connections"])
+async def test_private_roster_verified_non_admin_is_403(path, monkeypatch):
     """A verified linked wallet that is not a platform admin gets 403 — any
     authenticated user being able to enumerate every other user would still be
     the leak, just behind a signup."""
-    from archimedes.api.wallet_routes import require_linked_wallet
     from archimedes.main import app
 
-    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", "0xadmin000000000000000000000000000000000001")
-    app.dependency_overrides[require_linked_wallet] = lambda: "0xnotadmin0000000000000000000000000000000002"
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", _ADMIN)
+    dep = _override_linked_wallet(app, _NON_ADMIN)
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.get("/api/metrics/wallets")
+            resp = await client.get(path)
     finally:
-        app.dependency_overrides.pop(require_linked_wallet, None)
+        app.dependency_overrides.pop(dep, None)
 
     assert resp.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_get_wallets_admin_shape_and_boundary(monkeypatch):
+async def test_private_wallets_admin_shape_and_boundary(monkeypatch):
     """The admin path keeps issue #1028 AC1's response shape unchanged.
 
     Mocks the identity-ledger boundary (consistent with how this file already
     mocks the Redis/user-count boundaries) so the assertion is deterministic
     regardless of what other tests have written into the shared DB.
     """
-    from archimedes.api.wallet_routes import require_linked_wallet
     from archimedes.main import app
 
-    admin = "0xadmin000000000000000000000000000000000001"
-    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", admin)
-    app.dependency_overrides[require_linked_wallet] = lambda: admin
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", _ADMIN)
+    dep = _override_linked_wallet(app, _ADMIN)
 
     fake_wallets = [
         {
@@ -218,13 +251,13 @@ async def test_get_wallets_admin_shape_and_boundary(monkeypatch):
     ]
     try:
         with (
-            patch("archimedes.api.metrics_routes.count_human_wallets", return_value=1),
-            patch("archimedes.api.metrics_routes.list_human_wallets", return_value=fake_wallets),
+            patch("archimedes.api.metrics_private_routes.count_human_wallets", return_value=1),
+            patch("archimedes.api.metrics_private_routes.list_human_wallets", return_value=fake_wallets),
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-                resp = await client.get("/api/metrics/wallets")
+                resp = await client.get("/api/metrics/private/wallets")
     finally:
-        app.dependency_overrides.pop(require_linked_wallet, None)
+        app.dependency_overrides.pop(dep, None)
 
     assert resp.status_code == 200
     data = resp.json()
@@ -234,24 +267,22 @@ async def test_get_wallets_admin_shape_and_boundary(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_wallet_connections_admin_shape(monkeypatch):
+async def test_private_wallet_connections_admin_shape(monkeypatch):
     """Admin path keeps issue #1028 AC2's response shape unchanged."""
-    from archimedes.api.wallet_routes import require_linked_wallet
     from archimedes.main import app
 
-    admin = "0xadmin000000000000000000000000000000000001"
-    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", admin)
-    app.dependency_overrides[require_linked_wallet] = lambda: admin
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", _ADMIN)
+    dep = _override_linked_wallet(app, _ADMIN)
 
     fake_connections = [
         {"wallet": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "connected_at": "2026-07-01T00:00:00+00:00"},
     ]
     try:
-        with patch("archimedes.api.metrics_routes.list_wallet_connections", return_value=fake_connections):
+        with patch("archimedes.api.metrics_private_routes.list_wallet_connections", return_value=fake_connections):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-                resp = await client.get("/api/metrics/wallets/connections")
+                resp = await client.get("/api/metrics/private/wallets/connections")
     finally:
-        app.dependency_overrides.pop(require_linked_wallet, None)
+        app.dependency_overrides.pop(dep, None)
 
     assert resp.status_code == 200
     data = resp.json()

--- a/backend/tests/test_metrics_routes.py
+++ b/backend/tests/test_metrics_routes.py
@@ -145,14 +145,68 @@ async def test_metrics_survives_a_redis_reset_without_regressing():
 
 
 @pytest.mark.asyncio
-async def test_get_wallets_endpoint_shape_and_boundary():
-    """GET /api/metrics/wallets — issue #1028 AC1 enumeration endpoint.
+async def test_get_wallets_unauthenticated_is_401_never_a_roster():
+    """#1366 guard demo: the wallet roster must NOT be publicly enumerable.
+
+    This endpoint served the complete per-wallet user roster (addresses +
+    first/last-seen) to anonymous callers in production. The guard is shown
+    rejecting the exact request that leaked: unauthenticated GET → 401, and the
+    body must not contain a wallets list.
+    """
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/metrics/wallets")
+
+    assert resp.status_code == 401
+    assert "wallets" not in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_get_wallet_connections_unauthenticated_is_401():
+    """#1366 guard demo: the per-wallet connection ledger is identity data."""
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/metrics/wallets/connections")
+
+    assert resp.status_code == 401
+    assert "connections" not in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_get_wallets_verified_non_admin_is_403(monkeypatch):
+    """A verified linked wallet that is not a platform admin gets 403 — any
+    authenticated user being able to enumerate every other user would still be
+    the leak, just behind a signup."""
+    from archimedes.api.wallet_routes import require_linked_wallet
+    from archimedes.main import app
+
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", "0xadmin000000000000000000000000000000000001")
+    app.dependency_overrides[require_linked_wallet] = lambda: "0xnotadmin0000000000000000000000000000000002"
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/metrics/wallets")
+    finally:
+        app.dependency_overrides.pop(require_linked_wallet, None)
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_wallets_admin_shape_and_boundary(monkeypatch):
+    """The admin path keeps issue #1028 AC1's response shape unchanged.
 
     Mocks the identity-ledger boundary (consistent with how this file already
     mocks the Redis/user-count boundaries) so the assertion is deterministic
     regardless of what other tests have written into the shared DB.
     """
+    from archimedes.api.wallet_routes import require_linked_wallet
     from archimedes.main import app
+
+    admin = "0xadmin000000000000000000000000000000000001"
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", admin)
+    app.dependency_overrides[require_linked_wallet] = lambda: admin
 
     fake_wallets = [
         {
@@ -162,12 +216,15 @@ async def test_get_wallets_endpoint_shape_and_boundary():
             "last_auth_at": "2026-07-02T00:00:00+00:00",
         }
     ]
-    with (
-        patch("archimedes.api.metrics_routes.count_human_wallets", return_value=1),
-        patch("archimedes.api.metrics_routes.list_human_wallets", return_value=fake_wallets),
-    ):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.get("/api/metrics/wallets")
+    try:
+        with (
+            patch("archimedes.api.metrics_routes.count_human_wallets", return_value=1),
+            patch("archimedes.api.metrics_routes.list_human_wallets", return_value=fake_wallets),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.get("/api/metrics/wallets")
+    finally:
+        app.dependency_overrides.pop(require_linked_wallet, None)
 
     assert resp.status_code == 200
     data = resp.json()
@@ -177,16 +234,24 @@ async def test_get_wallets_endpoint_shape_and_boundary():
 
 
 @pytest.mark.asyncio
-async def test_get_wallet_connections_endpoint():
-    """GET /api/metrics/wallets/connections — issue #1028 AC2: which wallets connected, and when."""
+async def test_get_wallet_connections_admin_shape(monkeypatch):
+    """Admin path keeps issue #1028 AC2's response shape unchanged."""
+    from archimedes.api.wallet_routes import require_linked_wallet
     from archimedes.main import app
+
+    admin = "0xadmin000000000000000000000000000000000001"
+    monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", admin)
+    app.dependency_overrides[require_linked_wallet] = lambda: admin
 
     fake_connections = [
         {"wallet": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "connected_at": "2026-07-01T00:00:00+00:00"},
     ]
-    with patch("archimedes.api.metrics_routes.list_wallet_connections", return_value=fake_connections):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            resp = await client.get("/api/metrics/wallets/connections")
+    try:
+        with patch("archimedes.api.metrics_routes.list_wallet_connections", return_value=fake_connections):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.get("/api/metrics/wallets/connections")
+    finally:
+        app.dependency_overrides.pop(require_linked_wallet, None)
 
     assert resp.status_code == 200
     data = resp.json()

--- a/backend/tests/test_metrics_routes.py
+++ b/backend/tests/test_metrics_routes.py
@@ -161,12 +161,42 @@ async def test_old_public_wallet_roster_paths_are_gone():
             assert "wallets" not in body and "connections" not in body
 
 
+def _wallet_bearing_fields(model, prefix: str = "", seen: frozenset = frozenset()) -> list[str]:
+    """Collect dotted paths of every field named ``*wallet*`` in ``model``,
+    RECURSING into nested pydantic models (including through list/dict/Optional
+    annotations). The re-review of #1373 showed a flat top-level walk is a
+    false-negative guard: WalletConnectionsResponse's own field names are
+    ``count``/``connections``/``timestamp`` — the per-wallet address lives one
+    level down in WalletConnectionOut.wallet, so only recursion catches a
+    re-mounted connections roster."""
+    import typing
+
+    from pydantic import BaseModel
+
+    if not (isinstance(model, type) and issubclass(model, BaseModel)) or model in seen:
+        return []
+    seen = seen | {model}
+    found: list[str] = []
+    for field_name, field in model.model_fields.items():
+        path = f"{prefix}{model.__name__}.{field_name}"
+        if "wallet" in field_name.lower():
+            found.append(path)
+        stack = [field.annotation]
+        while stack:
+            ann = stack.pop()
+            if isinstance(ann, type) and issubclass(ann, BaseModel):
+                found.extend(_wallet_bearing_fields(ann, prefix=f"{path} -> ", seen=seen))
+            else:
+                stack.extend(typing.get_args(ann))
+    return found
+
+
 @pytest.mark.asyncio
 async def test_no_public_metrics_route_carries_a_wallet_response_model():
     """#1366 AC2 regression guard: no route on the public ``metrics_router`` may
-    declare a response model with a wallet-bearing field. Walks the router so
-    the SAME drift (mounting an identity roster on the anonymous traction
-    instrument) cannot recur silently."""
+    declare a response model with a wallet-bearing field AT ANY DEPTH. Walks the
+    router so the SAME drift (mounting an identity roster on the anonymous
+    traction instrument) cannot recur silently."""
     from archimedes.api.metrics_routes import metrics_router
 
     offending: list[str] = []
@@ -174,10 +204,42 @@ async def test_no_public_metrics_route_carries_a_wallet_response_model():
         model = getattr(route, "response_model", None)
         if model is None:
             continue
-        for field_name in getattr(model, "model_fields", {}):
-            if "wallet" in field_name.lower():
-                offending.append(f"{route.path} -> {model.__name__}.{field_name}")
+        for hit in _wallet_bearing_fields(model):
+            offending.append(f"{route.path} -> {hit}")
     assert offending == [], f"public metrics routes expose wallet fields: {offending}"
+
+
+def test_the_walk_guard_catches_both_roster_models():
+    """Negative control for the guard itself (a guard must be shown to reject
+    something): mounting either roster model on a throwaway router IS flagged —
+    including WalletConnectionsResponse, whose wallet field is nested one level
+    down and which a flat top-level walk provably missed (#1373 re-review)."""
+    from fastapi import APIRouter
+
+    from archimedes.models.telemetry import WalletConnectionsResponse, WalletsResponse
+
+    throwaway = APIRouter()
+
+    @throwaway.get("/drifted-roster", response_model=WalletsResponse)
+    async def _a():  # pragma: no cover - never called
+        raise NotImplementedError
+
+    @throwaway.get("/drifted-connections", response_model=WalletConnectionsResponse)
+    async def _b():  # pragma: no cover - never called
+        raise NotImplementedError
+
+    flagged: dict[str, list[str]] = {}
+    for route in throwaway.routes:
+        model = getattr(route, "response_model", None)
+        if model is not None:
+            flagged[route.path] = _wallet_bearing_fields(model)
+
+    assert flagged["/drifted-roster"], "top-level wallets field must be flagged"
+    assert flagged["/drifted-connections"], (
+        "the NESTED WalletConnectionOut.wallet field must be flagged — a flat "
+        "top-level walk misses it, which is exactly the false negative this "
+        "control exists to prevent"
+    )
 
 
 # ── The roster endpoints on their new ADMIN paths (#1366 six-case minimum:


### PR DESCRIPTION
## Problem

`GET /api/metrics/wallets` and `GET /api/metrics/wallets/connections` returned the complete per-identity wallet roster (addresses, actor class, first/last-seen timestamps) to **anonymous** callers. Wallet addresses are pseudonymous but permanently linkable to on-chain activity, so open enumeration lets anyone list every user of the platform and trace their chain history. The router split documents the public metrics surface as aggregate and PII-free by design — these two endpoints (built for #1028's identity-ledger acceptance, consumed by no UI page) violated that contract.

## Fix (issue #1366 — D1: AC1 + AC2 + AC6-backend)

- **Moved both endpoints onto `metrics_private_router`** (`/api/metrics/private/wallets`, `/api/metrics/private/wallets/connections`) — they inherit the router-level `require_platform_admin` dependency: anonymous → **401**, verified non-admin linked wallet → **403** (any authenticated user enumerating every other user would still be the leak, just behind a signup). The old public paths **404** — the roster is off the public surface entirely, not merely gated.
- **AC2 regression guard**: a test walks `metrics_router.routes` and asserts no route's `response_model` declares a field containing `wallet` **at any depth** — the walk recurses into nested models (the re-review caught that a flat top-level walk misses `WalletConnectionsResponse`, whose wallet field nests inside `WalletConnectionOut`). An in-suite negative control mounts both roster models on a throwaway router and asserts each is flagged, so the guard is permanently demonstrated to reject the exact case the flat version missed.
- Six-case minimum met: both endpoints × {401 anonymous, 403 non-admin, 200 admin-shape}, parametrized. The #1028 AC1/AC2 response shapes are preserved unchanged on the admin path (anti-goal honored — shape assertions survive the move).

## Guard demonstration (AC6 — full revert, then restore)

```
FAILED test_old_public_wallet_roster_paths_are_gone            - AssertionError: /api/metrics/wallets   (200 with the roster)
FAILED test_no_public_metrics_route_carries_a_wallet_response_model
       - AssertionError: public metrics routes expose wallet fields: ['/api/metrics/...']
FAILED test_private_roster_unauthenticated_is_401[...wallets]              - assert 404 == 401
FAILED test_private_roster_unauthenticated_is_401[...wallets/connections]  - assert 404 == 401
FAILED test_private_roster_verified_non_admin_is_403[...wallets]           - assert 404 == 403
FAILED test_private_roster_verified_non_admin_is_403[...wallets/connections] - assert 404 == 403
6 failed  →  restored: 6 passed
```

## Verification

- AC1's exact command, hermetic: `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_metrics_routes.py backend/tests/test_metrics_private_routes.py -q` → **21 passed, 0 failed**
- Full `pytest -m "not integration"` → **3383 passed, 0 failed**
- `ruff format --check` clean on all three touched files

**Addresses #1366 — D1 (AC1, AC2, AC6-backend).** D2–D4 (AC3–AC5 + AC6-frontend, `Insights.jsx`) are the companion PR #1375. The issue stays open until both merge and the production endpoints are re-verified (roster paths 404 / private paths 401 against the live site).

