### PR TITLE
[corpus] Fix Corpus search returning zero results for every term

### DIFF
--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -33,6 +33,19 @@ def _paper_row_to_dict(r) -> dict:
     }
 
 
+def _any_paper_processed(session) -> bool:
+    """True if the KB pipeline has clustered at least one paper.
+
+    Cheap existence probe (LIMIT 1), not a count — this runs on every catalog
+    request. Deliberately not memoised: the pipeline can land at any time and a
+    stale `False` would keep serving the unfiltered corpus after processing
+    exists, which is the less honest of the two failure directions.
+    """
+    from archimedes.models.corpus_store import PaperRecord
+
+    return session.query(PaperRecord.arxiv_id).filter(PaperRecord.cluster_id.isnot(None)).first() is not None
+
+
 @papers_router.get("/")
 async def list_papers(
     page: int = Query(1, ge=1),
@@ -63,7 +76,15 @@ async def list_papers(
     with get_session() as session:
         query = session.query(PaperRecord)
 
-        if processed_only:
+        if processed_only and _any_paper_processed(session):
+            # The filter is applied ONLY when the KB pipeline has actually
+            # clustered something. When nothing is processed — the live state,
+            # since the pipeline has never run (corpus_kg_built=false) — this
+            # predicate matches zero rows for EVERY query. The two `total == 0`
+            # fallbacks below rescue the unfiltered catalog, but both are
+            # guarded by `and not search`, so an empty catalog view looked fine
+            # while every search returned nothing. That combination is what made
+            # corpus search 100% dead rather than merely empty.
             query = query.filter(PaperRecord.cluster_id.isnot(None))
         if category:
             query = query.filter(PaperRecord.categories.contains(category))

--- a/backend/tests/test_papers_routes.py
+++ b/backend/tests/test_papers_routes.py
@@ -52,12 +52,12 @@ def _ctx_session(session):
     return _CtxSession(session)
 
 
-def _add_paper(session, arxiv_id, *, authors, cluster_id=None):
+def _add_paper(session, arxiv_id, *, authors, cluster_id=None, title=None, abstract="Abstract"):
     session.add(
         PaperRecord(
             arxiv_id=arxiv_id,
-            title=f"Paper {arxiv_id}",
-            abstract="Abstract",
+            title=title if title is not None else f"Paper {arxiv_id}",
+            abstract=abstract,
             authors=json.dumps(authors),
             primary_category="q-fin.PM",
             categories='["q-fin.PM"]',
@@ -125,3 +125,98 @@ class TestListPapersAuthorsFallback:
 
         assert result["total"] == 0
         assert result["papers"] == []
+
+
+class TestCatalogSearchOnUnprocessedCorpus:
+    """Corpus search returned zero results for every term, always.
+
+    `processed_only` defaults to True and filters `cluster_id IS NOT NULL`. The
+    KB pipeline has never run in production, so that predicate matches zero
+    rows. The two `total == 0` fallbacks that rescue the catalog are both
+    guarded by `and not category and not search` — deliberately, so a search
+    could not be silently widened. The combination meant: empty search box →
+    full 10,000-paper catalog; type anything → nothing, for every term.
+
+    Verified against production before the fix:
+        /api/papers/?search=momentum                        → total=0
+        /api/papers/?search=momentum&processed_only=false   → total=119
+    """
+
+    def test_search_returns_matches_when_nothing_is_kb_processed(self, session, monkeypatch):
+        """THE REGRESSION: every cluster_id is null and a search must still hit."""
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.10001", authors=["A"], title="Cross-sectional momentum in equities")
+        _add_paper(session, "2601.10002", authors=["B"], title="Volatility targeting and drawdown")
+        _add_paper(session, "2601.10003", authors=["C"], title="Unrelated microstructure paper")
+        session.commit()
+
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="momentum", processed_only=True)
+        )
+
+        assert result["total"] == 1, "search over an unprocessed corpus returned nothing"
+        assert result["papers"][0]["arxiv_id"] == "2601.10001"
+
+    def test_search_matches_the_abstract_too(self, session, monkeypatch):
+        from archimedes.api import papers_routes
+
+        _add_paper(
+            session,
+            "2601.10004",
+            authors=["A"],
+            title="A title with no keyword",
+            abstract="This abstract mentions momentum explicitly.",
+        )
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="momentum", processed_only=True)
+        )
+        assert result["total"] == 1
+
+    def test_search_still_discriminates(self, session, monkeypatch):
+        """The fix must not turn search into 'return everything'."""
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.10005", authors=["A"], title="Cross-sectional momentum")
+        _add_paper(session, "2601.10006", authors=["B"], title="Volatility targeting")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="zzzznonsense", processed_only=True)
+        )
+        assert result["total"] == 0
+        assert result["papers"] == []
+
+    def test_processed_only_still_filters_once_the_pipeline_has_run(self, session, monkeypatch):
+        """Intent preserved: where processed rows DO exist, the filter applies."""
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.10007", authors=["A"], title="Momentum, processed", cluster_id=3)
+        _add_paper(session, "2601.10008", authors=["B"], title="Momentum, unprocessed")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="momentum", processed_only=True)
+        )
+        assert result["total"] == 1
+        assert result["papers"][0]["arxiv_id"] == "2601.10007"
+
+    def test_category_filter_also_works_on_an_unprocessed_corpus(self, session, monkeypatch):
+        """`category` was guarded by the same `and not category` clause."""
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.10009", authors=["A"], title="Anything")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category="q-fin.PM", search=None, processed_only=True)
+        )
+        assert result["total"] == 1


