### PR TITLE
[frontend] Fix Insights bot-exclusion claim, country map, and copy (#1366)

### DIFF
--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -40,11 +40,26 @@ const FUNNEL_LABELS = {
 
 const DEVICE_LABELS = { mobile: 'Mobile', tablet: 'Tablet', desktop: 'Desktop', tv: 'TV', unknown: 'Unknown' }
 
-const COUNTRY_NAMES = {
-  US: 'United States', GB: 'United Kingdom', DE: 'Germany', BR: 'Brazil', TR: 'Türkiye',
-  CA: 'Canada', FR: 'France', IN: 'India', NL: 'Netherlands', SG: 'Singapore',
-  ZZ: 'Unknown / not provided',
+// Built-in Intl API resolves any ISO-3166 alpha-2 code to a display name —
+// no dependency, no hand-maintained (and inevitably incomplete) map (#1366
+// AC4). ZZ needs an explicit case: Intl.DisplayNames renders it as "Unknown
+// Region", which would contradict the "unknown / not provided" wording this
+// page already uses for ZZ (see the visitor-insights caption below).
+const REGION_NAMES = new Intl.DisplayNames(['en'], { type: 'region' })
+
+function countryName(code) {
+  if (code === 'ZZ') return 'Unknown / not provided'
+  try {
+    return REGION_NAMES.of(code) || code
+  } catch {
+    return code
+  }
 }
+
+// Labels for the per-stage by_agent_type split the funnel API already
+// returns (issue #788) and this page now renders instead of describing a
+// filter the write path doesn't perform (#1366 AC3).
+const AGENT_TYPE_LABELS = { human: 'Human', external: 'External bot', internal: 'Internal' }
 
 const card = {
   background: 'var(--surface-1)',
@@ -104,6 +119,12 @@ export default function Insights() {
   const landed = funnel ? (funnel.stages?.find(s => s.stage === 'landed')?.distinct_visitors ?? 0) : null
   const totalDevices = visitors ? Object.values(visitors.devices || {}).reduce((a, b) => a + b, 0) : 0
   const maxCountry = visitors?.countries?.[0]?.distinct_visitors ?? 0
+  // Formatted, not hard-coded (#1366 AC4) — metrics.epoch_started_at is the
+  // real durable-counting start time; null only when no snapshot has ever
+  // been recorded, in which case we say so rather than guessing a date.
+  const epochStarted = metrics?.epoch_started_at
+    ? new Date(metrics.epoch_started_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+    : null
 
   return (
     <div style={{ maxWidth: 880, margin: '0 auto', padding: '8px 4px 48px' }}>
@@ -114,7 +135,7 @@ export default function Insights() {
         </button>
       </div>
       <p style={{ color: 'var(--text-2)', marginTop: 0, fontSize: 14 }}>
-        Live conversion instruments for our (un-promoted) traffic. Read-only, PII-free.
+        Public, read-only conversion and traffic metrics. PII-free by design.
       </p>
 
       {error && (
@@ -132,8 +153,10 @@ export default function Insights() {
           <Stat label="Real users (accounts)" value={metrics?.real_users} accent="#3fb56b" />
         </div>
         <p style={{ color: 'var(--text-2)', fontSize: 12.5, marginBottom: 0, marginTop: 14 }}>
-          The honest “how many people” numbers. <strong>Distinct visitors</strong> = unique people who loaded
-          the app (JS-gated, so crawlers and bots drop out — this is the funnel’s <em>Landed</em> count below).
+          The honest “how many people” numbers. <strong>Distinct visitors</strong> = every browser session
+          that loaded the app (JS-gated) — this is the funnel’s <em>Landed</em> count below, and it still
+          includes sessions the telemetry classifier positively tags as agents. See the human / external
+          bot / internal split under each stage below for exactly how many.
           <strong> Real users</strong> = canonical Better Auth accounts, all-time. This differs from
           “Connected Wallet”, which counts visitor sessions reaching optional wallet-link step.
         </p>
@@ -154,21 +177,35 @@ export default function Insights() {
         ) : !funnel ? (
           <Empty>Couldn’t load the funnel{error ? `: ${error}` : '.'}</Empty>
         ) : landed === 0 ? (
-          <Empty>No visitors recorded yet. The funnel started collecting when it deployed today.</Empty>
+          <Empty>
+            No visitors recorded yet.{' '}
+            {epochStarted ? `Durable counting began ${epochStarted}.` : 'Durable counting start date is unknown.'}
+          </Empty>
         ) : (
           <div style={{ display: 'grid', gap: 14 }}>
-            {funnel.stages.map((s, i) => (
-              <div key={s.stage}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, marginBottom: 5 }}>
-                  <span>{FUNNEL_LABELS[s.stage] || s.stage}</span>
-                  <span style={{ color: 'var(--text-2)' }}>
-                    <strong style={{ color: 'var(--text-1)' }}>{s.distinct_visitors}</strong>
-                    {i > 0 && <> · {(s.step_conversion * 100).toFixed(0)}% of prev</>}
-                  </span>
+            {funnel.stages.map((s, i) => {
+              const bt = s.by_agent_type || {}
+              const tagged = (bt.human ?? 0) + (bt.external ?? 0) + (bt.internal ?? 0)
+              // HLL estimates on both sides of the subtraction, so floor at 0
+              // rather than show a nonsensical negative "unclassified" count.
+              const unclassified = Math.max(0, s.distinct_visitors - tagged)
+              return (
+                <div key={s.stage}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, marginBottom: 5 }}>
+                    <span>{FUNNEL_LABELS[s.stage] || s.stage}</span>
+                    <span style={{ color: 'var(--text-2)' }}>
+                      <strong style={{ color: 'var(--text-1)' }}>{s.distinct_visitors}</strong>
+                      {i > 0 && <> · {(s.step_conversion * 100).toFixed(0)}% of prev</>}
+                    </span>
+                  </div>
+                  <Bar pct={s.pct_of_landed * 100} color={i === 0 ? '#5b9dff' : s.distinct_visitors > 0 ? '#3fb56b' : '#3a3f4b'} />
+                  <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 3 }}>
+                    {Object.entries(AGENT_TYPE_LABELS).map(([key, label]) => `${label} ${bt[key] ?? 0}`).join(' · ')}
+                    {' · Unclassified '}{unclassified}
+                  </div>
                 </div>
-                <Bar pct={s.pct_of_landed * 100} color={i === 0 ? '#5b9dff' : s.distinct_visitors > 0 ? '#3fb56b' : '#3a3f4b'} />
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </section>
@@ -198,7 +235,7 @@ export default function Insights() {
                 {(visitors.countries || []).slice(0, 8).map(c => (
                   <div key={c.code}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
-                      <span>{COUNTRY_NAMES[c.code] || c.code}</span>
+                      <span>{countryName(c.code)}</span>
                       <strong>{c.distinct_visitors}</strong>
                     </div>
                     <Bar pct={maxCountry ? (c.distinct_visitors / maxCountry) * 100 : 0} color="#7c6cff" />

--- a/ui/src/components/Insights.jsx
+++ b/ui/src/components/Insights.jsx
@@ -135,7 +135,7 @@ export default function Insights() {
         </button>
       </div>
       <p style={{ color: 'var(--text-2)', marginTop: 0, fontSize: 14 }}>
-        Public, read-only conversion and traffic metrics. PII-free by design.
+        Read-only conversion and traffic metrics. PII-free by design.
       </p>
 
       {error && (

--- a/ui/test/app-visuals.test.js
+++ b/ui/test/app-visuals.test.js
@@ -23,6 +23,10 @@ const portfolio = readFileSync(
 	new URL("../src/components/Portfolio.jsx", import.meta.url),
 	"utf8",
 );
+const insights = readFileSync(
+	new URL("../src/components/Insights.jsx", import.meta.url),
+	"utf8",
+);
 
 test("authenticated shell has isolated operational tokens and journey rail", () => {
 	assert.match(layout, /shell app-site/);
@@ -159,4 +163,30 @@ test("leaderboard caveat banner is own-scope-gated with only the refresh residua
 	// fixes, so pin the banner's own load-bearing phrases, not the comment.)
 	assert.doesNotMatch(leaderboard, /live execution currently interprets/);
 	assert.doesNotMatch(leaderboard, /awaiting\s*\n?\s*live-trading sign-off/);
+});
+
+test("Insights headline claim matches the write path — no bot-exclusion claim, per-stage split shown instead (#1366 AC3)", () => {
+	// record_funnel writes the landed HLL for every beacon regardless of the
+	// classifier's verdict (metrics_routes.py:278 runs before is_agent is even
+	// read at :285) — the funnel's landed count does NOT drop crawlers/bots.
+	// The old copy claimed otherwise; it must not come back.
+	assert.doesNotMatch(insights, /crawlers and bots drop out/);
+	// The fix: render the by_agent_type per-stage split the API already
+	// returns (issue #788) instead of describing a filter the code doesn't
+	// perform.
+	assert.match(insights, /by_agent_type/);
+});
+
+test("Insights country names use Intl.DisplayNames, not a hand-maintained map, and the epoch date is real (#1366 AC4)", () => {
+	assert.doesNotMatch(insights, /const COUNTRY_NAMES/);
+	assert.match(insights, /Intl\.DisplayNames/);
+	// ZZ must stay an explicit case — Intl renders it "Unknown Region", which
+	// would contradict the "unknown / not provided" copy this page uses for ZZ.
+	assert.match(insights, /ZZ.*Unknown \/ not provided/);
+	assert.doesNotMatch(insights, /deployed today/);
+	assert.match(insights, /epoch_started_at/);
+});
+
+test("Insights drops the first-person operator copy (#1366 AC5)", () => {
+	assert.doesNotMatch(insights, /Live conversion instruments for our/);
 });


### PR DESCRIPTION
Addresses #1366 — D2/D3/D4 (AC3, AC4, AC5, AC6-frontend); the D1 backend gate is PR #1373.

## What changed (`ui/src/components/Insights.jsx`)

**AC3 — the bot-exclusion claim was false, fixed by showing the data instead of describing a filter.**
`record_funnel` writes the `landed` HLL for every beacon *before* the classifier verdict is even read (`metrics_routes.py:278` runs ahead of `:285`) — live: `landed=326`, `by_agent_type.external=18`. The old copy said crawlers/bots "drop out" of that number. Removed the claim; the funnel now renders the `by_agent_type` per-stage split (human / external bot / internal, plus a computed "unclassified" remainder floored at 0 for HLL noise) that the API already returns, under every stage row.

**AC4 — `COUNTRY_NAMES` → `Intl.DisplayNames`, real epoch date.**
The hand-maintained 11-entry country map is gone; `new Intl.DisplayNames(['en'], { type: 'region' })` resolves any ISO-3166 code, no dependency added. Kept an explicit `ZZ` → `"Unknown / not provided"` case, since `Intl.DisplayNames` renders `ZZ` as `"Unknown Region"`, which would contradict the page's existing "unknown / not provided" wording for `ZZ`. The hard-coded "deployed today" literal in the empty-funnel state is replaced with a formatted `metrics?.epoch_started_at` (falls back to an honest "unknown" rather than a guessed date when absent).

**AC5 — operator copy removed.** The first-person "Live conversion instruments for our (un-promoted) traffic" line is replaced with neutral, factual copy ("Public, read-only conversion and traffic metrics. PII-free by design.").

**New copy on the "Real people" card** (verbatim):
> The honest "how many people" numbers. **Distinct visitors** = every browser session that loaded the app (JS-gated) — this is the funnel's *Landed* count below, and it still includes sessions the telemetry classifier positively tags as agents. See the human / external bot / internal split under each stage below for exactly how many. **Real users** = canonical Better Auth accounts, all-time. This differs from "Connected Wallet", which counts visitor sessions reaching optional wallet-link step.

## Tests (`ui/test/app-visuals.test.js`)

Added `insights` to the existing `readFileSync` block and three new `test()` blocks with the exact required assertions:

```js
assert.doesNotMatch(insights, /crawlers and bots drop out/);
assert.match(insights, /by_agent_type/);

assert.doesNotMatch(insights, /const COUNTRY_NAMES/);
assert.match(insights, /Intl\.DisplayNames/);
assert.doesNotMatch(insights, /deployed today/);
assert.match(insights, /epoch_started_at/);

assert.doesNotMatch(insights, /Live conversion instruments for our/);
```

`cd ui && node --test` → **pass 93, fail 0** (baseline before this PR: `pass 90, fail 0`).

## AC6 — mutation check (guard shown to reject something)

Reverted the fix (`"crawlers and bots drop out"` string restored in `Insights.jsx`), re-ran `cd ui && node --test`. Failing output:

```
✖ Insights headline claim matches the write path — no bot-exclusion claim, per-stage split shown instead (#1366 AC3) (1.796042ms)
  AssertionError [ERR_ASSERTION]: The input was expected to not match the regular expression /crawlers and bots drop out/. Input:
  ...
    operator: 'doesNotMatch',

ℹ tests 93
ℹ suites 0
ℹ pass 92
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```

Fix restored, re-ran: `pass 93, fail 0` — all green.

## Anti-goals honored

- Funnel's `landed` still counts every beacon regardless of classification — no exclusion added, only the claim about it was fixed.
- The agent-tagged HLLs (`by_agent_type`) are unmodified; only newly *rendered*.
- `vault_deployed` stage isn't special-cased — the new per-stage breakdown renders generically over `funnel.stages` for all four stages identically (out of scope per #1266).
- No new dependency — `Intl.DisplayNames` is a built-in (Node v26 / evergreen browsers).

## Scope

Frontend only (`ui/src/components/Insights.jsx`, `ui/test/app-visuals.test.js`). No backend files touched — the wallet-roster admin gate (AC1/AC2) is PR #1373, being reworked separately. This issue closes only when both PRs merge and prod is re-verified — no `Closes` keyword here.

## Verification run locally

```
cd ui && node --test        # pass 93, fail 0
cd ui && npm run lint       # clean
cd ui && npm run build      # succeeds
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
