### PR TITLE
[infra] Serve .webmanifest as application/manifest+json, not octet-stream

### DIFF
--- a/backend/tests/test_local_setup_contract.py
+++ b/backend/tests/test_local_setup_contract.py
@@ -151,7 +151,15 @@ class TestLocalSetupContract(unittest.TestCase):
         override = "types { application/manifest+json webmanifest; }"
         self.assertIn(override, nginx)
         override_index = nginx.index(override)
-        server_block_index = nginx.index("server {\n    listen 8080;")
+        server_block_anchor = "server {\n    listen 8080;"
+        server_block_index = nginx.find(server_block_anchor)
+        self.assertNotEqual(
+            server_block_index,
+            -1,
+            f"anchor {server_block_anchor!r} not found in nginx.conf — this "
+            "test's anchor has drifted from the real file and needs updating, "
+            "not a ValueError from nginx.index() with no context",
+        )
         self.assertLess(
             override_index,
             server_block_index,
@@ -159,6 +167,22 @@ class TestLocalSetupContract(unittest.TestCase):
             "context) — nested inside it, `types {}` replaces rather than "
             "extends the inherited MIME map, breaking every other static "
             "asset's content type",
+        )
+        # The above only pins the POSITION of this one override line — it
+        # says nothing about any OTHER `types {}` block. A second `types {}`
+        # declared inside `server {}` (this override left untouched at http
+        # level) still replaces the inherited MIME map for every other
+        # static asset that block serves — verified live against the pinned
+        # image (nginxinc/nginx-unprivileged:1.31.2-alpine): with any
+        # `types {}` inside `server {}`, /style.css, /bundle.js, and / all
+        # degrade to application/octet-stream. Guard the whole hazard class,
+        # not just this one line's position.
+        self.assertNotIn(
+            "types {",
+            nginx[server_block_index:],
+            "no `types {}` block may appear inside `server {}` — it "
+            "replaces rather than extends the inherited MIME map for every "
+            "static asset that block serves",
         )
 
 

--- a/backend/tests/test_local_setup_contract.py
+++ b/backend/tests/test_local_setup_contract.py
@@ -128,6 +128,39 @@ class TestLocalSetupContract(unittest.TestCase):
         self.assertIn("location = /openapi.json", nginx)
         self.assertIn("proxy_pass http://backend_api/openapi.json;", nginx)
 
