### PR TITLE
[infra] terraform.tfvars.example + operational-variables landmine doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,15 @@ infra/.terraform.lock.hcl
 infra/terraform.tfstate
 infra/terraform.tfstate.backup
 
+# Terraform variable files — operator-specific config (wallet addresses,
+# feature-flag values, and, transiently, the Aurora master password if ever
+# piped through a local file instead of TF_VAR_*). Most of it isn't secret,
+# but it's per-deploy operational state, not something to commit — see
+# infra/README.md "Operational variables". The maintained example stays
+# tracked so the real file has something to be copied from.
+infra/*.tfvars
+!infra/*.tfvars.example
+
 # Secrets / credentials — global patterns (never commit these)
 *.pem
 *.key

--- a/infra/README.md
+++ b/infra/README.md
@@ -133,6 +133,40 @@ terraform import 'aws_route.private_nat[1]' rtb-<id>_0.0.0.0/0
 > without the reboot, `-target` them; to stop Terraform proposing the reboot for a
 > bootstrap-script edit, add `lifecycle { ignore_changes = [user_data] }`.
 
+### Operational variables — always apply via terraform.tfvars, never a bare TF_VAR_* export
+
+**The landmine:** `infra/` ships no `terraform.tfvars`. Every operationally-significant
+variable in [`variables.tf`](variables.tf) defaults to the *feature-off* value (`false` /
+`""`). Setting one only via a one-off `TF_VAR_*` shell export — the pattern this README
+used to document exclusively, e.g. for `aurora_master_password` above — is one bare
+`terraform apply` away from silently reverting it: a different shell, a later session, a
+teammate who doesn't know the export was ever needed. For the OAuth flags that strips the
+whole `secrets{}` block for that provider out of the auth task definition
+([`ecs.tf`](ecs.tf) lines 662-665 / 666-669); for the wallet variables it blanks a live env
+value ([`ecs.tf`](ecs.tf) lines 589-590). No error, no destructive-looking plan line — just
+a quiet, successful apply that undoes prod config.
+
+**The rule:** copy [`terraform.tfvars.example`](terraform.tfvars.example) to
+`terraform.tfvars` (gitignored — the real file with real values is never committed) and
+keep it current with whatever is actually live in prod. Terraform auto-loads
+`terraform.tfvars` from the working directory on every plan/apply — no `-var-file` flag
+needed — so once it's maintained, a bare `terraform apply` stops being a trap.
+`aurora_master_password` stays on the existing SSM-piped
+`TF_VAR_aurora_master_password=$(aws ssm get-parameter ...)` export documented above — it's
+a true secret (`sensitive = true`, no default) and belongs in SSM, not a local file, even a
+gitignored one.
+
+Known operationally-set variables as of 2026-08-20 — re-grep `variables.tf` for new
+`var.*` conditionals in `ecs.tf` any time a new operational flag is added:
+
+| Variable | Declared | Gates | Default | Status |
+| --- | --- | --- | --- | --- |
+| `google_oauth_enabled` | `variables.tf:100` | Google OAuth `secrets{}` block — `ecs.tf:662-665` | `false` | Live-set in prod via a bare `TF_VAR_*` export — verify the current value before any apply; not captured in a tfvars file before this PR. |
+| `github_oauth_enabled` | `variables.tf:106` | GitHub OAuth `secrets{}` block — `ecs.tf:666-669` | `false` | Same as above. |
+| `platform_admin_wallets` | `variables.tf:123` | `PLATFORM_ADMIN_WALLETS` env — `ecs.tf:589` | `""` | **Confirmed:** Dan applied a real value via `TF_VAR_platform_admin_wallets` on 2026-08-20. Not captured anywhere durable — the next bare apply reverts it to `""` and silently removes the admin-wallet publish bypass. |
+| `archimedes_treasury_wallet` | `variables.tf:129` | `ARCHIMEDES_TREASURY_WALLET` env — `ecs.tf:590` | `""` | Same landmine class and same `ecs.tf` gating pattern as `platform_admin_wallets`. This PR did **not** confirm whether a real value is currently applied in prod — check with Dan before any apply that could touch it. |
+| `alarm_email` | `cloudwatch.tf:17` | SNS email subscription — `cloudwatch.tf:33-36` | `""` | Lower stakes: `cloudwatch.tf` is additive-only (see Monitoring section above), so reverting this only drops a page subscription, not a feature. Same rule applies if a real address has been set. |
+
 ### Admin Access (SSM Session Manager)
 
 Once VPC migration is complete, admin access is via AWS SSM:

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,65 @@
+# infra/terraform.tfvars.example
+#
+# Copy this file to infra/terraform.tfvars (gitignored — see .gitignore;
+# NEVER commit the real file) and fill in real values before running
+# `terraform apply` from infra/. Terraform auto-loads terraform.tfvars from
+# the working directory on every plan/apply — no -var-file flag needed.
+#
+# THE LANDMINE THIS FILE CLOSES: every variable below defaults to the
+# feature-OFF value (false / "") in variables.tf. If a variable is only ever
+# set via a one-off `TF_VAR_*` shell export — never persisted here — then the
+# next bare `terraform apply` (a different shell, a different session, a
+# teammate who doesn't know the export was ever needed) silently reverts it
+# to that default. For the OAuth flags that strips the whole Google/GitHub
+# secrets{} block out of the auth task definition; for the wallet variables
+# it blanks a live env value. No error, no destructive-looking plan line —
+# just a quiet, successful apply that undoes prod config. See
+# infra/README.md "Operational variables" for the full writeup and the rule:
+# EVERY apply must go through a maintained terraform.tfvars, never a bare
+# TF_VAR_* export used once and forgotten.
+#
+# NOT listed here: infra/variables.tf's aurora_master_password. It is a true
+# secret (sensitive = true, no default) and deliberately stays on the
+# existing SSM-piped `TF_VAR_aurora_master_password=$(aws ssm get-parameter
+# ...)` pattern documented in infra/README.md — putting a live DB password in
+# a tfvars file, even a gitignored one, is a worse blast radius than a
+# per-apply env var for the one variable Terraform genuinely cannot apply
+# without.
+
+# ── Better Auth OAuth providers (variables.tf:100, variables.tf:106) ───────
+# Gate the Google/GitHub secrets{} blocks in the "auth" container definition
+# (infra/ecs.tf:662-665 and :666-669). Only flip to true once BOTH SSM
+# parameters in the matching pair already exist —
+# /archimedes/prod/GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET, or
+# /archimedes/prod/GITHUB_CLIENT_ID + GITHUB_CLIENT_SECRET — seeded via
+# infra/scripts/setup-ssm-secrets.sh. Default false; verify the CURRENT
+# live value before you apply — do not assume false just because that's
+# the variable's declared default.
+google_oauth_enabled = false
+github_oauth_enabled = false
+
+# ── Marketplace / admin config (variables.tf:123, variables.tf:129) ────────
+# Public wallet addresses — not secrets, but operator-specific and NOT baked
+# into the image or a box .env (issue #1037 / PR #958). Sourced straight into
+# plain (non-secret) ECS task-definition env (infra/ecs.tf:589-590).
+#
+# Space/comma-separated wallets allowed to publish `is_example` strategies.
+# CONFIRMED: Dan applied a real value to prod via a one-off
+# TF_VAR_platform_admin_wallets export — that value is NOT captured anywhere
+# durable yet. Get the current value from Dan before your first real apply,
+# or the next bare apply blanks it.
+platform_admin_wallets = "" # e.g. "0xabc...,0xdef..." — confirm current prod value with Dan first
+
+# Platform revenue-share wallet (marketplace publish 10% split). Publishing
+# 503s (backend/archimedes/api/marketplace_routes.py) until this is set.
+# Same landmine class as platform_admin_wallets above; this PR did not
+# confirm whether a real value is currently applied in prod — check with Dan.
+archimedes_treasury_wallet = "" # e.g. "0x123..." — confirm current prod value with Dan first
+
+# ── Optional: CloudWatch alarm paging (cloudwatch.tf:17) ───────────────────
+# Email subscribed to the CloudWatch alarm SNS topic. Lower stakes than the
+# vars above — cloudwatch.tf is additive-only, so a reverted value only means
+# a missed page, not a stripped feature — but the same landmine class: if a
+# real address has been TF_VAR-exported and applied, put it here too so a
+# bare apply doesn't silently unsubscribe it.
+alarm_email = ""


### PR DESCRIPTION
## Problem

`infra/` ships no `terraform.tfvars`. Every operationally-significant flag in
[`infra/variables.tf`](infra/variables.tf) defaults to the *feature-off* value
(`false` / `""`). Today those flags are set only by exporting `TF_VAR_*` in the
shell before running `terraform apply` — a pattern with no persistence: the
next bare `terraform apply`, run from a different shell, a later session, or
by a teammate who doesn't know the export was ever needed, silently reverts
each one to its default. For the OAuth flags that strips the entire
Google/GitHub `secrets{}` block out of the auth task definition
(`infra/ecs.tf` lines 662-665 / 666-669); for the wallet variables it blanks a
live plain-env value (`infra/ecs.tf` lines 589-590). There is no error and no
destructive-looking line in `terraform plan` — just a quiet, successful apply
that undoes prod config.

## What this PR does

1. **`infra/terraform.tfvars.example`** (new) — documents every
   operationally-relevant variable this PR found, with placeholder values and
   comments on what gates what. No real values anywhere in this file or this
   PR.
2. **`.gitignore`** — adds `infra/*.tfvars` (with `!infra/*.tfvars.example` to
   keep the example tracked). `*.tfstate*` was already covered; tfvars was
   not — and tfvars can carry non-secret-but-operational config (wallet
   lists), so it needed its own rule.
3. **`infra/README.md`** — new "Operational variables" section stating the
   rule: every apply goes through a maintained `terraform.tfvars`, copied from
   the example and kept current with what's actually live in prod, never a
   one-off `TF_VAR_*` export used once and forgotten. `aurora_master_password`
   deliberately stays on its existing SSM-piped `TF_VAR_aurora_master_password`
   pattern — it's a true secret and belongs in SSM, not a local file even if
   gitignored.

## Variables documented (grepped `variables.tf` for defaults `ecs.tf` /
`cloudwatch.tf` gate behavior on)

| Variable | Declared | Gates | Default | Status |
| --- | --- | --- | --- | --- |
| `google_oauth_enabled` | `variables.tf:100` | Google OAuth `secrets{}` block — `ecs.tf:662-665` | `false` | Live-set in prod via a bare `TF_VAR_*` export — verify current value before any apply; wasn't captured in a tfvars file before this PR. |
| `github_oauth_enabled` | `variables.tf:106` | GitHub OAuth `secrets{}` block — `ecs.tf:666-669` | `false` | Same as above. |
| `platform_admin_wallets` | `variables.tf:123` | `PLATFORM_ADMIN_WALLETS` env — `ecs.tf:589` | `""` | **Confirmed:** Dan applied a real value via `TF_VAR_platform_admin_wallets` today (2026-08-20). Not captured anywhere durable — the next bare apply reverts it to `""`. |
| `archimedes_treasury_wallet` | `variables.tf:129` | `ARCHIMEDES_TREASURY_WALLET` env — `ecs.tf:590` | `""` | Same landmine class and same `ecs.tf` gating pattern as `platform_admin_wallets`, sitting right next to it in the same env block. **This PR did not confirm whether a real value is currently applied in prod — check with Dan before any apply that could touch it.** |
| `alarm_email` | `cloudwatch.tf:17` | SNS email subscription — `cloudwatch.tf:33-36` | `""` | Lower stakes — `cloudwatch.tf` is additive-only per the existing Monitoring section, so reverting this only drops a page subscription, not a stripped feature. Same rule applies if a real address has been set. |

`aurora_master_password` (`variables.tf:25`) is intentionally **not** in the
tfvars example — it's `sensitive = true` with no default, already documented
in `infra/README.md` as an SSM-piped `TF_VAR_*` export, and putting a live DB
password in a local file (even gitignored) is a worse blast radius than
keeping it a per-apply env var.

`redis_auth_token` (`elasticache.tf`) is declared but only referenced in a
commented-out line — not currently wired to anything live, so it's excluded.

## Landmine-class finding: `platform_admin_wallets` default vs. today's applied value

Per the task brief: **yes**, `variables.tf:123`'s `platform_admin_wallets`
default (`""`) would silently strip whatever value Dan applied via
`TF_VAR_platform_admin_wallets` earlier today, on the next bare
`terraform apply` — this is the exact landmine class described above, not a
hypothetical. `infra/ecs.tf:589` reads `var.platform_admin_wallets` straight
into the `PLATFORM_ADMIN_WALLETS` plain-env value with no other source of
truth (no tfvars file existed, no SSM parameter backs it). Until a
`terraform.tfvars` capturing the current value is created and maintained
(this PR ships the `.example` template but does not — and per the "no real
values" constraint, cannot — create the real file), **any subsequent bare
apply will blank the admin-wallet allowlist without warning.** Flagging this
explicitly rather than fixing it silently, since only Dan can confirm/re-set
the correct real value.

## Verification

- `terraform -chdir=infra fmt -check -diff` — clean (no `.tf` files touched
  by this PR).
- `terraform fmt -check -diff` doesn't process `.tfvars.example` directly
  (only `.tf`/`.tfvars`/`.tftest.hcl`), so I copied the example's content to
  a scratch `terraform.tfvars` and ran `terraform fmt -check -diff` against
  it — caught and fixed two inline-comment spacing nits, then reran clean
  (exit 0).
- `make docs-check` — 0 broken links (1136 scanned across 145 files), 0
  orphaned docs, index complete.

## Deviations from the brief

None substantive. One judgment call: `alarm_email` isn't in the brief's named
list (`google_oauth_enabled`, `github_oauth_enabled`,
`platform_admin_wallets`) but matches the same pattern (`ecs.tf`-*adjacent*
`cloudwatch.tf` gate, default `""`, previously referenced by the README as
"set via tfvars" with no tfvars file ever existing) — included it as lower
priority/lower stakes rather than leaving it out entirely.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M