### PR TITLE
[backend] fix canonical_artifact_hash volatile-field dedupe (#1347)

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1742,6 +1742,7 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         from archimedes.models.paper_ref import PaperRef
         from archimedes.models.strategy import StrategyPassport, StrategyStatus
         from archimedes.models.strategy_store import StrategyRecord
+        from archimedes.services.backtest_mapper import canonical_artifact_hash
         from archimedes.services.backtest_repository import (
             SOURCE_PIPELINE_PORTFOLIO_BACKTESTER,
             insert_backtest_if_missing,
@@ -1762,7 +1763,21 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
             num_trials_for_dsr=max(1, num_trials),
         )
         artifact_json = _json.dumps(artifact, default=str)
-        content_hash = hashlib.sha256(artifact_json.encode("utf-8")).hexdigest()
+        # Issue #1347 follow-up: this used to be an ad hoc
+        # hashlib.sha256(artifact_json) — a hash `artifact` (built by
+        # portfolio_backtester.backtest_portfolio, which stamps its own
+        # "run_id"/"timestamp_utc" volatile keys, same shape as cli.py's
+        # artifact) can never reproduce, because canonical_artifact_hash
+        # excludes those keys and this ad hoc call didn't. That gap meant the
+        # dedupe migration could normalize this writer's HISTORICAL rows to
+        # the canonical hash while every NEW row from this exact call site
+        # kept minting a fresh, non-matching hash — restarting duplicate
+        # accumulation for this one pipeline the moment it ran again. Route
+        # through the same canonical_artifact_hash run_backtests.py and
+        # seed_backtests_from_artifacts.py already use, so all three writer
+        # call sites that mint run_id/timestamp_utc-bearing artifacts compute
+        # hashes the same, reproducible way.
+        content_hash = canonical_artifact_hash(artifact)
 
         # Re-grade the REAL returns through the live gate, exactly as the DSL
         # sibling above does and as strategies_routes._to_strategy_response does

--- a/backend/archimedes/services/backtest_mapper.py
+++ b/backend/archimedes/services/backtest_mapper.py
@@ -116,10 +116,48 @@ class AnalyticsArtifactModel(BaseModel):
     results: list[OperationResultModel]
 
 
+# Top-level artifact keys that vary between two runs over IDENTICAL backtest
+# CONTENT and must therefore be excluded before hashing (issue #1347) — every
+# artifact producer mints these fresh per invocation, so hashing them made
+# every run's content_hash unique by construction and permanently defeated
+# `insert_backtest_if_missing`'s content-hash dedupe (0 rows ever skipped;
+# ~30 rows/strategy re-inserted per container restart once #1263 unmasked the
+# insert path). Each exclusion is justified individually, not just "trim
+# volatile stuff":
+#
+# - "run_id": a fresh identifier minted per invocation, never derived from the
+#   run's measured content. `analytics-engine/.../cli.py` mints it once per
+#   `run_command()` call; `portfolio_backtester.py` mints
+#   f"gen-{datetime.now(UTC):%Y%m%dT%H%M%SZ}-{strategy_id[:8]}" — itself a
+#   wall-clock timestamp wrapped in a string. Two runs over identical inputs
+#   producing identical metrics still get two different run_ids.
+# - "timestamp_utc": `datetime.now(UTC).isoformat()` stamped at artifact-build
+#   time (same two producers, cli.py and portfolio_backtester.py). By
+#   definition wall-clock, never content.
+#
+# Deliberately NOT excluded — both are content, not run metadata:
+# - "data_hashes": a hash of the INPUT DATA the run actually read. Two runs
+#   against different underlying data legitimately deserve different
+#   artifact hashes even if every other field lines up.
+# - everything under "results" (the measured metrics themselves) and every
+#   other top-level key (`strategy`, `assumptions`, `integrity_flags`,
+#   `operations`) — these describe what was measured and how, which is
+#   exactly the content two "identical" runs must agree on to collapse.
+_VOLATILE_HASH_KEYS: frozenset[str] = frozenset({"run_id", "timestamp_utc"})
+
+
 def canonical_artifact_hash(payload: dict[str, Any]) -> str:
-    """Deterministic SHA-256 for artifact payload."""
+    """Deterministic SHA-256 for artifact CONTENT.
+
+    Excludes `_VOLATILE_HASH_KEYS` (see module-level docstring above) before
+    hashing, so two artifacts describing the same backtest — same strategy
+    code, same measured metrics, same assumptions — hash identically even
+    though each carries its own unique `run_id`/`timestamp_utc`. This is what
+    makes `insert_backtest_if_missing`'s content-hash dedupe actually fire.
+    """
+    content = {k: v for k, v in payload.items() if k not in _VOLATILE_HASH_KEYS}
     canonical = json.dumps(
-        payload,
+        content,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,

--- a/backend/archimedes/services/backtest_mapper.py
+++ b/backend/archimedes/services/backtest_mapper.py
@@ -143,6 +143,27 @@ class AnalyticsArtifactModel(BaseModel):
 #   other top-level key (`strategy`, `assumptions`, `integrity_flags`,
 #   `operations`) — these describe what was measured and how, which is
 #   exactly the content two "identical" runs must agree on to collapse.
+#
+# Writer-call-site coverage — every place that mints a `content_hash` for
+# `backtest_results`, checked individually rather than assumed from "the two
+# producers that build run_id/timestamp_utc-bearing artifacts":
+# - `scripts/run_backtests.py` — calls `canonical_artifact_hash` on the
+#   analytics-engine `cli.py` artifact directly. Covered from day one.
+# - `scripts/seed_backtests_from_artifacts.py` — calls
+#   `canonical_artifact_hash` on the same `cli.py`-shaped artifact, replayed
+#   from disk. Covered from day one.
+# - `agents/generation_pipeline.py`'s `SOURCE_PIPELINE_PORTFOLIO_BACKTESTER`
+#   writer — builds its `artifact` via `portfolio_backtester.backtest_portfolio`
+#   (same run_id/timestamp_utc shape as `cli.py`) but used to hash it with an
+#   ad hoc `hashlib.sha256(artifact_json)` that never excluded those keys, so
+#   this ONE writer stayed unfixed even after this function was. Now routed
+#   through `canonical_artifact_hash` too (issue #1347 follow-up review).
+# - `agents/generation_pipeline.py`'s `SOURCE_PIPELINE_DSL_FUSION` writer —
+#   still its own ad hoc `hashlib.sha256(artifact_json)`, left AS IS. Its
+#   artifact (`{"results": ..., "source": ..., "data_source": ...}`) never
+#   included `run_id`/`timestamp_utc` in the first place, so it never had
+#   this bug and doesn't need this function — noted here so "every writer
+#   enumerated" doesn't silently mean "the two that were convenient to check."
 _VOLATILE_HASH_KEYS: frozenset[str] = frozenset({"run_id", "timestamp_utc"})
 
 

--- a/backend/migrations/versions/f0ab58339d55_dedupe_backtest_results_canonical_hash.py
+++ b/backend/migrations/versions/f0ab58339d55_dedupe_backtest_results_canonical_hash.py
@@ -67,7 +67,7 @@ of a surviving row's content, so there is nothing a downgrade could restore
 that the survivor doesn't already carry.
 
 Revision ID: f0ab58339d55
-Revises: c9396e0d95d4
+Revises: e2b7f4c81d93
 Create Date: 2026-08-20 00:00:00.000000
 
 """
@@ -83,7 +83,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "f0ab58339d55"
-down_revision: str | Sequence[str] | None = "c9396e0d95d4"
+down_revision: str | Sequence[str] | None = "e2b7f4c81d93"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/migrations/versions/f0ab58339d55_dedupe_backtest_results_canonical_hash.py
+++ b/backend/migrations/versions/f0ab58339d55_dedupe_backtest_results_canonical_hash.py
@@ -1,0 +1,172 @@
+"""collapse backtest_results duplicates onto the fixed canonical hash
+
+Issue #1347. Root cause: ``canonical_artifact_hash``
+(``backend/archimedes/services/backtest_mapper.py``) used to hash the WHOLE
+artifact payload, including ``run_id`` and ``timestamp_utc`` — both minted
+fresh on every run regardless of content — so every run's ``content_hash`` was
+unique by construction and ``insert_backtest_if_missing``'s content-hash
+dedupe could never fire. #1263 fixed an unrelated ``PermissionError`` that
+had, as a side effect, always killed the refresh *before* the DB insert, which
+masked this defect (zero rows ever persisted). Once #1263 landed, every
+scheduled refresh started re-inserting every strategy's backtest on every
+container restart. Measured against production 2026-08-20 (read-only query):
+**646 rows over 51 distinct strategies**, top offenders 31 / 25 / 24 rows,
+long tail at ~22 — consistent with the restart cadence around the #1309 /
+#1328 / #1329 / #1337 crash-loop window.
+
+The code fix (same PR, ``backtest_mapper.py``) makes ``canonical_artifact_hash``
+exclude ``run_id``/``timestamp_utc`` before hashing, going forward. This
+migration is the one-time cleanup for rows already written under the old,
+volatile-inclusive hash: it does NOT change what future rows hash to (that is
+entirely the code fix); it only recomputes each EXISTING row's canonical hash
+from the row's own stored ``artifact_json`` payload — using the SAME
+``canonical_artifact_hash`` function the app now uses, imported directly
+rather than reimplemented, so migration and app can never define "canonical
+hash" two different ways — and collapses rows that recompute to the same
+(strategy_id, hash) pair.
+
+Per (strategy_id, recomputed_hash) group with more than one row, the EARLIEST
+row survives (ordered by ``created_at`` ascending, tiebreak ``id`` ascending —
+the same "when did the row land" ordering ``backtest_repository.py`` already
+uses for "latest", just reversed), and every other row in the group is
+deleted. The survivor's ``content_hash`` column is then normalized to the
+recomputed value (even for rows that were never part of a duplicate group) so
+that after this migration, EVERY row's ``content_hash`` agrees with what the
+fixed ``canonical_artifact_hash`` would produce for its own stored payload —
+which is what makes a future re-run's dedupe check
+(``WHERE strategy_id = ? AND content_hash = ?``) actually match a normalized
+historical row instead of just failing to find a match forever.
+
+Rows whose ``artifact_json`` is NULL or fails to parse are left untouched
+(their existing ``content_hash`` stands in as their own "recomputed" value, so
+they never merge with anything) — there is no payload to recompute a
+canonical hash FROM, and refusing to guess is the honest choice (see
+CLAUDE.md's fail-soft principle: an unresolvable row stays exactly as it is,
+never silently coerced into a group it cannot be proven to belong to).
+
+FK safety: grepped every model under ``backend/archimedes/models/*.py`` for
+``ForeignKey`` — nothing references ``backtest_results.id`` (or any other
+``backtest_results`` column). Every consumer of ``BacktestResultRecord``
+(``backtest_repository.py``, ``strategies_routes.py``,
+``audit_backtest_universe.py``) looks rows up by ``strategy_id`` /
+``content_hash``, never by a stored foreign row id. Deleting superseded rows
+here is therefore FK-safe with no re-pointing needed.
+
+Idempotent by construction: a second run recomputes the same hash from the
+same stored ``artifact_json`` for every surviving row, finds each
+(strategy_id, hash) group already collapsed to one row, and updates nothing
+(the survivor's ``content_hash`` already equals its recomputed value from the
+first run) — see ``test_dedupe_backtest_results_migration_upgrade_is_idempotent``
+in ``backend/tests/test_alembic_migrations.py``.
+
+Downgrade is a documented no-op: this migration makes no schema change (no
+column added/removed), so there is nothing to structurally revert. The row
+deletions themselves are NOT reversible — the deleted rows' data is gone —
+and that is honest, not a gap: they were byte-for-byte redundant duplicates
+of a surviving row's content, so there is nothing a downgrade could restore
+that the survivor doesn't already carry.
+
+Revision ID: f0ab58339d55
+Revises: c9396e0d95d4
+Create Date: 2026-08-20 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f0ab58339d55"
+down_revision: str | Sequence[str] | None = "c9396e0d95d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Recompute canonical hashes from stored payloads; collapse duplicates."""
+    # Deferred, function-local import: alembic revision modules are not on
+    # the app's normal import path (see migrations/env.py's own comment on
+    # why it inserts backend/ onto sys.path), but backend/ IS on sys.path by
+    # the time `upgrade()` runs inside the alembic subprocess, so importing
+    # the app's OWN hashing function here — rather than re-deriving the same
+    # logic a second time — is safe and is what keeps this migration from
+    # ever drifting out of sync with what canonical_artifact_hash means.
+    from archimedes.services.backtest_mapper import canonical_artifact_hash
+
+    bind = op.get_bind()
+
+    rows = (
+        bind.execute(
+            sa.text(
+                "SELECT id, strategy_id, content_hash, artifact_json, created_at "
+                "FROM backtest_results "
+                "ORDER BY strategy_id, created_at ASC, id ASC"
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    # (strategy_id, recomputed_hash) -> [(id, existing_content_hash), ...] in
+    # created_at/id ascending order (guaranteed by the ORDER BY above), so
+    # group[0] is always the earliest row for that group.
+    groups: dict[tuple[str, str], list[tuple[int, str]]] = defaultdict(list)
+
+    for row in rows:
+        payload = None
+        if row["artifact_json"]:
+            try:
+                payload = json.loads(row["artifact_json"])
+            except (TypeError, ValueError):
+                payload = None
+
+        # No resolvable payload: fall back to the row's own existing hash,
+        # which — by the pre-existing uq_backtest_strategy_content constraint
+        # — is already unique per strategy_id, so this row is its own
+        # singleton group and is never merged with anything.
+        recomputed_hash = canonical_artifact_hash(payload) if isinstance(payload, dict) else row["content_hash"]
+
+        groups[(row["strategy_id"], recomputed_hash)].append((row["id"], row["content_hash"]))
+
+    to_delete: list[int] = []
+    to_update: list[dict[str, object]] = []
+
+    for (_strategy_id, recomputed_hash), members in groups.items():
+        survivor_id, survivor_old_hash = members[0]
+        to_delete.extend(member_id for member_id, _old_hash in members[1:])
+        if survivor_old_hash != recomputed_hash:
+            to_update.append({"id": survivor_id, "content_hash": recomputed_hash})
+
+    # Delete duplicates FIRST: only after a group has collapsed to one row is
+    # it safe to update that survivor's content_hash to the shared recomputed
+    # value without transiently colliding with a sibling row that is about to
+    # be deleted anyway (uq_backtest_strategy_content is (strategy_id,
+    # content_hash) and would otherwise reject the UPDATE mid-migration).
+    if to_delete:
+        bind.execute(
+            sa.text("DELETE FROM backtest_results WHERE id = :id"),
+            [{"id": row_id} for row_id in to_delete],
+        )
+
+    if to_update:
+        bind.execute(
+            sa.text("UPDATE backtest_results SET content_hash = :content_hash WHERE id = :id"),
+            to_update,
+        )
+
+
+def downgrade() -> None:
+    """Documented no-op — see the module docstring's "Downgrade" section.
+
+    No schema change was made (no column added/removed), so there is nothing
+    structural to revert. The row deletions performed by `upgrade()` are not
+    reversible: the deleted rows were byte-for-byte content duplicates of a
+    surviving row, so nothing is lost that the survivor doesn't already
+    carry, and there is no prior state to restore them from.
+    """

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -372,3 +372,242 @@ def test_alembic_strategy_store_matches_a_fresh_create_all_schema(tmp_path):
     assert "strategy_spec" in create_all_cols
     assert "strategy_spec" in alembic_cols
     assert create_all_cols == alembic_cols
+
+
+# ── backtest_results dedupe data migration (issue #1347) ────────────────────
+#
+# canonical_artifact_hash used to hash run_id/timestamp_utc along with the
+# rest of the artifact payload, so every run's content_hash was unique by
+# construction and insert_backtest_if_missing's dedupe never fired — see
+# backend/archimedes/services/backtest_mapper.py's module-level docstring.
+# This migration (f0ab58339d55) is the one-time cleanup: it recomputes every
+# row's canonical hash from its OWN stored artifact_json and collapses rows
+# that recompute to the same (strategy_id, hash), keeping the earliest.
+
+_DEDUPE_MIGRATION_REVISION = (
+    "f0ab58339d55"  # migrations/versions/f0ab58339d55_dedupe_backtest_results_canonical_hash.py
+)
+
+
+def _dedupe_migration_down_revision() -> str:
+    """The dedupe migration's OWN down_revision, looked up from the script
+    directory (not hardcoded) — same rationale as the strategy_spec test
+    above: stays correct if another migration lands on top later."""
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(Config(str(_BACKEND_DIR / "alembic.ini")))
+    target = script.get_revision(_DEDUPE_MIGRATION_REVISION).down_revision
+    assert isinstance(target, str), f"expected a single down_revision, got {target!r}"
+    return target
+
+
+def _artifact_payload(run_id: str, timestamp_utc: str, sharpe: float) -> dict:
+    """Minimal artifact payload shaped like a real run_backtests.py artifact:
+    run_id/timestamp_utc are the two volatile fields the code fix excludes;
+    everything else is content."""
+    return {
+        "run_id": run_id,
+        "timestamp_utc": timestamp_utc,
+        "strategy": {"backtest_code_hash": "sha256:dedupe-fixture"},
+        "assumptions": {"transaction_cost_bps": 10},
+        "results": [{"operation": "SPY", "metrics": {"sharpe_ratio": sharpe, "total_trades": 12}}],
+    }
+
+
+def _seed_pre_dedupe_rows(db_path: Path) -> None:
+    """Seed rows AS THEY WOULD HAVE BEEN WRITTEN under the unfixed hash:
+    genuinely identical content (strat_A) but a distinct content_hash per
+    row, exactly like every real run_backtests.py refresh cycle produced
+    before the code fix. Uses the real ORM factory
+    (`BacktestResultRecord.from_backtest_result`) against the
+    already-alembic-built schema, so seeding tracks real column
+    nullability/defaults instead of hand-enumerating them.
+    """
+    import json as _json
+    from datetime import UTC, datetime
+
+    import sqlalchemy as sa
+    from archimedes.models.backtest import BacktestResult
+    from archimedes.models.backtest_store import BacktestResultRecord
+    from sqlalchemy.orm import sessionmaker
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    SessionLocal = sessionmaker(bind=engine)
+
+    def _result(sharpe: float) -> BacktestResult:
+        return BacktestResult(
+            strategy_id="unused",  # overwritten by from_backtest_result's own kwarg
+            sharpe_ratio=sharpe,
+            sortino_ratio=0.0,
+            max_drawdown=0.0,
+            cagr=0.0,
+            calmar_ratio=0.0,
+            win_rate=0.0,
+            profit_factor=0.0,
+            total_trades=12,
+            avg_holding_period_days=0.0,
+            correlation_to_spy=None,
+            correlation_to_btc=None,
+            equity_curve=[],
+            monthly_returns=[],
+            backtest_start=None,
+            backtest_end=None,
+            backtest_engine="backtrader",
+        )
+
+    with SessionLocal() as session:
+        # strat_A: three refreshes of IDENTICAL content (sharpe=0.7 every
+        # time), each stamped with the OLD volatile-inclusive hash — a
+        # different stale value per row even though the content never
+        # changed. Must collapse to ONE row: the earliest (r1, 2026-08-01).
+        for run_id, ts, created in (
+            ("r1", "2026-08-01T00:00:00+00:00", datetime(2026, 8, 1, tzinfo=UTC)),
+            ("r2", "2026-08-02T00:00:00+00:00", datetime(2026, 8, 2, tzinfo=UTC)),
+            ("r3", "2026-08-03T00:00:00+00:00", datetime(2026, 8, 3, tzinfo=UTC)),
+        ):
+            row = BacktestResultRecord.from_backtest_result(
+                strategy_id="strat_A",
+                content_hash=f"stale-hash-{run_id}",
+                result=_result(0.7),
+                source_pipeline="run_backtests",
+                run_id=run_id,
+                artifact_json=_json.dumps(_artifact_payload(run_id, ts, 0.7)),
+            )
+            row.created_at = created
+            session.add(row)
+
+        # strat_B: two rows with GENUINELY DIFFERENT content (sharpe 0.5 vs
+        # 0.9) — must NOT collapse; both survive, each gets its content_hash
+        # normalized to its own recomputed value.
+        for run_id, ts, sharpe, created in (
+            ("r4", "2026-08-01T00:00:00+00:00", 0.5, datetime(2026, 8, 1, tzinfo=UTC)),
+            ("r5", "2026-08-02T00:00:00+00:00", 0.9, datetime(2026, 8, 2, tzinfo=UTC)),
+        ):
+            row = BacktestResultRecord.from_backtest_result(
+                strategy_id="strat_B",
+                content_hash=f"stale-hash-{run_id}",
+                result=_result(sharpe),
+                source_pipeline="run_backtests",
+                run_id=run_id,
+                artifact_json=_json.dumps(_artifact_payload(run_id, ts, sharpe)),
+            )
+            row.created_at = created
+            session.add(row)
+
+        # strat_C: a row with NO resolvable artifact_json — must be left
+        # untouched (no payload to recompute a canonical hash from; the
+        # migration never guesses).
+        row_c = BacktestResultRecord.from_backtest_result(
+            strategy_id="strat_C",
+            content_hash="stale-hash-r6",
+            result=_result(0.3),
+            source_pipeline="run_backtests",
+            run_id="r6",
+            artifact_json=None,
+        )
+        row_c.created_at = datetime(2026, 8, 1, tzinfo=UTC)
+        session.add(row_c)
+
+        session.commit()
+
+    engine.dispose()
+
+
+def _fetch_backtest_rows(db_path: Path) -> list[sqlite3.Row]:
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    try:
+        cur = con.cursor()
+        cur.execute("SELECT id, strategy_id, content_hash, run_id, artifact_json FROM backtest_results ORDER BY id")
+        return cur.fetchall()
+    finally:
+        con.close()
+
+
+def test_dedupe_backtest_results_migration_collapses_duplicates_and_keeps_earliest(tmp_path):
+    """Acceptance criterion: post-migration row count == number of distinct
+    recomputed canonical hashes, and the EARLIEST row per group survives.
+
+    strat_A: 3 content-identical rows -> 1 survivor (the earliest, r1).
+    strat_B: 2 content-DIFFERENT rows -> both survive, untouched-in-count.
+    strat_C: 1 unresolvable-payload row -> survives unchanged (own group).
+    Total before: 6 rows over 3 (strategy_id, recomputed_hash) groups (A has
+    1 distinct group despite 3 rows; B has 2; C has 1) -> 4 distinct groups,
+    4 rows after.
+    """
+    from archimedes.services.backtest_mapper import canonical_artifact_hash
+
+    db_path = tmp_path / "dedupe_collapse.db"
+    database_url = f"sqlite:///{db_path}"
+
+    pre = _run_alembic("upgrade", _dedupe_migration_down_revision(), database_url=database_url)
+    assert pre.returncode == 0, pre.stderr
+
+    _seed_pre_dedupe_rows(db_path)
+    assert len(_fetch_backtest_rows(db_path)) == 6, "sanity: 6 rows seeded before the dedupe migration runs"
+
+    post = _run_alembic("upgrade", "head", database_url=database_url)
+    assert post.returncode == 0, f"dedupe migration failed:\nSTDOUT:\n{post.stdout}\nSTDERR:\n{post.stderr}"
+
+    rows = _fetch_backtest_rows(db_path)
+    by_strategy: dict[str, list[sqlite3.Row]] = {}
+    for row in rows:
+        by_strategy.setdefault(row["strategy_id"], []).append(row)
+
+    # Row count == number of distinct recomputed canonical hashes (AC).
+    assert len(rows) == 4, f"expected 4 surviving rows, got {len(rows)}: {[dict(r) for r in rows]}"
+    recomputed_hashes = {row["content_hash"] for row in rows}
+    assert len(recomputed_hashes) == len(rows), "every surviving row must carry a distinct content_hash"
+
+    # strat_A collapsed to exactly the EARLIEST row (r1), and its content_hash
+    # is the fixed canonical_artifact_hash of its OWN payload — proving the
+    # migration used the real function, not a placeholder.
+    assert len(by_strategy["strat_A"]) == 1
+    survivor_a = by_strategy["strat_A"][0]
+    assert survivor_a["run_id"] == "r1", "the EARLIEST duplicate must survive, not an arbitrary one"
+    expected_hash_a = canonical_artifact_hash(_artifact_payload("r1", "2026-08-01T00:00:00+00:00", 0.7))
+    assert survivor_a["content_hash"] == expected_hash_a
+    # And that recomputed hash is identical to what r2/r3's payloads would
+    # produce too (proving run_id/timestamp really are excluded) even though
+    # r2/r3 themselves are gone.
+    assert expected_hash_a == canonical_artifact_hash(_artifact_payload("r2", "2026-08-02T00:00:00+00:00", 0.7))
+
+    # strat_B: both distinct-content rows survive, each normalized to its own
+    # recomputed hash (never merged with each other).
+    assert len(by_strategy["strat_B"]) == 2
+    hashes_b = {row["content_hash"] for row in by_strategy["strat_B"]}
+    assert hashes_b == {
+        canonical_artifact_hash(_artifact_payload("r4", "2026-08-01T00:00:00+00:00", 0.5)),
+        canonical_artifact_hash(_artifact_payload("r5", "2026-08-02T00:00:00+00:00", 0.9)),
+    }
+
+    # strat_C: unresolvable payload -> left exactly as it was.
+    assert len(by_strategy["strat_C"]) == 1
+    assert by_strategy["strat_C"][0]["content_hash"] == "stale-hash-r6"
+
+
+def test_dedupe_backtest_results_migration_upgrade_is_idempotent(tmp_path):
+    """Running the dedupe migration's upgrade a second time (downgrade to its
+    own down_revision — a documented structural no-op — then upgrade to head
+    again, which re-executes the SAME upgrade() body against
+    already-deduped data) must be a no-op: identical row set, no error."""
+    db_path = tmp_path / "dedupe_idempotent.db"
+    database_url = f"sqlite:///{db_path}"
+    down_revision = _dedupe_migration_down_revision()
+
+    pre = _run_alembic("upgrade", down_revision, database_url=database_url)
+    assert pre.returncode == 0, pre.stderr
+    _seed_pre_dedupe_rows(db_path)
+
+    first = _run_alembic("upgrade", "head", database_url=database_url)
+    assert first.returncode == 0, first.stderr
+    rows_after_first = [dict(r) for r in _fetch_backtest_rows(db_path)]
+
+    second_down = _run_alembic("downgrade", down_revision, database_url=database_url)
+    assert second_down.returncode == 0, second_down.stderr
+    second_up = _run_alembic("upgrade", "head", database_url=database_url)
+    assert second_up.returncode == 0, f"second upgrade head failed:\n{second_up.stderr}"
+
+    rows_after_second = [dict(r) for r in _fetch_backtest_rows(db_path)]
+    assert rows_after_second == rows_after_first, "re-running the dedupe migration changed already-deduped data"

--- a/backend/tests/test_backtest_mapper.py
+++ b/backend/tests/test_backtest_mapper.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 
 import pytest
 from archimedes.services.backtest_mapper import (
     AnalyticsArtifactModel,
+    canonical_artifact_hash,
     map_artifact_to_backtest_result,
     select_operation_result,
 )
@@ -162,3 +164,99 @@ def test_map_artifact_to_backtest_result_returns_multi_feed_operation_label() ->
 
     assert operation == "SPY/NIKKEI/GOLD/TREASURY/OIL"
     assert mapped.sharpe_ratio == pytest.approx(0.42)
+
+
+# ── canonical_artifact_hash volatile-field exclusion (issue #1347) ──────────
+#
+# Root cause: canonical_artifact_hash used to hash the WHOLE payload including
+# "run_id" and "timestamp_utc", both minted fresh on every run regardless of
+# content, so every run's hash was unique by construction and
+# insert_backtest_if_missing's content-hash dedupe could never match — the
+# table grew ~30 rows/strategy per container restart. These tests are
+# mutation-proven: reverting canonical_artifact_hash to `json.dumps(payload,
+# sort_keys=True, ...)` (no exclusion) makes
+# test_canonical_artifact_hash_ignores_run_id_and_timestamp FAIL, because two
+# payloads differing only in the excluded keys would then hash differently.
+# See the PR body for the revert/re-apply transcript.
+
+
+def _full_artifact_payload() -> dict:
+    """A raw artifact payload with BOTH volatile fields present, shaped like
+    what cli.py / portfolio_backtester.py actually emit (run_id and
+    timestamp_utc as siblings at the top level, alongside content)."""
+    return {
+        "run_id": "20260518T223743Z",
+        "timestamp_utc": "2026-05-18T22:37:43.964677+00:00",
+        "operations": ["SPY"],
+        "strategy": {
+            "path": "strategies/pipeline_buy_hold.py",
+            "class_name": "BuyAndHold",
+            "backtest_code_hash": "sha256:deadbeef",
+            "paper_claimed_sharpe": 0.5,
+        },
+        "assumptions": {
+            "start": "2018-01-01",
+            "end": "2026-01-01",
+            "transaction_cost_bps": 10,
+            "backtest_engine": "backtrader",
+        },
+        "results": [
+            {
+                "operation": "SPY",
+                "symbol": "SPY",
+                "metrics": {"sharpe_ratio": 0.71, "total_trades": 12},
+            }
+        ],
+        "data_hashes": ["f4096541e95c439b4cc82cd8660309f63855130e66c4e60f65942ffb96088384"],
+        "integrity_flags": {"lookahead_audit_passed": True},
+    }
+
+
+def test_canonical_artifact_hash_ignores_run_id_and_timestamp() -> None:
+    """Two payloads differing ONLY in run_id/timestamp_utc must hash equal.
+
+    Mutation check: this assertion fails against the unfixed
+    canonical_artifact_hash (plain sort_keys dump of the whole payload,
+    no exclusion) because run_id/timestamp_utc differ between the two
+    payloads below and would then perturb the hash.
+    """
+    run_a = _full_artifact_payload()
+    run_b = copy.deepcopy(run_a)
+    run_b["run_id"] = "20260519T010101Z"
+    run_b["timestamp_utc"] = "2026-05-19T01:01:01.000000+00:00"
+
+    assert run_a != run_b  # sanity: the two payloads are not byte-identical
+    assert canonical_artifact_hash(run_a) == canonical_artifact_hash(run_b)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("results", 0, "metrics", "sharpe_ratio"), 0.99),
+        (("strategy", "backtest_code_hash"), "sha256:different"),
+        (("assumptions", "transaction_cost_bps"), 25),
+        (("data_hashes",), ["a-completely-different-input-data-hash"]),
+    ],
+)
+def test_canonical_artifact_hash_changes_on_content_mutation(path: tuple, value: object) -> None:
+    """Any CONTENT field — including data_hashes, which is a hash of the
+    INPUT DATA and therefore not volatile — must still change the hash.
+    Guards against an over-broad exclusion swallowing real content."""
+    base = _full_artifact_payload()
+    mutated = copy.deepcopy(base)
+
+    node = mutated
+    for key in path[:-1]:
+        node = node[key]
+    node[path[-1]] = value
+
+    assert canonical_artifact_hash(base) != canonical_artifact_hash(mutated)
+
+
+def test_canonical_artifact_hash_stable_without_volatile_keys() -> None:
+    """A payload that never had run_id/timestamp_utc (e.g. the DSL-fusion
+    artifact shape, which never included them) hashes the same before and
+    after the exclusion — the fix must be a no-op when the keys are absent."""
+    payload = {"results": [{"metrics": {"daily_returns": [0.01, -0.02]}}], "source": "dsl_fusion"}
+
+    assert canonical_artifact_hash(payload) == canonical_artifact_hash(copy.deepcopy(payload))

--- a/backend/tests/test_backtest_repository.py
+++ b/backend/tests/test_backtest_repository.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import copy
 from datetime import date
 
 from archimedes.models.backtest import BacktestResult
 from archimedes.models.backtest_store import BacktestResultRecord
 from archimedes.models.chat import Base
+from archimedes.services.backtest_mapper import canonical_artifact_hash
 from archimedes.services.backtest_repository import (
     insert_backtest_if_missing,
     latest_backtests_by_strategy,
@@ -70,6 +72,66 @@ def test_insert_backtest_is_idempotent_on_content_hash() -> None:
         assert inserted2 is False
         assert row1_id == row2.id
         assert len(rows) == 1
+
+
+def test_insert_backtest_if_missing_skips_duplicate_run_with_only_run_id_and_timestamp_diff() -> None:
+    """End-to-end reproduction of issue #1347's production symptom: two
+    "refreshes" of the SAME strategy content (identical metrics, differing
+    only in run_id/timestamp_utc — exactly what a scheduled re-run of
+    run_backtests.py produces on a container restart) must collapse to ONE
+    row via content_hash, not two.
+
+    Mutation-proven: with canonical_artifact_hash reverted to hash the whole
+    payload (no volatile-key exclusion), `hash_a != hash_b` below and this
+    test fails with `inserted2 is True` / `len(rows) == 2`. See the PR body
+    for the revert/re-apply transcript.
+    """
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    payload_a = {
+        "run_id": "20260518T223743Z",
+        "timestamp_utc": "2026-05-18T22:37:43.964677+00:00",
+        "strategy": {"backtest_code_hash": "sha256:deadbeef"},
+        "assumptions": {"transaction_cost_bps": 10},
+        "results": [{"operation": "SPY", "metrics": {"sharpe_ratio": 0.71, "total_trades": 12}}],
+    }
+    payload_b = copy.deepcopy(payload_a)
+    payload_b["run_id"] = "20260519T010101Z"
+    payload_b["timestamp_utc"] = "2026-05-19T01:01:01.000000+00:00"
+
+    hash_a = canonical_artifact_hash(payload_a)
+    hash_b = canonical_artifact_hash(payload_b)
+    assert hash_a == hash_b, "two runs over identical content must produce equal canonical hashes"
+
+    with SessionLocal() as session:
+        row1, inserted1 = insert_backtest_if_missing(
+            session,
+            strategy_id="s1",
+            content_hash=hash_a,
+            result=_sample_result("s1", sharpe=0.71),
+            run_id=payload_a["run_id"],
+            source_pipeline="run_backtests",
+        )
+        session.commit()
+
+        row2, inserted2 = insert_backtest_if_missing(
+            session,
+            strategy_id="s1",
+            content_hash=hash_b,
+            result=_sample_result("s1", sharpe=0.71),
+            run_id=payload_b["run_id"],
+            source_pipeline="run_backtests",
+        )
+        session.commit()
+
+        rows = session.query(BacktestResultRecord).filter(BacktestResultRecord.strategy_id == "s1").all()
+
+    assert inserted1 is True
+    assert inserted2 is False, "the second (content-identical) refresh must be SKIPPED, not re-inserted"
+    assert row1.id == row2.id
+    assert len(rows) == 1
 
 
 def test_latest_backtests_by_strategy_picks_newest_row() -> None:

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -288,3 +288,201 @@ class TestPoolCorrelationDSR:
         _patch_dsr_with_pool_correlation(candidates)
 
         assert fusion_candidate.rigor_verdict == fusion_verdict, "fusion candidate's real DSR must be untouched"
+
+
+# ── PORTFOLIO_BACKTESTER writer hash unification (issue #1347 follow-up) ────
+#
+# NOT hermetic-in-the-"no DB" sense the module docstring above describes —
+# these seed a per-test in-memory sqlite DB (monkeypatching
+# `archimedes.db.engine`/`SessionLocal` directly, NOT the
+# `monkeypatch.setenv DATABASE_URL` + `init_db()` pattern used elsewhere in
+# this suite — see `_isolated_db`'s own docstring for why that pattern
+# doesn't actually isolate here) — but still fully offline: no live Redis,
+# no live Postgres, no network, no LLM.
+#
+# `_backtest_and_persist`'s `content_hash` computation used to be an ad hoc
+# `hashlib.sha256(artifact_json)` over an artifact that
+# `portfolio_backtester.backtest_portfolio` stamps with its own fresh
+# `run_id`/`timestamp_utc` on every call — the same volatile-field shape
+# `canonical_artifact_hash` was fixed to exclude, but this ONE writer never
+# routed through that fixed function. Two "real" backtests of identical
+# content through this exact writer therefore never deduped, even after the
+# `canonical_artifact_hash` fix landed. This test exercises the REAL
+# `_backtest_and_persist` closure end to end — not a reimplementation of its
+# hashing logic — with `backtest_portfolio` mocked at the module boundary
+# (CLAUDE.md: mock at boundaries, not internals) so it is genuinely tied to
+# the writer's own code, not to a copy of it.
+
+
+class TestPortfolioBacktesterWriterDedupe:
+    @pytest.fixture(autouse=True)
+    def _isolated_db(self, monkeypatch):
+        """A genuinely per-test-isolated DB, NOT the ``monkeypatch.setenv
+        DATABASE_URL`` + ``init_db()`` pattern used elsewhere in this suite.
+
+        ``archimedes.db``'s ``engine``/``SessionLocal`` are module-level
+        singletons bound to ``DATABASE_URL`` at FIRST IMPORT — and
+        ``conftest.py``'s own top-level import of
+        ``archimedes.services.strategy_provider`` transitively imports
+        ``archimedes.db`` during collection, before any test fixture runs.
+        Setting the env var afterward is a no-op against the already-created
+        engine, so that pattern silently falls back to sharing
+        ``backend/archimedes_chat.db`` on disk — which then ACCUMULATES rows
+        across separate test runs (verified: two runs of this test's own
+        precursor left 3 rows for one strategy_id, not the expected 1/2 —
+        pre-existing rows from a prior process leaking in). Monkeypatching
+        the module's ``engine``/``SessionLocal`` attributes directly — what
+        ``get_session()`` actually reads at call time — sidesteps the
+        singleton-binding problem instead of fighting it.
+
+        ``poolclass=StaticPool`` is required, not cosmetic: SQLAlchemy's
+        default pool for a ``sqlite:///:memory:`` URL is
+        ``SingletonThreadPool`` — one connection PER THREAD, i.e. a fresh,
+        empty in-memory DB on any thread other than the one that ran
+        ``create_all``. ``_backtest_and_persist`` does its DB work inside
+        ``asyncio.to_thread(...)`` specifically to keep it off the event
+        loop, so without ``StaticPool`` (one shared connection across every
+        thread) the worker thread sees "no such table: backtest_results" —
+        caught by ``_backtest_and_persist``'s own broad ``except Exception``
+        and merely logged, so the failure mode is a silently-empty table, not
+        a raised error. Reproduced directly before adding this.
+        """
+        import sqlalchemy as sa
+        from archimedes.models import kg, strategy_passport_record  # noqa: F401 — register their tables
+        from archimedes.models.chat import Base
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
+
+        engine = sa.create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=engine)
+        session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+        import archimedes.db as db_module
+
+        monkeypatch.setattr(db_module, "engine", engine)
+        monkeypatch.setattr(db_module, "SessionLocal", session_factory)
+
+    @staticmethod
+    def _candidate() -> _CandidateResult:
+        return _CandidateResult(
+            candidate_id="cand-1",
+            strategy_name="Test Portfolio Strategy",
+            thesis="thesis",
+            asset_universe=["sSPY", "sGLD"],
+            source_papers=[],
+            weights={"sSPY": 0.6, "sGLD": 0.4},
+            reasoning="r",
+            rigor_verdict={},
+            passes_rigor=True,
+            generation_method="portfolio_agent_streaming",
+        )
+
+    @staticmethod
+    def _fake_artifact(run_id: str, timestamp_utc: str) -> dict:
+        """Shaped like the real ``backtest_portfolio`` artifact
+        (``portfolio_backtester.py``'s own construction): ``run_id`` and
+        ``timestamp_utc`` as top-level siblings, everything else content."""
+        return {
+            "run_id": run_id,
+            "timestamp_utc": timestamp_utc,
+            "operations": ["sSPY", "sGLD"],
+            "strategy": {"path": "generated/strat-1", "class_name": "GeneratedStaticRebalance"},
+            "assumptions": {"transaction_cost_bps": 10, "backtest_engine": "portfolio-simulator-v1"},
+            "results": [
+                {
+                    "operation": "PORTFOLIO",
+                    "symbol": "PORTFOLIO",
+                    "metrics": {
+                        "daily_returns": [0.001, 0.002, -0.001, 0.0015] * 5,
+                        "sharpe_ratio": 0.8,
+                    },
+                }
+            ],
+        }
+
+    @staticmethod
+    def _fake_result() -> "BacktestResult":  # noqa: F821,UP037 — deferred import, only inside this function
+        from archimedes.models.backtest import BacktestResult
+
+        return BacktestResult(
+            strategy_id="strat-1",
+            sharpe_ratio=0.8,
+            sortino_ratio=0.9,
+            max_drawdown=0.1,
+            cagr=0.15,
+            calmar_ratio=1.5,
+            win_rate=0.55,
+            profit_factor=1.2,
+            total_trades=4,
+            avg_holding_period_days=30.0,
+            correlation_to_spy=0.5,
+            correlation_to_btc=0.1,
+            equity_curve=[1.0, 1.01, 1.02],
+            monthly_returns=[0.01],
+            backtest_start=None,
+            backtest_end=None,
+            look_ahead_audit_passed=True,
+            backtest_engine="portfolio-simulator-v1",
+        )
+
+    async def test_second_persist_of_identical_content_is_skipped(self, monkeypatch):
+        """Two persists through ``_backtest_and_persist`` whose
+        ``backtest_portfolio`` artifacts differ ONLY in
+        ``run_id``/``timestamp_utc`` must collapse to ONE ``backtest_results``
+        row — the exact production symptom (identical strategy, identical
+        content, re-run through the society/portfolio-backtester path).
+
+        Mutation-proven: fails against the pre-fix ad hoc
+        ``hashlib.sha256(artifact_json)`` — see the PR body for the
+        revert/re-apply transcript.
+        """
+        from archimedes.agents.generation_pipeline import _backtest_and_persist
+        from archimedes.db import get_session
+        from archimedes.models.backtest_store import BacktestResultRecord
+        from archimedes.services.backtest_repository import SOURCE_PIPELINE_PORTFOLIO_BACKTESTER
+
+        artifacts = iter(
+            [
+                self._fake_artifact("gen-20260501T000000Z-strat1", "2026-05-01T00:00:00+00:00"),
+                self._fake_artifact("gen-20260502T000000Z-strat1", "2026-05-02T00:00:00+00:00"),
+            ]
+        )
+
+        def _fake_backtest_portfolio(*, strategy_id, weights, paper_title=None, num_trials_for_dsr=1, **kwargs):
+            return self._fake_result(), next(artifacts)
+
+        monkeypatch.setattr(
+            "archimedes.services.portfolio_backtester.backtest_portfolio",
+            _fake_backtest_portfolio,
+        )
+
+        class _NullEmitter:
+            async def emit(self, event, **payload):
+                return 0
+
+        strategy_id = "strat-1"
+        c = self._candidate()
+        emit = _NullEmitter()
+
+        await _backtest_and_persist(c, strategy_id, emit, num_trials=1)
+        await _backtest_and_persist(c, strategy_id, emit, num_trials=1)
+
+        with get_session() as session:
+            rows = (
+                session.query(BacktestResultRecord)
+                .filter(
+                    BacktestResultRecord.strategy_id == strategy_id,
+                    BacktestResultRecord.source_pipeline == SOURCE_PIPELINE_PORTFOLIO_BACKTESTER,
+                )
+                .all()
+            )
+            row_info = [(r.id, r.content_hash, r.run_id) for r in rows]
+
+        assert len(rows) == 1, (
+            "expected the second persist to be SKIPPED (identical content, "
+            f"differing only in run_id/timestamp_utc); got {len(rows)} rows: {row_info}"
+        )


### PR DESCRIPTION
## Summary

Closes #1347.

`canonical_artifact_hash` hashed the whole artifact payload, including `run_id` and `timestamp_utc` — both minted fresh on every run regardless of content. Every run's `content_hash` was therefore unique by construction, so `insert_backtest_if_missing`'s content-hash dedupe could never match. #1263 fixed an unrelated `PermissionError` that, as a side effect, had always killed the refresh *before* the DB insert — masking this defect entirely (zero rows ever persisted). Once #1263 landed, every scheduled refresh started re-inserting every strategy's backtest on every container restart.

Production, measured read-only 2026-08-20: **646 rows over 51 distinct strategies**, top offenders 31 / 25 / 24 rows, long tail at ~22 — consistent with the restart cadence around the #1309 / #1328 / #1329 / #1337 crash-loop window.

Three changes, same PR:

1. **Code fix** (`backend/archimedes/services/backtest_mapper.py`): exclude volatile fields from the hash going forward.
2. **Data migration** (`backend/migrations/versions/f0ab58339d55_...py`): collapse the existing duplicate rows already written under the broken hash.
3. **Writer unification** (`backend/archimedes/agents/generation_pipeline.py`), added after first-round review caught a real gap (see below): the `SOURCE_PIPELINE_PORTFOLIO_BACKTESTER` writer had its own ad hoc hash that the code fix in (1) never touched, so it stayed broken even after this PR's first version.

## Review round 2 — what was actually wrong and how it's fixed

First-round review confirmed 2 majors:

- The migration recomputes and rewrites `content_hash` for **every** row via `canonical_artifact_hash`, including historical `SOURCE_PIPELINE_PORTFOLIO_BACKTESTER` rows — but `generation_pipeline.py:1659-1660` was still computing its content_hash as a raw `hashlib.sha256(artifact_json)`, a hash that writer can never reproduce (its artifact, from `portfolio_backtester.backtest_portfolio`, carries the same `run_id`/`timestamp_utc` volatile shape as `cli.py`'s artifact, and the ad hoc call never excluded them). So the very next identical run through that pipeline was guaranteed to miss the dedupe match and restart duplicate accumulation for that one writer.
- The PR body and the `backtest_mapper.py` comment claimed both producers ("cli.py and portfolio_backtester.py") were checked and covered — false: `portfolio_backtester.py`'s artifact reaches the DB through **two different call sites** (`generation_pipeline.py`'s DSL_FUSION branch and its PORTFOLIO_BACKTESTER branch), and only run_backtests.py / seed_backtests_from_artifacts.py were actually routed through the fixed function.

Fix: `generation_pipeline.py`'s PORTFOLIO_BACKTESTER writer now imports and calls the same `canonical_artifact_hash(artifact)` the other two writers use, replacing the ad hoc `hashlib.sha256(artifact_json)`. `backtest_mapper.py`'s comment now enumerates every writer call site individually — see below.

**With the writer unified, "the migration-normalized hash is reproducible going forward" is now literally true for every writer that can produce a duplicate:** the migration rewrites historical rows to `canonical_artifact_hash(payload)`; `run_backtests.py`, `seed_backtests_from_artifacts.py`, and now `generation_pipeline.py`'s PORTFOLIO_BACKTESTER branch all compute NEW rows' `content_hash` via that exact same function. A future identical-content run through any of the three now lands on the same hash the migration already normalized historical rows to, so `insert_backtest_if_missing`'s `WHERE strategy_id = ? AND content_hash = ?` check actually matches. (The DSL_FUSION branch is the one remaining ad hoc hash — see the enumeration below for why it was never broken and is deliberately left as is.)

## Excluded-field enumeration + justification

A module-level `_VOLATILE_HASH_KEYS: frozenset[str] = frozenset({"run_id", "timestamp_utc"})`, with a docstring, is checked against the top-level payload before hashing:

- **`run_id`** — a fresh identifier minted per invocation, never derived from measured content. `analytics-engine/.../cli.py` mints it once per `run_command()` call; `portfolio_backtester.py` mints `f"gen-{datetime.now(UTC):%Y%m%dT%H%M%SZ}-{strategy_id[:8]}"` — itself a wall-clock timestamp wrapped in a string. Two runs over identical inputs producing identical metrics still get two different `run_id`s.
- **`timestamp_utc`** — `datetime.now(UTC).isoformat()` stamped at artifact-build time (same two producers). Wall-clock by definition, never content.

**Deliberately NOT excluded** (both are content, not run metadata — a mutation test in `test_backtest_mapper.py` guards this so the exclusion can't quietly grow):
- `data_hashes` — a hash of the **input data** the run actually read. Two runs against different underlying data legitimately deserve different artifact hashes even if everything else lines up.
- Everything under `results` (the measured metrics), plus `strategy`, `assumptions`, `integrity_flags`, `operations`.

### Writer call-site coverage — literally true this time

Every place that mints a `content_hash` for `backtest_results`, checked individually:

| Writer | Hash function | Ever broken? |
|---|---|---|
| `scripts/run_backtests.py` | `canonical_artifact_hash` on the `cli.py` artifact | No — fixed from day one of this PR |
| `scripts/seed_backtests_from_artifacts.py` | `canonical_artifact_hash`, replayed `cli.py`-shaped artifact | No — fixed from day one of this PR |
| `generation_pipeline.py` — `SOURCE_PIPELINE_PORTFOLIO_BACKTESTER` | **Now** `canonical_artifact_hash(artifact)` (was ad hoc `hashlib.sha256`) | **Yes — this is round 2's fix** |
| `generation_pipeline.py` — `SOURCE_PIPELINE_DSL_FUSION` | Its own ad hoc `hashlib.sha256(artifact_json)`, unchanged | No — its artifact (`{"results": ..., "source": ..., "data_source": ...}`) never carried `run_id`/`timestamp_utc` in the first place, so it never had this defect. Left as is; not part of this issue's scope. |

## Anti-goals — confirmed untouched

- Rigor-gate math: not touched.
- `artifact_json` content / serialization: unchanged in every writer — only the HASH computation was rerouted, per the coordinator's explicit instruction to keep the stored blob shape as is.
- Artifact write path (#1263's fix): unchanged.

## Mutation transcripts (guard-must-reject-something)

### 1. Hash fix (`backtest_mapper.py`)

Reverted `canonical_artifact_hash` to the pre-fix `json.dumps(payload, sort_keys=True, ...)` (no exclusion):

```
$ git stash push -- backend/archimedes/services/backtest_mapper.py   # reverts to unfixed hash
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
    backend/tests/test_backtest_mapper.py backend/tests/test_backtest_repository.py -q

FAILED backend/tests/test_backtest_mapper.py::test_canonical_artifact_hash_ignores_run_id_and_timestamp
  AssertionError: assert '7064d246...' == 'ce5f4ba0...'
FAILED backend/tests/test_backtest_repository.py::test_insert_backtest_if_missing_skips_duplicate_run_with_only_run_id_and_timestamp_diff
  AssertionError: two runs over identical content must produce equal canonical hashes
2 failed, 21 passed

$ git stash pop   # fix restored
2 previously-failing tests now pass; 23 passed total
```

### 2. Migration (`f0ab58339d55_...py`)

Neutered `upgrade()` to `return` immediately:

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
    backend/tests/test_alembic_migrations.py -q -k dedupe

FAILED backend/tests/test_alembic_migrations.py::test_dedupe_backtest_results_migration_collapses_duplicates_and_keeps_earliest
  AssertionError: expected 4 surviving rows, got 6: [...]
1 failed, 1 passed   # the idempotency test trivially "passes" on a no-op — expected, different property

# real upgrade() restored — 2 passed
```

### 3. Writer unification (`generation_pipeline.py`) — round 2

Reverted the PORTFOLIO_BACKTESTER writer's `content_hash` line back to `hashlib.sha256(artifact_json.encode("utf-8")).hexdigest()`, ran the new end-to-end test (exercises the real `_backtest_and_persist` closure, `backtest_portfolio` mocked at the module boundary, genuinely isolated in-memory DB via `StaticPool` — see the test's own docstring for why the `monkeypatch.setenv(DATABASE_URL)` pattern used elsewhere in this suite does NOT actually isolate against `archimedes.db`'s module-level engine singleton, and why plain in-memory SQLite without `StaticPool` fails when the closure crosses threads via `asyncio.to_thread`):

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
    backend/tests/test_generation_pipeline.py -q -k PortfolioBacktesterWriterDedupe

FAILED ...::test_second_persist_of_identical_content_is_skipped
  AssertionError: expected the second persist to be SKIPPED (identical content,
  differing only in run_id/timestamp_utc); got 2 rows:
  [(1, 'd3d4c081...', 'gen-20260501T000000Z-strat1'),
   (2, 'fe9254c3...', 'gen-20260502T000000Z-strat1')]
1 failed

# real canonical_artifact_hash call restored — 1 passed, repeatable across
# two consecutive process runs with zero stray on-disk DB state
```

## Migration — FK safety, ordering, idempotency

- **FK safety**: grepped every `backend/archimedes/models/*.py` (and the new `e2b7f4c81d93_add_generation_costs.py` migration pulled in by the rebase) for `ForeignKey` — nothing references `backtest_results.id` or any other `backtest_results` column. Deleting superseded duplicates is FK-safe with no re-pointing needed.
- **Ordering**: per (`strategy_id`, recomputed hash) group, survivor = earliest by `created_at` ascending, tiebreak `id` ascending. Duplicates are deleted **before** the survivor's `content_hash` is updated, avoiding a transient collision with `uq_backtest_strategy_content`.
- **Unresolvable rows** (`artifact_json` NULL/malformed): left untouched.
- **Idempotent**: verified manually against a seeded sqlite file (downgrade → reupgrade) and via a dedicated test.
- **Downgrade**: documented no-op (no schema change; row deletions are not reversible, stated honestly).
- **Rebased onto current `main`** (this PR was behind after #1373/#1372 merged, which added `e2b7f4c81d93_add_generation_costs.py` onto the same prior head `c9396e0d95d4`); the migration's `down_revision` now chains onto `e2b7f4c81d93` — verified single linear head, full chain applies from empty, downgrade/reupgrade stays idempotent.

## Tests

New/changed test files:
- `backend/tests/test_backtest_mapper.py` — hash-equality-on-volatile-diff, hash-changes-on-content-diff (parametrized over 4 content fields incl. `data_hashes`), stability when volatile keys are absent.
- `backend/tests/test_backtest_repository.py` — end-to-end `insert_backtest_if_missing` dedupe across two "runs" differing only in `run_id`/`timestamp_utc`.
- `backend/tests/test_alembic_migrations.py` — collapse-duplicates-keep-earliest, upgrade-is-idempotent.
- `backend/tests/test_generation_pipeline.py` — **new (round 2)**: end-to-end `_backtest_and_persist` dedupe test for the PORTFOLIO_BACKTESTER writer specifically, with a properly isolated in-memory DB fixture (`StaticPool`, monkeypatching `archimedes.db.engine`/`SessionLocal` directly).

Tallies:
- `test_backtest_mapper.py` + `test_backtest_repository.py`: **23 passed**
- `test_alembic_migrations.py`: **10 passed** (6 original + 2 from this PR + 2 pulled in by the rebase from the generation_costs migration), confirms a single alembic head
- `test_generation_pipeline.py`: **18 passed** (17 pre-existing pure-math tests + 1 new writer-dedupe test)
- Hermetic gate — `env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_backtest_mapper.py backend/tests/test_backtest_repository.py backend/tests/test_alembic_migrations.py backend/tests/test_generation_pipeline.py -q` → **49 passed, 0 failed**
- Full suite from worktree root, `pytest -m "not integration"` (post-rebase) → **3478 passed, 2 skipped (pre-existing, unrelated), 2 deselected, 0 failed**
- `ruff format --check .` (whole repo, pinned `ruff==0.15.13` matching CI) → clean
- `ruff check --select E9,F63,F7,F40,F82 .` (whole repo) → clean

## Files touched

- `backend/archimedes/services/backtest_mapper.py` — the hash fix + corrected, per-call-site coverage comment
- `backend/archimedes/agents/generation_pipeline.py` — round 2: PORTFOLIO_BACKTESTER writer routed through `canonical_artifact_hash`
- `backend/migrations/versions/f0ab58339d55_dedupe_backtest_results_canonical_hash.py` — new data migration (down_revision `e2b7f4c81d93`, current head post-rebase)
- `backend/tests/test_backtest_mapper.py`
- `backend/tests/test_backtest_repository.py`
- `backend/tests/test_alembic_migrations.py`
- `backend/tests/test_generation_pipeline.py`
