### PR TITLE
[frontend] Fix sign-blind colouring and dead fields in the Library table

### DIFF
--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -8,6 +8,7 @@ import useDialogFocus from '../hooks/useDialogFocus'
 
 import { apiGet, apiPost, apiDelete } from '../api'
 import { compactCostCell } from '../generationCost.js'
+import { signClass } from '../signClass.js'
 
 // A compact "deployable at your level" chip for a library row, driven by the
 // strategy's min_passing_level (from the live gate) and the user's strictness.
@@ -111,32 +112,13 @@ export function fmtUsd(n, fractionDigits = 0) {
   })
 }
 
-// ── Strategy Grid Card ────────────────────────────────────────
-
-// Inline period + projected-value line. Shows backtest window, the $1k -> $X
-// it would have produced over the same period, and an explicit *backward-looking*
-// disclaimer. Hidden entirely if we don't know the period (CAGR alone isn't
-// enough to make a defensible projection).
-export function BacktestHorizon({ s, principal = 1000 }) {
-  const years = periodInYears(s.backtest_start, s.backtest_end)
-  const endValue = projectedEndValue(principal, s.cagr, years)
-  if (years == null) return null
-  // Backend ships ISO datetimes; strip the T... for display so it reads as a date.
-  const startStr = (s.backtest_start || '').slice(0, 10)
-  const endStr = (s.backtest_end || '').slice(0, 10)
-  return (
-    <div className="caption" style={{ marginBottom: 8, color: 'var(--text-3)', lineHeight: 1.5 }}>
-      Backtested <span className="mono">{startStr}</span> → <span className="mono">{endStr}</span>
-      {' '}({years.toFixed(1)} yrs) ·{' '}
-      <strong>{fmtUsd(principal)}</strong> →{' '}
-      <strong style={{ color: 'var(--positive)' }}>{fmtUsd(endValue)}</strong>
-      {' '}<span style={{ opacity: 0.7 }}>over the backtest window (historical, not a forecast)</span>
-    </div>
-  )
-}
-
-
 // ── Library Table ─────────────────────────────────────────────
+//
+// (The grid-card view's `BacktestHorizon` helper was deleted in #1361: it was
+// never mounted anywhere in src/ or test/, and it carried the identical
+// hard-coded `var(--positive)` bug this issue fixes below. Dead code that
+// mis-colours a loss is worse than no code — resurrect it wired to
+// `signClass` if the grid-card view comes back.)
 
 // Compact tabular view — replaces the old big-card grid. Dense, scannable,
 // sortable. Click a row → expand inline detail (period + paper-claim delta
@@ -147,7 +129,8 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
   const [open, setOpen] = useState(isHighlighted)
   const rowRef = useRef(null)
   const years = periodInYears(s.backtest_start, s.backtest_end)
-  const endValue = projectedEndValue(1000, s.cagr, years)
+  const principal = 1000
+  const endValue = projectedEndValue(principal, s.cagr, years)
   const startStr = (s.backtest_start || '').slice(0, 10)
   const endStr = (s.backtest_end || '').slice(0, 10)
   const paperCite = [
@@ -155,8 +138,10 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
     s.paper_year && `(${s.paper_year})`,
   ].filter(Boolean).join(' ')
 
-  const sharpeCI = s.sharpe_ci_95 != null ? s.sharpe_ci_95 : null
-  const driftFlag = s.drift_detected === true
+  // Real API fields (backend/archimedes/api/schemas.py) — the singular-CI
+  // and drift-boolean fields this used to read never existed in any API
+  // response (#1361).
+  const sharpeCI = s.sharpe_ci_lower != null && s.sharpe_ci_upper != null ? [s.sharpe_ci_lower, s.sharpe_ci_upper] : null
   const detailId = `lib-detail-${s.id}`
   // Absence is the point: a strategy nothing measured gets an em-dash and a
   // tooltip that says so, never a zero (#1326).
@@ -219,17 +204,12 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
                 accessible name tree and `title` on a bare span is not
                 reliably exposed — the rigor-gate verdict, the fact that
                 decides whether a strategy may be deployed, was sighted-only
