### PR TITLE
[frontend] Fix onboarding tour: anonymous /sign-in eject + off-screen mobile spotlight

### DIFF
--- a/ui/src/AuthenticatedApp.jsx
+++ b/ui/src/AuthenticatedApp.jsx
@@ -36,10 +36,14 @@ export default function AuthenticatedApp({
 	user,
 }) {
 	const [walletAddr, setWalletAddr] = useState(null);
-	// No auto-tour for anonymous visitors (#1194 revision d): its cards
-	// spotlight Generate and Library, which would bounce a logged-out browser
-	// straight to /sign-in — a modal ad for a door that's locked. The manual
-	// help-icon path still works for everyone.
+	// No AUTO-open for anonymous visitors: it would announce itself as a
+	// modal the instant an anonymous session mounts, before the visitor has
+	// done anything. The manual help-icon path (Layout's "?" button, always
+	// rendered — see onOpenTour below) does work for everyone: OnboardingTour
+	// is passed `user` and gates its own anchor-navigation on
+	// canNavigateTo(anchor, user) (#1364), so an anonymous viewer who opens
+	// the tour and reaches the library/reasoning cards gets a centered card
+	// with no anchor instead of being bounced to /sign-in.
 	const [tourOpen, setTourOpen] = useState(() => (user ? !hasCompletedOnboarding() : false));
 	const [journeyStage, setJourneyStage] = useState(null);
 	// A detected-but-unlinked browser wallet that backs pre-account (SIWE-era)
@@ -298,6 +302,7 @@ export default function AuthenticatedApp({
 					}
 				}}
 				setPage={navigateToPage}
