### PR TITLE
[backend] Fix _weights_present: huggingface nests the cache under hub/ (regression from #1328)

### DIFF
--- a/backend/archimedes/services/paper_rag.py
+++ b/backend/archimedes/services/paper_rag.py
@@ -121,45 +121,66 @@ def paper_rag_health(probe: bool = False) -> PaperRAGHealth:
     return PaperRAGHealth(status="degraded", reason="embedding model unavailable, TF-IDF fallback")
 
 
-def _weights_present() -> bool:
-    """Cheap on-disk check that the baked model cache holds our model.
-
-    The Docker image bakes the weights into ``HF_HOME`` at build time
-    (backend/Dockerfile:70) and runs with ``HF_HUB_OFFLINE=1``, so "the
-    directory for this model exists and is non-empty" is the strongest claim
-    available without importing torch. It is deliberately NOT reported as
-    ``live`` — presence on disk is not proof the model loads.
-    """
-    hf_home = os.getenv("HF_HOME")
-    if not hf_home:
-        return False
-    slug = _model_name().replace("/", "--")
-    root = Path(hf_home)
-    try:
-        for candidate in root.iterdir():
-            if not candidate.is_dir():
-                continue
-            name = candidate.name
-            if slug in name or name in (slug, f"models--sentence-transformers--{slug}"):
-                return any(candidate.rglob("*.safetensors")) or any(candidate.rglob("*.bin"))
-    except OSError:
-        return False
-    return False
-
-
 def _semantic_enabled() -> bool:
     """Check the feature flag. Default ON for production."""
     val = os.getenv("FUSION_SEMANTIC_RETRIEVAL", "true").strip().lower()
     return val in _TRUTHY
 
 
-# ── Embedding engine ─────────────────────────────────────────────
-
 # Lazy-loaded embedding model (sentence-transformers).
 _embedding_model: Any = None
 # Sentinel: True once a load attempt has been made and failed, so repeated
 # health checks don't retry indefinitely (the result is cached after first try).
 _embedding_load_attempted: bool = False
+
+_weights_present_cache: bool | None = None
+
+
+def _weights_present() -> bool:
+    """Cheap on-disk check that the baked model cache holds our model.
+
+    The Docker image bakes the weights into ``HF_HOME`` at build time
+    (backend/Dockerfile:70-74) and runs with ``HF_HUB_OFFLINE=1``.
+
+    huggingface_hub NESTS its cache: the model lives at
+    ``$HF_HOME/hub/models--<org>--<name>/snapshots/<sha>/model.safetensors``,
+    not directly under ``$HF_HOME`` (whose top level holds only ``hub`` and
+    ``xet``). The first version of this function scanned one level with
+    ``iterdir()``, found neither, and reported ``degraded`` on a container
+    where the model loads perfectly — so search the tree instead.
+
+    Memoised: the cache is a static build artifact, and ``/health`` is polled
+    every 30s by the ALB. Presence on disk is deliberately NOT reported as
+    ``live`` — it is not proof the model loads.
+    """
+    global _weights_present_cache
+    if _weights_present_cache is not None:
+        return _weights_present_cache
+    _weights_present_cache = _scan_for_weights()
+    return _weights_present_cache
+
+
+def _scan_for_weights() -> bool:
+    hf_home = os.getenv("HF_HOME")
+    if not hf_home:
+        return False
+    slug = _model_name().replace("/", "--")
+    tail = slug.rsplit("--", 1)[-1]
+    root = Path(hf_home)
+    try:
+        for candidate in root.rglob("*"):
+            if not candidate.is_dir():
+                continue
+            name = candidate.name
+            if not (slug in name or tail in name):
+                continue
+            if next(candidate.rglob("*.safetensors"), None) is not None:
+                return True
+            if next(candidate.rglob("*.bin"), None) is not None:
+                return True
+    except OSError:
+        return False
+    return False
 
 
 def _get_embedding_model():

--- a/backend/tests/test_paper_rag.py
+++ b/backend/tests/test_paper_rag.py
@@ -515,6 +515,9 @@ class TestWeightsPresent:
     def setup_method(self):
         _reset_model_cache()
 
+    def teardown_method(self):
+        _reset_model_cache()
+
     def test_finds_weights_in_the_real_nested_hf_layout(self, monkeypatch):
         """THE REGRESSION: weights nested under hub/ must be found."""
         monkeypatch.setenv("MINILM_MODEL", "all-MiniLM-L6-v2")

--- a/backend/tests/test_paper_rag.py
+++ b/backend/tests/test_paper_rag.py
@@ -17,7 +17,10 @@ never touched. Tests cover:
 
 from __future__ import annotations
 
+import contextlib
+import tempfile
 import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import archimedes.services.paper_rag as rag_module
@@ -39,6 +42,7 @@ def _reset_model_cache() -> None:
     """Reset module-level model singleton so each test starts clean."""
     rag_module._embedding_model = None
     rag_module._embedding_load_attempted = False
+    rag_module._weights_present_cache = None
 
 
 def _fake_model(embeddings: dict[str, list[float]] | None = None):
@@ -168,7 +172,8 @@ class TestHealthDoesNotLoadModel:
     def test_ready_when_weights_present_but_unloaded(self, monkeypatch):
         monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
         _reset_model_cache()
-        with patch.object(rag_module, "_weights_present", return_value=True):
+        with _baked_hf_cache() as hf_home:
+            monkeypatch.setenv("HF_HOME", hf_home)
             h = paper_rag_health()
         assert h.status == "ready"
         assert "not loaded" in h.reason
@@ -177,7 +182,8 @@ class TestHealthDoesNotLoadModel:
         """No weights on disk is a real problem and must not read as 'ready'."""
         monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
         _reset_model_cache()
-        with patch.object(rag_module, "_weights_present", return_value=False):
+        with tempfile.TemporaryDirectory() as empty:
+            monkeypatch.setenv("HF_HOME", empty)
             h = paper_rag_health()
         assert h.status == "degraded"
 
@@ -200,7 +206,7 @@ class TestHealthDoesNotLoadModel:
         monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "false")
         _reset_model_cache()
         probe = MagicMock(return_value=True)