-                (1.1.1). --warning replaces the hardcoded base-dark amber so the drift
-                triangle follows the light palette (2.15:1 on a white card
-                before; --warning is 5.12:1 there and 8.12:1 in dark). */}
+                (1.1.1). */}
             {s.passes_rigor_gate === true && (
               <span role="img" aria-label="Passes rigor gate" className="i-lucide-check w-3.5 h-3.5 text-[var(--positive)]" title="Passes rigor gate" />
             )}
             {s.passes_rigor_gate === false && (
               <span role="img" aria-label="Does not pass rigor gate" className="i-lucide-x w-3.5 h-3.5 text-[var(--text-4)]" title="Does not pass rigor gate" />
-            )}
-            {driftFlag && (
-              <span role="img" aria-label="Drift detected" className="i-lucide-alert-triangle w-3.5 h-3.5 text-[var(--warning)]" title="Drift detected" />
             )}
             <DeployabilityChip deploy={deploy} level={level} />
           </div>
@@ -247,7 +227,7 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
             </div>
           )}
         </td>
-        <td className="mono positive" style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
+        <td className={`mono ${signClass(s.cagr)}`} style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
         <td className="mono negative" style={{ textAlign: 'right' }}>
           {s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}
           {/* Same defect: crossing the 0.5 overfitting threshold was signalled
@@ -261,7 +241,15 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
             </div>
           )}
         </td>
-        <td className="mono" style={{ textAlign: 'right', color: 'var(--positive)' }}>{fmtUsd(endValue)}</td>
+        <td className={`mono ${signClass(endValue != null ? endValue - principal : null)}`} style={{ textAlign: 'right' }}>
+          {fmtUsd(endValue)}
+          {/* fmtPct prepends '-' for a losing CAGR, so colour alone is never the
+              only signal there; fmtUsd never emits a sign (endValue can't go
+              below 0), so this cell needs its own text alternative (1.4.1). */}
+          {endValue != null && endValue < principal && (
+            <span className="sr-only"> — below the {fmtUsd(principal)} starting principal</span>
+          )}
+        </td>
         <td className="caption" style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>{years != null ? `${years.toFixed(1)} yrs` : '—'}</td>
         <td
           className={genCost.measured ? 'mono' : 'caption'}
@@ -448,7 +436,6 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
   const years = periodInYears(s.backtest_start, s.backtest_end)
   const startStr = (s.backtest_start || '').slice(0, 10)
   const endStr = (s.backtest_end || '').slice(0, 10)
