### PR TITLE
[frontend] Drop-in company/social links footer (github/discord/x/company)

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -4520,7 +4520,48 @@ button:where(.tag) {
 .public-footer .public-shell {
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
 	gap: 20px;
+}
+
+.public-footer__brand {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 16px;
+}
+
+/* Shared footer icon-link row — public shell (public-footer, above) and app
+   shell (app-footer, below) both mount CompanyLinksFooter.jsx into one of
+   these, undecorated so it inherits whichever shell's --text-3/--accent/
+   --glass-border/--accent-muted tokens are in scope. Mirrors the existing
+   .topbar-icon-btn idiom (Layout.jsx) rather than inventing a new one. */
+.footer-links {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.footer-icon-link {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	border: 1px solid var(--glass-border);
+	color: var(--text-3);
+	transition:
+		color 0.15s ease,
+		border-color 0.15s ease,
+		background 0.15s ease;
+}
+
+.footer-icon-link:hover,
+.footer-icon-link:focus-visible {
+	color: var(--accent);
+	border-color: var(--accent);
+	background: var(--accent-muted);
 }
 
 .public-site .page-content {
@@ -4853,6 +4894,17 @@ button:where(.tag) {
 .app-site .main-area {
 	min-height: 100vh;
 	background: var(--app-canvas);
+}
+
+/* Layout-bottom footer (Layout.jsx) — mirrors .public-footer's role in the
+   public shell: the one place CompanyLinksFooter.jsx mounts for every /app
+   page. Right-aligned, unlike the public footer's brand+links split, since
+   the sidebar already carries the Archimedes wordmark on every app page. */
+.app-site .app-footer {
+	padding: var(--space-4) var(--space-6);
+	border-top: 1px solid var(--glass-border);
+	display: flex;
+	justify-content: flex-end;
 }
 
 .app-site .sidebar {

--- a/ui/src/companyLinks.js
+++ b/ui/src/companyLinks.js
@@ -1,0 +1,29 @@
+// Company and social links rendered in both shells' footers — the public
+// site (PublicLayout.jsx, wraps Landing + Architecture) and the
+// authenticated app (Layout.jsx). Both consume this through
+// socialLinks.js's activeSocialLinks(), which is the one place that reads
+// these values; nothing else in the UI should import this object directly.
+//
+// THE RULE (claims-must-be-true, see CLAUDE.md's "hard constraint, above
+// everything else"): an empty string means the corresponding link renders
+// NOWHERE. A footer icon that opens a 404, an unissued Discord invite, or a
+// handle nobody has claimed yet is a false claim about what exists — exactly
+// the class of thing that rule exists to forbid. Do not "temporarily" point
+// a key at a placeholder URL to make the icon appear before the destination
+// is real.
+//
+// Drop-in instructions for the owner — fill each in only once it is real:
+//   - discord: the invite URL once one is issued, e.g. "https://discord.gg/xxxxxxxx".
+//   - x:       the profile URL once the handle exists, e.g. "https://x.com/<handle>".
+//   - company: "https://aprin.ai" once APRIN Labs' site is actually live.
+//              The domain is being registered as of 2026-08-20 — the eventual
+//              value is already known, but do NOT fill it in before the site
+//              resolves; a live-looking link to nothing is the exact failure
+//              mode this file's rule exists to prevent.
+export const companyLinks = {
+	// Real today — the public repo this UI ships from.
+	github: "https://github.com/a-apin/archimedes",
+	discord: "",
+	x: "",
+	company: "",
+};

--- a/ui/src/components/CompanyLinksFooter.jsx
+++ b/ui/src/components/CompanyLinksFooter.jsx
@@ -1,0 +1,29 @@
+import { activeSocialLinks } from "../socialLinks";
+
+// Shared footer link row for both shells (PublicLayout.jsx, Layout.jsx).
+// activeSocialLinks() (../socialLinks.js) already filtered out every empty
+// entry, so this component never has to re-check companyLinks.js itself —
+// it renders exactly what it's handed, or nothing at all when nothing is
+// configured yet (github is always non-empty today, so in practice this
+// never returns null, but the guard stays honest for a config-only state).
+export default function CompanyLinksFooter({ className = "footer-links" }) {
+	const links = activeSocialLinks();
+	if (links.length === 0) return null;
+	return (
+		<div className={className} aria-label="Archimedes elsewhere">
+			{links.map(({ key, url, icon, label }) => (
+				<a
+					key={key}
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="footer-icon-link"
+					aria-label={label}
+					title={label}
+				>
+					<span className={icon} aria-hidden="true" />
+				</a>
+			))}
+		</div>
+	);
+}

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -205,15 +205,8 @@ export default function Landing({ onNavigate }) {
 					</div>
 				</div>
 			</section>
-
-			<footer className="public-footer">
-				<div className="public-shell">
-					<span>Archimedes</span>
-					<span>
-						Research-grounded strategy generation · Arc public testnet
-					</span>
-				</div>
-			</footer>
+			{/* Footer moved to PublicLayout.jsx (shared shell chrome, also covers
+			    Architecture + not-found) — see the .public-footer block there. */}
 		</main>
 	);
 }

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import WalletConnect from "./WalletConnect";
 import Breadcrumbs from "./Breadcrumbs";
+import CompanyLinksFooter from "./CompanyLinksFooter";
 import { getStoredWalletName } from "../config";
 import { deriveChainStatus } from "../chainStatus";
 import { fetchHealth } from "../health";
@@ -471,6 +472,13 @@ export default function Layout({
 					)}
 					{children}
 				</main>
+				{/* Layout-bottom footer, shared across every /app page (Layout wraps
+				    all of them — App.jsx). Company/social links pick up
+				    automatically as companyLinks.js fills in; see
+				    CompanyLinksFooter.jsx. */}
+				<footer className="app-footer">
+					<CompanyLinksFooter />
+				</footer>
 			</div>
 		</div>
 	);

--- a/ui/src/components/PublicLayout.jsx
+++ b/ui/src/components/PublicLayout.jsx
@@ -1,3 +1,5 @@
+import CompanyLinksFooter from "./CompanyLinksFooter";
+
 export default function PublicLayout({ user, children }) {
 	return (
 		<div className="public-site">
@@ -32,6 +34,22 @@ export default function PublicLayout({ user, children }) {
 			<div id="public-content" tabIndex="-1">
 				{children}
 			</div>
+			{/* Shell-level footer: shared by every public page (Landing,
+			    Architecture, not-found) rather than duplicated per page. Moved
+			    here from Landing.jsx so Architecture also carries the brand line
+			    and the company/social links pick up automatically as
+			    companyLinks.js fills in — see CompanyLinksFooter.jsx. */}
+			<footer className="public-footer">
+				<div className="public-shell">
+					<div className="public-footer__brand">
+						<span>Archimedes</span>
+						<span>
+							Research-grounded strategy generation · Arc public testnet
+						</span>
+					</div>
+					<CompanyLinksFooter />
+				</div>
+			</footer>
 		</div>
 	);
 }

--- a/ui/src/socialLinks.js
+++ b/ui/src/socialLinks.js
@@ -1,0 +1,30 @@
+// Extensioned import: this module is real-imported directly by
+// test/company-links.test.js under plain Node ESM (no bundler), which
+// requires an explicit specifier — unlike Vite, it won't resolve a bare
+// "./companyLinks".
+import { companyLinks } from "./companyLinks.js";
+
+// Icon + accessible label per possible link. `icon` is a UnoCSS class drawn
+// from a collection already registered in uno.config.js's presetIcons
+// (simple-icons for brand marks, lucide for the generic company/globe mark);
+// `label` becomes the aria-label / title on the icon-only anchor
+// CompanyLinksFooter.jsx renders for it.
+export const SOCIAL_LINK_META = {
+	github: { icon: "i-simple-icons-github", label: "Archimedes on GitHub" },
+	discord: {
+		icon: "i-simple-icons-discord",
+		label: "Join the Archimedes Discord",
+	},
+	x: { icon: "i-simple-icons-x", label: "Archimedes on X" },
+	company: { icon: "i-lucide-globe", label: "APRIN Labs" },
+};
+
+// The one place that enforces companyLinks.js's rule — empty string means
+// "does not render." CompanyLinksFooter.jsx calls this instead of
+// re-implementing the check inline so the public and app shells can never
+// drift apart on which links are live.
+export function activeSocialLinks(links = companyLinks) {
+	return Object.keys(SOCIAL_LINK_META)
+		.filter((key) => Boolean(links[key]))
+		.map((key) => ({ key, url: links[key], ...SOCIAL_LINK_META[key] }));
+}

--- a/ui/test/company-links.test.js
+++ b/ui/test/company-links.test.js
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { companyLinks } from "../src/companyLinks.js";
+import { activeSocialLinks, SOCIAL_LINK_META } from "../src/socialLinks.js";
+
+// ── companyLinks.js: the drop-in config itself ──────────────────────────────
+//
+// github is real today (the public repo, wired at launch). discord/x/company
+// are pinned to '' — not "probably empty", a hard assertion. If the owner
+// fills one in without touching this file, the assertion for that field goes
+// from pass to fail, which is deliberate: the whole point (per the config's
+// own comment) is that a real URL is a conscious edit to this test, not a
+// silent drop-in. See socialLinks.js's activeSocialLinks() below for the
+// production behaviour this state produces.
+
+test("companyLinks: github is real, discord/x/company are pinned empty today", () => {
+	assert.equal(companyLinks.github, "https://github.com/a-apin/archimedes");
+	assert.equal(companyLinks.discord, "");
+	assert.equal(companyLinks.x, "");
+	assert.equal(companyLinks.company, "");
+});
+
+// ── socialLinks.js: activeSocialLinks() is the ONE filter both shells rely
+// on. These two tests are independent of companyLinks.js's current values —
+// they pass a synthetic links object so the filtering behaviour itself stays
+// pinned even after the owner fills discord/x/company in.
+
+test("activeSocialLinks: empty-string entries are dropped entirely, non-empty entries pass through with their icon/label", () => {
+	const result = activeSocialLinks({
+		github: "https://github.com/a-apin/archimedes",
+		discord: "",
+		x: "https://x.com/example",
+		company: "",
+	});
+	const keys = result.map((r) => r.key);
+	assert.deepEqual(keys, ["github", "x"]);
+	assert.deepEqual(result[0], {
+		key: "github",
+		url: "https://github.com/a-apin/archimedes",
+		...SOCIAL_LINK_META.github,
+	});
+	assert.deepEqual(result[1], {
+		key: "x",
+		url: "https://x.com/example",
+		...SOCIAL_LINK_META.x,
+	});
+});
+
+test("activeSocialLinks: all-empty config renders nothing — mutation-check target", () => {
+	// If the filter in socialLinks.js were ever weakened to render
+	// unconditionally (e.g. mapping every key instead of filtering first),
+	// this would start returning 4 entries — including url: "" anchors, i.e.
+	// exactly the dead links the claims-must-be-true rule forbids. Verified
+	// manually: commenting out the `.filter((key) => Boolean(links[key]))`
+	// line in socialLinks.js makes this assertion fail (4 entries returned,
+	// three with url: ""); see PR body for the transcript.
+	const result = activeSocialLinks({ github: "", discord: "", x: "", company: "" });
+	assert.deepEqual(result, []);
+});
+
+test("activeSocialLinks: today's real companyLinks.js produces exactly one active link — github", () => {
+	// This is the load-bearing assertion for the PR: it runs the real filter
+	// against the real config, not a synthetic stand-in. Combined with the
+	// companyLinks pin above, this fails the moment either (a) the filter
+	// breaks or (b) a placeholder ships into discord/x/company without this
+	// test being touched.
+	const result = activeSocialLinks(companyLinks);
+	assert.deepEqual(result.map((r) => r.key), ["github"]);
+	assert.equal(result[0].url, "https://github.com/a-apin/archimedes");
+});
+
+// ── CompanyLinksFooter.jsx: renders only what activeSocialLinks() hands it,
+// with an accessible name and a real external-link pattern per anchor ──────
+
+const companyLinksFooter = readFileSync(
+	new URL("../src/components/CompanyLinksFooter.jsx", import.meta.url),
+	"utf8",
+);
+
+test("CompanyLinksFooter: uses the shared filter, not an inline re-check, and renders nothing when it returns empty", () => {
+	assert.match(companyLinksFooter, /from ["']\.\.\/socialLinks["']/);
+	assert.match(companyLinksFooter, /activeSocialLinks\(\)/);
+	assert.match(companyLinksFooter, /if \(links\.length === 0\) return null;/);
+	// No second, independent emptiness check on companyLinks itself — that
+	// would be exactly the "re-implementing the check inline" drift
+	// socialLinks.js's comment warns against.
+	assert.doesNotMatch(companyLinksFooter, /companyLinks\[/);
+});
+
+test("CompanyLinksFooter: every anchor is a real external link with an accessible name", () => {
+	assert.match(companyLinksFooter, /target="_blank"/);
+	assert.match(companyLinksFooter, /rel="noopener noreferrer"/);
+	assert.match(companyLinksFooter, /aria-label=\{label\}/);
+	// Icon itself is decorative — the anchor already carries the name.
+	assert.match(companyLinksFooter, /aria-hidden="true"/);
+});
+
+// ── Wiring: both shells mount CompanyLinksFooter, per shell's existing
+// footer pattern ─────────────────────────────────────────────────────────
+
+const publicLayout = readFileSync(
+	new URL("../src/components/PublicLayout.jsx", import.meta.url),
+	"utf8",
+);
+const layout = readFileSync(
+	new URL("../src/components/Layout.jsx", import.meta.url),
+	"utf8",
+);
+const landing = readFileSync(
+	new URL("../src/components/Landing.jsx", import.meta.url),
+	"utf8",
+);
+const css = readFileSync(new URL("../src/App.css", import.meta.url), "utf8");
+
+test("PublicLayout: mounts the shared footer once for every public page (Landing, Architecture, not-found)", () => {
+	assert.match(publicLayout, /import CompanyLinksFooter from ["']\.\/CompanyLinksFooter["']/);
+	assert.match(publicLayout, /<footer className="public-footer">/);
+	assert.match(publicLayout, /<CompanyLinksFooter \/>/);
+	// The per-page duplicate in Landing.jsx must be gone — otherwise Landing
+	// renders two footers while Architecture renders none, and the links
+	// would only ever appear on one of the two public pages.
+	assert.doesNotMatch(landing, /<footer className="public-footer">/);
+});
+
+test("Layout: mounts the shared footer at the bottom of every /app page", () => {
+	assert.match(layout, /import CompanyLinksFooter from ["']\.\/CompanyLinksFooter["']/);
+	assert.match(layout, /<footer className="app-footer">/);
+	assert.match(layout, /<CompanyLinksFooter \/>/);
+});
+
+test("App.css: both footers style the shared link row with the existing icon-button idiom, not a new one", () => {
+	assert.match(css, /^\.footer-icon-link \{/m);
+	// Mirrors .topbar-icon-btn's hover/focus treatment (Layout.jsx's existing
+	// icon idiom) rather than inventing new tokens.
+	assert.match(
+		css,
+		/\.footer-icon-link:hover,\n\.footer-icon-link:focus-visible \{\n\tcolor: var\(--accent\);/,
+	);
+	assert.match(css, /^\.app-site \.app-footer \{/m);
+});
+
+// ── uno.config.js: dynamic icon classes must be safelisted or they silently
+// never render — the icon key comes from a JS object, not a static string
+// UnoCSS's scanner can see in the JSX. ─────────────────────────────────────
+
+const unoConfig = readFileSync(new URL("../uno.config.js", import.meta.url), "utf8");
+
+test("uno.config.js: every brand icon used in SOCIAL_LINK_META is safelisted", () => {
+	for (const { icon } of Object.values(SOCIAL_LINK_META)) {
+		assert.match(
+			unoConfig,
+			new RegExp(`'${icon}'`),
+			`${icon} is not in uno.config.js's safelist — it would never render`,
+		);
+	}
+});

--- a/ui/uno.config.js
+++ b/ui/uno.config.js
@@ -127,6 +127,13 @@ export default defineConfig({
     'i-simple-icons-tesla',
     'i-simple-icons-nvidia',
     'i-simple-icons-coinbase',
+    // Footer company/social links (socialLinks.js SOCIAL_LINK_META) — the
+    // icon class comes from a JS object, not a static string UnoCSS's
+    // scanner can see, so it must be safelisted explicitly like the brand
+    // logos above.
+    'i-simple-icons-github',
+    'i-simple-icons-discord',
+    'i-simple-icons-x',
     'i-logos-metamask',
     'i-token-branded-metamask',
   ],


### PR DESCRIPTION
## Summary

Drop-in company/social links footer for both UI shells, ahead of the owner
supplying the real Discord invite and X handle (aprin.ai — APRIN Labs — is
also not live yet; domain is being registered).

- `ui/src/companyLinks.js`: single config `{ github, discord, x, company }`.
  `github` is real today (this repo). `discord`/`x`/`company` are `''`.
  **Rule (claims-must-be-true):** an empty string means the link renders
  **nowhere** — no placeholder/dead links ship.
- `ui/src/socialLinks.js`: `activeSocialLinks(links)` — the one place that
  enforces the empty-string filter, plus the icon/label metadata per link.
- `ui/src/components/CompanyLinksFooter.jsx`: shared component both shells
  mount; renders one icon-only `<a target="_blank" rel="noopener noreferrer">`
  per non-empty link, or nothing at all.
- **Public shell** (`PublicLayout.jsx`): the footer that used to live only in
  `Landing.jsx` (so Architecture had none, and Landing would have gotten a
  duplicate) is moved up to `PublicLayout.jsx`, which wraps Landing,
  Architecture, and not-found — one footer, consistently, everywhere in the
  public shell, brand+tagline on the left, links on the right.
- **App shell** (`Layout.jsx`): new layout-bottom `<footer className="app-footer">`
  under `<main>`, right-aligned, mirroring the public footer's role.
- Icons reuse the existing UnoCSS idiom (`i-simple-icons-github/-discord/-x`,
  `i-lucide-globe` for the company link) and the existing `.topbar-icon-btn`
  hover/focus treatment (new `.footer-icon-link` class). New icon classes
  added to `uno.config.js`'s safelist (they come from a JS object, not a
  static string UnoCSS's scanner can see).

## Owner drop-in steps

1. Fill in `ui/src/companyLinks.js`:
   - `discord: "<invite URL>"`
   - `x: "<profile URL>"`
   - `company: "https://aprin.ai"` — **only once the site actually resolves**
2. Update the three pinned-empty assertions in
   `ui/test/company-links.test.js` (`companyLinks.discord === ''` etc.) —
   they fail on purpose the moment a value is filled in, so this step can't
   be skipped silently.
3. Flip the PR out of draft.

No other code changes needed — icons and rendering are already wired and
will appear automatically.

## Tests

`ui/test/company-links.test.js` (node --test, source-assertion style,
matches the rest of `ui/test/`):

- Pins today's `companyLinks.js` state (github real, discord/x/company `''`).
- Unit-tests `activeSocialLinks()`'s filter against synthetic input
  (independent of `companyLinks.js`'s current values, so it stays a
  permanent regression guard).
- Confirms `activeSocialLinks(companyLinks)` (the real config) yields exactly
  one active link today (github).
- Source-asserts `CompanyLinksFooter.jsx` uses the shared filter (not an
  inline re-check), has the `links.length === 0` → `null` guard, and every
  anchor carries `target="_blank" rel="noopener noreferrer"` +
  `aria-label`.
- Source-asserts both shells wire `CompanyLinksFooter` into their existing
  footer patterns, and that `Landing.jsx`'s old per-page footer is gone
  (no duplicate).
- Asserts every icon class in `SOCIAL_LINK_META` is present in
  `uno.config.js`'s safelist.

### Mutation-check transcript (guards-need-an-adversarial-pass)

Per the repo's guard discipline: before pushing, I disabled the filter in
`socialLinks.js` (commented out `.filter((key) => Boolean(links[key]))`, so
`activeSocialLinks` maps every key unconditionally — the exact "renders
unconditionally" bug the tests exist to catch) and re-ran the suite:

```
$ node --test test/company-links.test.js
✔ companyLinks: github is real, discord/x/company are pinned empty today
✖ activeSocialLinks: empty-string entries are dropped entirely, non-empty entries pass through with their icon/label
✖ activeSocialLinks: all-empty config renders nothing — mutation-check target
✖ activeSocialLinks: today's real companyLinks.js produces exactly one active link — github
✔ CompanyLinksFooter: uses the shared filter, not an inline re-check, and renders nothing when it returns empty
✔ CompanyLinksFooter: every anchor is a real external link with an accessible name
✔ PublicLayout: mounts the shared footer once for every public page (Landing, Architecture, not-found)
✔ Layout: mounts the shared footer at the bottom of every /app page
✔ App.css: both footers style the shared link row with the existing icon-button idiom, not a new one
✔ uno.config.js: every brand icon used in SOCIAL_LINK_META is safelisted

ℹ tests 10
ℹ pass 7
ℹ fail 3
```

3 of 10 tests fail exactly as expected — the "today's real config" test
reported `['github', 'discord', 'x', 'company']` instead of `['github']`,
and the synthetic-input test reported `url: ''` anchors would have been
returned. Reverted the filter immediately after; full suite is green again
(`193 passed, 0 failed`).

## Verification

```
$ node --test        # 193 passed, 0 failed
$ npm run lint        # clean
$ npm run build       # succeeds; pre-existing >500kB chunk warning unrelated
                       # to this change (verified against a baseline build of
                       # unmodified main: the same-sized shared chunk already
                       # exists there, named after health.js instead — the
                       # public shell's Architecture.jsx and the app shell's
                       # Layout.jsx already share that module across the
                       # eager/lazy boundary; CompanyLinksFooter.jsx joining
                       # that same shared-chunk group added ~0.8kB)
```

## Deviations from spec

- Consolidated the public-shell footer into `PublicLayout.jsx` rather than
  only touching `Landing.jsx`, and deleted the old per-page footer in
  `Landing.jsx`. The task named "the public shell — Landing/Architecture
  layout" as the target file, and leaving the old footer in place would have
  produced either a duplicate footer on Landing or no footer at all on
  Architecture. No test pinned the old two-`<span>` footer structure, so
  this was a safe, minimal-risk consolidation.
- Company link's icon is `i-lucide-globe` (generic site icon) rather than a
  brand mark, since APRIN Labs has no distinct brand icon shipped in this
  repo's icon collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M
