### PR TITLE
[frontend] /architecture: stop claiming wallet/passkey sign-in

### DIFF
--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -235,7 +235,7 @@ function SystemFlowDiagram() {
 const CORE_PIPELINE_STEPS = [
 	{
 		title: "Your brief",
-		sub: "plain English, optional asset classes, risk profile, and a model cost picker · sign in with any wallet or a passkey",
+		sub: "plain English, optional asset classes, risk profile, and a model cost picker · sign in or create a free account",
 	},
 	{
 		title: "Debate",
@@ -1256,7 +1256,7 @@ function CallToAction({ onNavigate }) {
 			>
 				{ROADMAP_SURFACES_ENABLED
 					? ROADMAP_COPY.ctaLede
-					: "Describe a strategy in plain English, then sign in with any wallet or a passkey to see it through the rigor gate."}
+					: "Describe a strategy in plain English, then sign in to see it through the rigor gate."}
 			</p>
 			<div className="flex justify-center gap-3 flex-wrap">
 				<button

--- a/ui/test/signin-claims.test.js
+++ b/ui/test/signin-claims.test.js
@@ -1,0 +1,85 @@
+// Claim-integrity guard for sign-in method claims on the public surfaces
+// (#1431): /architecture told visitors to "sign in with any wallet or a
+// passkey" while the live providers endpoint reports passkey:false and no
+// wallet provider at all — and AuthPage itself states "Circle wallet passkeys
+// ... do not sign in to Archimedes". The copy was wrong, not the product
+// state, so the fix is copy plus this guard, never enabling passkeys.
+//
+// Same shape as roadmap-copy.test.js's prose guard: a raw source-text scan
+// (readFileSync, no JSX parsing) over the public explainer surfaces. It is
+// deliberately generic ("sign in", not a provider list) on the fixed side —
+// per #1431's anti-goal, hard-coding "email, Google or GitHub" would drift
+// the next time a provider flips — while the guard side pins the specific
+// false claims that shipped.
+//
+// AuthPage.jsx is deliberately NOT scanned: it is the one surface allowed to
+// talk about wallet passkeys, because it does so accurately, in negation
+// ("They do not sign in to Archimedes").
+//
+// Anti-vacuity, mirroring roadmap-copy.test.js: every scanned file must
+// exist (a rename must fail loudly, not shrink the scan to nothing), and
+// every pattern must match its own canonical example (a pattern that stops
+// matching anything is guarding nothing).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+
+const SCANNED_SURFACES = [
+	"components/Architecture.jsx",
+	"components/Landing.jsx",
+	"components/PublicLayout.jsx",
+	"components/Layout.jsx",
+];
+
+// Each entry: a phrase-shape that claims a sign-in method the providers
+// endpoint reports as unavailable, plus the canonical example it must match.
+const FALSE_SIGNIN_CLAIMS = [
+	{
+		pattern: /sign[- ]?in with (any |a )?(wallet|passkey)/i,
+		canonical: "sign in with any wallet",
+	},
+	{
+		pattern: /wallet or a passkey/i,
+		canonical: "sign in with any wallet or a passkey",
+	},
+	{
+		pattern: /passkey to sign[- ]?in/i,
+		canonical: "use a passkey to sign in",
+	},
+];
+
+test("every scanned surface file exists (scan cannot silently shrink)", () => {
+	for (const rel of SCANNED_SURFACES) {
+		assert.doesNotThrow(
+			() => readFileSync(join(SRC, rel), "utf8"),
+			`${rel} is declared in SCANNED_SURFACES but unreadable — update the list, do not let the scan shrink silently`,
+		);
+	}
+});
+
+test("every pattern matches its canonical example (guard is not vacuous)", () => {
+	for (const { pattern, canonical } of FALSE_SIGNIN_CLAIMS) {
+		assert.match(
+			canonical,
+			pattern,
+			`pattern ${pattern} no longer matches its own canonical example — it is guarding nothing`,
+		);
+	}
+});
+
+test("public surfaces never claim wallet or passkey sign-in", () => {
+	for (const rel of SCANNED_SURFACES) {
+		const source = readFileSync(join(SRC, rel), "utf8");
+		for (const { pattern } of FALSE_SIGNIN_CLAIMS) {
+			assert.doesNotMatch(
+				source,
+				pattern,
+				`${rel} claims a sign-in method the providers endpoint reports as unavailable (${pattern}) — see #1431; fix the copy, do not enable the method`,
+			);
+		}
+	}
+});


### PR DESCRIPTION
Closes #1431.

`/architecture` told visitors — twice, including in the flag-off else-branch written for the shipped build — to "sign in with any wallet or a passkey". Production providers: `{"emailPassword":true,"google":true,"github":true,"passkey":false}`, and no wallet sign-in path exists (`AuthPage.jsx` states passkeys "do not sign in to Archimedes"). The copy was wrong, not the product state.

## Changes

- `Architecture.jsx`: pipeline step 1 now ends "sign in or create a free account"; the closing CTA now reads "…then sign in to see it through the rigor gate." Generic on purpose — the issue's anti-goal rules out a new hard-coded provider list that drifts the next time a provider flips.
- `ui/test/signin-claims.test.js`: source-scan claim-integrity guard over the four public surfaces (Architecture, Landing, PublicLayout, Layout), mirroring `roadmap-copy.test.js`, with the same anti-vacuity coverage (scanned files must exist; every pattern must match its canonical example). `AuthPage.jsx` is deliberately excluded — it is the one surface allowed to discuss wallet passkeys because it does so accurately, in negation.

## Acceptance evidence

1. `grep -rn "wallet or a passkey" ui/src/` → no match.
2. `cd ui && node --test` → **294 pass, 0 fail**.
3. **Mutation check (guard shown to reject):** reverted `Architecture.jsx` to HEAD (unfixed copy), ran `node --test test/signin-claims.test.js` → **1 fail** ("public surfaces never claim wallet or passkey sign-in"), then re-applied the fix. The guard rejects the exact strings that shipped.
4. Deployed check post-merge: `curl -s https://archimedes-arc.com/$(curl -s https://archimedes-arc.com/ | grep -o '/assets/index-[^\"]*\.js') | grep -c "wallet or a passkey"` → expect `0`.

Anti-goals honored: passkeys not enabled anywhere; `CreateVaultModal.jsx` / `DepositFlow.jsx` Circle wallet-passkey code untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCr9L8iz189eQ6v1QTPz2M