-  const driftFlag = s.drift_detected === true
   const genCost = compactCostCell(s.generation_cost)
 
   useEffect(() => {
@@ -491,12 +478,11 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
         >
           {statusLabel(s.status, s.passes_rigor_gate)}
         </span>
-        {driftFlag && <span role="img" aria-label="Drift detected" className="i-lucide-alert-triangle w-3.5 h-3.5 text-[var(--warning)]" title="Drift detected" />}
         <DeployabilityChip deploy={deploy} level={level} />
       </div>
       <div className="lib-card-stats">
         <div><div className="caption">Sharpe</div><div className="mono">{fmt(s.sharpe_ratio)}</div></div>
-        <div><div className="caption">CAGR</div><div className="mono positive">{fmtPct(s.cagr)}</div></div>
+        <div><div className="caption">CAGR</div><div className={`mono ${signClass(s.cagr)}`}>{fmtPct(s.cagr)}</div></div>
         <div><div className="caption">Max DD</div><div className="mono negative">{s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}</div></div>
         <div title={genCost.title}><div className="caption">Gen tokens</div><div className={genCost.measured ? 'mono' : 'caption'}>{genCost.label}</div></div>
       </div>
@@ -635,8 +621,10 @@ function coerceGenerated(row) {
     is_backtest_placeholder: true,
     passes_rigor_gate: verdict ? Boolean(verdict.passing) : null,
     dsr_p_value: verdict?.dsr_p_value ?? null,
-    sharpe_ci_95: null,
-    drift_detected: null,
+    // No real backtest has run yet on a pre-backtest hypothesis, so there is
+    // no CI to report — honestly null, on the real field names (#1361).
+    sharpe_ci_lower: null,
+    sharpe_ci_upper: null,
     // Durable generation-cost record (#1326) served by /api/strategies/generated.
     // Absent for anything generated before the meter — passed through as null so
     // the cost column renders "not measured" rather than a fabricated zero.

--- a/ui/src/signClass.js
+++ b/ui/src/signClass.js
@@ -1,0 +1,15 @@
+// Shared sign-based CSS class helper (#1361).
+//
+// Colour must be derived from the *value's own sign*, never hard-coded at the
+// call site — that was the defect: the Library table painted CAGR and the
+// "$1k ->" projection profit-green unconditionally, so a strategy that lost
+// money still rendered green under a header reading "$1k ->".
+//
+// Same rule, same class names as `changeClass()` in AssetModal.jsx /
+// AssetGroupModal.jsx (`v >= 0 ? 'positive' : 'negative'`, `''` for
+// null/NaN so an unknown value gets no colour rather than a guessed one).
+// Strategies.jsx imports this rather than adding a third hand-rolled copy.
+export function signClass(v) {
+	if (v == null || Number.isNaN(v)) return ""
+	return v >= 0 ? "positive" : "negative"
+}

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -260,10 +260,6 @@ test("informative icons and charts carry a text alternative", () => {
 	// `title` on a bare span is not reliably exposed.
 	assert.match(strategies, /role="img" aria-label="Passes rigor gate"/);
 	assert.match(strategies, /role="img" aria-label="Does not pass rigor gate"/);
-	assert.match(strategies, /role="img" aria-label="Drift detected"/);
-	// The drift triangle was hardcoded to base-dark amber: 2.15:1 on a white
-	// card in the light theme.
-	assert.doesNotMatch(strategies, /#f59e0b/);
 	// The knowledge graph is a 500px informative SVG that had no role at all.
 	assert.match(
 		corpusKg,
@@ -276,6 +272,10 @@ test("threshold verdicts do not rely on colour alone", () => {
 	assert.match(strategies, /replicated \? '✓' : '✗'/);
 	assert.match(strategies, /below the 50% replication threshold/);
 	assert.match(strategies, /above the 0\.50 overfitting threshold/);
+	// The Library table's "$1k ->" projection painted every strategy
+	// profit-green regardless of sign; fmtUsd never emits a minus, so a losing
+	// projection needs its own sr-only text alternative (#1361).
+	assert.match(strategies, /below the \{fmtUsd\(principal\)\} starting principal/);
 	assert.match(css, /^\.sr-only \{/m);
 });
 

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -260,6 +260,9 @@ test("informative icons and charts carry a text alternative", () => {
 	// `title` on a bare span is not reliably exposed.
 	assert.match(strategies, /role="img" aria-label="Passes rigor gate"/);
 	assert.match(strategies, /role="img" aria-label="Does not pass rigor gate"/);
+	// Strategies.jsx must use --warning, never the raw amber hex: 2.15:1 on a
+	// white card in the light theme.
+	assert.doesNotMatch(strategies, /#f59e0b/);
 	// The knowledge graph is a 500px informative SVG that had no role at all.
 	assert.match(
 		corpusKg,

--- a/ui/test/sign-class.test.js
+++ b/ui/test/sign-class.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { signClass } from "../src/signClass.js";
+
+// #1361: the Library table (/app/library) painted CAGR and the "$1k ->"
+// projection profit-green *unconditionally* — the sign of the value was
+// never consulted. 12 of 34 live strategies had a negative CAGR and still
+// rendered green under a column literally headed "$1k ->". The table also
+// read `sharpe_ci_95` / `drift_detected`, neither of which any backend
+// endpoint has ever produced — so the Sharpe band never rendered in the
+// table and the drift triangle could structurally never fire.
+
+const strategies = readFileSync(
+	new URL("../src/components/Strategies.jsx", import.meta.url),
+	"utf8",
+);
+
+// ── signClass: pure sign->CSS-class mapping ────────────────────────────────
+// Same shape as changeClass() in AssetModal.jsx / AssetGroupModal.jsx — this
+// is the shared module those two inline copies should have been (#1361 lifts
+// a would-be third copy into src/signClass.js instead of writing it again).
+
+test("signClass: negative value maps to 'negative'", () => {
+	assert.equal(signClass(-0.0432), "negative");
+});
+
+test("signClass: positive value maps to 'positive'", () => {
+	assert.equal(signClass(0.0432), "positive");
+});
+
+test("signClass: null maps to '' (no colour claimed for an unknown value)", () => {
+	assert.equal(signClass(null), "");
+});
+
+test("signClass: zero maps to 'positive' (matches changeClass's v >= 0 rule)", () => {
+	assert.equal(signClass(0), "positive");
+});
+
+test("signClass: undefined and NaN also map to ''", () => {
+	assert.equal(signClass(undefined), "");
+	assert.equal(signClass(NaN), "");
+});
+
+// ── Wiring pins on Strategies.jsx ───────────────────────────────────────────
+// readFileSync + regex, same pattern as a11y.test.js: the harness has no
+// jsdom/testing-library, so JSX wiring is pinned on the source rather than
+// on rendered output.
+
+test("Strategies.jsx imports the shared sign helper", () => {
+	assert.match(strategies, /import \{ signClass \} from '\.\.\/signClass\.js'/);
+});
+
+test("no cell hard-codes profit-green regardless of sign", () => {
+	// The three original defect sites, literally: className="mono positive"
+	// (desktop CAGR + mobile card) and the inline `color: 'var(--positive)'`
+	// on the "$1k ->" cell.
+	assert.doesNotMatch(strategies, /"mono positive"/);
+	assert.doesNotMatch(strategies, /color: 'var\(--positive\)'/);
+	// Both cells must instead derive colour from signClass(...).
+	assert.match(strategies, /className=\{`mono \$\{signClass\(s\.cagr\)\}`\}/);
+	assert.match(
+		strategies,
+		/className=\{`mono \$\{signClass\(endValue != null \? endValue - principal : null\)\}`\}/,
+	);
+});
+
+test("the rigor-gate check icon keeps its literal var(--positive) — it encodes a boolean pass, not a signed number", () => {
+	assert.match(
+		strategies,
+		/aria-label="Passes rigor gate" className="i-lucide-check w-3\.5 h-3\.5 text-\[var\(--positive\)\]"/,
+	);
+});
+
+test("the dead grid-card export with the same hard-coded-green bug (never mounted) is gone", () => {
+	assert.doesNotMatch(strategies, /export function BacktestHorizon/);
+});
+
+test("no field the API never sends is read", () => {
+	assert.doesNotMatch(strategies, /sharpe_ci_95/);
+	assert.doesNotMatch(strategies, /drift_detected/);
+	assert.doesNotMatch(strategies, /Drift detected/);
+});
+
+test("the Sharpe CI band is wired to the real sharpe_ci_lower / sharpe_ci_upper pair", () => {
+	assert.match(
+		strategies,
+		/s\.sharpe_ci_lower != null && s\.sharpe_ci_upper != null \? \[s\.sharpe_ci_lower, s\.sharpe_ci_upper\] : null/,
+	);
+	// coerceGenerated (the generated-row mapper) reports the real fields as
+	// honestly null rather than continuing to emit the fabricated ones.
+	assert.match(strategies, /sharpe_ci_lower: null,/);
+	assert.match(strategies, /sharpe_ci_upper: null,/);
+});
+
+test("the '$1k ->' cell carries a text alternative for a loss, not colour alone (1.4.1)", () => {
+	assert.match(
+		strategies,
+		/endValue != null && endValue < principal && \(\s*<span className="sr-only">/,
+	);
+});


### PR DESCRIPTION
Closes #1361

## Summary

The Library table (`/app/library`) painted CAGR and the `$1k →` projection **profit-green unconditionally**, regardless of sign — 12 of 34 live strategies had a negative CAGR and still rendered green under a header reading `$1k →`. The same rows also read `s.sharpe_ci_95` and `s.drift_detected`, neither of which any backend endpoint has ever produced, so the Sharpe confidence band never rendered in the table and the "Drift detected" warning triangle was structurally incapable of ever firing.

## Fix

- Added a shared `signClass(v)` helper (`ui/src/signClass.js`) — same rule as `changeClass()` in `AssetModal.jsx`/`AssetGroupModal.jsx` (`v >= 0 ? 'positive' : 'negative'`, `''` for null/NaN) — and derived colour from it at all three original defect sites instead of a hard-coded class/style:
  - Desktop CAGR cell (was `className="mono positive"`)
  - `$1k →` cell (was `style={{ color: 'var(--positive)' }}`)
  - Mobile card CAGR (was `className="mono positive"`)
- Gave the `$1k →` cell an `sr-only` text alternative for a loss — `fmtPct` already prepends `-` for a losing CAGR, but `fmtUsd` never emits a sign, so colour alone was the only signal there (WCAG 1.4.1).
- Wired the table's Sharpe CI to the real `sharpe_ci_lower`/`sharpe_ci_upper` fields (same fields `StrategyPassport.jsx` already reads correctly). Deleted the drift marker and its two `s.drift_detected` reads (desktop + mobile), and the corresponding `a11y.test.js` assertion pinning the now-deleted marker's `aria-label="Drift detected"`. **Correction (post-review):** the original PR also deleted a second, unrelated assertion in the same test — `assert.doesNotMatch(strategies, /#f59e0b/)` — a general guard against `Strategies.jsx` ever hard-coding the raw `--warning` hex instead of the token (2.15:1 contrast on a white card in the light theme), not scoped to the drift triangle. That guard has been restored with its comment repointed away from the deleted marker.
- Dropped the fabricated `sharpe_ci_95`/`drift_detected` keys from the generated-row mapper (`coerceGenerated`) in favour of the real field names, explicitly null (no real backtest has run yet on a pre-backtest hypothesis, so there's honestly no CI to report).
- Deleted the dead, never-mounted `BacktestHorizon` export — it carried the identical hard-coded-`var(--positive)` bug and had zero references anywhere in `src/` or `test/`. Left a comment pointing at `signClass` if the grid-card view is ever resurrected.
- Left the rigor-gate check icon's `text-[var(--positive)]` untouched — it encodes a boolean pass, not a signed number, per the issue's anti-goal.
- Did not touch `fmtPct`/`fmtUsd`/`periodInYears`/`projectedEndValue`, the `--positive`/`--negative` token values, or add any DOM/render test dependency.

## Acceptance criteria (all four, run from `ui/`)

```
$ grep -cE '"mono positive"' src/components/Strategies.jsx
0
$ grep -cF -- "color: 'var(--positive)'" src/components/Strategies.jsx
0
$ grep -cE 'sharpe_ci_95|drift_detected' src/components/Strategies.jsx
0
$ grep -cE 'sharpe_ci_lower' src/components/Strategies.jsx
2
```

```
$ node --test 2>&1 | tail -8
ℹ tests 138
ℹ suites 0
ℹ pass 138
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```
Baseline on this branch's base commit (`a77dd918`, current `main` at start of work — the issue's cited `c0e6400f`/90-baseline predates three now-merged in-flight PRs) was **126 pass, 0 fail**. This PR is **+12 tests, additive** (5 pure `signClass` unit tests including the exact 4 cases the issue specifies, 7 source-regex wiring pins), all in new/touched files.

```
$ npm run lint 2>&1 | grep -c 'src/components/Strategies.jsx'
0
$ npm run build   # succeeds, pre-existing >500kB chunk-size warning only, unrelated
```

## Mutation check (required — CLAUDE.md § "A guard must be shown to reject something")

Reverted the three CAGR/`$1k →` call sites to the exact pre-fix literals quoted in the issue (`className="mono positive"` / `style={{ color: 'var(--positive)' }}` / `className="mono positive"`), ran `node --test`, and got exactly 3 failures — then re-applied the fix and confirmed 138/138 pass again:

```
✖ threshold verdicts do not rely on colour alone           (a11y.test.js — new sr-only assertion)
✖ no cell hard-codes profit-green regardless of sign        (sign-class.test.js)
✖ the '$1k ->' cell carries a text alternative for a loss, not colour alone (1.4.1)   (sign-class.test.js)
ℹ fail 3
```
A guard that passes both ways is not a guard — these three reject the unfixed code and pass on the fixed code.

## In-flight collisions (per the issue)

Rebased against current `main` (`a77dd918`) before starting; re-derived every line offset from source rather than trusting the issue's line numbers, which were stale by design (`c0e6400f`). Confirmed the merged #1334 cost-column mapper lines (`sharpe_ci_95: null, drift_detected: null`) were exactly the two lines this PR deletes — no silent re-add.

**Correction (review round 1):** the base `a77dd918` includes #1334/cost column at colSpan=9, but **not** #1331/Published-tab or #1348/WCAG residuals — both merged after this base (`git merge-base --is-ancestor <their-merge-commits> a77dd918` → NO for both). The branch is currently behind `origin/main`; per CLAUDE.md's "stale base" rule, re-verify against current `main` at merge time rather than trusting this PR's frozen CI snapshot.

## Anti-goals honoured

- `BacktestHorizon` not mounted as-is — deleted (zero references) rather than fixed-but-left-dead.
- No client-side `drift_detected` invention, and did not map off `drift_detected_at` (verified that field is untouched — it's the unrelated paper-trading deployment column in `PaperTrading.jsx`).
- `fmtPct`/`fmtUsd`/`periodInYears`/`projectedEndValue` unchanged.
- `--positive`/`--negative` token values in `App.css` unchanged.
- No new top-level dependency; no `jsdom`/`testing-library`/`vitest`.
- Rigor-gate check icon (`:225`-ish, boolean pass) left on its literal `var(--positive)`.