### PR DESCRIPTION
## Summary

Typing anything into the Corpus catalog search box returns nothing — for any term, always. Reported by Dan; reproduced against production before the fix:

```
GET /api/papers/?search=momentum                       -> total=0
GET /api/papers/?search=momentum&processed_only=false  -> total=119   <- the real matches
GET /api/papers/?search=volatility                     -> total=0
GET /api/papers/?search=<empty>                        -> total=10000
```

## Why it fails, and why it looked fine

`processed_only` defaults to `True` and filters `cluster_id IS NOT NULL`. **The KB pipeline has never run in production** — `/health` reports `corpus_kg_built: false`, `corpus_kg_entities: 0` — so that predicate matches **zero rows for every query**.

Two `total == 0` fallbacks exist to rescue precisely this situation, but both are guarded by `and not category and not search`:

```python
if total == 0 and not category and not search:
    ...                       # re-query unfiltered
if total == 0 and not category and not search:
    ...                       # file-manifest fallback
```

That guard is deliberate and correct in intent — a user's search must not be silently widened into an unfiltered result set. But combined with a filter that matches nothing, it is what made search **dead rather than merely empty**:

- **No search term** → fallback fires → full 10,000-paper catalog renders → page looks healthy.
- **Any search term** → fallback skipped → `cluster_id IS NOT NULL` stands alone → zero results.

So the failure is invisible until the moment a user tries to use the feature. The same guard clause disabled the **category filter** for the same reason.

## The fix

Apply the `processed_only` filter only when at least one paper has actually been clustered:

```python
if processed_only and _any_paper_processed(session):
    query = query.filter(PaperRecord.cluster_id.isnot(None))
```

Where the pipeline **has** run, behaviour is unchanged and the filter still restricts to processed papers — covered by a test. Where it has not, the filter is skipped rather than zeroing the query. The honest reading of "processed only" when nothing is processed is not "show nothing".

`_any_paper_processed` is a `LIMIT 1` existence probe, not a count, since this runs on every catalog request. It is deliberately **not** memoised: the pipeline can land at any time, and a stale `False` would keep serving the unfiltered corpus after processing exists — the less honest of the two directions to be wrong in.

The two `total == 0` fallbacks are left exactly as they are; they still cover the genuinely-empty-DB case.

## Verification

```
pytest backend/tests/test_papers_routes.py -q     → 8 passed
ruff format --check + ruff check                  → clean
```

Five new tests, in `TestCatalogSearchOnUnprocessedCorpus`:

| test | pins |
|---|---|
| `test_search_returns_matches_when_nothing_is_kb_processed` | the regression itself |
| `test_search_matches_the_abstract_too` | abstract matching, not just title |
| `test_search_still_discriminates` | the fix does **not** turn search into "return everything" |
| `test_processed_only_still_filters_once_the_pipeline_has_run` | original intent preserved |
| `test_category_filter_also_works_on_an_unprocessed_corpus` | the same guard broke `category` |

**Mutation check** (`CLAUDE.md` § "A guard must be shown to reject something") — restoring the unconditional filter:

```
FAILED test_search_returns_matches_when_nothing_is_kb_processed
       - AssertionError: search over an unprocessed corpus returned nothing
FAILED test_search_matches_the_abstract_too              - assert 0 == 1
FAILED test_category_filter_also_works_on_an_unprocessed_corpus - assert 0 == 1
3 failed, 5 passed
```

Restored → `8 passed`. Note `test_search_still_discriminates` passes in **both** states by design — it is the guard against over-correcting, so it should not flip.

## Anti-goals honoured

- **Does NOT** widen the `total == 0` fallbacks to fire on a search. That would answer a user's query with unfiltered results, which is the thing the original guard exists to prevent.
- **Does NOT** change the default of `processed_only`, the `ilike` search predicate, or the file-manifest fallback.
- **Does NOT** touch the knowledge-graph surfaces (#1368) — this is the catalog search only.

## Related

- Search quality itself is untouched here: it remains `title ILIKE %term% OR abstract ILIKE %term%`. That is a reasonable floor and it does return sensible matches (119 for "momentum"), but ranking, stemming and author search are all absent — worth a separate issue rather than scope-creeping this fix.