-        with patch.object(rag_module, "_weights_present", probe):
+        with patch.object(rag_module, "_scan_for_weights", probe):
             h = paper_rag_health()
         probe.assert_not_called()
         assert h.status == "disabled"
@@ -473,3 +479,74 @@ class TestAugmentCandidateScores:
         by_title = {c.title: s for c, s in results}
         assert by_title["Paper One about momentum"] == 0.9  # not collapsed to 0.2
         assert by_title["Paper Two about value"] == 0.2
+
+
+# ── _weights_present must understand the REAL huggingface_hub layout ─────────
+#
+# The first version of this scanned one level with iterdir(). huggingface_hub
+# nests the cache as $HF_HOME/hub/models--<org>--<name>/snapshots/<sha>/..., so
+# the top level of HF_HOME holds only "hub" and "xet" — neither matched, and
+# production reported paper_rag="degraded" (and corpus_embedded=false on a
+# public surface) on a container where /health/paper-rag proved the model loads.
+#
+# It shipped because the tests mocked _weights_present itself instead of
+# exercising it — CLAUDE.md's "mock at boundaries, not internals". These build a
+# real directory tree.
+
+
+@contextlib.contextmanager
+def _baked_hf_cache(model: str = "all-MiniLM-L6-v2", weight: str = "model.safetensors"):
+    """A tmp HF_HOME laid out exactly as the Docker image bakes it."""
+    with tempfile.TemporaryDirectory() as root:
+        snap = (
+            Path(root)
+            / "hub"
+            / f"models--sentence-transformers--{model}"
+            / "snapshots"
+            / "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"
+        )
+        snap.mkdir(parents=True)
+        (snap / weight).write_bytes(b"\x00")
+        (Path(root) / "xet").mkdir()
+        yield root
+
+
+class TestWeightsPresent:
+    def setup_method(self):
+        _reset_model_cache()
+
+    def test_finds_weights_in_the_real_nested_hf_layout(self, monkeypatch):
+        """THE REGRESSION: weights nested under hub/ must be found."""
+        monkeypatch.setenv("MINILM_MODEL", "all-MiniLM-L6-v2")
+        with _baked_hf_cache() as hf_home:
+            monkeypatch.setenv("HF_HOME", hf_home)
+            assert rag_module._weights_present() is True
+
+    def test_finds_pytorch_bin_layout_too(self, monkeypatch):
+        monkeypatch.setenv("MINILM_MODEL", "all-MiniLM-L6-v2")
+        with _baked_hf_cache(weight="pytorch_model.bin") as hf_home:
+            monkeypatch.setenv("HF_HOME", hf_home)
+            assert rag_module._weights_present() is True
+
+    def test_false_when_model_dir_exists_but_holds_no_weights(self, monkeypatch):
+        monkeypatch.setenv("MINILM_MODEL", "all-MiniLM-L6-v2")
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "hub" / "models--sentence-transformers--all-MiniLM-L6-v2").mkdir(parents=True)
+            monkeypatch.setenv("HF_HOME", root)
+            assert rag_module._weights_present() is False
+
+    def test_false_when_hf_home_unset(self, monkeypatch):
+        monkeypatch.delenv("HF_HOME", raising=False)
+        assert rag_module._weights_present() is False
+
+    def test_result_is_memoised(self, monkeypatch):
+        """/health is polled every 30s; the tree must be walked once."""
+        monkeypatch.setenv("MINILM_MODEL", "all-MiniLM-L6-v2")
+        with _baked_hf_cache() as hf_home:
+            monkeypatch.setenv("HF_HOME", hf_home)
+            spy = MagicMock(return_value=True)
+            with patch.object(rag_module, "_scan_for_weights", spy):
+                rag_module._weights_present()
+                rag_module._weights_present()
+                rag_module._weights_present()
+            assert spy.call_count == 1