+				user={user}
 			/>
 		</>
 	);

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -198,7 +198,9 @@ export default function OnboardingTour({ open, onClose, setPage, user }) {
   // Measure the current step's anchor element. Falls back to `null` (centered
   // card) when there's no anchor, the element is absent, or it's not on
   // screen — mobile drawer closed → a full-size rect translated to
-  // left ≈ -260 (non-zero, off-viewport), collapsed sidebar → zero-size.
+  // left ≈ -260 (non-zero, off-viewport). A zero-size rect (e.g. a
+  // `display:none` ancestor) is rejected too. The collapsed rail (72px)
+  // still measures a normal on-screen box and spotlights as usual.
   // See rectOnScreen in ../tourGeometry.js.
   const measure = useCallback(() => {
     const c = CARDS[cardIndex]

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -196,8 +196,10 @@ export default function OnboardingTour({ open, onClose, setPage, user }) {
   const isLast = cardIndex === CARDS.length - 1
 
   // Measure the current step's anchor element. Falls back to `null` (centered
-  // card) when there's no anchor, the element is absent, or it's hidden
-  // (mobile drawer closed, collapsed sidebar → zero-size rect).
+  // card) when there's no anchor, the element is absent, or it's not on
+  // screen — mobile drawer closed → a full-size rect translated to
+  // left ≈ -260 (non-zero, off-viewport), collapsed sidebar → zero-size.
+  // See rectOnScreen in ../tourGeometry.js.
   const measure = useCallback(() => {
     const c = CARDS[cardIndex]
     if (!c.anchor) { setRect(null); return }
@@ -238,6 +240,12 @@ export default function OnboardingTour({ open, onClose, setPage, user }) {
   useEffect(() => {
     if (!open || rect !== null || !card.anchor) return
     if (!canNavigateTo(card.anchor, user)) return
+    // `rect === null` covers two cases and only one wants a navigation: the
+    // anchor absent from the DOM (navigating mounts it, e.g. from Landing),
+    // or the anchor mounted but off-screen (mobile drawer closed) — same
+    // page already, navigating just pushes a pointless history entry per
+    // card. Only navigate when the anchor truly isn't mounted yet.
+    if (document.querySelector(`[data-tour="${card.anchor}"]`)) return
     setPage(card.anchor)
     // Sidebar mounts on the next render; re-measure after it paints.
     const id = setTimeout(measure, 60)

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useLayoutEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { roadmapSurfaceHidden } from '../featureFlags.js'
+import { canNavigateTo } from '../routes.js'
+import { rectOnScreen } from '../tourGeometry.js'
 import useDialogFocus from '../hooks/useDialogFocus'
 
 const STORAGE_KEY = 'archimedes.onboarding.v1'
@@ -178,7 +180,7 @@ const TIP_W = 340         // tooltip width
 const TIP_GAP = 16        // gap between hole and tooltip
 const TIP_EST_H = 380     // height estimate used only to keep the tooltip on-screen
 
-export default function OnboardingTour({ open, onClose, setPage }) {
+export default function OnboardingTour({ open, onClose, setPage, user }) {
   const [cardIndex, setCardIndex] = useState(0)
   // Bounding rect of the spotlighted element, in viewport coords. `null`
   // means "no anchor / element not measurable" → render a centered card.
@@ -202,7 +204,7 @@ export default function OnboardingTour({ open, onClose, setPage }) {
     const el = document.querySelector(`[data-tour="${c.anchor}"]`)
     if (!el) { setRect(null); return }
     const r = el.getBoundingClientRect()
-    if (r.width === 0 || r.height === 0) { setRect(null); return }
+    if (!rectOnScreen(r, window.innerWidth, window.innerHeight)) { setRect(null); return }
     setRect({ top: r.top, left: r.left, width: r.width, height: r.height })
   }, [cardIndex])
 
@@ -224,13 +226,23 @@ export default function OnboardingTour({ open, onClose, setPage }) {
   // the sidebar — so the nav anchors don't exist. Navigating to the step's page
   // mounts the Layout shell (sidebar + nav), then we re-measure once it paints.
   // Guarded by `rect === null` so it fires at most once per step.
+  //
+  // Also guarded by `canNavigateTo` (#1364): `library` and `reasoning` are
+  // app pages an anonymous visitor may not open — before this guard, a
+  // missing anchor for those pages (anonymous viewer, or any page not yet
+  // mounted) drove setPage() anyway, App.jsx answered with
+  // `window.location.replace('/sign-in?next=…')`, and the tour unmounted
+  // along with the page the visitor was reading. When navigation isn't
+  // allowed we deliberately do nothing and fall through to the
+  // centered-card render below (`rect` stays null), which needs no anchor.
   useEffect(() => {
     if (!open || rect !== null || !card.anchor) return
+    if (!canNavigateTo(card.anchor, user)) return
     setPage(card.anchor)
     // Sidebar mounts on the next render; re-measure after it paints.
     const id = setTimeout(measure, 60)
     return () => clearTimeout(id)
-  }, [open, rect, card, setPage, measure])
+  }, [open, rect, card, setPage, measure, user])
 
   const finish = useCallback(() => {
     try {
@@ -342,7 +354,7 @@ export default function OnboardingTour({ open, onClose, setPage }) {
   if (!rect) {
     return createPortal(
       <div
-        className="tour-overlay fixed inset-0 flex items-center justify-center z-[1000]"
+        className="tour-overlay fixed inset-0 flex items-center justify-center z-[10001]"
         onClick={finish}
         role="dialog"
         aria-modal="true"
@@ -383,8 +395,11 @@ export default function OnboardingTour({ open, onClose, setPage }) {
 
   // pointer-events on each dim panel catch stray clicks (→ finish); the hole
   // between them has no element, so clicks reach the live nav button.
+  // z-indices (10001/10002/10003) clear the mobile drawer's 10000 (App.css)
+  // so a visitor who opens the drawer to find the spotlighted item sees the
+  // tooltip painted above it, not behind it (#1364).
   const dim = 'rgba(0,0,0,0.78)'
-  const panelStyle = { position: 'fixed', background: dim, zIndex: 1000 }
+  const panelStyle = { position: 'fixed', background: dim, zIndex: 10001 }
 
   return createPortal(
     <div role="dialog" aria-modal="true" aria-labelledby="onboarding-title">
@@ -403,7 +418,7 @@ export default function OnboardingTour({ open, onClose, setPage }) {
         style={{
           position: 'fixed',
           top: hole.top, left: hole.left, width: hole.width, height: hole.height,
-          zIndex: 1001, pointerEvents: 'none',
+          zIndex: 10002, pointerEvents: 'none',
         }}
         aria-hidden="true"
       />
@@ -415,7 +430,7 @@ export default function OnboardingTour({ open, onClose, setPage }) {
         className="card-elevated tour-tooltip p-5"
         style={{
           position: 'fixed', top: tipTop, left: tipLeft, width: TIP_W, maxWidth: '90vw',
-          zIndex: 1002, background: 'var(--surface-1)',
+          zIndex: 10003, background: 'var(--surface-1)',
         }}
         onClick={e => e.stopPropagation()}
       >

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -44,6 +44,17 @@ export function isAnonymousAppPage(page) {
   return ANON_APP_PAGES.has(page)
 }
 
+// True when `user` may navigate to `page` — signed in, always; anonymous,
+// only for the browsable ANON_APP_PAGES set above. Delegates to
+// isAnonymousAppPage so the two never drift (#1364): the onboarding tour's
+// navigation effect gates on this, not on a hard-coded card id, so any page
+// the product later adds to ANON_APP_PAGES becomes anon-navigable for the
+// tour automatically, and any page NOT added stays a centered card instead
+// of ejecting the visitor to /sign-in.
+export function canNavigateTo(page, user) {
+  return user != null || isAnonymousAppPage(page)
+}
+
 const PAGE_PATHS = Object.fromEntries(Object.entries(APP_PATHS).map(([path, page]) => [page, path]))
 const LEGACY_PATHS = Object.fromEntries(
   Object.entries(APP_PATHS)

--- a/ui/src/tourGeometry.js
+++ b/ui/src/tourGeometry.js
@@ -1,0 +1,20 @@
+// Pure geometry predicate for the onboarding tour's spotlight (#1364).
+//
+// `measure()` in OnboardingTour.jsx only rejected a *zero-sized* anchor
+// rect. Below 1024px the sidebar is an off-canvas drawer positioned with
+// `transform: translateX(-100%)`, not removed from layout — so a closed
+// drawer's nav button reports a full-size rect translated to
+// `left ≈ -260`, which is non-zero and was accepted. The spotlight ring
+// and dim-panel cut-out then painted entirely off-screen.
+//
+// Kept as a plain, dependency-free module (no JSX, no DOM) so it is
+// importable and unit-testable under bare `node --test` (see
+// ui/package.json's `"test": "node --test"` — no jsdom, no
+// @testing-library).
+export function rectOnScreen(r, vw, vh) {
+	const width = r.right - r.left
+	const height = r.bottom - r.top
+	if (width === 0 || height === 0) return false
+	if (r.right <= 0 || r.bottom <= 0 || r.left >= vw || r.top >= vh) return false
+	return true
+}

--- a/ui/test/onboarding.test.js
+++ b/ui/test/onboarding.test.js
@@ -16,6 +16,14 @@ import { rectOnScreen } from "../src/tourGeometry.js";
 //      `transform`-positioned, not removed from layout, so its closed rect
 //      is non-zero but entirely off-screen; `measure()`'s zero-size-only
 //      check accepted it. Fixed by the pure predicate `rectOnScreen` below.
+//      Fixing #2 this way introduced a follow-on: `rectOnScreen` now
+//      correctly nulls `rect` for a mounted-but-off-screen anchor too, which
+//      would otherwise satisfy the anchor-navigation effect's `rect === null`
+//      condition and call `setPage` on every anchored card for a signed-in
+//      mobile visitor with the drawer closed — a same-page anchor that
+//      navigating cannot help. Fixed by gating that effect on DOM presence
+//      (`document.querySelector('[data-tour=...]')`) so it only navigates
+//      when the anchor is genuinely unmounted.
 //
 // ui/package.json's `"test": "node --test"` is bare node — no JSX
 // transform, no jsdom, no @testing-library (see the anti-goal against
@@ -26,8 +34,18 @@ import { rectOnScreen } from "../src/tourGeometry.js";
 // ones — they prove the component calls the tested predicate, not that the
 // resulting DOM is correct, which no harness here can observe.
 //
-// Every assertion in this file was confirmed to FAIL against the pre-fix
-// tree (transcripts in the PR body).
+// Swapping this file's OnboardingTour.jsx source for origin/main's (pre-fix)
+// while keeping everything else from this branch — the exact tree this file
+// regression-guards against — fails five tests: the `canNavigateTo` and
+// `rectOnScreen` wiring pins, the `user`-prop shape pin, the mobile
+// same-page-navigation guard, and the z-index floor (`node --test` →
+// `tests 11 / pass 6 / fail 5`). The five `rectOnScreen` cases above test
+// the new pure predicate directly, so they pass regardless of
+// OnboardingTour.jsx's content — see the guard transcripts in the PR body
+// for that predicate's own revert-and-check. The anti-goal `doesNotMatch`
+// check below also passes pre-fix, by construction: the string it guards
+// against was never in the tree, so it guards a future bad fix, not the
+// reported bug.
 
 const onboardingTour = readFileSync(
 	new URL("../src/components/OnboardingTour.jsx", import.meta.url),
@@ -85,10 +103,26 @@ test("OnboardingTour is wired to canNavigateTo before it calls setPage", () => {
 	assert.match(onboardingTour, /canNavigateTo\(/);
 	// The gate must run before setPage in the anchor-navigation effect —
 	// pin the shape, not just presence, so a guard added elsewhere in the
-	// file (e.g. only around measure()) doesn't satisfy this check.
+	// file (e.g. only around measure()) doesn't satisfy this check. Bounded
+	// (not `.*`) so it still can't match across unrelated effects; widened
+	// from immediate adjacency to allow the DOM-presence guard (#1364
+	// round-2) that now also sits between this gate and `setPage`.
 	assert.match(
 		onboardingTour,
-		/if \(!canNavigateTo\(card\.anchor, user\)\) return\s*\n\s*setPage\(card\.anchor\)/,
+		/if \(!canNavigateTo\(card\.anchor, user\)\) return[\s\S]{0,700}setPage\(card\.anchor\)/,
+	);
+});
+
+test("the anchor-navigation effect does not navigate when the anchor is already mounted", () => {
+	// `rect === null` fires the same whether the anchor is missing from the
+	// DOM entirely (navigating helps — mounts the Layout shell) or the
+	// anchor is mounted but off-screen behind a closed mobile drawer
+	// (navigating buys nothing and would push a history entry per card for
+	// every signed-in mobile visitor). Pin the shape: a DOM-presence check
+	// must gate `setPage` after the `canNavigateTo` gate.
+	assert.match(
+		onboardingTour,
+		/if \(!canNavigateTo\(card\.anchor, user\)\) return[\s\S]{0,600}if \(document\.querySelector\(`\[data-tour="\$\{card\.anchor\}"\]`\)\) return\s*\n\s*setPage\(card\.anchor\)/,
 	);
 });
 

--- a/ui/test/onboarding.test.js
+++ b/ui/test/onboarding.test.js
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { rectOnScreen } from "../src/tourGeometry.js";
+
+// Onboarding tour regression guards (#1364).
+//
+// Two independent bugs, two independent fixes:
+//   1. Anonymous eject — the tour's anchor-navigation effect drove
+//      window.location.replace('/sign-in?…') for anonymous visitors on
+//      cards 3–4 ('library', 'reasoning'). Fixed by gating that effect on
+//      the pure predicate `canNavigateTo` (routes.js, tested in
+//      routes.test.js).
+//   2. Off-screen spotlight — below 1024px the sidebar drawer is
+//      `transform`-positioned, not removed from layout, so its closed rect
+//      is non-zero but entirely off-screen; `measure()`'s zero-size-only
+//      check accepted it. Fixed by the pure predicate `rectOnScreen` below.
+//
+// ui/package.json's `"test": "node --test"` is bare node — no JSX
+// transform, no jsdom, no @testing-library (see the anti-goal against
+// adding either). So the decision logic (`rectOnScreen`, `canNavigateTo`)
+// is genuinely unit-tested here as plain `.js`, and OnboardingTour.jsx's
+// *use* of them is pinned by readFileSync + regex, same shape as
+// ui/test/a11y.test.js. The regex pins are wiring checks, not behavioural
+// ones — they prove the component calls the tested predicate, not that the
+// resulting DOM is correct, which no harness here can observe.
+//
+// Every assertion in this file was confirmed to FAIL against the pre-fix
+// tree (transcripts in the PR body).
+
+const onboardingTour = readFileSync(
+	new URL("../src/components/OnboardingTour.jsx", import.meta.url),
+	"utf8",
+);
+
+// ── rectOnScreen: pure geometry predicate ──────────────────────────────────
+
+test("rectOnScreen rejects a closed mobile drawer translated off-screen", () => {
+	// getBoundingClientRect() on `.sidebar` with `transform: translateX(-100%)`
+	// applied to a 260px-wide drawer: full-size, non-zero, but left ≈ -260.
+	assert.equal(
+		rectOnScreen({ left: -260, top: 100, right: 0, bottom: 140 }, 390, 844),
+		false,
+	);
+});
+
+test("rectOnScreen accepts the same element once the drawer is open", () => {
+	assert.equal(
+		rectOnScreen({ left: 0, top: 100, right: 260, bottom: 140 }, 390, 844),
+		true,
+	);
+});
+
+test("rectOnScreen rejects a zero-size rect (element absent/hidden)", () => {
+	assert.equal(
+		rectOnScreen({ left: 0, top: 100, right: 0, bottom: 100 }, 390, 844),
+		false,
+	);
+});
+
+test("rectOnScreen rejects a rect entirely below or right of the viewport", () => {
+	// left/top >= viewport: on-screen origin, but the whole box is past the
+	// visible edge — the width/height!=0 check alone would accept this.
+	assert.equal(
+		rectOnScreen({ left: 400, top: 100, right: 460, bottom: 140 }, 390, 844),
+		false,
+	);
+	assert.equal(
+		rectOnScreen({ left: 0, top: 900, right: 60, bottom: 940 }, 390, 844),
+		false,
+	);
+});
+
+test("rectOnScreen accepts an ordinary on-screen rect", () => {
+	assert.equal(
+		rectOnScreen({ left: 20, top: 20, right: 200, bottom: 60 }, 390, 844),
+		true,
+	);
+});
+
+// ── Wiring: the component calls both predicates ─────────────────────────
+
+test("OnboardingTour is wired to canNavigateTo before it calls setPage", () => {
+	assert.match(onboardingTour, /canNavigateTo\(/);
+	// The gate must run before setPage in the anchor-navigation effect —
+	// pin the shape, not just presence, so a guard added elsewhere in the
+	// file (e.g. only around measure()) doesn't satisfy this check.
+	assert.match(
+		onboardingTour,
+		/if \(!canNavigateTo\(card\.anchor, user\)\) return\s*\n\s*setPage\(card\.anchor\)/,
+	);
+});
+
+test("OnboardingTour is wired to rectOnScreen in measure()", () => {
+	assert.match(onboardingTour, /rectOnScreen\(/);
+	assert.match(
+		onboardingTour,
+		/if \(!rectOnScreen\(r, window\.innerWidth, window\.innerHeight\)\)/,
+	);
+});
+
+test("OnboardingTour accepts a user prop (not just open/onClose/setPage)", () => {
+	assert.match(
+		onboardingTour,
+		/export default function OnboardingTour\(\{ open, onClose, setPage, user \}\)/,
+	);
+});
+
+// ── Z-index: every tour layer clears the mobile drawer (z-index: 10000) ──
+
+test("every tour layer's z-index clears .sidebar's 10000 (App.css)", () => {
+	const zs = [
+		...onboardingTour.matchAll(/zIndex:\s*(\d+)|z-\[(\d+)\]/g),
+	].map((m) => Number(m[1] ?? m[2]));
+	assert.ok(zs.length >= 4, `expected >=4 z-index declarations, found ${zs.length}`);
+	assert.ok(
+		zs.every((z) => z > 10000),
+		`tour z-indices must clear .sidebar (10000): ${zs}`,
+	);
+});
+
+// ── Anti-goal: no escape hatch keyed on a hard-coded anchor id ───────────
+
+test("the navigation gate is not a hard-coded id check on 'generate'", () => {
+	// 'generate' is in ANON_NAV_IDS (visible in the anon nav) but NOT in
+	// ANON_APP_PAGES (routes.js) — an id-keyed escape hatch here would look
+	// like it fixes the reported cards while leaving 'generate' itself
+	// exposed to the exact same eject the moment it fails to measure
+	// (mobile drawer, collapsed rail, slow mount).
+	assert.doesNotMatch(onboardingTour, /anchor === ['"]generate['"]/);
+});

--- a/ui/test/routes.test.js
+++ b/ui/test/routes.test.js
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 import { parseFeatures } from "../src/features.js";
 import {
+	canNavigateTo,
 	pageToPath,
 	postAuthPath,
 	resolveRoute,
@@ -200,4 +201,26 @@ test("anonymous nav shows browse + the Generate conversion path, nothing statefu
 		{ id: "explore" },
 		{ id: "generate" },
 	]);
+});
+
+test("canNavigateTo gates on ANON_APP_PAGES for a null user, always true when signed in (#1364)", () => {
+	// The onboarding tour's card 3 ('library') and card 4 ('reasoning') are
+	// app pages an anonymous visitor may not open (routes.js ANON_APP_PAGES).
+	// Before this predicate existed, the tour navigated to them unconditionally
+	// and App.jsx's anonymous-app-page guard replaced the whole page with
+	// /sign-in — this is the pure check that now gates that navigation.
+	assert.equal(canNavigateTo("library", null), false);
+	assert.equal(canNavigateTo("reasoning", null), false);
+	// 'generate' is in ANON_NAV_IDS (visible in the anon nav, so it measures
+	// fine on desktop) but NOT in ANON_APP_PAGES — the exact trap the issue's
+	// anti-goal warns against gating on an id allowlist instead of this.
+	assert.equal(canNavigateTo("generate", null), false);
+	assert.equal(canNavigateTo("explore", null), true);
+	assert.equal(canNavigateTo("leaderboard", null), true);
+	assert.equal(canNavigateTo("corpus", null), true);
+	// Any page is navigable once a user is present — canNavigateTo does not
+	// re-derive ANON_APP_PAGES for the signed-in branch.
+	assert.equal(canNavigateTo("library", { id: "u1" }), true);
+	assert.equal(canNavigateTo("reasoning", { id: "u1" }), true);
+	assert.equal(canNavigateTo("generate", { id: "u1" }), true);
 });


### PR DESCRIPTION
Closes #1364

## Summary

Two independent bugs in the onboarding tour's anchor-navigation, both fixed with a tested pure predicate instead of an id-keyed special case.

**1 — Anonymous eject.** The tour's anchor-navigation effect drove `setPage('library')` / `setPage('reasoning')` for *any* visitor whose anchor wasn't mounted — including anonymous ones. `App.jsx`'s anonymous-app-page guard then answered with `window.location.replace('/sign-in?next=…')`, a full-page navigation that unmounted the tour and the page the visitor was reading. Reopening the tour restarted at card 1, so cards 3–4 were unreachable without an account.

**2 — Off-screen spotlight on mobile.** Below 1024px the sidebar is an off-canvas drawer positioned with `transform`, not removed from layout. `measure()` only rejected zero-sized rects, so a closed drawer's nav button — full-size, non-zero, `left ≈ -260` — was accepted, and the spotlight ring/cutout painted entirely off-screen. Also fixed the drawer/tour z-order (tour layers were 1000–1002 against the drawer's 10000).

**Round-2 fix (post-review).** Fixing #2 the way described above introduced a follow-on: `rectOnScreen` now correctly nulls `rect` for a mounted-but-off-screen anchor too, which satisfies the anchor-navigation effect's `rect === null` condition just as well as a genuinely-absent anchor does — so on mobile, with the drawer closed, the effect started calling `setPage` for every anchored card for every signed-in visitor, pushing a history entry per card for no visual benefit (the anchor is on the same page, just behind a closed drawer). Fixed by gating the effect on DOM presence, not just `rect === null`.

## Fix

- `ui/src/routes.js` — new exported predicate `canNavigateTo(page, user)`, delegating to the existing `isAnonymousAppPage` so the two never drift.
- `ui/src/tourGeometry.js` (new) — pure `rectOnScreen(r, vw, vh)` predicate: false when width/height is 0, or the rect's `right/bottom/left/top` puts it entirely outside the viewport. Plain `.js`, no JSX — importable under bare `node --test`.
- `ui/src/components/OnboardingTour.jsx` — the anchor-navigation effect now checks `canNavigateTo(card.anchor, user)` before calling `setPage`; when navigation isn't allowed it's a no-op and the existing centered-card branch renders (no anchor needed). `measure()` now uses `rectOnScreen` instead of the zero-size-only check. All four tour z-indices raised: `1000/1000/1001/1002` → `10001/10001/10002/10003`, above the drawer's `10000`. **(round 2)** The anchor-navigation effect additionally checks `document.querySelector('[data-tour="${card.anchor}"]')` before calling `setPage`, so it only navigates when the anchor is genuinely unmounted — not when it's mounted but off-screen behind a closed mobile drawer. Also corrected `measure()`'s doc comment, which still described the pre-fix zero-size-only premise the fix above debunks. **(round 3)** That correction was itself incomplete: it kept a trailing `collapsed sidebar → zero-size` clause that App.css contradicts — `.sidebar-collapsed .nav-link` (App.css:576-579) only changes `justify-content`/`padding`; it stays `display:flex`, 72px wide, on-screen, and is never in the `display:none` list at App.css:507-513. The collapsed rail measures a normal on-screen rect and spotlights exactly like the expanded one. The comment now says so instead of asserting a fallback case that can't happen.
- `ui/src/AuthenticatedApp.jsx` — passes `user` into `OnboardingTour`; corrects the code comment that asserted "the manual help-icon path still works for everyone" while naming the exact failure mode it was wrong about.
- Tests: extended `ui/test/routes.test.js` with `canNavigateTo` coverage; new `ui/test/onboarding.test.js` covering `rectOnScreen`, the source-pin wiring checks (component actually calls all three predicates/guards, in the right place), the z-index floor, and the anti-goal (no hard-coded `'generate'` escape hatch).

No changes to `ANON_APP_PAGES` / `ANON_NAV_IDS` membership (Dan's product call, #1194 rev d) — the tour adapts to them, not the reverse.

## Guard transcripts

Per CLAUDE.md "a guard must be shown to reject something" — each guard reverted alone (all others intact), confirmed to fail, then restored:

**1. `canNavigateTo` gate removed** (`if (!canNavigateTo(...)) return` deleted, `setPage` called ungated, as before the fix):
```
✖ OnboardingTour is wired to canNavigateTo before it calls setPage
✖ the anchor-navigation effect does not navigate when the anchor is already mounted
ℹ tests 11
ℹ pass 9
ℹ fail 2
```
(Both fail: the second test's regex also anchors on the `canNavigateTo` gate line, since the round-2 guard sits downstream of it.)

**2. `rectOnScreen` reverted to the old zero-size-only check** (`if (r.width === 0 || r.height === 0) { setRect(null); return }`):
```
✖ OnboardingTour is wired to rectOnScreen in measure()
ℹ tests 11
ℹ pass 10
ℹ fail 1
```

**3. A z-index restored to its pre-fix value** (dim-panel `zIndex: 10001` → `zIndex: 1000`):
```
✖ every tour layer's z-index clears .sidebar's 10000 (App.css)
ℹ tests 11
ℹ pass 10
ℹ fail 1
```

**4. Round-2 guard removed** (`if (document.querySelector(...)) return` deleted, `setPage` called as soon as `rect === null`, as before the round-2 fix):
```
✖ the anchor-navigation effect does not navigate when the anchor is already mounted
ℹ tests 11
ℹ pass 10
ℹ fail 1
```

Each mutation failed exactly the test(s) that pin the corresponding guard, and no others — confirming each is load-bearing, not incidental coverage.

## Verification

```
$ export PATH="$(conda info --base)/envs/archimedes/bin:$PATH"
$ cd ui && npm ci && npm test
ℹ tests 138
ℹ pass 138
ℹ fail 0
```
(Base commit on this branch already carried 126 tests; #1364's stated `523a1bae` baseline was 90 — both comfortably clear "greater than 90". 138 = 137 + 1, the round-2 regression guard added in review.)

```
$ npm run lint
> eslint .
(exit 0, no output — no new warnings)

$ npm run build
✓ built in 5.24s
```

Anti-goal greps (all exit 1, no output, as required):
```
$ grep -n "anchor === .generate." src/components/OnboardingTour.jsx   # exit 1
$ grep -n "help-icon path still works for everyone" src/AuthenticatedApp.jsx   # exit 1
$ grep -nE "jsdom|@testing-library" package.json   # exit 1
```

Z-index floor:
```
$ grep -noE "zIndex: [0-9]+|z-\[[0-9]+\]" src/components/OnboardingTour.jsx
357:z-[10001]
402:zIndex: 10001
421:zIndex: 10002
433:zIndex: 10003
```

## Manual checks (no browser harness in CI — traced against the fixed logic, not run in a live browser by this session)

1. **Signed out at `/app/explore`, click "?", press Continue three times.** Card 0 ('what', no anchor) → centered. Card 1 ('generate', anchor present in `ANON_NAV_IDS` and mounted on desktop) → spotlighted normally, no navigation needed since it measures. Card 2 ('library') → anchor absent for anon, `canNavigateTo('library', null)` is `false` → effect no-ops → centered card, "3 of 4", URL unchanged. Card 3 ('reasoning') → same, centered card, "4 of 4". Three `Continue` clicks land exactly on card 4 of 4 with no `/sign-in` navigation at any point.
2. **390×844, cleared `localStorage`, signed in, load `/app`.** The sidebar drawer is closed by default on mobile, so every anchored card's rect fails `rectOnScreen` (translated off-screen) and falls through to the centered-card branch — no ring or cutout is painted off-screen for any card. **The anchor-navigation effect does not fire either:** `rect === null`, but the round-2 DOM-presence guard finds the anchor already mounted (just off-screen) and returns before `setPage`, so `/app` stays `/app` through all four cards — no history entries pushed, no page changes.
3. **Drawer open with the tour on screen.** Anchor becomes on-screen and measured; tooltip (`zIndex: 10003`) / ring (`10002`) / dim panels (`10001`) all clear the drawer's `10000`, so the tooltip paints above it.

## Notes on test shape

`ui/package.json`'s `"test": "node --test"` is bare Node — no JSX transform, no jsdom, no `@testing-library`. `canNavigateTo` and `rectOnScreen` are genuinely unit-tested as plain `.js`; `OnboardingTour.jsx`'s *use* of them is pinned by `readFileSync` + regex (the `a11y.test.js` pattern) — a wiring check, not a behavioural one. Stated honestly per the issue's own framing of this constraint.

**Correction (post-review):** `ui/test/onboarding.test.js`'s header originally claimed "every assertion in this file was confirmed to FAIL against the pre-fix tree." That's false for one case by construction: `assert.doesNotMatch(onboardingTour, /anchor === ['"]generate['"]/)` (the anti-goal check) can never fail against the pre-fix tree, because that string was never in it — `grep -n "anchor === 'generate'" ` on pre-fix `OnboardingTour.jsx` already exits 1. It's a guard against a future bad fix, not evidence the reported bug existed. Likewise, the five `rectOnScreen` unit tests exercise the new pure predicate directly and pass regardless of `OnboardingTour.jsx`'s content — they're validated by transcript 2 above, not by "the pre-fix tree." The header now states precisely which of the 11 assertions fail against origin/main's `OnboardingTour.jsx` (5, all wiring/z-index pins) and which pass by construction or by testing an unrelated pure function.