+    def test_nginx_webmanifest_mime_override_is_additive_not_nested_in_server(self) -> None:
+        """#1380: stock nginx `mime.types` has no `.webmanifest` entry, so a
+        served `site.webmanifest` fell back to `default_type`
+        (application/octet-stream) instead of `application/manifest+json`.
+
+        The override MUST live at this file's top level (http context, via
+        the conf.d splice documented in the file header) rather than nested
+        inside `server {}`. A `types {}` block does not merge into an
+        ancestor context's type map when declared in a child context — it
+        replaces it outright for that context, so declaring this inside
+        `server {}` would silently blank the content type of every other
+        static asset (.css/.js/.html) served by that block back to
+        `default_type` too. Verified live with nginx 1.31.2 (the pinned
+        image): moving this exact line inside `server {}` turned
+        `/style.css` and `/` from their correct types into
+        `application/octet-stream`. Placed here, at the same http-context
+        level where the base image's own `include mime.types;` already ran
+        (before this conf.d fragment is spliced in), it appends to that
+        existing map instead — the anti-goal's "additive override only"."""
+        nginx = (ROOT / "nginx/nginx.conf").read_text()
+        override = "types { application/manifest+json webmanifest; }"
+        self.assertIn(override, nginx)
+        override_index = nginx.index(override)
+        server_block_index = nginx.index("server {\n    listen 8080;")
+        self.assertLess(
+            override_index,
+            server_block_index,
+            "the .webmanifest MIME override must precede `server {}` (http "
+            "context) — nested inside it, `types {}` replaces rather than "
+            "extends the inherited MIME map, breaking every other static "
+            "asset's content type",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -131,6 +131,23 @@ limit_req_zone $binary_remote_addr zone=api_write:10m rate=20r/m;
 # timeout + buffering). This is the DRY win: one place to change a header,
 # applied everywhere.
 
+# ── Extra MIME type: .webmanifest (#1380) ──────────────────────────────
+# Stock nginx `mime.types` (included by the base image's own /etc/nginx/nginx.conf
+# before this conf.d fragment is spliced in) has no `.webmanifest` entry, so a
+# `site.webmanifest` served from the static root fell back to `default_type`
+# (application/octet-stream) — out of spec vs. the manifest RFC's
+# `application/manifest+json` and enough for some PWA install heuristics to balk.
+# MUST live here, at this file's top level (http context, via the conf.d splice —
+# see the file-header comment), NOT nested inside `server {}` below. A `types {}`
+# block does not merge into an ancestor context's type map — it replaces it
+# outright for whatever context declares it. Declared inside `server {}` this
+# block would wholesale-blank every other extension's content type for that
+# server (.css/.js/.html all falling back to octet-stream too) — verified live
+# with this exact snippet moved into `server {}`. Declared here, at the same
+# http-context level where the base image's `include mime.types;` already ran,
+# it appends to that existing map instead: a genuinely additive override.
+types { application/manifest+json webmanifest; }
+
 server {
     listen 8080;
     server_name archimedes-arc.com;


### PR DESCRIPTION
## Summary

`nginx/nginx.conf` served `site.webmanifest` as `application/octet-stream` because stock nginx `mime.types` has no `.webmanifest` entry and nothing in this repo's config filled the gap. Adds an additive MIME-type override so it serves as `application/manifest+json` per spec, without disturbing any other extension's content type.

Closes #1380

## Fix

```nginx
types { application/manifest+json webmanifest; }
```

Placed at the **http-context level** of `nginx/nginx.conf` — i.e. before `server {}`, in the part of the file that (per the file's own header comment) is spliced into the base image's `http {}` block via `conf.d` — rather than nested inside `server {}` as the issue's literal suggested snippet located it.

That placement choice is load-bearing, not stylistic: a `types {}` block does not merge into an ancestor context's type map when declared in a child context — it replaces it outright for that context. Declaring it inside `server {}` blanks the content type of *every other* static asset served by that block (`.css`, `.js`, `.html` all fall back to `default_type` too), which is exactly the "replace mime.types wholesale" outcome the issue's own anti-goal warns against. Declared at the http level instead, where the base image's `include mime.types;` already ran before this conf.d fragment loads, the new mapping appends to that existing map — genuinely additive.

## Verification

All against the pinned image (`nginxinc/nginx-unprivileged:1.31.2-alpine`), booted with the real `docker-entrypoint.d` envsubst-on-templates flow (same mechanism prod uses), a temp docroot (`index.html`, `style.css`, `bundle.js`, `site.webmanifest`), and `nginx -t`.

**Before fix** (bug reproduction):
```
$ curl -sI http://localhost:18080/site.webmanifest | grep -i content-type
Content-Type: application/octet-stream
```

**Issue's literal suggested placement — `types{}` nested inside `server {}`** (proves the anti-goal violation the fix must avoid):
```
--- /site.webmanifest ---
Content-Type: application/manifest+json          ← fixed
--- /style.css (should stay text/css) ---
Content-Type: application/octet-stream           ← BROKEN
--- /bundle.js (should stay a JS type) ---
Content-Type: application/octet-stream           ← BROKEN
--- / index.html (should stay text/html) ---
Content-Type: application/octet-stream           ← BROKEN
```

**Shipped fix — `types{}` at http-context level, outside `server {}`**:
```
$ nginx -t
nginx: configuration file /etc/nginx/nginx.conf test is successful

--- /site.webmanifest (acceptance criterion) ---
Content-Type: application/manifest+json
--- /style.css ---
Content-Type: text/css
--- /bundle.js ---
Content-Type: application/javascript
--- / (index.html) ---
Content-Type: text/html
```

Meets the issue's stated acceptance check verbatim (`curl -sI .../site.webmanifest | grep -i content-type` → `application/manifest+json`), plus the sibling-type checks needed to prove the anti-goal ("additive override only") is actually honored rather than merely asserted.

## Regression test — guard shown to reject the pre-fix state and the regression variant

Added `test_nginx_webmanifest_mime_override_is_additive_not_nested_in_server` to `backend/tests/test_local_setup_contract.py`, following the existing text-assertion pattern in that file (`test_nginx_proxies_backend_docs_through_sole_ingress`). It asserts the override string is present *and* appears before the `server {}` block start.

Per repo convention (CLAUDE.md "a test that passes against unfixed code proves nothing"), reverted and re-ran before pushing:

```
$ git stash push -- nginx/nginx.conf   # revert to pre-#1380 main
$ pytest backend/tests/test_local_setup_contract.py::...webmanifest... -q
FAILED ... AssertionError: 'types { application/manifest+json webmanifest; }' not found in ...
$ git stash pop                         # fix restored
```

Also verified the guard catches the *specific* regression this fix is designed to prevent — the override present but moved inside `server {}` (the issue's own literal wording):

```
FAILED ... AssertionError: 8489 not less than 8422 : the .webmanifest MIME
override must precede `server {}` (http context) — nested inside it, `types {}`
replaces rather than extends the inherited MIME map, breaking every other
static asset's content type
```

## Test tallies

- New/touched test file: `pytest backend/tests/test_local_setup_contract.py -q` → **6 passed**
- Full unit suite: `pytest -m "not integration" -q` from repo root → **3552 passed, 2 skipped, 2 deselected** in 326.00s
- `ruff format --check backend/tests/test_local_setup_contract.py` → 1 file already formatted
- `ruff check --select E9,F63,F7,F40 backend/tests/test_local_setup_contract.py` → All checks passed
- `git diff --stat` → 2 files changed (`nginx/nginx.conf`, `backend/tests/test_local_setup_contract.py`), 0 files deleted/renamed

## Anti-goal compliance

`mime.types` is never touched or re-included wholesale — `grep -n "mime.types" nginx/nginx.conf` shows only the two explanatory comments this PR adds, both describing the *base image's* stock include, which stays untouched.

## Scope note

Not a regression of #1339 (open, adds `site.webmanifest` itself) — this PR only fixes the nginx MIME mapping, per #1380's own "deliberately split out per one-logical-change" framing. No `site.webmanifest` file is added here.

## Post-review round 2 (2026-08-20) — 2 findings fixed

1. **The regression guard pinned only the POSITION of the `.webmanifest`
   override, not the hazard class its own docstring describes.** It asserted
   `override_index < server_block_index` but nothing about any *other*
   `types {}` occurrence — a future `types {}` block added inside `server
   {}` (this override left untouched at http level) re-breaks every other
   static asset's content type while the test keeps passing. Reproduced live
   against the pinned image: with any `types {}` inside `server {}`,
   `/style.css`, `/bundle.js`, and `/` all degrade to
   `application/octet-stream`. **Fix:** added
   `self.assertNotIn("types {", nginx[server_block_index:], ...)`, guarding
   the whole class rather than just this one line's position. Mutation-
   verified: injecting a second `types {}` block inside `server {}` makes
   the new assertion fail with the intended message; reverting restores a
   clean pass. Secondary fix in the same test: the anchor lookup now uses
   `nginx.find(...)` + `self.assertNotEqual(-1, ...)` with a clear message,
   instead of `nginx.index(...)`, which previously raised an opaque
   `ValueError` (test ERROR, not a crafted assertion) if the anchor ever
   drifted.
2. **The PR was a draft with a green check describing a base 20+ commits
   stale** (per CLAUDE.md's "a stale PR's green check describes a base that
   no longer exists" rule). Confirmed the semantic fit before touching
   anything: `git diff --name-only <old-base>..origin/main` returned nothing
   for `nginx.conf`/`test_local_setup_contract.py`, so the fix was orthogonal
   to everything that landed on `main` since. **Fix:** rebased onto current
   `origin/main` (`c4465a3b`) — mechanical, zero conflicts, confirmed by
   `git rev-list --left-right --count origin/main...HEAD` → `0	2`. Re-ran
   both the touched test file and the full suite against the rebased tree
   (tallies below). **Left as draft, not flipped to ready** — that step is
   deliberately out of scope for this pass; a human decides when this and
   the other backlog PRs in this batch are ready to merge.

### Round 2 verification tallies

- `pytest backend/tests/test_local_setup_contract.py -q` (rebased tree): **6 passed**.
- `pytest -m "not integration" -q` (rebased tree, repo root, CI's exact command): **3576 passed, 2 skipped, 2 deselected** in 366.61s — no regressions from this PR's two-file diff (up from round 1's 3552 passed purely because `origin/main` gained tests in the 20+ commits this rebase picked up; none of them touch `nginx.conf` or `test_local_setup_contract.py`).
- `ruff check backend/tests/test_local_setup_contract.py` / `ruff format --check` on the same file: clean.
- Mutation check on the new `assertNotIn`: injecting `types { text/plain log; }` immediately inside `server {}` (leaving the `.webmanifest` override untouched at http level) makes the guard fail with `AssertionError: 'types {' unexpectedly found in ...`; removing the injected block restores a clean pass.

