### PR TITLE
API reference: capability-grouped docs/api/ + bidirectional drift guard (#1381 scope 1+2)

### DIFF
--- a/backend/tests/test_api_docs_drift.py
+++ b/backend/tests/test_api_docs_drift.py
@@ -1,0 +1,287 @@
+"""``docs/api/*.md`` must stay in sync with the LIVE FastAPI route table.
+
+House promise-checked-against-the-truth pattern (cf. ``test_asset_universe_doc.py``'s
+SSOT-vs-doc contract): parse every ``### METHOD /path`` heading across ``docs/api/*.md``
+into a DOCUMENTED set, walk ``archimedes.main``'s real route table into a LIVE set, and
+assert both directions:
+
+  (a) every documented (method, path) exists live — the docs can't promise a route the
+      app doesn't actually serve (docs can't drift *ahead* of the app).
+  (b) every live route is either documented, or listed in the frozen ``_UNDOCUMENTED``
+      allowlist below with a one-line reason — a new route can't silently ship undocumented
+      (the app can't drift *ahead* of the docs either).
+
+``_SIDECAR_ONLY_DOCS`` is the mirror-image exemption for (a): ``auth-and-accounts.md``
+documents the Better Auth Node sidecar's own HTTP contract (``auth/auth.js`` on port 3000,
+proxied by nginx) — those headings are real API surface, just never mounted as
+``archimedes.main`` FastAPI routes, so they can never appear in the live set no matter how
+faithful the docs are. Frozen with the same one-line-reason-per-entry discipline as
+``_UNDOCUMENTED`` so a *new* heading in that file still has to earn its way onto the list
+instead of silently exempting itself.
+
+Hermetic: TESTING=1 import of ``archimedes.main`` (conftest sets it before any archimedes
+import) plus in-memory regex parsing of the committed docs. No DB / Redis / RPC / network.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import fastapi.routing as fastapi_routing
+from fastapi.routing import APIRoute
+
+# Pair = (HTTP method, path), e.g. ("GET", "/api/vaults/{address}/chat").
+Pair = tuple[str, str]
+
+_IGNORED_METHODS = {"HEAD", "OPTIONS"}
+
+# ── docs → DOCUMENTED set ────────────────────────────────────────────────────────────
+
+# A "### " heading line; captures everything after the marker so a single heading like
+# "### GET /api/health (and GET /health)" can yield more than one pair below.
+_HEADING_RE = re.compile(r"^### (.+)$", re.MULTILINE)
+# One METHOD + path token inside a heading. Path stops at whitespace or a closing paren
+# so "(and GET /health)" parses as a second, separate pair rather than swallowing the
+# paren into the path.
+_METHOD_PATH_RE = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE)\s+(/[^\s)]*)")
+
+
+def _repo_root() -> Path:
+    import archimedes  # backend/archimedes/__init__.py → parents: archimedes, backend, <repo>
+
+    return Path(archimedes.__file__).resolve().parents[2]
+
+
+def _docs_api_dir() -> Path:
+    return _repo_root() / "docs" / "api"
+
+
+def _documented_pairs() -> dict[Pair, list[str]]:
+    """(method, path) -> sorted list of doc filenames whose heading(s) claim it."""
+    docs_dir = _docs_api_dir()
+    pairs: dict[Pair, list[str]] = {}
+    for md in sorted(docs_dir.glob("*.md")):
+        text = md.read_text(encoding="utf-8")
+        for heading in _HEADING_RE.findall(text):
+            for method, raw_path in _METHOD_PATH_RE.findall(heading):
+                path = raw_path.rstrip(").,;:")
+                pairs.setdefault((method, path), []).append(md.name)
+    return pairs
+
+
+# ── live app → LIVE set ──────────────────────────────────────────────────────────────
+
+
+def _live_pairs() -> set[Pair]:
+    """Flatten archimedes.main's real route table into (method, path) pairs.
+
+    fastapi>=0.139 (see backend/requirements.txt) resolves ``app.include_router(...)``
+    lazily: top-level ``app.routes`` holds a mix of real ``APIRoute`` objects (routes
+    added directly via ``@app.get`` etc.) and opaque ``_IncludedRouter`` wrappers for
+    every ``include_router`` call, which only expose their *effective* (fully-prefixed,
+    dependency-merged) routes through ``effective_route_contexts()``. Walk both shapes so
+    this reflects the exact route table FastAPI would actually dispatch against — no
+    guessing at prefixes by re-deriving them from router source. Falls back to a flat
+    ``isinstance(route, APIRoute)`` scan on older fastapi where ``include_router`` eagerly
+    flattens sub-routes into real ``APIRoute`` objects and ``_IncludedRouter`` doesn't
+    exist at all.
+    """
+    os.environ.setdefault("TESTING", "1")
+    from archimedes.main import app
+
+    included_router_cls = getattr(fastapi_routing, "_IncludedRouter", None)
+
+    def walk(routes) -> list[tuple[set[str], str]]:
+        found: list[tuple[set[str], str]] = []
+        for route in routes:
+            if isinstance(route, APIRoute):
+                found.append((route.methods, route.path))
+            elif included_router_cls is not None and isinstance(route, included_router_cls):
+                for ctx in route.effective_route_contexts():
+                    if isinstance(ctx.original_route, APIRoute):
+                        found.append((ctx.methods, ctx.path_format))
+        return found
+
+    pairs: set[Pair] = set()
+    for methods, path in walk(app.routes):
+        for method in methods:
+            if method not in _IGNORED_METHODS:
+                pairs.add((method, path))
+    return pairs
+
+
+# ── frozen exemptions, one-line reason per entry ─────────────────────────────────────
+
+# Direction (a) exemption: docs/api/auth-and-accounts.md documents the colocated Better
+# Auth Node sidecar's own HTTP contract (auth/auth.js, port 3000 — nginx proxies
+# /api/auth/ straight to it, never through FastAPI). Real, load-bearing API surface, but
+# it will never appear in archimedes.main's route table under any circumstance.
+_SIDECAR_ONLY_DOCS: dict[Pair, str] = {
+    ("POST", "/api/auth/sign-up/email"): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+    ("POST", "/api/auth/sign-in/email"): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+    ("POST", "/api/auth/sign-out"): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+    ("GET", "/api/auth/get-session"): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+    ("GET", "/api/auth/verify-email"): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+    ("GET", "/api/auth/providers"): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+    ("POST", "/api/auth/sign-in/social"): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+    (
+        "GET",
+        "/api/auth/callback/{provider}",
+    ): "Better Auth Node sidecar route, not a FastAPI route (auth-and-accounts.md)",
+}
+
+# Direction (b) exemption: real archimedes.main FastAPI routes that are deliberately not
+# (yet) covered by docs/api/*.md. Each reason is honest about *why* — either the route
+# belongs to a capability area documented elsewhere (docs/agent-api.md's own drift guard
+# is backend/tests/test_agent_discovery.py), it's an internal service-to-service route
+# never reachable from the browser UI, or it's a real gap in docs/api/ coverage that
+# hasn't been written yet. A route leaving this list because its doc landed is a welcome
+# diff; a route silently disappearing from *and* the docs is exactly what this test
+# guards against.
+_UNDOCUMENTED: dict[Pair, str] = {
+    # legacy SIWE router (auth_siwe.py) — TESTING-only, main.py mounts it only under
+    # TESTING so signature-verification tests can exercise its proof helpers; 404s in
+    # every real environment. Shares the /api/auth prefix with the Better Auth sidecar
+    # by coincidence of URL space, not identity — auth-and-accounts.md explicitly scopes
+    # itself to the sidecar and says this capability area "is not documented here".
+    ("GET", "/api/auth/nonce"): "legacy SIWE router, TESTING-only, out of scope per auth-and-accounts.md",
+    ("GET", "/api/auth/session"): "legacy SIWE router, TESTING-only, out of scope per auth-and-accounts.md",
+    ("POST", "/api/auth/verify"): "legacy SIWE router, TESTING-only, out of scope per auth-and-accounts.md",
+    ("POST", "/api/auth/logout"): "legacy SIWE router, TESTING-only, out of scope per auth-and-accounts.md",
+    # internal-key gated (X-Internal-Agent-Key), agent-runner-only — never called from
+    # the browser UI, fails closed if INTERNAL_AGENT_API_KEY is unset.
+    (
+        "POST",
+        "/api/agent/bootstrap-liquidity",
+    ): "internal-key gated (X-Internal-Agent-Key); agent-runner-only, never browser-facing",
+    # agent_manifest_routes.py / rigor_verify_routes.py — both fully documented at
+    # docs/agent-api.md, which is a separate written surface with its own drift guard
+    # (backend/tests/test_agent_discovery.py asserts every route string there resolves
+    # against the running app), not docs/api/.
+    (
+        "GET",
+        "/api/agent/manifest",
+    ): "documented at docs/agent-api.md, guarded by test_agent_discovery.py, not docs/api/",
+    ("POST", "/api/rigor/verify"): "CLI `verify` command backend, documented at docs/agent-api.md, not docs/api/",
+    # agent_routes.py status/health introspection — internal system health, distinct
+    # concept from agent_manifest_routes.py's external-agent-facing /manifest.
+    ("GET", "/api/agent/status"): "agent-runner status introspection; not yet in docs/api/",
+    ("GET", "/api/agent/circle-status"): "Circle integration status probe; not yet in docs/api/",
+    (
+        "GET",
+        "/api/agent/health/amm",
+    ): "AMM health probe (agent_routes.py twin of /api/health/amm); not yet in docs/api/",
+    # corpus_routes.py — KB pipeline / knowledge-graph introspection surface.
+    ("GET", "/api/corpus/runner-state"): "KB pipeline phase/manifest introspection; not yet in docs/api/",
+    ("GET", "/api/corpus/overview"): "corpus aggregate stats; not yet in docs/api/",
+    ("GET", "/api/corpus/graph"): "SPECTER2-similarity scatter data; not yet in docs/api/",
+    ("GET", "/api/corpus/kg/entities"): "knowledge-graph entity search; not yet in docs/api/",
+    ("GET", "/api/corpus/kg/entity/{entity_id}"): "knowledge-graph entity detail; not yet in docs/api/",
+    ("GET", "/api/corpus/kg/paper/{arxiv_id}"): "knowledge-graph triples for one paper; not yet in docs/api/",
+    # papers_routes.py — paper-corpus browser, distinct from corpus_routes.py's KG surface.
+    ("GET", "/api/papers/"): "paper-corpus browser list; not yet in docs/api/",
+    ("GET", "/api/papers/{arxiv_id}"): "single-paper browser detail; not yet in docs/api/",
+    # explore_routes.py — read-only Explore-page asset discovery (page-roles-spec.md).
+    ("GET", "/api/explore/assets"): "Explore-page asset list; not yet in docs/api/",
+    ("GET", "/api/explore/assets/{symbol}/history"): "Explore-page asset history; not yet in docs/api/",
+    # assets_routes.py — asset-universe list + price history.
+    ("GET", "/api/assets/"): "asset-universe list; not yet in docs/api/",
+    ("GET", "/api/assets/{symbol}/history"): "asset price history; not yet in docs/api/",
+    # features_routes.py — public feature-flag introspection.
+    ("GET", "/api/features"): "public feature-flag introspection; not yet in docs/api/",
+    # regime_routes.py.
+    ("GET", "/api/regime/current"): "current market-regime read; not yet in docs/api/",
+    ("GET", "/api/regime/transitions"): "regime transition history; not yet in docs/api/",
+    # risk_routes.py.
+    ("GET", "/api/risk/profiles"): "risk-profile bands; not yet in docs/api/",
+    ("GET", "/api/risk/portfolio"): "portfolio risk summary; not yet in docs/api/",
+    ("GET", "/api/risk/cvar"): "portfolio CVaR (quant-feature gated); not yet in docs/api/",
+    ("GET", "/api/risk/greeks"): "portfolio options-Greeks proxy (quant-feature gated); not yet in docs/api/",
+    # portfolio_routes.py — thin HTTP layer over services/portfolio_optimizer.py.
+    ("POST", "/api/portfolio/optimize"): "MVO/HRP/BL optimizer (quant-feature gated); not yet in docs/api/",
+    ("POST", "/api/portfolio/parameter-sweep"): "optimizer parameter sweep (quant-feature gated); not yet in docs/api/",
+    ("POST", "/api/portfolio/scenario-analysis"): "optimizer scenario analysis; not yet in docs/api/",
+    # proposals_routes.py — account-session gated, owner-scoped strategy_proposals reads.
+    ("GET", "/api/proposals/"): "owner-scoped generation-proposal history; not yet in docs/api/",
+    ("GET", "/api/proposals/{generation_id}/siblings"): "sibling-candidate comparison; not yet in docs/api/",
+    # account_usage_routes.py — the CLI's `meter` command backend.
+    ("GET", "/api/account/usage"): "CLI `meter` command backend, generation-quota usage; not yet in docs/api/",
+    # user_routes.py — legacy wallet-keyed profile, distinct from the canonical Better
+    # Auth account identity documented in auth-and-accounts.md.
+    ("GET", "/api/user/profile/{wallet}"): "legacy wallet-keyed profile read; not yet in docs/api/",
+    ("POST", "/api/user/profile"): "legacy wallet-keyed profile write; not yet in docs/api/",
+    # marketplace_routes.py — publish/subscribe CRUD (linked-wallet gated except the two
+    # public browse GETs). README.md's index already promises a "Trading & marketplace"
+    # section; this is the concrete gap in that promise, not a permanent exemption.
+    ("POST", "/api/marketplace/publish"): "publish a strategy to the marketplace; not yet in docs/api/",
+    ("POST", "/api/marketplace/subscribe"): "subscribe to a published strategy; not yet in docs/api/",
+    (
+        "DELETE",
+        "/api/marketplace/subscribe/{strategy_id}",
+    ): "unsubscribe from a published strategy; not yet in docs/api/",
+    ("DELETE", "/api/marketplace/publish/{strategy_id}"): "stop publishing a strategy; not yet in docs/api/",
+    ("GET", "/api/marketplace/published"): "public published-strategy list; not yet in docs/api/",
+    ("GET", "/api/marketplace/published/{strategy_id}"): "public published-strategy detail; not yet in docs/api/",
+    ("GET", "/api/marketplace/my-published"): "caller's own published strategies; not yet in docs/api/",
+    ("GET", "/api/marketplace/my-subscriptions"): "caller's own subscriptions; not yet in docs/api/",
+    ("POST", "/api/marketplace/publish/{strategy_id}/withdraw"): "withdraw publisher earnings; not yet in docs/api/",
+}
+
+
+def _fmt(pairs) -> str:
+    return ", ".join(f"{m} {p}" for m, p in sorted(pairs))
+
+
+# ── the two directions ───────────────────────────────────────────────────────────────
+
+
+def test_every_documented_route_exists_live() -> None:
+    """(a) docs/api/*.md can't promise a route archimedes.main doesn't actually serve."""
+    documented = _documented_pairs()
+    live = _live_pairs()
+
+    stale = {pair: files for pair, files in documented.items() if pair not in live and pair not in _SIDECAR_ONLY_DOCS}
+    assert not stale, (
+        "docs/api/*.md documents routes that do NOT exist in the live archimedes.main "
+        "route table (docs have drifted ahead of the app — fix the doc or the route):\n"
+        + "\n".join(f"  {m} {p}  (in {', '.join(files)})" for (m, p), files in sorted(stale.items()))
+    )
+
+
+def test_every_live_route_is_documented_or_allowlisted() -> None:
+    """(b) a live archimedes.main route can't ship silently undocumented."""
+    documented = _documented_pairs()
+    live = _live_pairs()
+
+    undocumented = live - set(documented) - set(_UNDOCUMENTED)
+    assert not undocumented, (
+        "archimedes.main serves routes that are neither documented in docs/api/*.md nor "
+        "listed in test_api_docs_drift._UNDOCUMENTED (add a doc heading, or add an "
+        "allowlist entry with a one-line reason):\n  " + _fmt(undocumented)
+    )
+
+
+def test_allowlists_do_not_accumulate_dead_entries() -> None:
+    """Every frozen exemption must still describe something real, or it's just noise.
+
+    A ``_SIDECAR_ONLY_DOCS`` entry that stops being a documented heading, or an
+    ``_UNDOCUMENTED`` entry for a route that got removed (or got its own doc heading),
+    should be deleted from the allowlist in the same commit — otherwise the allowlist
+    silently stops meaning anything and nobody notices when it does.
+    """
+    documented = _documented_pairs()
+    live = _live_pairs()
+
+    dead_sidecar_entries = set(_SIDECAR_ONLY_DOCS) - set(documented)
+    assert not dead_sidecar_entries, (
+        "_SIDECAR_ONLY_DOCS lists heading(s) no longer present in docs/api/*.md — "
+        "remove the stale allowlist entry:\n  " + _fmt(dead_sidecar_entries)
+    )
+
+    dead_undocumented_entries = set(_UNDOCUMENTED) - live
+    assert not dead_undocumented_entries, (
+        "_UNDOCUMENTED lists route(s) no longer live in archimedes.main — remove the "
+        "stale allowlist entry:\n  " + _fmt(dead_undocumented_entries)
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,21 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`architectural-principles.md`](architectural-principles.md) | current | Dan Browne | 2026-07-28 | The four primitives the product is built to defend. |
 | [`anti-features.md`](anti-features.md) | current | Dan Browne | 2026-07-28 | What Archimedes deliberately does not build. |
 
+## API reference
+
+| Doc | Status | Owner | Last verified | What it is |
+|---|---|---|---|---|
+| [`api/README.md`](api/README.md) | current | Dan Browne | 2026-08-20 | Index of the API reference: per-surface docs, the auth-model overview table, and the `/docs` (Swagger) production-gate note. |
+| [`api/auth-and-accounts.md`](api/auth-and-accounts.md) | current | Dan Browne | 2026-08-20 | The Better Auth sidecar (`/api/auth/*`): email/password + OAuth, session lookup, email verification. |
+| [`api/wallets.md`](api/wallets.md) | current | Dan Browne | 2026-08-20 | `/api/wallets/*` — EIP-4361 wallet-link challenge/verify. |
+| [`api/generation.md`](api/generation.md) | current | Dan Browne | 2026-08-20 | `/api/generate/*` — the debate-society generation pipeline, its x402 payment gate, and daily quotas. |
+| [`api/strategies-and-rigor.md`](api/strategies-and-rigor.md) | current | Dan Browne | 2026-08-20 | `/api/strategies/*` and `/api/selection-bias/*` — the strategy library, portfolio advisor, stress testing, and the rigor gate. |
+| [`api/paper-trading.md`](api/paper-trading.md) | current | Dan Browne | 2026-08-20 | `/api/paper/*` — deploy a strategy to an append-only, never-rewritten forward-return ledger. |
+| [`api/vaults-and-chain.md`](api/vaults-and-chain.md) | current | Dan Browne | 2026-08-20 | `/api/vaults/*`, `/api/traces/*`, `/api/swap/*`, `/api/config/contracts`, and the health/root endpoints. |
+| [`api/chat.md`](api/chat.md) | current | Dan Browne | 2026-08-20 | `/api/vaults/{address}/chat*` — per-vault chat: public reads, linked-wallet writes, internal-only system events. |
+| [`api/leaderboard-and-metrics.md`](api/leaderboard-and-metrics.md) | current | Dan Browne | 2026-08-20 | `/api/leaderboard` and the public, PII-free `/api/metrics/*` traction surface. |
+| [`api/admin-private.md`](api/admin-private.md) | current | Dan Browne | 2026-08-20 | `/api/metrics/private/*` — the platform-admin-gated cost/ops dashboard and per-wallet identity roster. |
+
 ## Product
 
 | Doc | Status | Owner | Last verified | What it is |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,79 @@
+# `docs/api/` — API Reference
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+Per-surface HTTP API reference for the FastAPI backend (and the colocated
+Better Auth Node sidecar). Each doc below covers one capability area: what
+each route does, its exact auth requirement, request/response shapes, every
+error it can raise and why, and a runnable `curl` example. This index is the
+entry point [`docs/README.md`](../README.md) links to — every file here must
+be reachable from the table below, per the repo's index rule.
+
+## Live interactive docs (Swagger / `/docs`)
+
+FastAPI's own interactive docs (`/docs`, `/openapi.json`) are **disabled in
+production** by default: `main.py` gates them off whenever `PUBLIC_DOMAIN` is
+set (the app's standard "am I in production" signal) unless
+`ENABLE_API_DOCS=1` is also set, in which case they re-enable in any
+environment. Local `docker-compose` does not set `PUBLIC_DOMAIN`, so `/docs`
+is served by default on a local stack — no flag needed. This written
+reference is therefore the canonical API surface for production; treat it as
+authoritative over any live `/docs` instance you happen to have access to.
+
+## Auth model
+
+Every route in every doc below states its auth requirement using one of
+these five levels:
+
+| Level | Requirement | Failure mode |
+|---|---|---|
+| `anonymous` | Nothing. No cookie, no header. | N/A — never 401s on auth grounds. |
+| `account-session` | A live Better Auth session — the `better-auth.session_token` cookie, verified by FastAPI against the colocated Better Auth sidecar's `GET /api/auth/get-session` on every request. | `401` with no/expired session. |
+| `linked-wallet` | An `account-session`, **plus** a wallet verified-linked to that account (`require_linked_wallet`). | `401` with no session; `403` with a session but no linked wallet. |
+| `platform-admin` | A `linked-wallet`, **plus** that wallet listed in the `PLATFORM_ADMIN_WALLETS` env allowlist. Grants **no fund/custody/treasury authority** — it is a read gate on the internal cost/ops dashboard, nothing more. | `401` no session; `403` linked-but-non-admin wallet. |
+| `internal-key` | A matching `X-Internal-Agent-Key` header, compared with `hmac.compare_digest` against `INTERNAL_AGENT_API_KEY`. Fails closed (rejects everyone) if that env var is unset. Used only by internal services (the agent runner) — never reachable from the browser UI. | `403` on any missing/wrong key. |
+
+Each level nests into the one above it (`linked-wallet` implies
+`account-session`; `platform-admin` implies `linked-wallet`) except
+`internal-key`, which is a separate, service-to-service credential.
+
+## Index
+
+### Identity & accounts
+
+| Doc | Covers |
+|---|---|
+| [`auth-and-accounts.md`](auth-and-accounts.md) | The Better Auth sidecar (`/api/auth/*`): email/password + OAuth sign-up/sign-in, session lookup, email verification. |
+| [`wallets.md`](wallets.md) | `/api/wallets/*` — EIP-4361 wallet-link challenge/verify, linking a wallet to an already-signed-in account. |
+
+### Generation & rigor
+
+| Doc | Covers |
+|---|---|
+| [`generation.md`](generation.md) | `/api/generate/*` — the debate-society generation pipeline: job-based start/stream/poll, the x402 payment gate, and daily quotas. |
+| [`strategies-and-rigor.md`](strategies-and-rigor.md) | `/api/strategies/*` and `/api/selection-bias/*` — the strategy library, portfolio advisor, stress testing, and the DSR/PBO/OOS rigor gate. |
+
+### Trading & marketplace
+
+| Doc | Covers |
+|---|---|
+| [`paper-trading.md`](paper-trading.md) | `/api/paper/*` — deploy a strategy to an append-only, never-rewritten forward-return ledger. |
+| [`vaults-and-chain.md`](vaults-and-chain.md) | `/api/vaults/*`, `/api/traces/*`, `/api/swap/*`, `/api/config/contracts`, and the health/root endpoints — vault creation and metadata, reasoning-trace publish/verify, the AMM swap preview, contract addresses. |
+| [`chat.md`](chat.md) | `/api/vaults/{address}/chat*` — per-vault chat, public reads, linked-wallet writes, internal-only system events. |
+
+### Platform metrics
+
+| Doc | Covers |
+|---|---|
+| [`leaderboard-and-metrics.md`](leaderboard-and-metrics.md) | `/api/leaderboard` (own-vs-curated strategy ranking) and the public, PII-free `/api/metrics/*` traction surface. |
+| [`admin-private.md`](admin-private.md) | `/api/metrics/private/*` — the platform-admin-gated cost/ops dashboard and per-wallet identity roster. |
+
+---
+
+Conventions for this directory follow [`../CONVENTIONS.md`](../CONVENTIONS.md)
+— front matter, staleness, and where a new API doc belongs. Adding a route
+to any router above without updating its doc in the same commit leaves the
+reference silently wrong; adding a new API doc without a row here leaves it
+unreachable per the repo's index rule.

--- a/docs/api/admin-private.md
+++ b/docs/api/admin-private.md
@@ -1,0 +1,116 @@
+# Admin Metrics API
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+`/api/metrics/private/*` — the internal cost/ops dashboard: Bedrock/infra spend (currently
+draft placeholders) and the per-wallet identity roster that the public, PII-free `GET
+/api/metrics` deliberately does not expose. Landed in #1373 (closing #1366) after a
+full-tree audit found `GET /api/metrics/wallets` and `GET /api/metrics/wallets/connections`
+serving the complete per-wallet address list to **anonymous** callers in production — a
+per-identity roster is not aggregate traction data. Those two routes were removed from the
+public router entirely (the old paths now `404`, they do not redirect) and re-mounted here
+behind an admin gate.
+
+**Auth model — the platform-admin gate.** Every route in this router shares one dependency
+chain, applied at the router level
+(`metrics_private_router = APIRouter(..., dependencies=[Depends(require_platform_admin)])`),
+so the same check order runs before any handler code executes:
+
+1. **Is there a session at all?** `require_platform_admin` depends on `require_linked_wallet`,
+   which first checks for a live Better Auth session. No session → **`401`**
+   "Authentication required".
+2. **Does that account have a verified linked wallet?** A session with no linked wallet →
+   **`403`** "A verified linked wallet is required" (raised inside `require_linked_wallet`
+   itself, `wallet_routes.py`).
+3. **Is that wallet a platform admin?** `require_platform_admin` then checks the linked
+   wallet (lowercased) against `PLATFORM_ADMIN_WALLETS` — a comma/whitespace-separated env
+   allowlist, parsed case-insensitively, empty by default. Not listed → **`403`** "Admin
+   access required."
+
+So in practice: **anonymous → 401; any signed-in-but-unlinked or signed-in-and-linked-but-
+non-admin caller → 403; only a session whose linked wallet is on the allowlist → 200.**
+Both 403 branches share the status code but not the message — the exact detail string
+tells you which of the two you hit. `PLATFORM_ADMIN_WALLETS` grants **no fund / custody /
+treasury authority** — it is a read gate on this dashboard (plus one narrow publish
+exception for example strategies, `wallet_can_publish` in `models/strategy_generators.py`),
+nothing more; a listed wallet still has to sign in and link normally like any other user
+(`.env.example`).
+
+The wallet-roster routes were moved here, not merely re-gated, specifically because a
+per-wallet address list is individually identity-bearing and permanently linkable to
+on-chain activity — the module docstring is explicit that "any linked wallet is not an
+appropriate bar for it," which is why the gate is `PLATFORM_ADMIN_WALLETS` membership and
+not merely "has a linked wallet."
+
+---
+
+### GET /api/metrics/private/cost
+Account + admin cost/ops dashboard. | **Auth**: platform-admin | **Flags**:
+`PLATFORM_ADMIN_WALLETS` env allowlist
+
+Request: none.
+Response: `{source: "draft", real_users: int, bedrock_monthly_usd: null,
+bedrock_daily_usd: null, infra_monthly_usd: null, cost_per_user_usd: null,
+cost_per_generation_usd: null, note: str, authenticated_wallet: str, timestamp: str}`.
+Errors: `401` — no session. `403` — session without a linked wallet, or a linked wallet
+not on the admin allowlist (see the two-flavor 403 note above).
+
+Every cost field is an explicit `null` placeholder — **not live-metered spend**. The live
+AWS Cost Explorer + Bedrock token-metering wiring is roadmap work, not yet built; only
+`real_users` (canonical Better Auth account count) is read live, so any per-user math a
+consumer does downstream is anchored to an honest denominator rather than the cumulative
+request tallies on the public `GET /api/metrics` (issue #830).
+
+```bash
+curl -sS -b /tmp/session.jar http://localhost:8080/api/metrics/private/cost
+```
+
+### GET /api/metrics/private/wallets
+Enumerate legacy verified human wallets. | **Auth**: platform-admin | **Flags**:
+`PLATFORM_ADMIN_WALLETS` env allowlist
+
+Request: none.
+Response: `{real_users: int, wallets: [{wallet_address, actor_class, first_seen_at,
+last_auth_at}], timestamp: str}` — `real_users` here means the wallet count on *this*
+endpoint (kept for issue #1028 AC1 response-shape compatibility), not the canonical
+account count; don't conflate it with `/private/cost`'s `real_users`.
+Errors: `401` / `403` — same admin-gate semantics as `/cost`, above.
+
+Fail-safe: an empty list / zero on a DB read error, never a `500`.
+
+```bash
+curl -sS -b /tmp/session.jar http://localhost:8080/api/metrics/private/wallets
+```
+
+### GET /api/metrics/private/wallets/connections
+"Which wallets connected, and when." | **Auth**: platform-admin | **Flags**:
+`PLATFORM_ADMIN_WALLETS` env allowlist
+
+Request: none.
+Response: `{count: int, connections: [{wallet: str, connected_at: str}], timestamp: str}`
+— one row per wallet, `connected_at = min(occurred_at)` over that wallet's
+`identity_events` rows where `event_type='auth_verified'`, earliest first.
+Errors: `401` / `403` — same admin-gate semantics as `/cost`, above.
+
+This query was impossible before the identity ledger existed: the pre-Better-Auth
+SIWE-verify path discarded the wallet into a stateless cookie with no durable write
+(issue #1028 AC2). Fail-safe: an empty list on a DB read error.
+
+```bash
+curl -sS -b /tmp/session.jar http://localhost:8080/api/metrics/private/wallets/connections
+```
+
+---
+
+**No admin UI today.** `ui/src/components/Insights.jsx` explicitly does *not* render this
+dashboard — its own header comment names `GET /api/metrics/private/cost` as "a SEPARATE,
+account + admin-linked-wallet-gated surface ... intentionally NOT rendered anywhere in this
+component." A repo-wide search finds no other frontend consumer of `/api/metrics/private/*`
+either. That is a UI gap, not an access gap: the API is fully live and enforced today, a
+caller just has to reach it directly (curl / an API client with a session cookie) rather
+than through app navigation.
+
+See also: `.env.example` (`PLATFORM_ADMIN_WALLETS` documentation block) and
+`docs/security/auth-model.md`.

--- a/docs/api/auth-and-accounts.md
+++ b/docs/api/auth-and-accounts.md
@@ -1,0 +1,190 @@
+# Account Authentication API
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+`/api/auth/*` — canonical account identity: email/password and (when configured) Google/GitHub
+OAuth sign-up, sign-in, session lookup, and email verification.
+
+**This is the Better Auth Node sidecar (`auth/`), not a FastAPI router.** `auth/auth.js`
+configures Better Auth `1.6.25` on Node 22; `auth/server.js` runs it as a standalone HTTP
+service (`archimedes-auth`) beside nginx and FastAPI in the same deploy. nginx owns public
+namespace routing and proxies the entire `/api/auth/` prefix straight to this sidecar
+(`nginx/nginx.conf`: `location /api/auth/ { proxy_pass http://auth_service/api/auth/; }`) —
+it never passes through FastAPI. FastAPI is a *consumer* of this service, not its host:
+`require_current_user` (`backend/archimedes/api/account_auth.py`) authenticates every
+private FastAPI route by forwarding the caller's `cookie` header to this sidecar's own
+`GET /api/auth/get-session`, over the internal ECS loopback
+(`BETTER_AUTH_INTERNAL_URL`, default `http://127.0.0.1:3000`), and trusting only a live,
+non-expired result. FastAPI never parses or signs the session cookie itself.
+
+**Auth model.** A successful `sign-in/email` (or a completed OAuth callback) sets the
+`better-auth.session_token` cookie: `HttpOnly`, `Secure` in production, `SameSite=Lax`,
+7-day `expiresIn` with a 1-day `updateAge`. There is no bearer-token flow for browser
+clients — every route below is either `anonymous` or reads that one cookie; a curl cookie
+jar (`-c`/`-b`) round-trips it exactly like a browser would.
+
+**Do not confuse this with the legacy SIWE router.** FastAPI separately defines routes
+literally named `/api/auth/nonce`, `/api/auth/verify`, `/api/auth/logout`, and
+`/api/auth/session` in `archimedes.api.auth_siwe` — a wallet-signature login path that
+predates Better Auth. That router is mounted **only when the `TESTING` env var is
+truthy** (`main.py`, "Legacy SIWE router remains test-only so signature-verification
+regression tests exercise its reusable proof helpers without exposing wallet login
+live") — it 404s in every real environment, including production, where nginx's
+`/api/auth/` block already claims the whole prefix for this sidecar. The two surfaces
+share a URL prefix only under `TESTING`; they never collide live. **This document covers
+the Better Auth sidecar only** — the SIWE test-only routes belong to a different
+capability area and are not documented here.
+
+---
+
+### POST /api/auth/sign-up/email
+Create a new email/password account. | **Auth**: anonymous | **Flags**: production-only
+rate limit 3 signups / 10 min (`auth/auth.js` `rateLimit.customRules['/sign-up/email']`;
+Better Auth's `rateLimit.enabled` is `NODE_ENV==='production'` only), plus nginx's own
+`/api/auth/` `limit_req` zone
+
+Request: JSON body `{name: str, email: str, password: str (12-128 chars), image?: str,
+callbackURL?: str, rememberMe?: bool}`.
+Response: `{token: str|null, user: {id, email, name, image, emailVerified, ...}}`, HTTP
+200 — no `set-cookie` (registration alone does not start a session; `autoSignIn: false`).
+Errors:
+- `400` — email already registered, or password outside the 12–128 char bound.
+- `429` — signup rate limit exceeded (production only).
+
+A verification email is sent on **every** signup regardless of enforcement (SES in
+deployed environments, a console mailer that logs the link locally) — see
+`docs/account-authentication.md`. Sign-in refusal for an unverified account is a separate,
+env-gated behavior (see `POST /api/auth/sign-in/email` below).
+
+```bash
+curl -sS -c /tmp/session.jar -X POST http://localhost:8080/api/auth/sign-up/email \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Dan","email":"dan@example.com","password":"correct horse battery staple"}'
+```
+
+### POST /api/auth/sign-in/email
+Authenticate with email + password and start a session. | **Auth**: anonymous | **Flags**:
+production-only rate limit 10 / minute (`rateLimit.customRules['/sign-in/email']`);
+refuses unverified accounts only when `EMAIL_VERIFICATION_ENFORCED=true` (currently
+`false` in production — the AWS account is in the SES sandbox, per
+`docs/account-authentication.md`)
+
+Request: JSON body `{email: str, password: str, callbackURL?: str, rememberMe?: bool=true}`.
+Response: `{redirect: false, token: str, url: str|null, user: {...}}`, HTTP 200; sets the
+`better-auth.session_token` cookie.
+Errors:
+- `401` — wrong credentials or unknown email (a password hash is computed either way, so
+  the response doesn't leak which side was wrong).
+- `403` — `EMAIL_NOT_VERIFIED`, only when `EMAIL_VERIFICATION_ENFORCED=true` and the
+  account hasn't clicked its verification link yet.
+- `429` — sign-in rate limit exceeded (production only).
+
+```bash
+curl -sS -c /tmp/session.jar -X POST http://localhost:8080/api/auth/sign-in/email \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"dan@example.com","password":"correct horse battery staple"}'
+```
+
+### POST /api/auth/sign-out
+Revoke the current session and clear its cookie. | **Auth**: anonymous (a request with no
+session cookie still returns 200 — there is nothing to revoke)
+
+Request: none (cookie only).
+Response: `{success: true}`, HTTP 200 — the DB-backed `auth_sessions` row is deleted and the
+cookie cleared.
+Errors: none raised.
+
+```bash
+curl -sS -b /tmp/session.jar -X POST http://localhost:8080/api/auth/sign-out
+```
+
+### GET /api/auth/get-session
+Read the caller's current session, if any. | **Auth**: anonymous (returns `null`, not
+401, when unauthenticated) | **Flags**: this is the exact endpoint FastAPI's
+`require_current_user` calls internally to authenticate every private FastAPI route — the
+single source of truth for "is this caller logged in" across the whole app
+
+Request: none (cookie only).
+Response: `{session: {id, token, expiresAt, ...}, user: {id, name, email, emailVerified,
+image, ...}}` on a live session; bare `null` (still HTTP 200) otherwise.
+Errors: none raised — `null` is the "not authenticated" signal, not an error.
+
+```bash
+curl -sS -b /tmp/session.jar http://localhost:8080/api/auth/get-session
+```
+
+### GET /api/auth/verify-email
+Verify an emailed verification token, marking the account's email verified. | **Auth**:
+anonymous (the token itself is the proof) | **Flags**: runs regardless of
+`EMAIL_VERIFICATION_ENFORCED` — that flag only gates whether `sign-in/email` refuses an
+unverified account, not whether this endpoint works
+
+Request: query params `token: str` (required — the token from the emailed link),
+`callbackURL?: str`.
+Response: `{user: {...}, status: true}`, HTTP 200 — or, when `callbackURL` was supplied, an
+HTTP redirect to it (`?error=<code>` appended on failure instead of a JSON error body).
+Errors:
+- `401` `TOKEN_EXPIRED` — link expired.
+- `401` `INVALID_TOKEN` — malformed or tampered token.
+- `401` `USER_NOT_FOUND` — token's email no longer matches an account.
+
+```bash
+curl -sS "http://localhost:8080/api/auth/verify-email?token=<token-from-emailed-link>"
+```
+
+### GET /api/auth/providers
+Which login methods are enabled right now — drives which buttons the sign-in/sign-up UI
+renders. | **Auth**: anonymous | **Flags**: served directly by `auth/server.js`, not by a
+generic Better Auth route
+
+Request: none.
+Response: `{emailPassword: true, google: bool, github: bool, passkey: false}`.
+`google`/`github` are `true` only when *both* halves of that provider's credential pair
+(`GOOGLE_CLIENT_ID`+`GOOGLE_CLIENT_SECRET`, or the GitHub equivalent) are set;
+`passkey` is hardcoded `false` — not wired.
+Errors: none.
+
+```bash
+curl -sS http://localhost:8080/api/auth/providers
+```
+
+### POST /api/auth/sign-in/social
+Start an OAuth sign-in with Google or GitHub. | **Auth**: anonymous | **Flags**: only
+usable for a provider `GET /api/auth/providers` reports `true` for — check there first
+
+Request: JSON body `{provider: "google"|"github", callbackURL?: str, disableRedirect?: bool}`.
+Response: `{url: str, redirect: bool}` — the provider's OAuth authorize URL; the browser is
+redirected there directly unless `disableRedirect: true`.
+Errors: `404` `PROVIDER_NOT_FOUND` — `provider` isn't configured (missing client ID/secret
+pair).
+
+```bash
+curl -sS -X POST http://localhost:8080/api/auth/sign-in/social \
+  -H 'Content-Type: application/json' \
+  -d '{"provider":"google","callbackURL":"https://archimedes-arc.com/app"}'
+```
+
+### GET /api/auth/callback/{provider}
+OAuth redirect target — completes the provider handshake and sets the session cookie. |
+**Auth**: anonymous (the OAuth `state`/`code` round-trip is the proof) | **Flags**: only
+reachable for a configured provider; callback URLs are `https://<domain>/api/auth/callback/google`
+and `.../github` (`docs/account-authentication.md`)
+
+Request: path `provider: "google"|"github"`; query params set by the OAuth provider
+(`code`, `state`, ...) — never called directly by a client.
+Response: HTTP redirect to `callbackURL` (or the app default) with the session cookie set
+on success.
+Errors: redirects to the callback URL with `?error=<code>` appended on failure, rather than
+returning a JSON error body.
+
+```bash
+# Not called directly — the browser lands here via redirect from Google/GitHub
+# after POST /api/auth/sign-in/social. Shown for completeness only.
+```
+
+---
+
+See also: `docs/account-authentication.md` (topology, login configuration, migration and
+rollback) and `docs/security/auth-model.md` (trust boundaries across the whole app).

--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -1,0 +1,88 @@
+# Chat API
+
+Per-vault chat for the Archimedes marketplace. Reads are deliberately public
+(anyone can follow a vault's chat), while writes require an authenticated
+account with a verified linked wallet; the AI (Archimedes) auto-responds when
+a message mentions `@archimedes`. Two additional endpoints post system events
+(rebalance, regime change) into a vault's chat feed from the internal agent
+runner — they are never reachable from the browser UI.
+
+**Auth model.** `anonymous` needs nothing. `linked-wallet` requires both a
+Better Auth account session (`better-auth.session_token` cookie) **and** a
+wallet verified-linked to that account (`require_linked_wallet`) — a session
+without a linked wallet is rejected, and a body-supplied `wallet_address` is
+checked against the server-resolved linked wallet but can never override it.
+`internal-key` requires a matching `X-Internal-Agent-Key` header, compared
+with `hmac.compare_digest` against the `INTERNAL_AGENT_API_KEY` env var; if
+that env var is unset the gate fails closed and rejects every caller. Examples
+needing a session assume an authenticated cookie jar at `/tmp/session.jar`.
+
+## Endpoints
+
+### GET /api/vaults/{address}/chat
+Get chat messages for a vault, oldest-first (chat display order). | **Auth**:
+anonymous
+
+Request: path `address`; query `limit: int(1..200)=50, before_id: int|null` (pagination cursor — messages before this ID).
+Response (`ChatMessageListResponse`): `{messages: [ChatMessageResponse{id, vault_address, wallet_address, message, is_ai: bool, verified: bool, created_at}], total: int, has_more: bool}`.
+Errors: none explicit.
+
+```bash
+curl -s "https://archimedes-arc.com/api/vaults/<address>/chat?limit=50"
+```
+
+### POST /api/vaults/{address}/chat
+Post as a verified wallet linked to the canonical account; AI auto-responds to
+`@archimedes` mentions. | **Auth**: linked-wallet | **Flags**: rate limit
+`20/minute` (disabled under `TESTING`)
+
+Request (`ChatPostRequest`): `{wallet_address: str|null, message: str}` — `wallet_address`, if given, must match the session-resolved linked wallet; it can never override which wallet the message is attributed to.
+Response (`ChatPostResponse`): `{message: ChatMessageResponse, ai_response: ChatMessageResponse|null}`.
+Errors: 400 `Message cannot be empty`; 400 `Message too long (max 2000 chars)`; 403 `wallet_address is not linked to the authenticated account` (body wallet mismatch); plus `require_linked_wallet`'s own 401 `Authentication required` (no session) and 403 `A verified linked wallet is required` (no linked wallet).
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/vaults/<address>/chat \
+  -b /tmp/session.jar -H "Content-Type: application/json" \
+  -d '{"message": "@archimedes what changed in this vault today?"}'
+```
+
+### GET /api/vaults/{address}/chat/count
+Get total message count for a vault. | **Auth**: anonymous
+
+Request: path `address`.
+Response: `{vault_address: str, message_count: int}`.
+Errors: none.
+
+```bash
+curl -s https://archimedes-arc.com/api/vaults/<address>/chat/count
+```
+
+### POST /api/vaults/{address}/chat/rebalance
+Post a rebalance event from the agent runner — internal-only. | **Auth**:
+internal-key | **Flags**: `INTERNAL_AGENT_API_KEY` (required; unset means the
+gate rejects every caller, since an empty expected value never matches)
+
+Request: `{reasoning: str="Portfolio rebalanced", trades: [{direction, amount, symbol}]|null}`.
+Response: result of `chat_service.post_rebalance_event()`.
+Errors: 403 `Forbidden` (missing or wrong `X-Internal-Agent-Key` header); 500 `Failed to post rebalance event` (service returned `None`).
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/vaults/<address>/chat/rebalance \
+  -H "X-Internal-Agent-Key: $INTERNAL_AGENT_API_KEY" -H "Content-Type: application/json" \
+  -d '{"reasoning": "Rebalanced toward momentum signal", "trades": [{"direction": "sell", "amount": 1000, "symbol": "sTSLA"}]}'
+```
+
+### POST /api/vaults/{address}/chat/regime-change
+Post a regime change event from the agent runner — internal-only. |
+**Auth**: internal-key | **Flags**: `INTERNAL_AGENT_API_KEY` (same gate as
+`/chat/rebalance`)
+
+Request: `{old_regime: str="unknown", new_regime: str="unknown", confidence: float=0.0}`.
+Response: result of `chat_service.post_regime_change()`.
+Errors: 403 `Forbidden` (missing/wrong `X-Internal-Agent-Key` header); 500 `Failed to post regime change` (service returned `None`).
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/vaults/<address>/chat/regime-change \
+  -H "X-Internal-Agent-Key: $INTERNAL_AGENT_API_KEY" -H "Content-Type: application/json" \
+  -d '{"old_regime": "risk_on", "new_regime": "risk_off", "confidence": 0.85}'
+```

--- a/docs/api/generation.md
+++ b/docs/api/generation.md
@@ -1,0 +1,228 @@
+# Generation API
+
+The generation surface turns a natural-language strategy brief into rigor-graded
+candidate strategies via the debate-society pipeline (the sole live generation
+path — see [debate-society-sole-generation-pipeline ADR](../adr/debate-society-sole-generation-pipeline.md)).
+The API is job-based: `POST /api/generate/start` enqueues a job and returns
+immediately (202); progress streams over Server-Sent Events at
+`GET /api/generate/stream/{job_id}`, with polling fallbacks at `/jobs` and
+`/jobs/{job_id}`. Generation sits behind an x402-style USDC paywall
+(`GENERATION_PAYMENT_REQUIRED`) plus daily volume quotas, both enforced inside
+`/start`; `GET /api/generate/quote` is the public price check whose exact
+payload also rides inside every 402 the paywall raises. Paper trading
+(`POST /api/paper/deployments`) is a separate, always-free surface — the
+payment gate documented here is scoped to `/api/generate/start` only.
+
+**Auth model.** Every route except `/quote` requires a Better Auth account
+session (the `better-auth.session_token` cookie, verified server-side against
+the colocated Better Auth service on every request — FastAPI never parses it
+itself). The payment gate and the premium-model entitlement gate additionally
+require a Better-Auth-linked, verified wallet on the account; a session alone
+is not sufficient once `GENERATION_PAYMENT_REQUIRED` is on or a premium `model`
+is requested. Examples below assume an authenticated session already sits in
+`/tmp/session.jar` (obtained via the Better Auth service, not documented
+here).
+
+## Endpoints
+
+### GET /api/generate/quote
+The upfront generation cost estimate — public, so a human can see the price
+before signing in and an agent can plan before paying; this exact payload also
+rides inside every 402 from `/start`. | **Auth**: anonymous | **Flags**:
+`GENERATION_PAYMENT_REQUIRED` (only the literal `"true"` enables the paywall
+elsewhere), `GENERATION_PRICE_USD` (default `$0.15`), `GATEWAY_CHAIN`,
+`PAYMENTS_DRY_RUN` (default `true`), `GENERATION_PAYMENT_RECIPIENT`
+
+Request: none.
+Response: `{payment_required: bool, pricing_model: "flat_v1", price: "$X.XXXXXX", asset: "USDC", chain: str, recipient: str|null, dry_run: bool, how: str}`.
+Errors: none raised directly.
+
+```bash
+curl -s https://archimedes-arc.com/api/generate/quote
+```
+
+### POST /api/generate/start
+Create an account-owned generation job (debate-society pipeline) and start it
+in the background; the caller tails progress via the SSE stream. | **Auth**:
+account-session | **Flags**: `GENERATION_PAYMENT_REQUIRED` (x402 paywall — see
+[the status-code flow](#the-payment-gate-status-code-flow-post-apigeneratestart)
+below), `GENERATION_DAILY_CAP_PER_USER` / `GENERATION_DAILY_CAP_PER_IP` (see
+[Quotas](#quotas)), `PREMIUM_MODELS_ENABLED` / `PREMIUM_MODELS_ALLOWLIST`
+(premium-model entitlement), slowapi `5/minute` (disabled under `TESTING`)
+
+Request (`GenerateStartRequest`): `{brief: {intent: str, risk_appetite: "fixed_income"|"conservative"|"moderate"|"aggressive"|"hyper_risky"="moderate", asset_classes: [str]|null, capital_usdc: float|null, max_papers: int(1..20)=5, name: str|null(<=80 chars, control-chars rejected)}, n_candidates: int(1..5)=1, mode: str|null (accepted for API compat, ignored post T1.1 Phase-3), model: str|null}`.
+Response (202, `GenerateStartResponse`): `{job_id: str, stream_url: str, ttl_seconds: int}`.
+Errors: 409 `wallet_link_required` (payment required, caller has no linked wallet); 402 (payment-gate failure, or a non-entitled premium `model`); 429 (daily generation-quota cap exceeded, unless `TESTING`; or the 5/min burst limit); 503 `payment_config_missing` (payment flag on, `GENERATION_PAYMENT_RECIPIENT` unset).
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/generate/start \
+  -b /tmp/session.jar -H "Content-Type: application/json" \
+  -d '{"brief": {"intent": "momentum strategy on large-cap tech", "risk_appetite": "moderate", "max_papers": 5}, "n_candidates": 1}'
+```
+
+### GET /api/generate/stream/{job_id}
+Server-Sent Events for one account-owned generation job. | **Auth**:
+account-session
+
+Request: path `job_id`; optional `Last-Event-ID` header to resume.
+Response: `text/event-stream` `StreamingResponse` of `GenerateEvent` frames — `id: int, event: EventName(job_queued|brief_validated|pipeline_selected|candidates_selected|agent_iteration|tool_called|tool_result|candidate_drafted|candidate_evaluated|best_selected|trace_hashed|persisted|done|error), data: dict`. A ~15s heartbeat comment keeps the connection from going byte-silent past intermediary idle-timeouts; the connection is capped at 300s and the client reconnects with `Last-Event-ID`.
+Errors: 404 `job {job_id} not found or expired` (unknown/expired job, or owned by a different account/wallet).
+
+```bash
+curl -N -b /tmp/session.jar https://archimedes-arc.com/api/generate/stream/<job_id>
+```
+
+### POST /api/generate/jobs/{job_id}/cancel
+Cancel a running job. Idempotent — hard-cancels the backing asyncio task when
+still live. | **Auth**: account-session
+
+Request: path `job_id`.
+Response: `{job_id: str, status: str}`.
+Errors: 404 `job {job_id} not found or expired` (unknown/expired, or not owned).
+
+```bash
+curl -s -X POST -b /tmp/session.jar https://archimedes-arc.com/api/generate/jobs/<job_id>/cancel
+```
+
+### GET /api/generate/jobs
+Recent jobs for the GenerationStatus UI, filtered to the canonical owner with
+linked-wallet fallback for legacy (pre-account) jobs. | **Auth**:
+account-session
+
+Request: query `limit: int(1..100)=20`.
+Response (`JobsListResponse`): `{jobs: [JobSummary{job_id, state: "queued"|"running"|"done"|"error"|"cancelled", brief_intent, created_at, updated_at, n_candidates, best_strategy_id: str|null, cost: dict|null}]}`.
+Errors: none beyond the global 401.
+
+```bash
+curl -s -b /tmp/session.jar "https://archimedes-arc.com/api/generate/jobs?limit=20"
+```
+
+### GET /api/generate/jobs/{job_id}
+One job's current state — the poll fallback for a client with no live stream.
+| **Auth**: account-session
+
+Request: path `job_id`.
+Response: `JobSummary` (same shape as the `/jobs` listing item).
+Errors: 404 `job {job_id} not found or expired` (unknown/expired, `job.type != "generate"`, or not owned).
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/generate/jobs/<job_id>
+```
+
+### GET /api/generate/jobs/{job_id}/cost
+What this generation actually consumed — raw measurement only (Bedrock token
+counts, wall/CPU seconds, peak RSS, write tallies), no prices. | **Auth**:
+account-session
+
+Request: path `job_id`.
+Response (`JobCostResponse`): `{job_id, state: "queued"|"running"|"done"|"error"|"cancelled", cost: dict|null}` — `cost` is `null` until the job reaches a terminal state, and for jobs older than the cost meter.
+Errors: 404 `job {job_id} not found or expired` (unknown, or not owned).
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/generate/jobs/<job_id>/cost
+```
+
+### GET /api/generate/jobs/{job_id}/candidates
+Rejected-candidate viewer. Empty list until the job reaches `done`. |
+**Auth**: account-session
+
+Request: path `job_id`.
+Response (`CandidatesListResponse`): `{job_id, best_candidate_id: str|null, candidates: [CandidateSummary{candidate_id, strategy_id: str|null, strategy_name, rigor_verdict: dict|null, passes_rigor: bool, selected: bool, regime: str|null, generation_method: str|null}]}`.
+Errors: 404 `job {job_id} not found or expired` (unknown, or not owned).
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/generate/jobs/<job_id>/candidates
+```
+
+## The payment-gate status-code flow (POST /api/generate/start)
+
+The paywall carries no payment fields in the request body — it is entirely a
+status-code + header contract, gated end-to-end by
+`GENERATION_PAYMENT_REQUIRED` (only the literal `"true"` enables it; while off,
+every step below is skipped and `/start` behaves exactly as if the gate did
+not exist). Order inside `/start` is deliberate — cheapest checks first, no
+work burned on a request that will be refused:
+
+1. **Quota** (`enforce_generation_quota`, runs first, skipped under `TESTING`) —
+   429 if either daily cap is exceeded; 503 `generation_quota_unavailable` if
+   the quota backend (Redis) itself is unreachable (fails **closed** — the
+   response says explicitly that nothing was counted). See [Quotas](#quotas).
+2. **Wallet-link precondition** (only when the payment flag is on) — no linked
+   wallet on the account → **409** `wallet_link_required`. This is 409, not
+   402: the blocker is account state (link a wallet, fund it — the faucet is
+   human-only), not a missing payment.
+3. **Payment gate** (`generation_payment.enforce_generation_payment`, only
+   reached once a wallet is linked):
+   - No `Payment-Signature` request header → **402**, body
+     `{reason: "payment_required", message, quote}` (the identical payload
+     `GET /api/generate/quote` returns) plus a `PAYMENT-REQUIRED` response
+     header carrying the machine-readable x402 requirements — built by the
+     same circlekit middleware that later settles. This 402 *is* the
+     quote-approval flow; there is no separate "authorize" call.
+   - Header present but its signed `from` doesn't match the caller's linked
+     wallet → **402** `payer_mismatch`; undecodable header → **402**
+     `payment_malformed`.
+   - `PAYMENTS_DRY_RUN` (default `true`): a well-formed, wallet-matching
+     header is accepted **without** verification or settlement — no real
+     value moves while the custody migration (#975) is pending; the server
+     logs this loudly so it can never be mistaken for revenue.
+   - Live mode (`PAYMENTS_DRY_RUN=false`): the middleware verifies then
+     settles via Circle's facilitator — **402** `payment_invalid` or
+     `payment_settle_failed` on failure; on success the settlement receipt
+     headers (`PAYMENT-RESPONSE`) are merged into the eventual 202 response.
+   - `GENERATION_PAYMENT_REQUIRED=true` with `GENERATION_PAYMENT_RECIPIENT`
+     unset → **503** `payment_config_missing` — fail-closed configuration
+     error, never a free pass.
+4. **Premium-model entitlement** (`enforce_model_entitlement`, independent of
+   the paywall flag, always checked) — a `model` naming an Anthropic
+   (`anthropic.` marker) Bedrock id from a wallet that is not entitled
+   (entitled = wallet-connected **and** (`PREMIUM_MODELS_ENABLED=true` **or**
+   wallet in `PREMIUM_MODELS_ALLOWLIST`)) → **402**, plain-text `detail` (no
+   `reason`/`quote` envelope — this is a separate gate from step 3). The
+   request is rejected outright, never silently downgraded to a free model.
+5. Only after every check above passes is the job enqueued and the background
+   pipeline started.
+
+```bash
+# 1) payment required but no wallet linked -> 409
+curl -s -X POST https://archimedes-arc.com/api/generate/start -b /tmp/session.jar \
+  -H "Content-Type: application/json" -d '{"brief": {"intent": "..."}}'
+# {"detail": {"reason": "wallet_link_required", "message": "..."}}
+
+# 2) linked wallet, no Payment-Signature -> 402 with PAYMENT-REQUIRED header + quote body
+curl -s -i -X POST https://archimedes-arc.com/api/generate/start -b /tmp/session.jar \
+  -H "Content-Type: application/json" -d '{"brief": {"intent": "..."}}'
+
+# 3) retry, signed
+curl -s -X POST https://archimedes-arc.com/api/generate/start -b /tmp/session.jar \
+  -H "Content-Type: application/json" -H "Payment-Signature: <x402 signature>" \
+  -d '{"brief": {"intent": "..."}}'
+```
+
+## Quotas
+
+Two stacked daily volume caps, both enforced before the payment gate on every
+`POST /api/generate/start` (skipped entirely under `TESTING`, same as the
+slowapi limiter):
+
+| Layer | Env var | Default | Key |
+|---|---|---|---|
+| Per-account | `GENERATION_DAILY_CAP_PER_USER` | 10/day | Better Auth `user.id` |
+| Per-IP | `GENERATION_DAILY_CAP_PER_IP` | 20/day | `X-Real-IP` (nginx/ALB-resolved; `X-Forwarded-For` is deliberately never trusted) |
+
+Both must pass; the user bucket is checked (and counted) first, so a caller
+over their own cap cannot drain the shared IP bucket for others behind the
+same NAT/office. `<= 0` disables that layer individually; both disabled means
+unlimited. Each day-bucket self-expires after ~36h (covers the UTC-day
+boundary + clock skew). The check **fails closed**: a Redis error on the
+quota check itself returns 503 `generation_quota_unavailable`, explicitly
+saying nothing was counted — never a silent 429 and never a silent pass.
+Separately, `/start` also carries a slowapi burst limit of `5/minute`
+(disabled under `TESTING`) — that bounds *rate*, this section bounds daily
+*volume*.
+
+```bash
+# daily cap hit -> 429
+# {"detail": {"message": "You've reached today's generation limit (10/day for this account)...",
+#             "reason": "generation_daily_cap", "scope": "user", "cap": 10}}
+```

--- a/docs/api/leaderboard-and-metrics.md
+++ b/docs/api/leaderboard-and-metrics.md
@@ -1,0 +1,180 @@
+# Leaderboard & Metrics API
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+Two surfaces bundled together because they answer the same question — "how
+is the platform doing?" — at two different scopes: `/api/leaderboard` ranks
+strategies (curated reference set, or the signed-in caller's own generated
+strategies), while `/api/metrics/*` reports platform traction. The public
+`/api/metrics` router (this doc) is **anonymous and PII-free by design** — no
+route on it may carry a wallet-bearing response model, and a test walks the
+router to enforce that. The admin-gated wallet roster and cost dashboard live
+on a **separate** router, `/api/metrics/private/*`, fully documented in
+[`admin-private.md`](admin-private.md) — this doc covers both for
+completeness but the detail lives there.
+
+**Auth model.** `GET /api/leaderboard`, `GET /api/metrics`, `GET
+/api/metrics/funnel`, `POST /api/metrics/funnel/event`, and `GET
+/api/metrics/visitors` are all anonymous — none of them ever 401s, by design
+(see each route below for its specific fail-soft behavior). `GET
+/api/metrics/private/*` requires platform-admin (see
+[`admin-private.md`](admin-private.md)).
+
+## Leaderboard
+
+### GET /api/leaderboard
+Rank strategies by a transparent, real-data-only conviction score. |
+**Auth**: anonymous — never 401s; scope is resolved from whether a session
+happens to be present, not required
+
+Request: query `scope: "own"|"curated"|null` (default: `"own"` when signed
+in, `"curated"` when anonymous — an anonymous request for `scope=own` is
+transparently served `curated` instead; the response's own `scope` field
+reports what was actually served, which may differ from what was asked for),
+`sort_by: "conviction_score"|"sharpe_ratio"|"cagr"|"sortino_ratio"|"calmar_ratio"|"deflated_sharpe_ratio"|"dsr_p_value"|"out_of_sample_sharpe"|"pbo_score" = "conviction_score"`,
+`order: "asc"|"desc" = "desc"`, `regime_tag: "bull"|"bear"|"regime_neutral"|null`,
+`min_rigor: bool = false`, `limit: int(1..200) = 50`.
+Response (`LeaderboardResponse`): `{entries: [LeaderboardEntry], total: int, sort_by: str, order: str, scope: str, scoring_engine: LeaderboardScoringEngine}` — see [Response shape](#response-shape) below.
+Errors: none — a data-source failure degrades to an empty board with the
+scoring-engine metadata intact, never a 5xx (module docstring: "the page must
+never hard-fail, for either scope").
+
+```bash
+curl -s "https://archimedes-arc.com/api/leaderboard?scope=curated&sort_by=conviction_score&limit=50"
+```
+
+#### `scope=own` vs `scope=curated`
+
+- **`own`** (single-user MVP default when signed in): the caller's own
+  generated strategies — published or not — ranked against each other. Never
+  includes the curated library (nobody owns it) and never includes another
+  user's strategies.
+- **`curated`** (default when anonymous): the curated seed library **union**
+  every *published* generated strategy across all users — explicitly a
+  reference set, never framed as "your competition." Publish status (not
+  rigor "live" promotion) is the only qualifying criterion for a generated
+  strategy here, because keying off rigor promotion would leak a private
+  strategy onto a shared board the moment it passed the gate.
+
+**A global, cross-user ranked cohort is a roadmap concept** (tracked in
+#1185) — `scope=curated` is a reference view, not a live competitive
+leaderboard; the machinery for a real public board exists server-side but is
+not exposed as one yet.
+
+#### Response shape
+
+`LeaderboardEntry` (per entry): `rank, medal: "gold"|"silver"|"bronze"|null,
+id, name, creator, conviction_score: float(0-100), score_components:
+{gate, dsr_confidence, oos_performance, overfitting_resistance,
+data_completeness}` (all `[0,1]`, `None`-backed inputs score `0` and are
+reflected in `data_completeness`), `sharpe_ratio, cagr, sortino_ratio,
+max_drawdown, calmar_ratio` (validation axis, `null` if not yet evaluated),
+`deflated_sharpe_ratio, dsr_p_value` (**a 0–1 confidence — higher is
+better — despite the legacy "p_value" name**), `pbo_score,
+out_of_sample_sharpe, passes_rigor_gate: bool, is_backtest_placeholder: bool,
+forward: {stockbench_status: "pending", stockbench_sortino: float|null,
+live_pnl_status: "pending", live_pnl_pct: float|null}` (per-strategy
+StockBench and live paper-P&L are not wired yet — always `"pending"`, shown
+honestly rather than hidden or fabricated), `regime_tag, return_source,
+status, papers: [PaperRef]`.
+
+`scoring_engine`: `{weights: dict[str,float], oos_target: float, methodology:
+str, validation_axis: "live", forward_axis: "pending", stockbench_global:
+{scope: "agent_pipeline_global", sortino, return_pct, max_drawdown_pct, rank,
+window, source}, disclaimer: str}` — `stockbench_global` is the one real
+StockBench result on hand (the whole agent-pipeline run, Chen et al. 2026),
+not a per-strategy number; it is surfaced as honest context, not as evidence
+about any individual entry.
+
+**The response's `scope` field is authoritative, not the request's `?scope=`
+param** — always read it back rather than assuming the server honored what
+was asked for.
+
+## Metrics (public, PII-free)
+
+### GET /api/metrics
+Live human-vs-agent traction counters, plus the honest user count. |
+**Auth**: anonymous
+
+Request: none.
+Response (`MetricsResponse`): `{human_count: int, agent_count: int, total_requests: int, real_users: int, epoch_started_at: str|null, epoch_resets: int|null, timestamp: str}`. `human_count`/`agent_count`/`total_requests` are **cumulative per-request tallies (site traffic, not users, not visitors)** since `epoch_started_at`; `real_users` is the canonical Better Auth account count, surfaced alongside so the two can never be conflated (issue #830). Counts are Postgres-snapshotted on every read so a Redis restart does not zero them; `epoch_resets` counts how many Redis resets have been absorbed into the durable total.
+Errors: none — always 200. A Redis outage falls back to the last durable Postgres snapshot rather than reporting a false zero.
+
+```bash
+curl -s https://archimedes-arc.com/api/metrics
+```
+
+### GET /api/metrics/funnel
+Conversion funnel — two independently-sourced views selected by `source`. |
+**Auth**: anonymous
+
+Request: query `day: str (YYYY-MM-DD)|null` (single-day window; omitted =
+all-time; ignored when `source=identity`, which is always queried live),
+`source: "visitor"|"identity" = "visitor"`, `human_only: bool = true`
+(`source=identity` only).
+Response (`FunnelResponse`): `{window: str, source: str, stages: [FunnelStageCount{stage, distinct_visitors, pct_of_landed, step_conversion, by_agent_type: dict[str,int]}], timestamp: str}`.
+Errors: none — `source=visitor` fails soft to zeros on a Redis outage; `source=identity` fails soft to an all-zero funnel on any DB error.
+
+Two sources, not two views of the same data:
+- **`source=visitor`** (default) — the pre-#1028 anonymous browser-id funnel
+  (`landed → wallet_connected → generation_started → vault_deployed`),
+  backed by Redis HyperLogLog. Every stage also carries `by_agent_type`
+  (`internal`/`external`/`human` breakdown), additive to `distinct_visitors`.
+- **`source=identity`** — `wallet_connected → generation_started →
+  vault_deployed`, each a live `COUNT(DISTINCT wallet)` over the durable
+  `identity_events` ledger, no Redis/HLL involved. `human_only=true`
+  (default) excludes `actor_class IN ('operator_dogfood','agent')` so
+  dogfooding/agent traffic can't inflate the honest human funnel;
+  `by_agent_type` is always empty here (no per-request agent_type on ledger
+  rows).
+
+```bash
+curl -s "https://archimedes-arc.com/api/metrics/funnel?source=identity&human_only=true"
+```
+
+### POST /api/metrics/funnel/event
+Client beacon for the top-of-funnel `landed` stage. | **Auth**: anonymous
+
+Request: `{stage: str}` — only stages in `CLIENT_EMITTABLE_STAGES` (today:
+`landed`) are accepted; every downstream funnel stage is recorded
+server-side at its authoritative transition, so a client can never inflate
+it.
+Response: `{recorded: bool}` — always HTTP 200; `recorded: false` for a
+stage that isn't client-emittable, not an error.
+Errors: none.
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/metrics/funnel/event \
+  -H "Content-Type: application/json" -d '{"stage": "landed"}'
+```
+
+### GET /api/metrics/visitors
+Where human traffic comes from, and on what device. | **Auth**: anonymous
+
+Request: none.
+Response (`VisitorInsightsResponse`): `{window: "all-time", countries: [{code, distinct_visitors}] (sorted desc), devices: dict[str,int] (mobile/tablet/desktop/tv/unknown), timestamp: str}` — counts are distinct HUMAN visitors only; agents/crawlers are excluded. Country comes from CloudFront viewer-country geolocation, device from CloudFront device headers (UA fallback).
+Errors: none — empty maps on a Redis outage, always 200.
+
+```bash
+curl -s https://archimedes-arc.com/api/metrics/visitors
+```
+
+## Metrics (admin-gated) — summary
+
+`/api/metrics/private/cost`, `/api/metrics/private/wallets`, and
+`/api/metrics/private/wallets/connections` require a Better Auth session
+**and** a linked wallet **and** membership in the `PLATFORM_ADMIN_WALLETS`
+env allowlist — anonymous gets `401`, a signed-in-but-non-admin caller gets
+`403`. These moved off the public router entirely in #1373 (closing #1366)
+after a full-tree audit found the wallet-roster routes serving a complete
+per-identity address list to anonymous callers. Full endpoint reference,
+request/response shapes, and the exact three-step gate order live in
+[`admin-private.md`](admin-private.md) — this doc does not duplicate them.
+
+---
+
+See also: `docs/api/admin-private.md` (the admin-gated half of this metrics
+split) and `docs/architecture.md` (telemetry middleware + identity-ledger
+overview).

--- a/docs/api/paper-trading.md
+++ b/docs/api/paper-trading.md
@@ -1,0 +1,144 @@
+# Paper Trading API
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+`/api/paper/*` — the verdict → paper-trade path (MVP). Deploying a strategy to
+paper trading snapshots its DSL spec and forward-runs the **same graded
+engine** one appended bar per day, so a paper track record tracks the graded
+backtest semantics by construction rather than a separate simulated broker.
+This surface never moves funds — it exists to let a strategy earn a forward
+track record before anyone considers a real deployment, and its ownership,
+rate limits, and error handling all read that way (an account session is
+sufficient proof; there is no fresh-wallet-signature gate here).
+
+**Ledger is append-only, never rewritten.** Each daily advance replays the
+strategy's full history and diffs it against what is already written. New
+dates are appended; dates the ledger already has are **never overwritten**
+even when a fresh replay disagrees with the stored value (an upstream data
+restatement — e.g. yfinance revising history) — the deployment is instead
+stamped `drift_detected_at` and the disagreement is logged loudly. A paper
+track record that could silently rewrite its own past is exactly the failure
+this product exists to oppose; see `services/paper_trading.py` module
+docstring.
+
+**Auth model.** Every route requires a Better Auth account session (the
+`better-auth.session_token` cookie via `require_current_user`) — ownership is
+`owner_user_id` only. `owner_wallet` is recorded on deploy as **provenance
+only** (the caller's linked wallet at that moment, if any) and never grants
+access; an account-only user with no linked wallet can deploy normally.
+Examples below assume an authenticated cookie jar at `/tmp/session.jar`.
+
+## Endpoints
+
+### POST /api/paper/deployments
+Deploy a strategy to paper trading — snapshots its DSL spec and opens a new
+ledger. | **Auth**: account-session | **Flags**: rate limit `10/minute`
+(disabled under `TESTING`)
+
+Request: `{strategy_id: str}`.
+Response (201): a `deployment_summary` object — see [Deployment summary shape](#deployment-summary-shape) below. The
+first daily advance runs synchronously and best-effort: if it fails (e.g. a
+transient data-source hiccup) the deployment is still created with zero rows,
+and the scheduled `paper_advance_loop` backfills it from `deployed_at` on its
+next pass.
+Errors:
+- `422` `strategy_id is required` — missing/blank body field.
+- `404` `Strategy not found` — unknown strategy, or not visible to the caller
+  (private-until-published rules, #850).
+- `422` `no_strategy_spec` — the strategy has no machine-readable DSL spec to
+  paper-trade.
+- `422` `invalid_strategy_spec` — the stored spec fails DSL validation.
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/paper/deployments \
+  -b /tmp/session.jar -H "Content-Type: application/json" \
+  -d '{"strategy_id": "<strategy_id>"}'
+```
+
+### GET /api/paper/deployments
+List the caller's own paper deployments, newest first. | **Auth**:
+account-session
+
+Request: none.
+Response: `{deployments: [deployment_summary, ...]}` — every deployment
+owned by the caller (`owner_user_id`), most recently created first.
+Errors: none beyond the global 401.
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/paper/deployments
+```
+
+### GET /api/paper/deployments/{deployment_id}
+Get one owned deployment's current summary. | **Auth**: account-session
+
+Request: path `deployment_id`.
+Response: a `deployment_summary` object.
+Errors: `404` `Paper deployment not found` — missing, or owned by a different
+account (existence is private — a wrong-owner lookup 404s exactly like an
+unknown ID, never a 403).
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/paper/deployments/<deployment_id>
+```
+
+### POST /api/paper/deployments/{deployment_id}/stop
+Stop an owned deployment — sets its status to `stopped`; the ledger already
+written is untouched. | **Auth**: account-session
+
+Request: path `deployment_id`.
+Response: `{deployment_id: str, status: "stopped"}`.
+Errors: `404` `Paper deployment not found` — missing, or not owned by the
+caller.
+
+```bash
+curl -s -X POST -b /tmp/session.jar https://archimedes-arc.com/api/paper/deployments/<deployment_id>/stop
+```
+
+## Deployment summary shape
+
+`POST /deployments`, `GET /deployments`, and `GET /deployments/{id}` all
+return this same shape (a bare list of it for `GET /deployments`):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `deployment_id` | str | The deployment's ID. |
+| `strategy_id` | str | The strategy this deployment paper-trades. |
+| `deployed_at` | str (date) | The date the snapshot was opened; the ledger only ever holds dates `>= deployed_at`. |
+| `status` | str | `active` or `stopped`. |
+| `days` | int | Number of daily ledger rows written so far. |
+| `total_return` | float | Compounded return over the ledger, `equity_index - 1.0` on the last row (`0.0` with zero rows). |
+| `drift_detected_at` | str (datetime) \| null | Set the first time a fresh replay disagreed with an already-written ledger row; never cleared automatically once set. |
+| `series` | array | One entry per ledger day, oldest first — see below. |
+
+Each `series` entry:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `date` | str (date) | The bar's date. |
+| `daily_return` | float | That day's portfolio return (dollar-sleeve-weighted across the strategy's asset universe, faithful to the graded backtest path). |
+| `equity_index` | float | Cumulative compounded equity starting from `1.0` at deploy — this is the sparkline series a client plots directly. |
+
+```json
+{
+  "deployment_id": "dep_abc123",
+  "strategy_id": "strat_xyz",
+  "deployed_at": "2026-08-01",
+  "status": "active",
+  "days": 3,
+  "total_return": 0.0142,
+  "drift_detected_at": null,
+  "series": [
+    {"date": "2026-08-01", "daily_return": 0.004, "equity_index": 1.004},
+    {"date": "2026-08-02", "daily_return": -0.001, "equity_index": 1.003},
+    {"date": "2026-08-03", "daily_return": 0.0112, "equity_index": 1.0142}
+  ]
+}
+```
+
+---
+
+See also: `backend/archimedes/services/paper_trading.py` (replay + ledger
+mechanics) and `docs/specs/strategy-dsl-spec.md` (the DSL the snapshot spec
+must validate against).

--- a/docs/api/strategies-and-rigor.md
+++ b/docs/api/strategies-and-rigor.md
@@ -1,0 +1,282 @@
+# Strategies & Rigor API
+
+This surface covers the strategy library (curated seed strategies plus
+fusion/architect-generated ones, unified through the `strategy_passports`
+table), the portfolio advisor, stress testing, and the rigor/selection-bias
+gate that grades every strategy on DSR (Deflated Sharpe Ratio), PBO
+(Probability of Backtest Overfitting), and chronological out-of-sample Sharpe
+before it is allowed to be promoted from `candidate` to `validated` or bound
+into a vault's `strategy_ids`. The badge (`passes_rigor_gate` /
+`rigor_gate_status`) and the numeric rigor fields served by `GET
+/api/strategies/` and `GET /api/strategies/{id}` come from the **same live
+gate run** `GET /api/selection-bias/gate` uses — none of these surfaces can
+disagree with another for the same strategy at the same strictness level.
+
+**Auth model.** Reads are anonymous by default — the library, passports, the
+advisor, stress testing, and every `/api/selection-bias/*` route are public.
+Ownership-scoped reads (`GET /api/strategies/generated`) and mutations
+(`PATCH /api/strategies/{id}`, the legacy `POST /api/strategies/generate`)
+require a Better Auth account session (the `better-auth.session_token`
+cookie). Several anonymous reads additionally consult an *optional* linked- or
+SIWE-verified-wallet header/cookie purely to decide whether an unpublished row
+is visible to *this* caller (private-until-published, 404-hides-existence) —
+absence of that proof is a normal anonymous request, never an error. Examples
+needing a session assume an authenticated cookie jar at `/tmp/session.jar`.
+
+## Library & strategy endpoints
+
+### GET /api/strategies/
+List strategies in the library, backed by `LocalStrategyProvider`; the badge
+and every numeric rigor field come from a single live-gate run over the FULL
+library, before pagination. | **Auth**: anonymous
+
+Request: query `status: "candidate"|"validated"|"live"|"retired"|null, limit: int(1..100)=20, offset: int(>=0)=0`.
+Response (`StrategyListResponse`): `{strategies: [StrategyResponse], total: int}`. `StrategyResponse` carries `id, papers[], methodology_summary, asset_universe, universe_source, position_sizing, rebalance_frequency, status, sharpe_ratio, sortino_ratio, cagr, max_drawdown, win_rate, calmar_ratio, correlation_to_spy, deflated_sharpe_ratio, dsr_p_value, pbo_score, out_of_sample_sharpe, kelly_fraction, passes_rigor_gate: bool, rigor_gate_status: "pass"|"fail"|"pending"|"degenerate", is_backtest_placeholder: bool, sharpe_ci_lower/upper, backtest_start/end, regime_tag, return_source: "risk_premium"|"mispricing"|"productive_growth"|"noise", return_source_note, generation_cost, can_publish`.
+Errors: 422 on invalid `status`/`limit`/`offset`.
+
+```bash
+curl -s "https://archimedes-arc.com/api/strategies/?status=validated&limit=20&offset=0"
+```
+
+### GET /api/strategies/generated
+List fusion/architect-generated strategies from the `strategy_store` table —
+private-until-published (visible when published, or owned by the caller). |
+**Auth**: account-session
+
+Request: query `limit: int(1..200)=50`.
+Response: `{strategies: [StrategyRecord.to_dict() + can_publish: bool + generation_cost], total: int}`.
+Errors: none explicit — a DB failure degrades to an empty list (logged warning), never a 500.
+
+```bash
+curl -s -b /tmp/session.jar "https://archimedes-arc.com/api/strategies/generated?limit=50"
+```
+
+### GET /api/strategies/signals
+Evaluate all strategies against live market data and return signals. |
+**Auth**: anonymous
+
+Request: none.
+Response (`StrategySignalsResponse`): `{strategy_count: int, regime: str (legacy name for the ensemble-consensus bucket), ensemble_consensus: str|null, confidence: float, target_weights: dict[str,float], strategies: [StrategySignalResponse{strategy_id, paper_title, signals: [SignalResponse{asset, signal: "long"|"flat"|"scaled", weight, reason, strategy_name}]}], timestamp: str}`.
+Errors: none explicit.
+
+```bash
+curl -s https://archimedes-arc.com/api/strategies/signals
+```
+Note: `regime` is the `flat_pct`-derived ensemble-consensus bucket, not a true market-regime detector output.
+
+### GET /api/strategies/advisor
+Portfolio allocation recommendation based on Kelly + risk-parity math
+(LLM-agent-assisted, with a rule-based fallback). | **Auth**: anonymous
+
+Request: query `risk_profile: "fixed_income"|"conservative"|"moderate"|"aggressive"|"hyper_risky"="moderate"`.
+Response: untyped dict (no `response_model`) — `regime, regime_confidence, regime_narrative, risk_profile, usdc_weight, synth_weight, allocations: [{symbol, sharpe, cagr, max_drawdown, vol_ann, kelly_fraction, weight, passes_rigor_gate, rigor_gate_status, deflated_sharpe_ratio, dsr_p_value, pbo_score, out_of_sample_sharpe, paper_claimed_*/paper_delta_*, ...}], expected_portfolio{sharpe,cagr,max_drawdown,vol_ann,diversification_ratio,risk_aversion_gamma,optimizer_converged}, risk_decomposition, correlation_pairs, rigor_summary{total_picks,passes_rigor_gate,dsr_significant,pbo_acceptable,oos_positive,...}, stress_tests, market_scan{universe_size,fetched,top_opportunities}, agent{used,thesis,model_id,served_model,num_picks,iterations,tool_calls}, reasoning_trace{trace_id,trace_hash,canonical_preview,anchored_on_chain,anchor_tx_hash,registry_address,decision_type,trigger}`. Degrades to `{"error": "No strategies with real backtest data available", "allocations": []}` when nothing qualifies.
+Errors: no `HTTPException` raised directly — every internal step (LLM agent call, price fetch, optimizer) fails soft into a fallback path.
+
+```bash
+curl -s "https://archimedes-arc.com/api/strategies/advisor?risk_profile=moderate"
+```
+
+### GET /api/strategies/stress/scenarios
+List the available stress scenarios with descriptions. | **Auth**: anonymous
+
+Request: none.
+Response: `{scenarios: [...]}` from `stress_engine.list_scenarios()`.
+Errors: none.
+
+```bash
+curl -s https://archimedes-arc.com/api/strategies/stress/scenarios
+```
+
+### POST /api/strategies/stress/run
+Apply a stress scenario to a caller-supplied portfolio. | **Auth**: anonymous
+| **Flags**: rate limit `20/minute` (disabled under `TESTING`)
+
+Request: `{allocations: [{symbol: str, weight: number|null, ...}], scenario: str="all", usdc_weight: number=0.0}`.
+Response: `{results: [{scenario, label, description, portfolio_pnl, portfolio_value_after, per_asset_pnl}]}`.
+Errors: 400 `allocations[] is required` (missing/empty list); 422 `allocations[i] must be an object` / `allocations[i].symbol is required and must be a non-empty string` / `allocations[i].weight must be a number` / `usdc_weight must be a number`; 404 `Unknown scenario: {scenario}`.
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/strategies/stress/run \
+  -H "Content-Type: application/json" \
+  -d '{"allocations": [{"symbol": "sTSLA", "weight": 0.3}], "scenario": "all", "usdc_weight": 0.2}'
+```
+
+### GET /api/strategies/passports
+List strategies from the unified `strategy_passports` table —
+private-until-published exactly as `/generated`. | **Auth**: anonymous
+
+Request: query `status: str|null, regime_tag: str|null, limit: int(1..200)=50`.
+Response: `{passports: [dict] (owner_wallet redacted unless caller owns it), total: int, source: "strategy_passports"}`.
+Errors: none explicit.
+
+```bash
+curl -s "https://archimedes-arc.com/api/strategies/passports?limit=50"
+```
+
+### GET /api/strategies/passports/{strategy_id}
+Get a single passport in its native dict shape from `strategy_passports`;
+unpublished non-example passports 404 for non-owners, never 403. | **Auth**:
+anonymous
+
+Request: path `strategy_id`.
+Response: dict — passport record's `to_dict()` with `owner_wallet` redacted unless caller owns it.
+Errors: 404 `Passport not found` (missing, or not visible to caller).
+
+```bash
+curl -s https://archimedes-arc.com/api/strategies/passports/<strategy_id>
+```
+
+### GET /api/strategies/{strategy_id}/returns
+Return persisted real daily returns for a strategy; never synthesizes from
+fixture metrics — only real persisted run data. | **Auth**: anonymous
+
+Request: path `strategy_id`.
+Response (`StrategyReturnsResponse`): `{strategy_id, source: "persisted_backtest", start: str|null, end: str|null, n: int, daily_returns: [float]}` — `owner_wallet` intentionally absent (PII redaction).
+Errors: 404 `Strategy not found` (nonexistent, or private and caller is not the owner); 404 `no persisted returns` (strategy exists but has no `BacktestResultRecord` row); 500 `Failed to load returns` (DB read failure).
+
+```bash
+curl -s https://archimedes-arc.com/api/strategies/<strategy_id>/returns
+```
+
+### GET /api/strategies/{strategy_id}
+Get a single strategy by ID — tries the curated `LocalStrategyProvider` first,
+falls through to the `strategy_passports` table for fusion/architect-generated
+strategies. | **Auth**: anonymous
+
+Request: path `strategy_id`.
+Response: `StrategyResponse` (same shape as the list endpoint's items).
+Errors: 404 `Strategy not found` (nonexistent, or private and caller is not the owner — a 404 here prevents existence probing).
+
+```bash
+curl -s https://archimedes-arc.com/api/strategies/<strategy_id>
+```
+
+### PATCH /api/strategies/{strategy_id}
+Rename an owned, generated strategy — owner-gated; curated examples
+(`is_example`) are not renamable. | **Auth**: account-session
+
+Request: `{name: str (1..80 chars after trim)}`.
+Response: `{strategy: StrategyRecord.to_dict()}`.
+Errors: 422 `'name' (string) is required` / `name must be 1–80 characters after trimming`; 404 `Strategy not found` (missing row, curated example, or unpublished + not owner); 403 `Not authorized to rename this strategy` (published row, caller not owner).
+
+```bash
+curl -s -X PATCH https://archimedes-arc.com/api/strategies/<strategy_id> \
+  -b /tmp/session.jar -H "Content-Type: application/json" -d '{"name": "Momentum v2"}'
+```
+
+### POST /api/strategies/generate
+**(roadmap-superseded — legacy direct-fusion path; `POST /api/generate/start`
+is the sole live interactive generation pipeline, per the
+[debate-society-sole-generation-pipeline ADR](../adr/debate-society-sole-generation-pipeline.md).
+The route's own docstring notes the `mode=fast` Strategy Architect branch was
+removed in #1064.)** Queue a strategy generation job via the direct-fusion
+path; returns 202 + `job_id` immediately. | **Auth**: account-session |
+**Flags**: `ARCHIMEDES_FUSION_ENABLED=1` (fusion disabled without it), rate
+limit `20/minute` (disabled under `TESTING`)
+
+Request: query `asset_classes: str="" (comma-separated), risk_appetite: str="moderate", strategic_direction: str="", max_papers: int=4`.
+Response (202): `{status: "queued", job_id: str}`.
+Errors: 503 `"Fusion is disabled. Set ARCHIMEDES_FUSION_ENABLED=1."` (fusion not enabled); 503 `"Insufficient corpus ({n} papers). Need ≥2 for fusion."` (corpus under 2 papers).
+
+```bash
+curl -s -X POST -b /tmp/session.jar \
+  "https://archimedes-arc.com/api/strategies/generate?asset_classes=equities&risk_appetite=moderate&max_papers=4"
+```
+
+### GET /api/strategies/generate/{job_id}
+Poll a strategy generation (fusion) job. Returns status + result when done. |
+**Auth**: account-session
+
+Request: path `job_id`.
+Response: raw job dict from `JobStore` (`job_type="fusion"`) — status + result.
+Errors: 404 `Job not found` (missing, or `owner_user_id` set and not the caller).
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/strategies/generate/<job_id>
+```
+
+## Rigor gate (selection-bias) endpoints
+
+### GET /api/selection-bias/gate
+Evaluate the rigor gate for all strategies in the library — DSR, PBO,
+chronological OOS Sharpe, plus the look-ahead static audit per strategy. |
+**Auth**: anonymous
+
+Request: query `strictness: int(1..5)=1` (1 = strictest/badge level).
+Response (`RigorGateResponse`): `{strategies: [StrategyRigorResult{strategy_id, strategy_name, passes_all: bool, gate_details: RigorGateDetail{dsr,pbo,oos_sharpe,look_ahead,cpcv,dsr_convention,iid,regime_robustness}, deflated_sharpe, dsr_p_value, pbo_score, oos_sharpe, in_sample_sharpe, library_pbo: LibraryPbo{value,data_vintage,selection_set_size,source}, strictness_level, min_passing_level, blocked_by_floor, num_trials_scope}], total, passing, failing, library_pbo, strictness_level}`.
+Errors: none explicit — strategies with fewer than 10 persisted daily returns report every `gate_details` field as an explicit `"MISSING (no backtest data)"` string rather than erroring. `cpcv` is always an explicit `NOT_RUN` status (the combinatorial-split OOS matrix isn't wired yet), never a bare `MISSING`.
+
+```bash
+curl -s "https://archimedes-arc.com/api/selection-bias/gate?strictness=1"
+```
+
+### GET /api/selection-bias/gate/{strategy_id}
+Evaluate the rigor gate for a single strategy at `strictness` (default =
+badge level); tries the curated cohort first, falls through to grading a
+DB-persisted (fusion/architect-generated) strategy on its own context. |
+**Auth**: anonymous | **Flags**: rate limit `10/minute` (disabled under
+`TESTING`)
+
+Request: path `strategy_id`; query `strictness: int(1..5)=1`.
+Response: `StrategyRigorResult` (same shape as the `/gate` list item).
+Errors: 404 `Strategy not found` (unknown to both the curated provider and the generated-strategy path, or not visible to caller); 404 `Strategy not found in gate results` (fallthrough after the full curated gate run).
+
+```bash
+curl -s "https://archimedes-arc.com/api/selection-bias/gate/<strategy_id>?strictness=1"
+```
+
+### GET /api/selection-bias/strictness-ladder
+Disclose the full 1–5 strictness ladder plus the always-on floors — single
+source of truth for the UI's strictness slider. | **Auth**: anonymous
+
+Request: none.
+Response (`StrictnessLadderResponse`): `{levels: [StrictnessLevelInfo{level,label,dsr_p_min,pbo_max,oos_is_ratio_min,description}], strictest_level, loosest_level, badge_level, default_level, floors: {dsr_p_floor, oos_abs_floor, cpcv_min_positive_fraction}}`.
+Errors: none.
+
+```bash
+curl -s https://archimedes-arc.com/api/selection-bias/strictness-ladder
+```
+
+### POST /api/selection-bias/pbo
+Compute PBO (Probability of Backtest Overfitting) across a caller-supplied
+set of strategy return series — a library-level metric. | **Auth**: anonymous
+| **Flags**: rate limit `20/minute` (disabled under `TESTING`)
+
+Request (`PBORequest`): `{returns_matrix: dict[str, list[float]], s_partitions: int=16}`.
+Response (`PBOResponse`): `{pbo_scores: dict[str, float], interpretation: str}`.
+Errors: none explicit.
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/selection-bias/pbo \
+  -H "Content-Type: application/json" \
+  -d '{"returns_matrix": {"strat_a": [0.001, -0.002, 0.003]}, "s_partitions": 16}'
+```
+
+## Rigor gate status semantics (honesty note)
+
+The gate reports a **multi-state status** — `rigor_gate_status` on
+`StrategyResponse`; `passes_all` + `gate_details` on `StrategyRigorResult` —
+never a plain pass/fail boolean pretending the underlying evidence is always
+conclusive:
+
+| Status | Meaning |
+|---|---|
+| `pass` | The live gate ran on persisted real returns and every enabled criterion (DSR significance, PBO, chronological OOS Sharpe, the look-ahead audit, plus the always-on floors) cleared at the requested strictness level. |
+| `fail` | The live gate ran and at least one criterion did not clear. |
+| `pending` | No live verdict could be computed — no, or fewer than 10, persisted daily returns, or a batch/DB failure. Rendered as `"MISSING (no backtest data)"` per criterion, never a fabricated pass or fail. |
+| `degenerate` | A persisted return series exists but is zero-variance (flat/placeholder). It is still graded on its own row, excluded from cohort correlation/PBO context so it cannot dilute other strategies' numbers, and reported honestly rather than silently passing or silently disappearing. |
+
+`passes_rigor_gate` (`StrategyResponse`) is the fail-closed boolean derived
+from this status — `True` only when the status is exactly `pass`.
+
+**Never quote a curated-library pass count anywhere** — not in this doc, not
+in UI copy, not in pitch material. A pass count is a snapshot of a live,
+per-request computation over whichever cohort and strictness level happened
+to be in view; it is not a static fact about the library. Three strategies
+once reported "passing" turned out to be grading a substitute data feed
+(equity-like ~18.5% annual vol) rather than the strategy's own series — the
+corrected count is **not established**, and restating any remembered number
+here would repeat exactly that mistake. If a surface needs to say something
+quantitative, point at the live `GET /api/selection-bias/gate` response — its
+`total`/`passing`/`failing` fields as of *this* call — rather than a cached or
+remembered figure.

--- a/docs/api/strategies-and-rigor.md
+++ b/docs/api/strategies-and-rigor.md
@@ -157,7 +157,7 @@ Rename an owned, generated strategy — owner-gated; curated examples
 
 Request: `{name: str (1..80 chars after trim)}`.
 Response: `{strategy: StrategyRecord.to_dict()}`.
-Errors: 422 `'name' (string) is required` / `name must be 1–80 characters after trimming`; 404 `Strategy not found` (missing row, curated example, or unpublished + not owner); 403 `Not authorized to rename this strategy` (published row, caller not owner).
+Errors: 422 `'name' (string) is required` / `name must be 1–80 characters after trimming`; 404 `Strategy not found` (missing row, curated example, or unpublished + not owner); 403 `Not authorized to rename this strategy.` (published row, caller not owner).
 
 ```bash
 curl -s -X PATCH https://archimedes-arc.com/api/strategies/<strategy_id> \

--- a/docs/api/vaults-and-chain.md
+++ b/docs/api/vaults-and-chain.md
@@ -1,0 +1,308 @@
+# Vaults & On-Chain API
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+The marketplace's on-chain surface: vault discovery and creation, off-chain
+vault metadata (display name, strategy bindings), reasoning-trace publish/
+verify, the AMM swap preview, deployed contract addresses, and the health/
+root endpoints operators and CI probe. Every route here was checked directly
+against its router source (`vaults_routes.py`, `traces_routes.py`,
+`swap_routes.py`, `config_routes.py`, `main.py`) — no undocumented route was
+found in their scope.
+
+**Vaults are non-custodial by design.** `POST /api/vaults/create` deploys the
+vault with the backend signer, then transfers on-chain `Ownable` ownership to
+the caller's verified linked wallet and pins the backend only as the
+rebalance-only agent — so `owner == user` and `agent == backend`. A
+compromised backend/agent key can rebalance but cannot re-point the oracle,
+widen slippage, pause, or otherwise drain the vault.
+
+**Server-side rigor enforcement, not just a UI gate.** Every path that binds
+a strategy to a vault — `POST /api/vaults/create`, `POST
+/api/vaults/metadata` — re-checks each strategy against the live rigor gate
+at the caller's chosen `strictness_level` **before** spending gas or
+persisting the link, and refuses (`422`) any strategy that hasn't passed at
+that level. The always-on correctness floors (look-ahead audit, positive OOS,
+DSR ≥ 0.50) hold at every strictness level — a caller can trade statistical
+confidence for breadth, never bypass the floor entirely. This exists because
+the frontend's own Deploy gate is defense-in-depth, not the guarantee: a
+direct API caller must hit the same wall a UI user does.
+
+**Auth model.** Reads (`GET /api/vaults/`, `GET /api/vaults/{address}`, `GET
+/api/vaults/{address}/health`, `GET /api/vaults/{address}/metadata`, and
+everything under `/api/traces/`, `/api/swap/`, `/api/config/`, and the health/
+root endpoints) are anonymous. Anything that spends gas, writes vault
+metadata, or derives allocations (`POST /api/vaults/create`, `POST
+/api/vaults/metadata`, `POST /api/vaults/{address}/derive-allocations`)
+requires a Better Auth account session **and** a verified linked wallet
+(`require_linked_wallet`). `POST /api/traces/publish` is `internal-key`
+(`X-Internal-Agent-Key`, `hmac.compare_digest` against
+`INTERNAL_AGENT_API_KEY` — fails closed if that env var is unset). Examples
+needing a session assume an authenticated cookie jar at `/tmp/session.jar`.
+
+## Vaults
+
+### GET /api/vaults/
+List vaults for the marketplace leaderboard. | **Auth**: anonymous
+
+Request: query `tier: int(1..2)|null, sort_by: "aum"|"return_24h"|"return_7d"|"sharpe"|"created_at" = "aum", order: "asc"|"desc" = "desc", limit: int(1..100)=20, offset: int(>=0)=0`.
+Response (`VaultListResponse`): `{vaults: [VaultSummaryResponse{address, name, symbol, tier, creator, aum_usdc, share_price, return_24h/7d/30d/inception: float|null, returns_source: "oracle_baseline"|"unavailable", sharpe_ratio, management_fee_pct, performance_fee_pct, is_agent_assisted, depositors, last_rebalance, created_at}], total: int}`. Return fields are `null` unless backed by a real oracle-price baseline comparison — `returns_source` names the provenance honestly rather than defaulting to `0`.
+Errors: none explicit.
+
+```bash
+curl -s "https://archimedes-arc.com/api/vaults/?tier=1&sort_by=aum&limit=20"
+```
+
+### POST /api/vaults/create
+Deploy a new vault on Arc via `VaultFactory`. | **Auth**: linked-wallet |
+**Flags**: rate limit `5/minute` (disabled under `TESTING`)
+
+Request (`VaultCreateRequest`): `{name: str(1..64), symbol: str(1..16), management_fee_bps: int=0, performance_fee_bps: int(0..3000)=0, agent_assisted: bool=true, strategy_ids: [str]=[], strictness_level: int(1..5)=1}`.
+Response (`VaultCreateResponse`): `{vault_address: str, strategy_ids: [str]}`.
+Errors: `422` — a bound strategy fails the rigor gate at `strictness_level` (server-side enforcement, see above); `503` — chain executor unavailable; `500` `Vault deployment failed` (generic — the raw chain/DB exception is never echoed to the client).
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/vaults/create \
+  -b /tmp/session.jar -H "Content-Type: application/json" \
+  -d '{"name": "Momentum Vault", "symbol": "MOMV", "strategy_ids": ["<strategy_id>"], "strictness_level": 1}'
+```
+
+### GET /api/vaults/{address}/health
+Vault health snapshot — agent liveness, rebalance staleness, AUM trend. |
+**Auth**: anonymous
+
+Request: path `address`.
+Response: `{vault_address, agent_alive: bool, last_heartbeat: str|null, last_rebalance: str|null, rebalance_age_seconds: float|null, aum_trend_pct: float, snapshot_count: int, latest_snapshot: dict|null, sharpe_drift: {available: bool, reason: str}, recent_events: [dict]}`. `agent_alive` is `true` only when the agent's Redis heartbeat is under 10 minutes old. `sharpe_drift.available` is currently always `false` (`reason: "baseline_backtest_sharpe_unavailable"`) — a strategy-specific backtest baseline isn't wired in yet, so drift is honestly reported as unavailable rather than computed from a stand-in value.
+Errors: none explicit — degrades to empty/default fields on a backing-store failure.
+
+```bash
+curl -s https://archimedes-arc.com/api/vaults/<address>/health
+```
+
+### GET /api/vaults/{address}
+Full vault detail page data — holdings, target allocations, equity curve,
+recent traces. | **Auth**: anonymous
+
+Request: path `address`.
+Response (`VaultDetailResponse`): `{address, name, symbol, tier, creator, aum_usdc, share_price, is_agent_assisted, management_fee_pct, performance_fee_pct, high_water_mark, holdings: [VaultHolding{symbol, token_address, amount, value_usdc, weight_pct}], target_allocations: [VaultHolding], return_24h/7d/30d/inception: float|null, returns_source: "oracle_baseline"|"unavailable", sharpe_ratio, max_drawdown, equity_curve: [PricePoint], strategy_ids: [str], current_regime: str|null, recent_traces: [TraceResponse], depositors, last_rebalance, created_at}`.
+Errors: `404` `Vault not found` — unknown address. `400`/`502` — the vault exists but its **fee guard** refuses it (issue #1138): `400` when fees are verifiably over-cap (the reason names the values), `502` when fees can't be verified on-chain (fail-closed rather than silently trusting an unverifiable number).
+
+```bash
+curl -s https://archimedes-arc.com/api/vaults/<address>
+```
+
+### POST /api/vaults/metadata
+Store off-chain vault metadata (display name, strategy bindings) — the
+client-signed deploy path's choke point. | **Auth**: linked-wallet | **Flags**:
+rate limit `10/minute` (disabled under `TESTING`)
+
+Request (`VaultMetadataRequest`): `{vault_address: "0x"+40hex, name: str(<=64)="", symbol: str(<=16)="", creator_address: str="", strategy_ids: [str]=[], strictness_level: int(1..5)=1}`.
+Response (`VaultMetadataResponse`): `{vault_address, name, symbol, creator_address, strategy_ids, created_at: str|null}`.
+Errors: `403` "Only the vault's on-chain owner may edit its metadata." — caller's linked wallet isn't the vault's actual on-chain `Ownable` owner (closes an IDOR, #916: metadata ownership is read from the contract, never "whoever wrote first"); `503` — on-chain owner unreadable, fails closed rather than letting an unverifiable caller claim the vault; `409` "Vault metadata belongs to another account" — a different account already owns this metadata row; `422` — any `strategy_ids` entry fails the rigor gate at `strictness_level`; `500` `Vault metadata update failed` (generic).
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/vaults/metadata \
+  -b /tmp/session.jar -H "Content-Type: application/json" \
+  -d '{"vault_address": "0x1234567890123456789012345678901234567890", "name": "Momentum Vault", "strategy_ids": ["<strategy_id>"], "strictness_level": 1}'
+```
+
+### GET /api/vaults/{address}/metadata
+Get off-chain vault metadata. | **Auth**: anonymous
+
+Request: path `address`.
+Response (`VaultMetadataResponse`): same shape as the `POST` above.
+Errors: `404` "No metadata for this vault" — no metadata row exists yet.
+
+```bash
+curl -s https://archimedes-arc.com/api/vaults/<address>/metadata
+```
+
+### POST /api/vaults/{address}/derive-allocations
+**(roadmap-hidden — the API is live and enforced; no frontend surface calls
+it. A repo-wide search of `ui/src` finds zero call sites for
+`derive-allocations`.)** Derive Kelly-sized target allocations from selected
+strategies — returns the derived weights for the UI to submit as an
+on-chain `setTargetAllocations` tx via the user's own wallet; does **not**
+execute on-chain itself. | **Auth**: linked-wallet | **Flags**: rate limit
+`20/minute` (disabled under `TESTING`)
+
+Request (`SetAllocationsRequest`): `{strategy_ids: [str]=[], usdc_floor_pct: float(0..80)=20.0, risk_profile: "fixed_income"|"conservative"|"moderate"|"aggressive"|"hyper_risky"="moderate", strictness_level: int(1..5)=1}`.
+Response (`SetAllocationsResponse`): `{allocations: [{symbol, token_address, weight_bps}], total_bps: int (should equal 10000), strategy_count: int, risk_profile: str, sized_strategies: dict[str,float] (per-strategy capital fraction = passport half-Kelly × profile multiplier), excluded_strategy_ids: [str] (selected strategies sized to zero — rigor-gate fail or no stored kelly_fraction)}`. With no strategies selected, allocations fall back to an even USDC-floor + synthetic-universe split.
+Errors: none explicit beyond the linked-wallet gate — a strategy that doesn't clear `strictness_level` sizes to zero (`excluded_strategy_ids`) rather than erroring the whole request.
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/vaults/<address>/derive-allocations \
+  -b /tmp/session.jar -H "Content-Type: application/json" \
+  -d '{"strategy_ids": ["<strategy_id>"], "risk_profile": "moderate", "strictness_level": 1}'
+```
+
+## Reasoning traces
+
+### GET /api/traces/
+List reasoning traces — merges off-chain (Redis) metadata with on-chain IDs,
+falling back to an on-chain-only listing when Redis is unavailable. |
+**Auth**: anonymous
+
+Request: query `vault_address: str|null, decision_type: "construction"|"rebalance"|"rotation"|"regime_change"|"skip"|null, limit: int(1..100)=20, offset: int(>=0)=0`.
+Response (`TraceListResponse`): `{traces: [TraceResponse], total: int}`. `TraceResponse` carries `id, vault_address, decision_type, trigger, timestamp, reasoning, confidence, trace_hash, arc_tx_hash: str|null, is_verified: bool, regime_at_decision, trades_executed, strategies_referenced, commit_tx_hash/commit_block_number, reveal_tx_hash/reveal_block_number, trade_tx_hash/trade_block_number, temporal_binding_valid: bool|null, temporal_binding_source: str="none"`.
+Errors: none explicit — a Redis outage degrades to the on-chain-only path rather than erroring.
+
+```bash
+curl -s "https://archimedes-arc.com/api/traces/?vault_address=<address>&limit=20"
+```
+
+### GET /api/traces/{trace_id}
+Get a single reasoning trace by ID (off-chain UUID or on-chain integer ID). |
+**Auth**: anonymous
+
+Request: path `trace_id`.
+Response: `TraceResponse` (same shape as the list item).
+Errors: `404` `Trace not found` — unknown ID, in either off-chain or on-chain form.
+
+```bash
+curl -s https://archimedes-arc.com/api/traces/<trace_id>
+```
+
+### POST /api/traces/publish
+Publish a reasoning trace — computes its hash, anchors it on Arc, persists it
+off-chain. Internal-only, called by the agent runner. | **Auth**:
+internal-key
+
+Request (`TracePublishRequest`): `{vault_address: str, decision_type: "construction"|"rebalance"|"rotation"|"regime_change"|"skip"="construction", trigger: str="manual", reasoning: str="", confidence: float=0.0, market_context: dict={}, portfolio_before: dict={}, portfolio_after: dict={}, trades_executed: [dict]=[], strategies_referenced: [str]=[]}`.
+Response (`TracePublishResponse`): `{id: str (uuid), trace_hash: str (keccak256), arc_tx_hash: str|null, is_anchored: bool, timestamp, vault_address, decision_type}`.
+Errors: `400` — invalid `decision_type`. `403` `Forbidden` — missing/wrong `X-Internal-Agent-Key`. `503` — off-chain persistence failed; the response names whether the on-chain anchor still landed (`"Trace anchored on-chain (tx {hash}) but off-chain persistence failed — retry publish."`) so a retry doesn't silently produce a trace with an anchor that can never be re-verified against its own content.
+
+```bash
+curl -s -X POST https://archimedes-arc.com/api/traces/publish \
+  -H "X-Internal-Agent-Key: $INTERNAL_AGENT_API_KEY" -H "Content-Type: application/json" \
+  -d '{"vault_address": "<address>", "decision_type": "rebalance", "reasoning": "Rotated into momentum sleeve.", "confidence": 0.82}'
+```
+
+### GET /api/traces/{trace_id}/verify
+Verify a reasoning trace against its on-chain anchor. | **Auth**: anonymous
+| **Flags**: rate-limit exempt
+
+Request: path `trace_id`.
+Response (`TraceVerifyResponse`): `{trace_id: int, trace_hash, is_verified: bool, agent, vault, on_chain_timestamp: int, details: str, temporal_binding_valid: bool|null, commit_block_number, trade_block_number, reveal_block_number}`.
+Errors: `404` `Trace not found` — unknown ID.
+
+On-chain verification is **O(1)**: the handler fetches the receipt for the
+trace's cached `arc_tx_hash` and decodes the `TracePublished` event directly,
+rather than the prior O(N) `getTracesByVault → getTraceById` scan that
+returned 504 on vaults with 40+ traces.
+
+```bash
+curl -s https://archimedes-arc.com/api/traces/<trace_id>/verify
+```
+
+### GET /api/traces/{trace_id}/canonical
+Get the canonical JSON used to compute a trace's hash — the exact bytes a
+verifier re-hashes to check `trace_hash`. | **Auth**: anonymous
+
+Request: path `trace_id`.
+Response: `text/plain` (raw canonical JSON string; not wrapped in an envelope).
+Errors: `404` `Trace not found` — unknown ID. `503` "Trace store temporarily unavailable — retry." — Redis unreachable; deliberately distinguished from `404` so a hash-reverification consumer retries instead of concluding the trace doesn't exist.
+
+```bash
+curl -s https://archimedes-arc.com/api/traces/<trace_id>/canonical
+```
+
+## Swap (AMM)
+
+**(roadmap-hidden — both routes below are live and enforced; no frontend
+surface calls them. A repo-wide search of `ui/src` finds no Swap/Exchange
+component and zero call sites for `/api/swap/*`.)**
+
+### GET /api/swap/quote
+Preview a swap via the AMM router before the user signs anything. |
+**Auth**: anonymous | **Flags**: rate limit `30/minute` (disabled under
+`TESTING`)
+
+Request: query `token_in: str (address), token_out: str (address), amount_in: float(>0)`.
+Response (`SwapQuoteResponse`): `{token_in, token_out, amount_in, amount_out, price_impact_pct, fee_pct: 0.3, min_amount_out}`.
+Errors: `400` "Quote failed — check the token pair and amount." — any chain/web3 failure is collapsed to this generic message; the raw exception (which can leak RPC internals, contract addresses, or revert reasons) is logged server-side only, never echoed to the client.
+
+```bash
+curl -s "https://archimedes-arc.com/api/swap/quote?token_in=<usdc_address>&token_out=<synth_address>&amount_in=100"
+```
+
+### GET /api/swap/pools
+List AMM pools and reserves. | **Auth**: anonymous
+
+Request: none.
+Response (`PoolListResponse`): `{pools: [PoolResponse{address, token0, token1, symbol0, symbol1, reserve0, reserve1, tvl_usdc, volume_24h_usdc: 0.0, fee_pct, apr_pct: null, total_supply}], total: int}`. `volume_24h_usdc` is always `0.0` (not wired) and `apr_pct` is always `null` — both honest placeholders, not computed estimates.
+Errors: none explicit — a per-pool read failure silently drops that pool from the list rather than failing the whole request.
+
+```bash
+curl -s https://archimedes-arc.com/api/swap/pools
+```
+
+## Config
+
+### GET /api/config/contracts
+All deployed contract addresses — what the frontend (or any direct on-chain
+caller) needs to call the chain itself. | **Auth**: anonymous
+
+Request: none.
+Response (`ContractAddressesResponse`): `{usdc, synthetic_factory, amm_router, vault_factory, reasoning_trace_registry, asset_registry, price_oracle, synthetics: dict[str,str] (symbol -> address), pools: dict[str,str] (pair -> address)}`.
+Errors: none explicit.
+
+**Contract counts come from this endpoint, not from prose** — per
+`docs/CONVENTIONS.md`, a stale count in a doc is worse than no count.
+
+```bash
+curl -s https://archimedes-arc.com/api/config/contracts
+```
+
+## Health and root
+
+### GET /api/health (and GET /health)
+Primary health check — Docker healthcheck, ALB target-group health, CI/CD. |
+**Auth**: anonymous | **Flags**: rate-limit exempt
+
+Request: none.
+Response: `{status: "ok"|"degraded", service: "archimedes-backend", version: str (git SHA), chain_connected: bool, human_count, agent_count, real_users, corpus_papers, corpus_db_count, corpus_source, corpus_last_intake, artifact_hash, corpus_embedded: bool, corpus_kg_built: bool, corpus_kg_entities: int, corpus_kg_relations: int, corpus_artifact_present: bool, fusion_enabled: bool, llm_provider, llm_backend, llm_model, llm_available, llm_has_api_key, llm_has_auth_token, llm_has_base_url, paper_rag: str, paper_rag_reason, regime_detector: str, regime_detector_reason, risk_data: str, risk_data_reason, strategy_count: int}`. `status` is deliberately still `"ok"` (HTTP 200) even when `chain_connected: false` — a transient Arc RPC blip must not cascade the whole ECS service down; the disconnect is instead logged loudly (`HEALTH_CHAIN_DISCONNECTED`) for a CloudWatch metric-filter alarm. `corpus_embedded`/`corpus_kg_built`/`corpus_kg_relations`/`corpus_artifact_present` are claim-integrity fields (issue #778) — they report what has actually been built on top of the manifest-seeded `papers` table, never a constant; today none of embeddings, KG, or a pipeline artifact exist in prod, so this endpoint reports that honestly rather than implying semantic retrieval that isn't there.
+Errors: none — always 200 (fail-soft by design; see `status` above).
+
+```bash
+curl -s https://archimedes-arc.com/api/health
+```
+
+### GET /health/paper-rag
+Dedicated paper-RAG health probe — the one endpoint allowed to pay the
+~521 MB model-load cost (the ALB-polled `/health` deliberately does not). |
+**Auth**: anonymous | **Flags**: rate-limit exempt
+
+Request: none.
+Response: `{paper_rag: str, reason: str}`.
+Errors: none.
+
+```bash
+curl -s https://archimedes-arc.com/health/paper-rag
+```
+
+### GET /api/health/amm (and GET /health/amm)
+AMM pool liquidity health — per-pool status for operator/judge probes. |
+**Auth**: anonymous | **Flags**: rate-limit exempt
+
+Request: none.
+Response: `{status: "ok", pool_count: int, pools: [{address, token0, token1, reserve0, reserve1} | {address, error: str}]}` on success.
+Errors: `503` `{status: "chain_disconnected", reason: "Cannot reach Arc RPC"}` — Arc RPC unreachable. `503` `{status: "amm_pools_not_initialized", reason: "...", pools: []}` — no pools exist yet. `503` `{status: "amm_health_check_failed", reason: "..."}` — any other failure; the raw exception is logged server-side only (never echoed) and this endpoint **never returns 404**.
+
+```bash
+curl -s https://archimedes-arc.com/api/health/amm
+```
+
+### GET /
+Root — service identity + agent-discoverability pointers. | **Auth**:
+anonymous | **Flags**: rate-limit exempt
+
+Request: none.
+Response: `{name: "Archimedes", tagline: str, docs: "/docs"|"disabled (production)", llms_txt: "/llms.txt", agent_manifest: "/api/agent/manifest", agent_docs: "see /llms.txt"}`. `docs` reports `"disabled (production)"` whenever `/docs` and `/openapi.json` are gated off — see [`README.md`](README.md) for the exact `PUBLIC_DOMAIN` / `ENABLE_API_DOCS` rule.
+Errors: none.
+
+```bash
+curl -s https://archimedes-arc.com/
+```

--- a/docs/api/wallets.md
+++ b/docs/api/wallets.md
@@ -1,0 +1,184 @@
+# Wallet Linking API
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-20
+
+`/api/wallets/*` — a verified EIP-4361 ("Sign-In with Ethereum" message format, repurposed
+here as a **link** proof rather than a login proof) that ties an external wallet
+(MetaMask, another EIP-1193 wallet, or a Circle Modular smart wallet) to the caller's
+canonical Better Auth account. Linking a wallet never creates or replaces an account
+session by itself — connecting a wallet is not how you log in; **you must already be
+signed in (`POST /api/auth/sign-in/email` or OAuth — see `docs/api/auth-and-accounts.md`)
+before you can link one.**
+
+**Auth model.** Every route below requires a Better Auth account session
+(`Depends(require_current_user)`, `backend/archimedes/api/account_auth.py`) — the same
+`better-auth.session_token` cookie the auth sidecar issues, checked by FastAPI via that
+sidecar's `GET /api/auth/get-session`. A verified link does **not** itself prove present
+control of the wallet on a later request: `GET /api/wallets` and its neighbors read a
+database row, not a fresh signature. Anything that moves funds or performs an irreversible
+on-chain action needs its own fresh signature elsewhere in the API, never this cached link.
+
+**The flow.**
+1. `POST /api/wallets/challenge` — signed in, ask the server to mint a challenge for
+   `{address, chain_id, provider}`. The server stores a SHA-256 hash of a random nonce
+   bound to the caller's user ID, the normalized address, chain ID, domain, URI, provider,
+   issue time, and a 5-minute expiry, and returns the exact EIP-4361 text to sign.
+2. The wallet signs that message (MetaMask, a browser EIP-1193 provider, a Circle passkey
+   wallet, or a raw key for a headless/agent caller — `provider: "headless"` exists
+   specifically for the last case, #1293).
+3. `POST /api/wallets/verify` — send back `{message, signature}`. The server re-derives the
+   expected message from the stored challenge byte-for-byte, atomically marks the challenge
+   consumed (a race loses with `409`), recovers the signer (EOA `secp256k1` first, falling
+   through to an ERC-1271/ERC-6492 deployless `eth_call` against Arc RPC for smart wallets),
+   and on success inserts (or returns) the `LinkedWallet` row.
+
+The EIP-4361 challenge message (`_challenge_message` in `wallet_routes.py`) has this exact
+shape:
+
+```
+<domain> wants you to sign in with your Ethereum account:
+<checksummed-address>
+
+Link this wallet to your authenticated Archimedes account.
+
+URI: <site-url>
+Version: 1
+Chain ID: <chain_id>
+Nonce: <32-hex-char nonce>
+Issued At: <ISO-8601 UTC>
+Expiration Time: <ISO-8601 UTC, issued + 5 min>
+```
+
+`domain`/`URI` resolve from `PUBLIC_DOMAIN`, falling back to `BETTER_AUTH_URL` — `503`
+("Wallet linking is not configured") if neither is a valid `http(s)://host` URL. `chain_id`
+must equal `ARC_CHAIN_ID` (env, default `5042002`) or the challenge is refused with `400`
+("Unsupported wallet chain") before any message is even built. The normalized link
+identity is `<chain_id>:<lowercase-address>` — unique per wallet-per-chain; a wallet
+already linked to a *different* account returns `409`, and ownership is never transferred
+automatically.
+
+**Legacy-data claim (side effect, not a separate call).** A successful verify auto-claims
+any pre-account (SIWE-era) `StrategyRecord` / `StrategyPassportRecord` /
+`StrategyProposal` / `VaultMetadata` row still carrying that wallet address with a `NULL
+owner_user_id` — and the first linked wallet on an account is automatically marked
+`is_primary`. `GET /api/wallets/check` lets the UI ask ahead of time, for a candidate
+address, whether linking it would actually claim anything — without yet proving control of
+that address (it answers only a boolean; counts stay behind the signature proof).
+
+---
+
+### GET /api/wallets
+List the caller's own linked wallets. | **Auth**: account-session
+
+Request: none.
+Response: `list[{id, address, display_address, chain_id, provider, is_primary,
+verified_at}]` — `provider ∈ {metamask, browser, circle, headless}`, recorded as
+provenance only (never a permission grant).
+Errors: `401` — no session.
+
+```bash
+curl -sS -b /tmp/session.jar http://localhost:8080/api/wallets
+```
+
+### GET /api/wallets/check
+Would linking `address` reclaim pre-account (SIWE-era) data for me? | **Auth**:
+account-session
+
+Request: query `address: str` (`^0x[a-fA-F0-9]{40}$`).
+Response: `{has_legacy_data: bool}`.
+Errors: `401` — no session. `422` — `address` fails the hex-address pattern.
+
+```bash
+curl -sS -b /tmp/session.jar \
+  "http://localhost:8080/api/wallets/check?address=0x1234567890123456789012345678901234567890"
+```
+
+### POST /api/wallets/challenge
+Issue an EIP-4361 wallet-link challenge to sign. | **Auth**: account-session | **Flags**:
+`chain_id` must equal `ARC_CHAIN_ID` (env, default `5042002`)
+
+Request: JSON body `{address: "0x"+40hex, chain_id: int>0, provider:
+"metamask"|"browser"|"circle"|"headless", circle_wallet_id?: str (only valid with
+provider="circle")}`.
+Response: `{message: str, expires_at: datetime}` — the exact text (see the flow above) to
+hand to the wallet for signing; valid 5 minutes.
+Errors:
+- `400` "Unsupported wallet chain" — `chain_id` isn't the supported Arc chain.
+- `503` "Wallet linking is not configured" — `PUBLIC_DOMAIN`/`BETTER_AUTH_URL` unset or
+  malformed.
+- `422` — body validation (bad address pattern, `circle_wallet_id` set with a
+  non-`circle` provider).
+- `401` — no session.
+
+```bash
+curl -sS -b /tmp/session.jar -X POST http://localhost:8080/api/wallets/challenge \
+  -H 'Content-Type: application/json' \
+  -d '{"address":"0x1234567890123456789012345678901234567890","chain_id":5042002,"provider":"metamask"}'
+```
+
+### POST /api/wallets/verify
+Verify the signed challenge and link the wallet to the account. | **Auth**:
+account-session | **Flags**: EOA secp256k1 recovery first, ERC-1271/ERC-6492 smart-wallet
+fallback second (deployless `eth_call` against Arc RPC)
+
+Request: JSON body `{message: str (1-4096 chars), signature: str (1-8192 chars)}` —
+`message` must be byte-for-byte the text `POST /api/wallets/challenge` returned.
+Response: `{id, address, display_address, chain_id, provider, is_primary, verified_at}` —
+the newly linked (or, if you already own this exact `<chain_id>:<address>`, the existing)
+wallet row.
+Errors:
+- `401` "Wallet challenge is invalid or expired" — no session, no matching challenge, or
+  challenge expired.
+- `401` "Wallet proof does not match its challenge" — the signed message doesn't
+  byte-for-byte match the stored challenge (checked twice: raw text equality, then a
+  field-by-field re-derivation).
+- `401` "Invalid wallet signature" — both EOA recovery and ERC-1271/ERC-6492 verification
+  failed.
+- `409` "Wallet challenge was already used" — race-condition guard, checked twice (an
+  atomic update-count check, then an `IntegrityError` fallback).
+- `409` "Wallet is already linked to another account" — the normalized `<chain_id>:<address>`
+  identity already belongs to a different user; ownership is never transferred
+  automatically. (A same-user re-verify of an already-linked wallet is idempotent, not an
+  error.)
+- `422` — body validation (message/signature length bounds).
+
+```bash
+curl -sS -b /tmp/session.jar -X POST http://localhost:8080/api/wallets/verify \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"<exact challenge text from /challenge>","signature":"0x..."}'
+```
+
+### POST /api/wallets/{wallet_id}/primary
+Set a linked wallet as the account's primary wallet. | **Auth**: account-session
+
+Request: path `wallet_id: str`.
+Response: `{id, address, display_address, chain_id, provider, is_primary, verified_at}`
+(now `is_primary: true`).
+Errors: `401` — no session. `404` "Wallet not found" — `wallet_id` not found for this user.
+
+```bash
+curl -sS -b /tmp/session.jar -X POST http://localhost:8080/api/wallets/wallet-abc123/primary
+```
+
+### DELETE /api/wallets/{wallet_id}
+Unlink a wallet from the account. | **Auth**: account-session
+
+Request: path `wallet_id: str`.
+Response: HTTP `204 No Content`.
+Errors:
+- `401` — no session.
+- `404` "Wallet not found" — `wallet_id` not found for this user.
+- `409` "Wallet backs existing Archimedes data and cannot be unlinked" — refused whenever
+  the wallet still owns a `StrategyRecord`, `StrategyPassportRecord`, `StrategyProposal`,
+  `VaultMetadata`, or `UserProfile` row.
+
+```bash
+curl -sS -b /tmp/session.jar -X DELETE http://localhost:8080/api/wallets/wallet-abc123
+```
+
+---
+
+See also: `docs/account-authentication.md` (§ Wallet linking, topology, migration and
+rollback) and `docs/security/auth-model.md` (§ Wallet proof, trust boundaries).

--- a/docs/api/wallets.md
+++ b/docs/api/wallets.md
@@ -141,7 +141,8 @@ Errors:
 - `409` "Wallet is already linked to another account" — the normalized `<chain_id>:<address>`
   identity already belongs to a different user; ownership is never transferred
   automatically. (A same-user re-verify of an already-linked wallet is idempotent, not an
-  error.)
+  error.) A rarer race path (concurrent link attempts hitting the `IntegrityError`
+  fallback) returns the same `409` with the shorter message "Wallet is already linked".
 - `422` — body validation (message/signature length bounds).
 
 ```bash


### PR DESCRIPTION
Delivers scopes 1 and 2 of #1381 (per Dan's 2026-08-20 request — per-endpoint reference, grouped by capability, with examples).

## What

**`docs/api/`** — 9 capability docs + index, built from an 82-route live catalog: auth-and-accounts (incl. the Better Auth Node sidecar surface clients actually call), wallets (EIP-4361 link flow), admin-private (the #1373 platform-admin surface: allowlist model, 401/403 semantics), generation (incl. the payment-gate status-code flow and quotas), strategies-and-rigor (tri-state verdict semantics, never-a-pass-count honesty note), chat, paper-trading (account-owned, free-by-design, summary/series shapes), leaderboard-and-metrics (public = aggregate/PII-free by design), vaults-and-chain (roadmap-hidden surfaces labeled, verified against zero ui/src call sites). Every endpooint: exact auth requirement (dependency-chain traced, router-level deps included), request/response field names from the actual schemas, real error codes with meanings, runnable curl. Index carries the auth-model table and the swagger state (`/docs` prod-gated by `PUBLIC_DOMAIN`; `ENABLE_API_DOCS=1` overrides; local compose serves it).

**`backend/tests/test_api_docs_drift.py`** — the reference cannot rot: (a) every documented `### METHOD /path` must exist in the live route table; (b) every live route must be documented or in a frozen, per-entry-reasoned allowlist; (c) a third test fails if allowlist entries go dead. Handles FastAPI ≥0.139's lazy include_router route shapes, cross-checked against `app.openapi()`'s 115-route count.

## Honest scope

The `_UNDOCUMENTED` allowlist currently holds **39 genuine coverage gaps** (marketplace CRUD, corpus/KG, risk, regime, portfolio optimizer, explore, papers browser, account usage, and friends — each with a one-line reason; two agent routes are covered by `docs/agent-api.md` + its own guard instead). This PR covers the MVP core surface; the gap list IS the phase-2 work plan and shrinking it fails loudly if attempted dishonestly.

## Verification

- Both drift-guard directions mutation-demonstrated (removed a real heading → failed naming it; added `GET /api/definitely-not-real` → failed naming it; both restored byte-identical).
- `make docs-check`: 0 broken links of 1134 scanned; 141/141 docs indexed.
- Independent accuracy pass sampled ≥12 endpoints against source (auth chains, error codes, schema field names, flag gates): two cosmetic findings, both fixed in the head commit (exact 403 body punctuation; the rarer race-path 409 message variant now enumerated).
- Drift test 3/3 green on the pushed head.

Follows: the GitHub Pages site scaffold (#1381 option B per Dan) is being built on a separate branch and renders this content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7