### PR DESCRIPTION
## Summary

**This fixes a regression I introduced in #1328.** Production has been reporting `paper_rag: "degraded"` and `corpus_embedded: false` ever since it deployed — on a container where the model loads perfectly.

Right now, live:

```
$ curl -s https://archimedes-arc.com/health | jq '{paper_rag, corpus_embedded}'
{ "paper_rag": "degraded", "corpus_embedded": false }

$ curl -s https://archimedes-arc.com/health/paper-rag
{"paper_rag":"live","reason":"model=all-MiniLM-L6-v2"}
```

The probe endpoint proves the model loads. The cheap check says it's broken.

## Cause

`_weights_present()` scanned **one level** with `root.iterdir()`. huggingface_hub **nests** its cache. From the actual production image:

```
$ docker run --rm --entrypoint sh <prod-image> -c 'ls -1 $HF_HOME'
hub
xet

$ find $HF_HOME -name "*.safetensors"
/app/model_cache/hub/models--sentence-transformers--all-MiniLM-L6-v2/snapshots/1110a243…/model.safetensors
```

The top level of `/app/model_cache` holds only `hub` and `xet`. Neither contains the model slug, so the loop matched nothing and returned `False`.

**This is worse than the fail-soft it replaced.** `degraded` means specifically "a load was attempted and failed". Nothing was attempted. It asserts a failure that did not happen — on `corpus_embedded`, which is a public claim surface. I introduced exactly the class of defect I've spent tonight filing against other code.

## Fix

Walk the tree instead of one level; match the model directory by full slug **or** bare name (`all-MiniLM-L6-v2`, so the `models--sentence-transformers--` prefix is not load-bearing); require an actual `.safetensors`/`.bin` **inside** it, so an empty directory is not mistaken for a present model. Memoised into `_weights_present_cache` — the cache is a static build artifact and the ALB polls `/health` every 30 seconds.

## Why it shipped, and what changed in the tests

The #1328 tests mocked the function that was broken:

```python
with patch.object(rag_module, "_weights_present", return_value=True):
```

That exercises the caller and never the callee — `CLAUDE.md` § "Mock at boundaries, not internals". The mock asserted the very thing that was wrong.

Replaced with a real temp directory laid out exactly as the image bakes it (`hub/models--sentence-transformers--<model>/snapshots/<sha>/model.safetensors`, plus a sibling `xet/`), covering: the nested layout, the `pytorch_model.bin` variant, a model directory that exists but holds no weights, `HF_HOME` unset, and a memoisation assertion.

## Verification

**Inside the real production image, with the real baked cache:**

```
weights_present : True
/health  status : ready
/health  reason : model=all-MiniLM-L6-v2 present, not loaded (no retrieval yet)
RSS delta       : 0.0 MB          torch imported: False
probe=True      : live
```

So the regression is fixed *and* #1328's actual benefit — never loading 521 MB of torch on the ALB probe path — is preserved.

```
pytest backend/tests/test_paper_rag.py -q     → 37 passed
ruff format --check + ruff check              → clean
```

**Mutation check:** restoring the `iterdir()` scan fails **3** tests, including `test_finds_weights_in_the_real_nested_hf_layout` and `test_ready_when_weights_present_but_unloaded` (`AssertionError: assert 'degraded' == 'ready'`).

### A second bug the tests could not have caught

While fixing this I removed `_embedding_model` and `_embedding_load_attempted` (module globals that sat inside the replaced region) and **the suite still passed 37/37** — because `_reset_model_cache()` in the test file *assigns* those globals, creating them at runtime and masking their absence. Only running the module standalone in the prod image surfaced `NameError: name '_embedding_model' is not defined`. Both are restored, and a module-level name diff against `main` now shows only the two intended additions (`_scan_for_weights`, `_weights_present_cache`).

Worth noting for reviewers generally: a test helper that assigns a module global will hide that global's deletion.

## Anti-goals honoured

- Does **not** relax `/health` back into loading the model — the RSS-delta and `torch not in sys.modules` guards from #1328 are intact and still mutation-checked.
- Does **not** widen `corpus_embedded` to accept `ready`. Weights on disk is still not proof the model loads; `corpus_embedded` remains strictly `status == "live"` and flips on first real retrieval.
- No change to `_get_embedding_model()`, the `torch.set_num_threads(1)` CPU guardrail, or the TF-IDF fallback.

