### PR TITLE
[infra] apply.sh — guarded terraform plan/apply wrapper

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -96,9 +96,12 @@ export TF_VAR_aurora_master_password="$(aws ssm get-parameter \
 ```bash
 cd infra/                # the LIVE stack (NOT infra/terraform/ — that's a separate, unwired module)
 terraform init           # downloads providers, connects to the S3 backend
-terraform plan           # ALWAYS preview first — scrutinize for `destroy` / route deletions
-terraform apply          # type `yes` to confirm
+./apply.sh               # ALWAYS preview first — see "Operational variables" below
+./apply.sh --apply       # applies after the same guarded preflight; prompts for confirmation
 ```
+
+`terraform plan` / `terraform apply` still work directly, but `./apply.sh` is the
+recommended entry point — see the next section for what it checks and why.
 
 **If a plan/apply was interrupted (Ctrl-C), the S3 state lock can go stale** —
 you'll see `Error acquiring the state lock … PreconditionFailed`. Clear it (only
@@ -155,6 +158,21 @@ needed — so once it's maintained, a bare `terraform apply` stops being a trap.
 `TF_VAR_aurora_master_password=$(aws ssm get-parameter ...)` export documented above — it's
 a true secret (`sensitive = true`, no default) and belongs in SSM, not a local file, even a
 gitignored one.
+
+**`./apply.sh` is the entry point that enforces this rule** — run it instead of a bare
+`terraform plan` / `terraform apply`. It always operates on `infra/` regardless of the
+caller's cwd, and before touching Terraform it: (1) requires `terraform.tfvars` to exist,
+pointing here if it doesn't; (2) re-derives the operational-variable list from
+`terraform.tfvars.example` at runtime (so a newly added variable can't silently drift out
+of the check) and warns loudly, by name, on anything missing or an empty string — pass
+`--allow-empty <var>` (repeatable) to proceed with a specific one intentionally unset, or
+it refuses; (3) refuses if any `TF_VAR_*` env var is currently set that would shadow a
+`terraform.tfvars` entry — the exact landmine this section describes; (4) confirms `aws sts
+get-caller-identity` succeeds and resolves to account `037613907429`, guarding against an
+apply run under the wrong `AWS_PROFILE`. It then runs `terraform plan` by default;
+`--apply` runs `terraform apply` (still prompting for confirmation unless `--yes` is also
+given); any other args pass through to terraform. See the script's own header comment for
+full usage.
 
 Known operationally-set variables as of 2026-08-20 — re-grep `variables.tf` for new
 `var.*` conditionals in `ecs.tf` any time a new operational flag is added:

--- a/infra/apply.sh
+++ b/infra/apply.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# infra/apply.sh — guarded terraform wrapper for the archimedes stack.
+#
+# Wraps `terraform plan` / `terraform apply` with the checks that used to be
+# tribal knowledge (or just forgotten): a maintained terraform.tfvars per
+# infra/README.md's "Operational variables" section (PR #1417), no stray
+# TF_VAR_* shell exports shadowing it (the landmine PR #1417 documented), and
+# a sanity check that you are actually authenticated into the right AWS
+# account before anything touches prod.
+#
+# Usage:
+#   infra/apply.sh                              # terraform plan
+#   infra/apply.sh --allow-empty alarm_email     # plan, tolerating one empty var
+#   infra/apply.sh --apply                       # terraform apply (interactive confirm)
+#   infra/apply.sh --apply --yes                 # terraform apply -auto-approve
+#   infra/apply.sh -- -target=aws_instance.foo   # extra args pass through to terraform
+#
+# Can be run from anywhere — it always operates on its own directory
+# (infra/), never the caller's cwd.
+
+# AWS-RunShellScript / some CI invokers run scripts with /bin/sh (dash),
+# which rejects `set -o pipefail`. Re-exec under bash first. Precedent:
+# .github/workflows/deploy-runners.yml (PR #1335).
+[ -z "${BASH_VERSION:-}" ] && exec /bin/bash "$0" "$@"
+set -euo pipefail
+
+# ─── 1. cd safety: always operate on infra/, never the caller's cwd ────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Sanity check that SCRIPT_DIR really is the infra/ terraform root and not a
+# stray copy of this script dropped somewhere else — "operate on infra/,
+# refuse to run from elsewhere."
+if [[ ! -f "variables.tf" || ! -f "terraform.tfvars.example" ]]; then
+  echo "ERROR: apply.sh must live in infra/ next to variables.tf and" >&2
+  echo "terraform.tfvars.example. Resolved script directory:" >&2
+  echo "  $SCRIPT_DIR" >&2
+  echo "does not look like the infra/ terraform root — refusing to run." >&2
+  exit 2
+fi
+
+TFVARS="terraform.tfvars"
+TFVARS_EXAMPLE="terraform.tfvars.example"
+
+# ─── Parse CLI args ─────────────────────────────────────────────────────────
+ALLOW_EMPTY=()
+DO_APPLY=0
+AUTO_YES=0
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-empty)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --allow-empty requires a variable name argument." >&2
+        exit 2
+      fi
+      ALLOW_EMPTY+=("$2")
+      shift 2
+      ;;
+    --apply)
+      DO_APPLY=1
+      shift
+      ;;
+    --yes)
+      AUTO_YES=1
+      shift
+      ;;
+    --)
+      shift
+      EXTRA_ARGS+=("$@")
+      break
+      ;;
+    *)
+      EXTRA_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "$AUTO_YES" -eq 1 && "$DO_APPLY" -ne 1 ]]; then
+  echo "ERROR: --yes only makes sense together with --apply (plan never" >&2
+  echo "prompts for confirmation, so there is nothing for --yes to approve)." >&2
+  exit 2
+fi
+
+# ─── 2. Preflight: terraform.tfvars must exist ─────────────────────────────
+if [[ ! -f "$TFVARS" ]]; then
+  cat >&2 <<EOF
+ERROR: $TFVARS not found in $SCRIPT_DIR.
+
+Copy the example and fill in real values before running apply.sh:
+  cp $TFVARS_EXAMPLE $TFVARS
+
+See README.md's "Operational variables" section for what each variable
+gates and the silent-revert landmine this file exists to close.
+EOF
+  exit 2
+fi
+
+# Derive the authoritative operational-variable list from the example file
+# itself (grep-level, no deps) rather than hardcoding it here, so a new
+# variable added to terraform.tfvars.example can't silently drift out of
+# this check. Matches top-level `name = value` assignments only — comment
+# lines start with '#' and are excluded by the anchor.
+OP_VARS=()
+while IFS= read -r v; do
+  [[ -n "$v" ]] && OP_VARS+=("$v")
+done < <(grep -oE '^[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*=' "$TFVARS_EXAMPLE" | sed -E 's/[[:space:]]*=$//')
+
+if [[ ${#OP_VARS[@]} -eq 0 ]]; then
+  echo "ERROR: could not derive any operational variables from $TFVARS_EXAMPLE — check its format." >&2
+  exit 2
+fi
+
+# Grep-level tfvars value lookup: returns "missing", "empty", or "ok" for a
+# given variable name. Strips a trailing inline comment (# ...) and
+# surrounding whitespace; treats a bare "" as empty. Explicit bool values
+# (true/false) are never "empty" — they are a real, intentional setting.
+tfvars_status() {
+  local name="$1" line raw
+  line="$(grep -E "^${name}[[:space:]]*=" "$TFVARS" | tail -n1 || true)"
+  if [[ -z "$line" ]]; then
+    echo "missing"
+    return
+  fi
+  raw="${line#*=}"
+  raw="${raw%%#*}"
+  raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  if [[ "$raw" == '""' || -z "$raw" ]]; then
+    echo "empty"
+  else
+    echo "ok"
+  fi
+}
+
+is_allowed_empty() {
+  local name="$1" a
+  if [[ ${#ALLOW_EMPTY[@]} -gt 0 ]]; then
+    for a in "${ALLOW_EMPTY[@]}"; do
+      [[ "$a" == "$name" ]] && return 0
+    done
+  fi
+  return 1
+}
+
+PROBLEM_NAMES=()
+PROBLEM_REASONS=()
+for v in "${OP_VARS[@]}"; do
+  status="$(tfvars_status "$v")"
+  if [[ "$status" == "missing" ]]; then
+    PROBLEM_NAMES+=("$v")
+    PROBLEM_REASONS+=("missing from $TFVARS")
+  elif [[ "$status" == "empty" ]]; then
+    PROBLEM_NAMES+=("$v")
+    PROBLEM_REASONS+=("empty string in $TFVARS")
+  fi
+done
+
+if [[ ${#PROBLEM_NAMES[@]} -gt 0 ]]; then
+  echo "WARNING: the following operational variables are missing or empty:" >&2
+  BLOCKING=()
+  for i in "${!PROBLEM_NAMES[@]}"; do
+    name="${PROBLEM_NAMES[$i]}"
+    reason="${PROBLEM_REASONS[$i]}"
+    if is_allowed_empty "$name"; then
+      echo "  - $name ($reason) — allowed via --allow-empty" >&2
+    else
+      echo "  - $name ($reason)" >&2
+      BLOCKING+=("$name")
+    fi
+  done
+  if [[ ${#BLOCKING[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "ERROR: refusing to proceed. Fill in a real value in $TFVARS, or pass" >&2
+    echo "--allow-empty <var> explicitly (repeatable) for each variable you" >&2
+    echo "intend to leave unset. Blocking: ${BLOCKING[*]}" >&2
+    exit 2
+  fi
+  echo "" >&2
+fi
+
+# ─── 3. Refuse if a TF_VAR_* env var shadows a maintained tfvars entry ─────
+# This is the exact landmine infra/README.md's "Operational variables"
+# section documents: a one-off TF_VAR_* export silently overriding the
+# maintained file on the next apply. Checks ALL tfvars entries, not just the
+# operational ones above, so it also catches aurora_master_password-style
+# vars if they ever land in tfvars.
+SHADOWED=()
+while IFS= read -r envname; do
+  [[ -z "$envname" ]] && continue
+  varname="${envname#TF_VAR_}"
+  if grep -qE "^${varname}[[:space:]]*=" "$TFVARS"; then
+    SHADOWED+=("$envname")
+  fi
+done < <(env | grep -oE '^TF_VAR_[A-Za-z0-9_]+' || true)
+
+if [[ ${#SHADOWED[@]} -gt 0 ]]; then
+  echo "ERROR: the following TF_VAR_* environment variables shadow entries" >&2
+  echo "already maintained in $TFVARS — this is the old landmine path" >&2
+  echo "(infra/README.md \"Operational variables\"): a bare terraform apply" >&2
+  echo "from a shell with these set would silently override the file." >&2
+  for v in "${SHADOWED[@]}"; do
+    echo "  - $v" >&2
+  done
+  echo "" >&2
+  echo "Move the value into $TFVARS and unset the env var, then re-run." >&2
+  exit 2
+fi
+
+# ─── 4. AWS sanity: right identity, right account ──────────────────────────
+EXPECTED_ACCOUNT="037613907429"
+if ! ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>&1)"; then
+  echo "ERROR: 'aws sts get-caller-identity' failed:" >&2
+  echo "$ACCOUNT_ID" >&2
+  echo "Hint: aws sso login --profile ArchimedesDanAdmin" >&2
+  exit 2
+fi
+
+if [[ "$ACCOUNT_ID" != "$EXPECTED_ACCOUNT" ]]; then
+  echo "ERROR: aws sts get-caller-identity resolved to account $ACCOUNT_ID," >&2
+  echo "expected $EXPECTED_ACCOUNT. This guards against applying with the" >&2
+  echo "wrong AWS_PROFILE. Check \$AWS_PROFILE and re-run 'aws sso login'." >&2
+  exit 2
+fi
+echo "AWS sanity OK — account $ACCOUNT_ID."
+
+# ─── 5. terraform plan (default) or apply (--apply) ────────────────────────
+if [[ "$DO_APPLY" -eq 1 ]]; then
+  CMD=(terraform apply)
+  if [[ "$AUTO_YES" -eq 1 ]]; then
+    CMD+=(-auto-approve)
+  fi
+else
+  CMD=(terraform plan)
+fi
+if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+  CMD+=("${EXTRA_ARGS[@]}")
+fi
+
+echo "+ ${CMD[*]}"
+"${CMD[@]}"


### PR DESCRIPTION
## What

`infra/apply.sh` — a guarded wrapper around `terraform plan` / `terraform apply` for the
`infra/` stack. **Builds directly on #1417's convention** (`infra/terraform.tfvars.example`
+ the "Operational variables" README section): that PR documented the rule ("every apply
goes through a maintained `terraform.tfvars`, never a bare `TF_VAR_*` export"); this PR
gives you a script that actually enforces it instead of relying on everyone remembering to
read the README first.

## What it does

Before touching Terraform, in order:

1. **cd safety.** Resolves its own script directory and `cd`s there — operates on `infra/`
   regardless of the caller's cwd. Refuses (exit 2) if that directory doesn't contain
   `variables.tf` + `terraform.tfvars.example` (i.e. doesn't look like the real `infra/`
   root — guards against a stray copy of the script running against the wrong directory).
2. **Preflight: `terraform.tfvars` must exist.** If missing, points at
   `terraform.tfvars.example` and `README.md`'s "Operational variables" section, exit 2.
3. **Operational-variable check, derived at runtime, not hardcoded.** Greps
   `terraform.tfvars.example` for every top-level `name = value` assignment to build the
   authoritative variable list (currently `google_oauth_enabled`, `github_oauth_enabled`,
   `platform_admin_wallets`, `archimedes_treasury_wallet`, `alarm_email`) — so a variable
   added to the example file later can't silently drift out of the check. For each one,
   warns loudly **by name** if it's missing from `terraform.tfvars` or present as an empty
   string. Explicit `false` is never treated as empty — only a genuinely missing or blank
   entry triggers the warning. Refuses (exit 2) unless every flagged variable is covered by
   an explicit `--allow-empty <var>` (repeatable).
4. **`TF_VAR_*` shadow guard.** Refuses (exit 2) if any `TF_VAR_<name>` environment variable
   is currently set where `<name>` already has an entry in `terraform.tfvars` — this is the
   exact landmine #1417's README section documents (a one-off shell export silently
   overriding the maintained file on the next apply). Names which env var(s) are shadowing.
5. **AWS sanity.** Requires `aws sts get-caller-identity` to succeed (prints an `aws sso
   login --profile ArchimedesDanAdmin` hint on failure) and the resolved account to equal
   `037613907429` — guards against applying with the wrong `AWS_PROFILE`.
6. **Then runs `terraform plan`** by default. `--apply` runs `terraform apply` instead
   (still interactive — prompts for confirmation); `--yes` (only valid alongside `--apply`)
   adds `-auto-approve`. Any other/extra args pass through to terraform (e.g. `-- -target=...`).

`infra/README.md`'s "Operational variables" section and core-loop example now name
`./apply.sh` as the entry point, alongside the existing bare-terraform commands (which still
work directly — the script is a safety wrapper, not a replacement for the terraform binary).

Bash conventions: `#!/usr/bin/env bash` + the dash re-exec guard
(`[ -z "${BASH_VERSION:-}" ] && exec /bin/bash "$0" "$@"`) before `set -euo pipefail`,
following the precedent in #1335 (`deploy-runners.yml`, for scripts that might be invoked
via `/bin/sh`). Verified portable to bash 3.2 (macOS's `/bin/bash`) — no `mapfile`, no bare
`"${arr[@]}"` on a possibly-empty array under `set -u` (that combination throws "unbound
variable" on bash <4.4; used the length-guarded-loop pattern throughout instead).

## Guard demonstrations (per CLAUDE.md rule 4 — a guard must be shown rejecting something)

All three run against a **scratch directory with a stub `terraform` on `PATH`** — no real
Terraform or AWS call is ever made. Technique:

```bash
SCRATCH=$(mktemp -d /tmp/apply-sh-guard-demo.XXXXXX)
mkdir -p "$SCRATCH/infra" "$SCRATCH/bin"

# Stub terraform: just echoes what it was called with, exits 0.
cat > "$SCRATCH/bin/terraform" <<'EOS'
#!/usr/bin/env bash
echo "[stub terraform] called with: $*"
exit 0
EOS
chmod +x "$SCRATCH/bin/terraform"

# Sentinel files apply.sh's cd-safety check requires, so the scratch dir
# passes as a legitimate infra/ root.
cp infra/apply.sh "$SCRATCH/infra/apply.sh"
cp infra/terraform.tfvars.example "$SCRATCH/infra/terraform.tfvars.example"
touch "$SCRATCH/infra/variables.tf"
chmod +x "$SCRATCH/infra/apply.sh"

export PATH="$SCRATCH/bin:$PATH"
```

Each demo below is also run from a **different cwd each time** (`/tmp`, the repo root,
`/`) to simultaneously prove the cd-safety behavior — the script always operates on its own
`infra/`, never wherever it was invoked from.

**(a) No `terraform.tfvars` → exit 2 with the pointer:**

```
$ cd /tmp && "$SCRATCH/infra/apply.sh"
ERROR: terraform.tfvars not found in /tmp/apply-sh-guard-demo.Rxqb68/infra.

Copy the example and fill in real values before running apply.sh:
  cp terraform.tfvars.example terraform.tfvars

See README.md's "Operational variables" section for what each variable
gates and the silent-revert landmine this file exists to close.
EXIT=2
```

**(b) `terraform.tfvars` present but missing `platform_admin_wallets` → named warning +
refusal:**

```
$ cd <repo-root> && "$SCRATCH/infra/apply.sh"
WARNING: the following operational variables are missing or empty:
  - platform_admin_wallets (missing from terraform.tfvars)

ERROR: refusing to proceed. Fill in a real value in terraform.tfvars, or pass
--allow-empty <var> explicitly (repeatable) for each variable you
intend to leave unset. Blocking: platform_admin_wallets
EXIT=2
```

**(c) `TF_VAR_github_oauth_enabled` set in env, shadowing a fully-populated tfvars →
refusal naming it:**

```
$ cd / && TF_VAR_github_oauth_enabled=true "$SCRATCH/infra/apply.sh"
ERROR: the following TF_VAR_* environment variables shadow entries
already maintained in terraform.tfvars — this is the old landmine path
(infra/README.md "Operational variables"): a bare terraform apply
from a shell with these set would silently override the file.
  - TF_VAR_github_oauth_enabled

Move the value into terraform.tfvars and unset the env var, then re-run.
EXIT=2
```

**Happy-path sanity (same scratch dir, stub `terraform` + stub `aws` returning
`037613907429`):** a fully-populated `terraform.tfvars`, no shadowing env, correct account
→ `apply.sh` prints `AWS sanity OK` and reaches `+ terraform plan` /
`+ terraform apply -auto-approve -target=aws_instance.foo` (for `--apply --yes -- -target=...`,
confirming extra-arg passthrough), and `--allow-empty alarm_email` against a tfvars with an
empty `alarm_email` warns but proceeds instead of refusing. A wrong-account stub `aws`
(`999999999999`) and a bare `--yes` without `--apply` were also exercised and correctly
refuse.

## Verification

- `bash -n infra/apply.sh` — clean, under both the conda env's bash and macOS's `/bin/bash`
  3.2 (the version the re-exec guard actually lands on).
- `shellcheck` — **not available in this environment** (not on PATH, not installed via
  Homebrew). Noting this as a known gap rather than skipping the check silently — someone
  with shellcheck installed should run it before/after merge.
- `make docs-check` — 0 broken links (1136 scanned / 145 files), 0 orphaned docs, index
  complete. (`infra/README.md` isn't part of the `docs/` index — it's a top-level repo
  README like the root `README.md` — so no index-row addition was needed.)

## Deviations from the brief

- **shellcheck unavailable** — see Verification above; not installed in this environment,
  noted rather than silently skipped.
- The brief's "cd safety: refuse to run from elsewhere" is implemented as: the script always
  resolves and `cd`s to its **own** directory (so the caller's cwd never matters), then
  refuses if that resolved directory doesn't contain the expected sentinel files
  (`variables.tf` + `terraform.tfvars.example`) — i.e. doesn't look like a genuine `infra/`
  root. This is a judgment call on an underspecified requirement; flagging it explicitly in
  case a stricter "must literally be named `infra/`" check was intended instead.
- Added two small extra guards beyond the brief, both demonstrated in testing above but not
  required to be shown per CLAUDE.md rule 4 since they aren't the three named guard demos:
  bare `--yes` without `--apply` refuses (nothing for it to auto-confirm), and a wrong AWS
  account number refuses with the account mismatch spelled out.
- `--allow-empty` only validates against the derived operational-variable list implicitly
  (an unrecognized `--allow-empty <var>` for a variable that isn't actually
  missing/empty is a harmless no-op, not a hard error) — kept minimal per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
