### PR TITLE
[backend] Route generation-path market data through the cached provider seam

### DIFF
--- a/backend/archimedes/services/fusion_market_data.py
+++ b/backend/archimedes/services/fusion_market_data.py
@@ -8,9 +8,11 @@ supplier:
 
 - resolves a spec's ``asset_universe`` to yfinance tickers via the
   Chainlink-only universe SSOT (``GLOBAL_ASSETS``, PR #842),
-- fetches real daily OHLCV through the analytics-engine's ``fetch_ohlcv``
-  (the single owner of the fetch+normalize contract — same reuse rationale as
-  ``portfolio_backtester``),
+- fetches real daily OHLCV through the market-data provider seam
+  (``archimedes.services.market_data_provider.get_provider().get_daily_ohlcv``,
+  #1218/#1282) — vendor-swappable via ``MARKET_DATA_PROVIDER`` and
+  cache-backed by ``asset_daily_bars``, same seam the request-path call sites
+  use; same reuse rationale as ``portfolio_backtester``,
 - strictly inner-joins the panel across assets (missing data is a lookahead /
   survivorship vector — same rule as ``portfolio_backtester._fetch_price_panel``),
 - hands back per-asset **feed factories**: a backtrader feed object is consumed
@@ -94,11 +96,16 @@ def _ensure_analytics_import() -> None:
 
 
 def _fetch_one(yf_ticker: str, start: str, end: str) -> Any:
-    """Fetch one symbol's normalized OHLCV DataFrame. Test seam — monkeypatch me."""
-    _ensure_analytics_import()
-    from archimedes_analytics_engine.data import fetch_ohlcv
+    """Fetch one symbol's normalized OHLCV DataFrame via the cached
+    market-data provider seam (#1218/#1282 —
+    ``archimedes.services.market_data_provider``), so this fetch honors
+    ``MARKET_DATA_PROVIDER`` and reads/writes the ``asset_daily_bars``
+    Postgres cache the same way the request-path call sites do — a
+    generation-path re-run of the same universe hits the cache, not the
+    vendor, after the first fetch. Test seam — monkeypatch me."""
+    from archimedes.services.market_data_provider import get_provider
 
-    return fetch_ohlcv(yf_ticker, start, end)
+    return get_provider().get_daily_ohlcv(yf_ticker, start, end)
 
 
 def resolve_universe(asset_universe: list[str]) -> dict[str, str]:

--- a/backend/archimedes/services/market_data_provider.py
+++ b/backend/archimedes/services/market_data_provider.py
@@ -445,6 +445,19 @@ def _read_cached_ohlcv(session, ticker: str, start_date: date, end_date: date, t
     if earliest > start_date + timedelta(days=_COVERAGE_TOLERANCE_DAYS):
         return None  # cache doesn't reach back far enough for this request
 
+    # Forward-coverage is load-bearing, not symmetry for its own sake: both
+    # call sites default `end` to "today" on every call, so a cache primed
+    # through day D is routinely re-read after the date rolls to D+1 while
+    # still inside the TTL. Without this check that read is a "hit" on a
+    # silently shorter frame — a backtest window truncation that moves every
+    # graded number with no signal. Known tradeoff: a symbol whose vendor
+    # data genuinely ends before `end_date` (delisted/halted) now misses and
+    # re-fetches every call; correctness over cache hits — recording a
+    # vendor-end marker at write time is the fix for that, out of scope here.
+    latest = rows[-1].trade_date
+    if latest < end_date - timedelta(days=_COVERAGE_TOLERANCE_DAYS):
+        return None  # cache doesn't reach forward to the requested end
+
     newest_fetch = max(r.fetched_at for r in rows)
     if newest_fetch.tzinfo is None:
         newest_fetch = newest_fetch.replace(tzinfo=UTC)

--- a/backend/archimedes/services/market_data_provider.py
+++ b/backend/archimedes/services/market_data_provider.py
@@ -10,7 +10,7 @@ package, but both read the SAME ``MARKET_DATA_PROVIDER`` env var and default
 to ``"yfinance"``, so a deploy of this change is a no-op until the flag
 flips).
 
-Three call sites route through here (grep-verified):
+Five call sites route through here (grep-verified):
   - ``strategy_signal_evaluator._fetch_price_history(ies)`` — daily close
     series for backtests/Explore's universe sweep (the #1218 volume driver).
   - ``chain.oracle_updater`` — the live oracle-push equity fetch, the VIX /
@@ -18,6 +18,10 @@ Three call sites route through here (grep-verified):
     independent reading.
   - ``services.asset_market_service._fetch_yfinance_series`` — the Explore
     per-asset history-modal endpoint.
+  - ``services.fusion_market_data._fetch_one`` — the GENERATION path's
+    fusion/debate real-data panel (#1218 generation-path seam fix).
+  - ``services.portfolio_backtester._fetch_price_panel`` — the GENERATION
+    path's portfolio-weights backtester (same fix).
 
 **#775 resolution, in one line:** the cross-check
 (``oracle_updater._cross_check_secondary``) reads its independent secondary
@@ -26,16 +30,19 @@ through ``get_provider()`` and treats ``provider_name()`` (not a hardcoded
 new vendor and the cross-check's secondary source swaps with it automatically
 — no separate change needed at the guardrail.
 
-**Caching, scoped intentionally.** Only ``get_daily_close_batch`` — the
-DAILY-bar shape that matches ``asset_daily_bars`` — is cache-backed
-(``CachingMarketDataProvider``). ``get_intraday_quote(s)`` (live oracle
-pushes, VIX, the cross-check's secondary) and ``get_series`` (the Explore
-history modal, any interval) pass straight through, uncached, on purpose: a
-stale daily close must never masquerade as a live push/guardrail reading, and
-a single-symbol drill-down isn't the volume driver #1218 identified — the
-280-symbol universe sweep behind ``get_daily_close_batch`` is. Background
-refresh is deliberately NOT built here (#1218 anti-goal: seam, not
-migration) — the cache primes itself on the first miss.
+**Caching, scoped intentionally.** ``get_daily_close_batch`` — the DAILY-bar
+close-only shape that matches ``asset_daily_bars`` — and ``get_daily_ohlcv``
+— the DAILY full-bar (Open/High/Low/Close/Volume) shape the generation path's
+backtrader feeds and Close+Volume panel need — are both cache-backed
+(``CachingMarketDataProvider``), and both read/write the SAME
+``asset_daily_bars`` table (a row primed by one method's writer that lacks a
+full bar is treated as a miss by the other, so the two never hand back a
+partially-populated frame as if it were complete). ``get_intraday_quote(s)``
+(live oracle pushes, VIX, the cross-check's secondary) and ``get_series`` (the
+Explore history modal, any interval) pass straight through, uncached, on
+purpose: a stale daily close must never masquerade as a live push/guardrail
+reading. Background refresh is deliberately NOT built here (#1218 anti-goal:
+seam, not migration) — the cache primes itself on the first miss.
 """
 
 from __future__ import annotations
@@ -125,6 +132,21 @@ class MarketDataProvider(ABC):
     def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
         """Generic close-price series at an arbitrary (period, interval) —
         the Explore history-modal shape. Never cached."""
+
+    @abstractmethod
+    def get_daily_ohlcv(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        """Full daily OHLCV history for one vendor ticker over ``[start, end)``
+        (ISO date strings) — the shape the GENERATION path needs: backtrader
+        feeds (``fusion_market_data.feed_factory``) and the portfolio
+        simulator's Close+Volume panel (``portfolio_backtester._fetch_price_panel``)
+        both consume a full OHLCV frame, not a close-only series, so this is a
+        separate method from ``get_daily_close_batch`` rather than a batch
+        variant of it. Columns ``Open``/``High``/``Low``/``Close``/``Volume``,
+        a ``DatetimeIndex``, normalized (dropna, monotonic — see
+        ``archimedes_analytics_engine.data.normalize_ohlcv``). Raises on a
+        genuinely unfetchable symbol/range rather than returning an empty
+        frame — callers already handle that (fail-closed to synthetic,
+        per-symbol skip) and rely on the exception, not a sentinel value."""
 
 
 class YFinanceProvider(MarketDataProvider):
@@ -268,6 +290,21 @@ class YFinanceProvider(MarketDataProvider):
             logger.warning("Failed to extract Close for %s: %s", ticker, exc)
             return pd.Series(dtype=float)
 
+    def get_daily_ohlcv(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        """Delegates to analytics-engine's ``data.fetch_ohlcv`` — the exact
+        fetch/retry/normalize contract ``fusion_market_data`` and
+        ``portfolio_backtester`` already depended on directly before this
+        seam existed (#1282). Reusing it here (rather than re-implementing
+        the fetch against yfinance a second time) is what guarantees the
+        cold-cache output is byte-identical to the pre-seam direct-fetch
+        path — the two are now the same function call."""
+        from archimedes.services.fusion_market_data import _ensure_analytics_import
+
+        _ensure_analytics_import()
+        from archimedes_analytics_engine.data import fetch_ohlcv
+
+        return fetch_ohlcv(ticker, start, end)
+
 
 _VENDOR_PROVIDERS: dict[str, type[MarketDataProvider]] = {
     "yfinance": YFinanceProvider,
@@ -376,6 +413,125 @@ def _write_cached_series(session, ticker: str, series: pd.Series, source: str) -
             )
 
 
+def _read_cached_ohlcv(session, ticker: str, start_date: date, end_date: date, ttl: timedelta) -> pd.DataFrame | None:
+    """Return a cached OHLCV ``DataFrame`` for ``ticker`` if the cache covers
+    back to (approximately) ``start_date``, holds through ``end_date``, every
+    row carries a full bar (not a close-only row written by
+    ``get_daily_close_batch``'s writer), and was written within ``ttl``.
+    ``None`` on any miss (caller re-fetches the whole range)."""
+    from archimedes.models.asset_daily_bars import AssetDailyBar
+
+    rows = (
+        session.query(AssetDailyBar)
+        .filter(
+            AssetDailyBar.symbol == ticker,
+            AssetDailyBar.trade_date >= start_date,
+            AssetDailyBar.trade_date <= end_date,
+        )
+        .order_by(AssetDailyBar.trade_date)
+        .all()
+    )
+    if not rows:
+        return None
+
+    # A row primed by get_daily_close_batch's writer only carries `close` —
+    # open/high/low/volume are NULL. Treat that as a miss for THIS method:
+    # a partial bar is not a valid OHLCV cache entry, and re-fetching the
+    # whole range fills it in properly (via _write_cached_ohlcv below).
+    if any(r.open is None or r.high is None or r.low is None or r.volume is None for r in rows):
+        return None
+
+    earliest = rows[0].trade_date
+    if earliest > start_date + timedelta(days=_COVERAGE_TOLERANCE_DAYS):
+        return None  # cache doesn't reach back far enough for this request
+
+    newest_fetch = max(r.fetched_at for r in rows)
+    if newest_fetch.tzinfo is None:
+        newest_fetch = newest_fetch.replace(tzinfo=UTC)
+    if datetime.now(UTC) - newest_fetch > ttl:
+        return None  # cache is past its freshness window
+
+    idx = pd.to_datetime([r.trade_date for r in rows])
+    return pd.DataFrame(
+        {
+            "Open": [r.open for r in rows],
+            "High": [r.high for r in rows],
+            "Low": [r.low for r in rows],
+            "Close": [r.close for r in rows],
+            "Volume": [r.volume for r in rows],
+        },
+        index=idx,
+    )
+
+
+def _write_cached_ohlcv(session, ticker: str, df: pd.DataFrame, source: str) -> None:
+    """Upsert a full OHLCV frame (indexed by date, columns
+    Open/High/Low/Close/Volume — ``fetch_ohlcv``'s output shape) into
+    ``asset_daily_bars`` for ``ticker``. Mirrors ``_write_cached_series`` but
+    persists the whole bar, not close-only, so the row is a valid cache entry
+    for ``get_daily_ohlcv`` as well as ``get_daily_close_batch``."""
+    from archimedes.models.asset_daily_bars import AssetDailyBar
+
+    def _float_or_none(value: object) -> float | None:
+        try:
+            v = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+        return None if math.isnan(v) else v
+
+    now = datetime.now(UTC)
+    to_write: list[tuple[date, float | None, float | None, float | None, float, float | None]] = []
+    for ts, row in df.iterrows():
+        close_f = _float_or_none(row.get("Close"))
+        if close_f is None:
+            continue
+        trade_date = ts.date() if hasattr(ts, "date") else ts
+        to_write.append(
+            (
+                trade_date,
+                _float_or_none(row.get("Open")),
+                _float_or_none(row.get("High")),
+                _float_or_none(row.get("Low")),
+                close_f,
+                _float_or_none(row.get("Volume")),
+            )
+        )
+    if not to_write:
+        return
+
+    dates = [d for d, *_ in to_write]
+    existing = {
+        row.trade_date: row
+        for row in session.query(AssetDailyBar)
+        .filter(AssetDailyBar.symbol == ticker, AssetDailyBar.trade_date.in_(dates))
+        .all()
+    }
+    for trade_date, open_f, high_f, low_f, close_f, volume_f in to_write:
+        row = existing.get(trade_date)
+        if row is not None:
+            row.open = open_f
+            row.high = high_f
+            row.low = low_f
+            row.close = close_f
+            row.volume = volume_f
+            row.source = source
+            row.fetched_at = now
+        else:
+            session.add(
+                AssetDailyBar(
+                    symbol=ticker,
+                    trade_date=trade_date,
+                    open=open_f,
+                    high=high_f,
+                    low=low_f,
+                    close=close_f,
+                    volume=volume_f,
+                    source=source,
+                    fetched_at=now,
+                )
+            )
+
+
 class CachingMarketDataProvider(MarketDataProvider):
     """Wraps another provider with the Postgres ``asset_daily_bars``
     read-through cache for ``get_daily_close_batch`` only. Every other method
@@ -447,6 +603,48 @@ class CachingMarketDataProvider(MarketDataProvider):
 
     def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
         return self._inner.get_series(ticker, period, interval)
+
+    def get_daily_ohlcv(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        """Read-through cache for the generation-path (fusion / portfolio
+        backtester) OHLCV fetch — the #1218 volume driver these two call
+        sites contribute alongside the universe sweep behind
+        ``get_daily_close_batch``. On a coverage/freshness miss, the whole
+        ``[start, end)`` range is fetched from the vendor and returned
+        UNCHANGED (only a best-effort cache write happens afterward) — a
+        fetch failure never gets a chance to corrupt the returned frame, and
+        a cold cache produces the exact same object the pre-seam direct call
+        would have."""
+        start_date = date.fromisoformat(start)
+        end_date = date.fromisoformat(end) if end else date.today()
+
+        session = self._session_factory()
+        try:
+            cached = _read_cached_ohlcv(session, ticker, start_date, end_date, self._ttl)
+        finally:
+            session.close()
+        if cached is not None:
+            return cached
+
+        fetched = self._inner.get_daily_ohlcv(ticker, start, end)
+        if fetched is None or fetched.empty:
+            return fetched
+
+        session = self._session_factory()
+        try:
+            _write_cached_ohlcv(session, ticker, fetched, self._source_name)
+            session.commit()
+        except IntegrityError:
+            # Same benign concurrent-writer race as get_daily_close_batch's
+            # prime — the loser rolls back; the fetch is still served.
+            session.rollback()
+            logger.info("asset_daily_bars OHLCV prime lost a concurrent-writer race (benign); next read is warm")
+        except SQLAlchemyError:
+            session.rollback()
+            logger.warning("asset_daily_bars OHLCV cache write failed (fetch still served)", exc_info=True)
+        finally:
+            session.close()
+
+        return fetched
 
 
 def get_provider() -> MarketDataProvider:

--- a/backend/archimedes/services/portfolio_backtester.py
+++ b/backend/archimedes/services/portfolio_backtester.py
@@ -9,7 +9,9 @@ rebalance period, not Python strategy code.
 
 This module fills that hole with a vanilla pandas/numpy simulator:
 
-  1. ``fetch_ohlcv`` (yfinance) for every ticker in ``weights``
+  1. ``market_data_provider.get_provider().get_daily_ohlcv`` (default
+     yfinance; vendor-swappable + ``asset_daily_bars``-cached, #1218/#1282)
+     for every ticker in ``weights``
   2. Wide-form close panel with strict inner-join on the business-day index
   3. Periodic rebalance with linear transaction costs (``tx_cost_bps``)
   4. Daily portfolio return series → Sharpe / Sortino / CAGR / max DD / Calmar
@@ -63,21 +65,6 @@ RF_DAILY = 0.05 / ANNUALIZATION  # 5% annual risk-free rate, daily equivalent
 MIN_BARS_FOR_BACKTEST = 60  # ~3 months; refuse to backtest shorter windows
 
 
-def _ensure_analytics_import() -> None:
-    """Place ``analytics-engine/src`` on sys.path so its ``data`` module imports.
-
-    Delegates to ``fusion_market_data._ensure_analytics_import``, which walks up
-    from its own file to find the package. The previous fixed ``parents[3]``
-    resolved to ``/`` inside the container (host and image layouts differ), so
-    every real-data backtest in prod raised ``No module named
-    'archimedes_analytics_engine'`` and strategies never left "pending"
-    (dogfood find, 2026-07-01). One function owns the path contract now.
-    """
-    from archimedes.services.fusion_market_data import _ensure_analytics_import as _walk_and_insert
-
-    _walk_and_insert()
-
-
 def _fetch_price_panel(symbols: list[str], start: str, end: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Fetch close prices and volumes for ``symbols`` and inner-join on the date index.
 
@@ -85,15 +72,23 @@ def _fetch_price_panel(symbols: list[str], start: str, end: str) -> tuple[pd.Dat
     public yet, forward-filling prices leaks the "survival" fact to the
     simulator. We strictly inner-join: the panel only contains days where
     EVERY requested symbol traded.
-    """
-    _ensure_analytics_import()
-    from archimedes_analytics_engine.data import fetch_ohlcv
 
+    Fetches via the market-data provider seam
+    (``archimedes.services.market_data_provider.get_provider().get_daily_ohlcv``,
+    #1218/#1282) rather than analytics-engine's ``fetch_ohlcv`` directly, so
+    this — the GENERATION path's portfolio-weights backtester — honors
+    ``MARKET_DATA_PROVIDER`` and reads/writes the ``asset_daily_bars`` cache
+    the same way the request-path call sites do, instead of re-hitting the
+    vendor on every backtest re-run.
+    """
+    from archimedes.services.market_data_provider import get_provider
+
+    provider = get_provider()
     closes: dict[str, pd.Series] = {}
     volumes: dict[str, pd.Series] = {}
     for sym in symbols:
         try:
-            df = fetch_ohlcv(sym, start, end)
+            df = provider.get_daily_ohlcv(sym, start, end)
             if not df.empty and "Close" in df.columns and "Volume" in df.columns:
                 closes[sym] = df["Close"]
                 volumes[sym] = df["Volume"]

--- a/backend/tests/services/test_generation_market_data_seam.py
+++ b/backend/tests/services/test_generation_market_data_seam.py
@@ -1,0 +1,194 @@
+"""Hermetic guard tests: the #1218 generation-path market-data seam fix.
+
+``fusion_market_data._fetch_one`` and ``portfolio_backtester._fetch_price_panel``
+used to import ``archimedes_analytics_engine.data.fetch_ohlcv`` directly —
+bypassing the #1282 cached provider seam
+(``archimedes.services.market_data_provider.get_provider()``) that the other
+backend call sites (``strategy_signal_evaluator``, ``oracle_updater``,
+``asset_market_service``) already used. This file proves both GENERATION-path
+call sites now route through that same seam: ``MARKET_DATA_PROVIDER``-swappable
+and ``asset_daily_bars``-cache-backed, with no second direct-fetch path left.
+
+Cold-cache-equivalence tests here are the anti-goal check: with the provider
+mocked at its boundary, a cold cache must return the vendor's frame UNCHANGED
+— no reshape/reindex/dtype coercion — so graded backtest numbers cannot
+silently shift when this seam was wired in.
+
+Mutation-check evidence (revert the routing fix -> the guard fails; restore
+-> it passes) is recorded in the PR body, not here.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+
+def _ohlcv_frame(n: int = 30, start: str = "2024-01-02", start_price: float = 100.0) -> pd.DataFrame:
+    idx = pd.bdate_range(start, periods=n)
+    close = pd.Series([start_price + i for i in range(n)], index=idx)
+    return pd.DataFrame(
+        {
+            "Open": close.to_numpy() - 0.5,
+            "High": close.to_numpy() + 1.0,
+            "Low": close.to_numpy() - 1.0,
+            "Close": close.to_numpy(),
+            "Volume": [1_000_000.0] * n,
+        },
+        index=idx,
+    )
+
+
+@pytest.fixture()
+def session_factory(tmp_path):
+    """An isolated SQLite engine/session factory with asset_daily_bars
+    created — independent of the app's module-level engine (same pattern as
+    test_market_data_provider.py's fixture of the same name)."""
+    from archimedes.db import Base
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'generation_seam.db'}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)
+
+
+# ─── Routing guard: both call sites must ask get_provider() for data ────
+
+
+class TestFusionMarketDataRoutesThroughSeam:
+    def test_fetch_one_calls_get_provider_get_daily_ohlcv(self, monkeypatch):
+        """Guard: _fetch_one must fetch via
+        market_data_provider.get_provider().get_daily_ohlcv, not a direct
+        vendor call. Mutation check: reverting _fetch_one to
+        ``from archimedes_analytics_engine.data import fetch_ohlcv`` makes
+        this fail — the mock below is never invoked, and the real fetch has
+        no network in this hermetic run."""
+        import archimedes.services.fusion_market_data as fmd
+        import archimedes.services.market_data_provider as mdp
+
+        frame = _ohlcv_frame()
+        fake_provider = MagicMock()
+        fake_provider.get_daily_ohlcv.return_value = frame
+        monkeypatch.setattr(mdp, "get_provider", lambda: fake_provider)
+
+        result = fmd._fetch_one("SPY", "2024-01-02", "2024-02-10")
+
+        fake_provider.get_daily_ohlcv.assert_called_once_with("SPY", "2024-01-02", "2024-02-10")
+        pd.testing.assert_frame_equal(result, frame)
+
+
+class TestPortfolioBacktesterRoutesThroughSeam:
+    def test_fetch_price_panel_calls_get_provider_get_daily_ohlcv(self, monkeypatch):
+        """Guard: _fetch_price_panel must fetch every symbol via
+        market_data_provider.get_provider().get_daily_ohlcv. Mutation check:
+        reverting to a direct archimedes_analytics_engine.data.fetch_ohlcv
+        import makes this fail the same way as the fusion guard above."""
+        import archimedes.services.market_data_provider as mdp
+        from archimedes.services.portfolio_backtester import _fetch_price_panel
+
+        frame = _ohlcv_frame(n=300)
+        fake_provider = MagicMock()
+        fake_provider.get_daily_ohlcv.return_value = frame
+        monkeypatch.setattr(mdp, "get_provider", lambda: fake_provider)
+
+        panel, volumes = _fetch_price_panel(["SPY", "TLT"], "2024-01-02", "2025-01-02")
+
+        assert fake_provider.get_daily_ohlcv.call_count == 2
+        fake_provider.get_daily_ohlcv.assert_any_call("SPY", "2024-01-02", "2025-01-02")
+        fake_provider.get_daily_ohlcv.assert_any_call("TLT", "2024-01-02", "2025-01-02")
+        assert list(panel.columns) == ["SPY", "TLT"]
+        assert list(volumes.columns) == ["SPY", "TLT"]
+
+
+# ─── No second direct-fetch path remains ────────────────────────────────
+
+
+class TestNoSecondDirectFetchPathRemains:
+    """Source-level guard, scoped to the specific fetch function (not the
+    whole module, which legitimately still names ``archimedes_analytics_engine``
+    in prose/other functions — e.g. ``_ensure_analytics_import``, which
+    ``market_data_provider.YFinanceProvider`` now uses as the ONE place
+    backend touches that package directly, itself reached only through
+    ``get_provider()``). Mutation check: re-adding
+    ``from archimedes_analytics_engine.data import fetch_ohlcv`` inside
+    either function below makes the matching test fail."""
+
+    def test_fusion_market_data_fetch_one_has_no_direct_analytics_engine_import(self):
+        import archimedes.services.fusion_market_data as fmd
+
+        source = inspect.getsource(fmd._fetch_one)
+        assert "archimedes_analytics_engine" not in source
+        assert "import fetch_ohlcv" not in source
+
+    def test_portfolio_backtester_fetch_price_panel_has_no_direct_analytics_engine_import(self):
+        from archimedes.services.portfolio_backtester import _fetch_price_panel
+
+        source = inspect.getsource(_fetch_price_panel)
+        assert "archimedes_analytics_engine" not in source
+        assert "import fetch_ohlcv" not in source
+
+
+# ─── Cache cold/warm behavior through the actual generation-path funcs ──
+
+
+class TestCacheColdWarmThroughGenerationPath:
+    """End-to-end through the real CachingMarketDataProvider (fake inner
+    vendor, isolated SQLite session) rather than a mocked get_provider() —
+    proves the whole seam (routing + cache) behaves correctly from the
+    call sites' own entry points, not just that they call the right method."""
+
+    def test_fusion_fetch_one_cold_then_warm(self, monkeypatch, session_factory):
+        import archimedes.services.fusion_market_data as fmd
+        import archimedes.services.market_data_provider as mdp
+
+        frame = _ohlcv_frame(40)
+        vendor = MagicMock()
+        vendor.get_daily_ohlcv.return_value = frame
+        cached_provider = mdp.CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        monkeypatch.setattr(mdp, "get_provider", lambda: cached_provider)
+
+        start = frame.index[0].date().isoformat()
+        end = frame.index[-1].date().isoformat()
+
+        cold = fmd._fetch_one("SPY", start, end)
+        # Anti-goal: cache-cold output equals the vendor's raw frame exactly.
+        pd.testing.assert_frame_equal(cold, frame)
+        assert vendor.get_daily_ohlcv.call_count == 1
+
+        warm = fmd._fetch_one("SPY", start, end)
+        assert vendor.get_daily_ohlcv.call_count == 1  # second call served from the cache
+        assert len(warm) == len(frame)
+        assert list(warm.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+    def test_portfolio_backtester_fetch_price_panel_cold_then_warm(self, monkeypatch, session_factory):
+        import archimedes.services.market_data_provider as mdp
+        from archimedes.services.portfolio_backtester import _fetch_price_panel
+
+        frame = _ohlcv_frame(300)
+        vendor = MagicMock()
+        vendor.get_daily_ohlcv.return_value = frame
+        cached_provider = mdp.CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        monkeypatch.setattr(mdp, "get_provider", lambda: cached_provider)
+
+        start = frame.index[0].date().isoformat()
+        end = frame.index[-1].date().isoformat()
+
+        panel_cold, volumes_cold = _fetch_price_panel(["SPY"], start, end)
+        assert vendor.get_daily_ohlcv.call_count == 1
+        pd.testing.assert_series_equal(panel_cold["SPY"], frame["Close"], check_names=False, check_freq=False)
+        pd.testing.assert_series_equal(volumes_cold["SPY"], frame["Volume"], check_names=False, check_freq=False)
+
+        panel_warm, volumes_warm = _fetch_price_panel(["SPY"], start, end)
+        assert vendor.get_daily_ohlcv.call_count == 1  # warm — vendor not hit again
+        # Values + calendar dates must match; the warm path's index round-trips
+        # through a SQLite DATE column and can legitimately land on a
+        # different datetime64 time-unit (e.g. [us] vs [s]) than the cold
+        # path's native pandas index — not a correctness issue, so compare
+        # values and calendar dates rather than raw index dtype.
+        assert (panel_warm["SPY"].to_numpy() == panel_cold["SPY"].to_numpy()).all()
+        assert (volumes_warm["SPY"].to_numpy() == volumes_cold["SPY"].to_numpy()).all()
+        assert list(panel_warm.index.date) == list(panel_cold.index.date)

--- a/backend/tests/services/test_market_data_provider.py
+++ b/backend/tests/services/test_market_data_provider.py
@@ -14,7 +14,7 @@ fake, not real yfinance.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -93,10 +93,55 @@ class _FakeVendor(MarketDataProvider):
     def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
         raise AssertionError("get_series must never be called by the caching wrapper's own logic")
 
+    def get_daily_ohlcv(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        raise AssertionError("get_daily_ohlcv must never be called by TestDailyCloseBatchCache")
+
 
 def _series(n_days: int = 30, start_price: float = 100.0) -> pd.Series:
     idx = pd.date_range(end=pd.Timestamp.now("UTC").normalize(), periods=n_days, freq="D")
     return pd.Series([start_price + i for i in range(n_days)], index=idx, name="X")
+
+
+def _ohlcv_frame(n_days: int = 30, start_price: float = 100.0) -> pd.DataFrame:
+    idx = pd.date_range(end=pd.Timestamp.now("UTC").normalize(), periods=n_days, freq="D")
+    close = pd.Series([start_price + i for i in range(n_days)], index=idx)
+    return pd.DataFrame(
+        {
+            "Open": close.to_numpy() - 0.5,
+            "High": close.to_numpy() + 1.0,
+            "Low": close.to_numpy() - 1.0,
+            "Close": close.to_numpy(),
+            "Volume": [1_000_000.0] * n_days,
+        },
+        index=idx,
+    )
+
+
+class _FakeOhlcvVendor(MarketDataProvider):
+    """A hand-rolled fake vendor for ``get_daily_ohlcv`` — records every call
+    it receives so tests can assert whether the cache actually skipped it."""
+
+    def __init__(self, frames_by_ticker: dict[str, pd.DataFrame]) -> None:
+        self.frames_by_ticker = frames_by_ticker
+        self.ohlcv_calls: list[tuple[str, str, str]] = []
+
+    def get_daily_close_batch(self, tickers: dict[str, str], period: str) -> dict[str, pd.Series]:
+        raise AssertionError("not exercised in TestDailyOhlcvCache")
+
+    def get_intraday_quote(self, ticker: str) -> tuple[float, datetime] | None:
+        raise AssertionError("not exercised in TestDailyOhlcvCache")
+
+    def get_intraday_quotes_batch(self, tickers: dict[str, str]) -> dict[str, float]:
+        raise AssertionError("not exercised in TestDailyOhlcvCache")
+
+    def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
+        raise AssertionError("not exercised in TestDailyOhlcvCache")
+
+    def get_daily_ohlcv(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        self.ohlcv_calls.append((ticker, start, end))
+        if ticker not in self.frames_by_ticker:
+            raise ValueError(f"no data for {ticker}")
+        return self.frames_by_ticker[ticker]
 
 
 class TestDailyCloseBatchCache:
@@ -241,6 +286,172 @@ class _FakeVendorPassthroughSpy(MarketDataProvider):
     def get_series(self, ticker: str, period: str, interval: str) -> pd.Series:
         self.series_calls.append((ticker, period, interval))
         return pd.Series([1.0, 2.0])
+
+    def get_daily_ohlcv(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        raise AssertionError("not exercised in TestUncachedPassthrough")
+
+
+# ─── Daily OHLCV cache (generation-path seam: fusion_market_data /
+#     portfolio_backtester, #1218 follow-up) ────────────────────────────
+
+
+class TestDailyOhlcvCache:
+    def test_cold_cache_is_a_miss_and_primes(self, session_factory):
+        frame = _ohlcv_frame(30)
+        vendor = _FakeOhlcvVendor({"SPY": frame})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        start = frame.index[0].date().isoformat()
+        end = frame.index[-1].date().isoformat()
+
+        result = provider.get_daily_ohlcv("SPY", start, end)
+
+        assert vendor.ohlcv_calls == [("SPY", start, end)]  # vendor WAS hit (cold cache)
+        # Anti-goal: cache-cold output must be byte-identical to the vendor's
+        # raw frame — the cache layer must never reshape/reindex/coerce it.
+        pd.testing.assert_frame_equal(result, frame)
+
+        from archimedes.models.asset_daily_bars import AssetDailyBar
+
+        session = session_factory()
+        try:
+            rows = session.query(AssetDailyBar).filter(AssetDailyBar.symbol == "SPY").all()
+            assert len(rows) == 30
+            assert all(r.source == "yfinance" for r in rows)
+            assert all(r.open is not None and r.high is not None and r.low is not None for r in rows)
+            assert all(r.volume is not None for r in rows)
+        finally:
+            session.close()
+
+    def test_warm_cache_within_ttl_skips_vendor(self, session_factory):
+        frame = _ohlcv_frame(30)
+        vendor = _FakeOhlcvVendor({"SPY": frame})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        start = frame.index[0].date().isoformat()
+        end = frame.index[-1].date().isoformat()
+
+        provider.get_daily_ohlcv("SPY", start, end)  # primes the cache
+        vendor.ohlcv_calls.clear()
+
+        result = provider.get_daily_ohlcv("SPY", start, end)
+
+        assert vendor.ohlcv_calls == []  # cache hit — vendor NOT called
+        assert len(result) == 30
+        assert list(result.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+    def test_stale_cache_past_ttl_refetches(self, session_factory):
+        frame = _ohlcv_frame(30)
+        vendor = _FakeOhlcvVendor({"SPY": frame})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        provider._ttl = timedelta(hours=1)
+        start = frame.index[0].date().isoformat()
+        end = frame.index[-1].date().isoformat()
+        provider.get_daily_ohlcv("SPY", start, end)
+
+        from archimedes.models.asset_daily_bars import AssetDailyBar
+
+        session = session_factory()
+        try:
+            for row in session.query(AssetDailyBar).all():
+                row.fetched_at = datetime.now(UTC) - timedelta(hours=2)
+            session.commit()
+        finally:
+            session.close()
+
+        vendor.ohlcv_calls.clear()
+        provider.get_daily_ohlcv("SPY", start, end)
+        assert vendor.ohlcv_calls == [("SPY", start, end)]  # stale → refetched
+
+    def test_insufficient_back_coverage_refetches(self, session_factory):
+        """A cache primed for a SHORT window does not satisfy a later request
+        reaching further back — the earliest cached row doesn't cover it."""
+        short_frame = _ohlcv_frame(30)
+        vendor = _FakeOhlcvVendor({"SPY": short_frame})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        short_start = short_frame.index[0].date().isoformat()
+        end = short_frame.index[-1].date().isoformat()
+        provider.get_daily_ohlcv("SPY", short_start, end)  # only 30 days cached
+
+        long_frame = _ohlcv_frame(365)
+        vendor.frames_by_ticker["SPY"] = long_frame
+        long_start = long_frame.index[0].date().isoformat()
+        vendor.ohlcv_calls.clear()
+
+        result = provider.get_daily_ohlcv("SPY", long_start, end)
+
+        assert vendor.ohlcv_calls == [("SPY", long_start, end)]  # coverage gap → refetched
+        assert len(result) == 365
+
+    def test_close_only_cached_row_is_not_a_valid_ohlcv_hit(self, session_factory):
+        """A row primed by ``get_daily_close_batch``'s writer only carries
+        ``close`` — open/high/low/volume are NULL. ``get_daily_ohlcv`` must
+        treat that as a miss (not hand back a frame with NaN OHLC columns)
+        and re-fetch + heal the row with the full bar."""
+        from archimedes.services.market_data_provider import _write_cached_series
+
+        close_series = _series(30)
+        session = session_factory()
+        try:
+            _write_cached_series(session, "SPY", close_series, "yfinance")
+            session.commit()
+        finally:
+            session.close()
+
+        frame = _ohlcv_frame(30)
+        vendor = _FakeOhlcvVendor({"SPY": frame})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        start = frame.index[0].date().isoformat()
+        end = frame.index[-1].date().isoformat()
+
+        result = provider.get_daily_ohlcv("SPY", start, end)
+
+        assert vendor.ohlcv_calls == [("SPY", start, end)]  # close-only row treated as a miss
+        assert list(result.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+        from archimedes.models.asset_daily_bars import AssetDailyBar
+
+        session = session_factory()
+        try:
+            rows = session.query(AssetDailyBar).filter(AssetDailyBar.symbol == "SPY").all()
+            assert all(r.open is not None for r in rows)  # row healed with the full bar
+        finally:
+            session.close()
+
+    def test_vendor_error_propagates_uncaught(self, session_factory):
+        """get_daily_ohlcv's contract is to RAISE on a genuinely unfetchable
+        symbol (matching fetch_ohlcv's contract) — the caching wrapper must
+        not swallow that into an empty/None result, since callers
+        (fusion_market_data, portfolio_backtester) rely on the exception for
+        their own fail-closed / per-symbol-skip handling."""
+        vendor = _FakeOhlcvVendor({})  # every ticker raises ValueError
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        with pytest.raises(ValueError, match="no data for NOPE"):
+            provider.get_daily_ohlcv("NOPE", "2024-01-01", "2024-02-01")
+
+
+class TestYFinanceProviderOhlcvBoundary:
+    def test_get_daily_ohlcv_delegates_to_analytics_engine_fetch_ohlcv(self):
+        """YFinanceProvider.get_daily_ohlcv must be a pure passthrough to
+        ``archimedes_analytics_engine.data.fetch_ohlcv`` — the exact
+        function ``fusion_market_data``/``portfolio_backtester`` imported
+        and called directly before this seam existed (#1282). Delegating
+        (rather than re-implementing the yfinance fetch a second time) is
+        what guarantees cold-cache output is unchanged from the pre-seam
+        direct-fetch path."""
+        import sys
+
+        frame = pd.DataFrame({"Open": [1.0], "High": [1.1], "Low": [0.9], "Close": [1.0], "Volume": [100.0]})
+        fake_data_module = MagicMock()
+        fake_data_module.fetch_ohlcv.return_value = frame
+
+        with patch.dict(
+            sys.modules,
+            {"archimedes_analytics_engine": MagicMock(), "archimedes_analytics_engine.data": fake_data_module},
+        ):
+            provider = YFinanceProvider()
+            result = provider.get_daily_ohlcv("SPY", "2020-01-01", "2020-02-01")
+
+        fake_data_module.fetch_ohlcv.assert_called_once_with("SPY", "2020-01-01", "2020-02-01")
+        assert result is frame  # identity, not a copy — nothing reshapes it in between
 
 
 # ─── YFinanceProvider — the default vendor's own boundary ──────────────

--- a/backend/tests/services/test_market_data_provider.py
+++ b/backend/tests/services/test_market_data_provider.py
@@ -381,6 +381,31 @@ class TestDailyOhlcvCache:
         assert vendor.ohlcv_calls == [("SPY", long_start, end)]  # coverage gap → refetched
         assert len(result) == 365
 
+    def test_insufficient_forward_coverage_refetches(self, session_factory):
+        """A warm, TTL-fresh cache primed through an earlier end day must NOT
+        satisfy a later request whose end has advanced past it. This is the
+        routine case, not an edge: both call sites default ``end`` to "today"
+        on every call, so any date rollover inside the TTL window lands here —
+        and serving the old frame silently truncates the backtest window
+        (moving every graded number computed over it) with no signal."""
+        old_frame = _ohlcv_frame(30)
+        old_frame.index = old_frame.index - pd.Timedelta(days=10)
+        vendor = _FakeOhlcvVendor({"SPY": old_frame})
+        provider = CachingMarketDataProvider(vendor, source_name="yfinance", session_factory=session_factory)
+        start = old_frame.index[0].date().isoformat()
+        old_end = old_frame.index[-1].date().isoformat()
+        provider.get_daily_ohlcv("SPY", start, old_end)  # primes through old_end only
+
+        new_frame = _ohlcv_frame(40)  # same first day, ends today (10 days later)
+        vendor.frames_by_ticker["SPY"] = new_frame
+        new_end = new_frame.index[-1].date().isoformat()
+        vendor.ohlcv_calls.clear()
+
+        result = provider.get_daily_ohlcv("SPY", start, new_end)
+
+        assert vendor.ohlcv_calls == [("SPY", start, new_end)]  # end advanced past cache → refetched
+        assert len(result) == 40
+
     def test_close_only_cached_row_is_not_a_valid_ohlcv_hit(self, session_factory):
         """A row primed by ``get_daily_close_batch``'s writer only carries
         ``close`` — open/high/low/volume are NULL. ``get_daily_ohlcv`` must

--- a/backend/tests/services/test_portfolio_backtester.py
+++ b/backend/tests/services/test_portfolio_backtester.py
@@ -389,18 +389,21 @@ class TestBacktestPortfolioIntegration:
             backtest_portfolio(strategy_id="x", weights={"SPY": 0.0, "TLT": 0.0})
 
     def test_empty_dataframe_vector(self) -> None:
-        import sys
-        from unittest.mock import MagicMock
+        """Mocked at the #1218/#1282 provider-seam boundary
+        (``market_data_provider.get_provider``), not the old
+        ``archimedes_analytics_engine.data`` sys.modules boundary —
+        ``_fetch_price_panel`` no longer imports that module directly."""
+        from unittest.mock import MagicMock, patch
 
         from archimedes.services.portfolio_backtester import _fetch_price_panel
 
-        mock_data = MagicMock()
-        mock_data.fetch_ohlcv.return_value = pd.DataFrame()
+        fake_provider = MagicMock()
+        fake_provider.get_daily_ohlcv.return_value = pd.DataFrame()
 
-        sys.modules["archimedes_analytics_engine"] = MagicMock()
-        sys.modules["archimedes_analytics_engine.data"] = mock_data
-
-        with pytest.raises(ValueError, match="Insufficient overlapping history"):
+        with (
+            patch("archimedes.services.market_data_provider.get_provider", return_value=fake_provider),
+            pytest.raises(ValueError, match="Insufficient overlapping history"),
+        ):
             _fetch_price_panel(["SPY", "TLT"], "2020-01-01", "2021-01-01")
 
     def test_rigor_metrics_match_evaluator(self) -> None:


### PR DESCRIPTION
## Summary

PR #1282 built a market-data vendor seam (`archimedes.services.market_data_provider`) with a `MARKET_DATA_PROVIDER`-selectable provider and a Postgres read-through cache (`asset_daily_bars`), and wired three backend call sites through it (`strategy_signal_evaluator`, `oracle_updater`, `asset_market_service`).

Two GENERATION-path call sites were not among them and still fetched market data directly:

- `backend/archimedes/services/fusion_market_data.py:96-101` (`_fetch_one`) — called `archimedes_analytics_engine.data.fetch_ohlcv` directly.
- `backend/archimedes/services/portfolio_backtester.py:89-96` (`_fetch_price_panel`) — same direct import/call, once per symbol.

Both are vendor-swappable in the sense that `archimedes_analytics_engine.data.fetch_ohlcv` is itself a façade over `archimedes_analytics_engine.market_data.get_provider()` (analytics-engine's *own*, separate, DB-less seam) — but that seam has no cache, since analytics-engine has no Postgres dependency. So every generation-path backtest re-fetch (fusion/debate variant sweeps, portfolio-weights backtests) hit the vendor fresh, never the `asset_daily_bars` cache the other call sites benefit from. Part of #1218.

## Before / after

**Before** (`fusion_market_data.py:96-101`):
```python
def _fetch_one(yf_ticker: str, start: str, end: str) -> Any:
    _ensure_analytics_import()
    from archimedes_analytics_engine.data import fetch_ohlcv
    return fetch_ohlcv(yf_ticker, start, end)
```

**After**:
```python
def _fetch_one(yf_ticker: str, start: str, end: str) -> Any:
    from archimedes.services.market_data_provider import get_provider
    return get_provider().get_daily_ohlcv(yf_ticker, start, end)
```

**Before** (`portfolio_backtester.py:89-96`, inside `_fetch_price_panel`):
```python
    _ensure_analytics_import()
    from archimedes_analytics_engine.data import fetch_ohlcv
    ...
    for sym in symbols:
        try:
            df = fetch_ohlcv(sym, start, end)
```

**After**:
```python
    from archimedes.services.market_data_provider import get_provider
    provider = get_provider()
    ...
    for sym in symbols:
        try:
            df = provider.get_daily_ohlcv(sym, start, end)
```

## What changed in the seam itself

`market_data_provider.MarketDataProvider` gains a new abstract method, `get_daily_ohlcv(ticker, start, end) -> pd.DataFrame` (full OHLCV, not just close — the shape both call sites need: backtrader feeds need Open/High/Low/Close/Volume, the portfolio simulator needs Close + Volume for its Almgren-impact cost model). This sits alongside the existing `get_daily_close_batch` rather than replacing it, since the two serve different shapes.

- `YFinanceProvider.get_daily_ohlcv` delegates to `archimedes_analytics_engine.data.fetch_ohlcv` — the exact function both call sites called directly before this change — so the vendor-fetch logic is not duplicated and cold-cache output is unchanged.
- `CachingMarketDataProvider.get_daily_ohlcv` adds read-through caching against the *same* `asset_daily_bars` table `get_daily_close_batch` already uses, with its own coverage/freshness checks. A row primed by `get_daily_close_batch`'s writer (close-only, other columns NULL) is treated as a miss by `get_daily_ohlcv` and gets healed with the full bar on re-fetch, so the two methods never hand back a partial row as if it were complete.
- On a full cache miss, the vendor's frame is returned **unchanged** (no reshape/reindex) before any (best-effort) cache write — this is what guarantees cold-cache output is identical to the pre-seam direct-fetch path.

## Anti-goals honored

- No graded-number changes: with the provider mocked at its boundary, a cold cache returns the vendor's frame byte-identical (`pd.testing.assert_frame_equal`) — see `TestDailyOhlcvCache` and `TestCacheColdWarmThroughGenerationPath` in the test files below.
- Rigor gate, quota, and payment logic: untouched — this PR only touches the market-data fetch layer.
- No new dependency: reuses `archimedes_analytics_engine.data.fetch_ohlcv`, which both call sites already depended on before this change.

## Tests (hermetic — no live yfinance/network; provider mocked at its boundary)

- `backend/tests/services/test_market_data_provider.py` — added `TestDailyOhlcvCache` (cold-miss-primes, warm-hit-skips-vendor, stale-TTL-refetches, insufficient-back-coverage-refetches, close-only-row-is-not-a-valid-hit, vendor-error-propagates-uncaught) and `TestYFinanceProviderOhlcvBoundary` (delegates to `archimedes_analytics_engine.data.fetch_ohlcv` unchanged). Extended the existing `_FakeVendor` / `_FakeVendorPassthroughSpy` fakes with the new abstract method.
- `backend/tests/services/test_generation_market_data_seam.py` (new) — routing guards for both call sites (`get_provider().get_daily_ohlcv` is actually called), source-level guards that neither call site imports `archimedes_analytics_engine.data.fetch_ohlcv` directly any more, and end-to-end cold/warm cache tests exercised through the real call-site functions with a real `CachingMarketDataProvider` (fake inner vendor, isolated SQLite session).
- `backend/tests/services/test_portfolio_backtester.py` — updated `test_empty_dataframe_vector` to mock at the new boundary (`market_data_provider.get_provider`) instead of the old `sys.modules["archimedes_analytics_engine.data"]` boundary.

Tallies: the four seam-related test files together — 65 passed, 0 failed. Full suite: `pytest -m "not integration"` from repo root — 3621 passed, 2 skipped (pre-existing, unrelated), 2 deselected, 0 failed.

## Mutation-check demonstrations

Each guard was verified to actually reject the thing it claims to reject (revert → fails; restore → passes), via `git diff HEAD > patch; git checkout HEAD -- <file>; run test; git apply --include=<file> patch`:

1. **Fusion routing guard** — reverted `fusion_market_data.py` to its pre-change state: `TestFusionMarketDataRoutesThroughSeam`, the fusion `TestNoSecondDirectFetchPathRemains` case, and the fusion cold/warm cache test all failed (`get_daily_ohlcv` called 0 times instead of once; the reverted code took the old direct-fetch path and returned a differently-shaped frame). Restored — all 3 pass again.
2. **Portfolio-backtester routing guard** — same recipe on `portfolio_backtester.py`: the portfolio routing guard, the portfolio `TestNoSecondDirectFetchPathRemains` case, the portfolio cold/warm cache test, and `test_empty_dataframe_vector` (mocked at the new boundary) all failed against the reverted file. Restored — all pass again.
3. **Close-only-row guard** (`_read_cached_ohlcv`'s completeness check) — temporarily disabled the `any(... is None ...)` check: `test_close_only_cached_row_is_not_a_valid_ohlcv_hit` failed (a close-only row was wrongly served as a complete OHLCV hit). Restored — passes.
4. **Back-coverage guard** — temporarily disabled the start-reach-back check: `test_insufficient_back_coverage_refetches` failed (a short-window cache entry was wrongly served for a longer request). Restored — passes.
5. **Cold-cache pass-through (anti-goal) guard** — temporarily changed the miss path to `return fetched.reset_index(drop=True)` instead of `return fetched`: the cold-cache-equivalence tests in both `test_market_data_provider.py` and `test_generation_market_data_seam.py` failed on index-shape mismatch. Restored — passes.

After all five mutation checks, `git diff HEAD` was confirmed byte-identical to the pre-mutation-check patch (no drift left behind).

## Lint / format

`ruff format --check` and `ruff check` pass clean on all touched files.
