### PR TITLE
[docs] Sprint card verification layer + corrections; de-number the quant plans

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -167,7 +167,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 
 | Doc | Status | Owner | Last verified | What it is |
 |---|---|---|---|---|
-| [`sprint/README.md`](sprint/README.md) | current | Dan Browne | 2026-08-16 | Index of per-session working cards for the Arc-mainnet sprint, sharded so each session reads ~50 lines instead of the full plan. |
+| [`sprint/README.md`](sprint/README.md) | current | Önder Akkaya | 2026-08-21 | Index of per-session working cards for the Arc-mainnet sprint, plus the per-card completion status and the corrections to the cards' own claims. |
 
 ## Audits and findings
 

--- a/docs/handovers/fourth-wave-handover.md
+++ b/docs/handovers/fourth-wave-handover.md
@@ -60,7 +60,8 @@ limitation in both files' docstrings.
 2. A `scripts/compute_library_pbo.py` that loads the store, builds the returns
    matrix, runs the CSCV PBO over the full library, and prints per-strategy and
    library-level results.
-3. A findings note `docs/specs/library-pbo.md` reporting the honest number.
+3. A findings note [`quant/library-pbo.md`](../quant/library-pbo.md) reporting the honest
+   number.
 
 **The constraint that shapes everything (do not fight it):** the legacy
 strategies' fixture-era return series **cannot be reproduced** — current

--- a/docs/plans/quant-roadmap.md
+++ b/docs/plans/quant-roadmap.md
@@ -14,8 +14,13 @@
 
 ## What the second wave taught us (the pivot)
 
-The library is at 22 strategies; **2 pass the rigor gate** (`moreira_muir_2017_volatility_managed`,
-`moskowitz_ooi_pedersen_2012_tsmom`). All nine second-wave additions are `CANDIDATE`.
+The library was at 22 strategies when this was written; for the count today ask the tree
+(`ls analytics-engine/strategies/*.py | wc -l`), not this doc. The two entries then read as
+clearing the gate were `moreira_muir_2017_volatility_managed` and
+`moskowitz_ooi_pedersen_2012_tsmom`, and all nine second-wave additions were `CANDIDATE`.
+**Both of those readings predate the data-feed-fallback finding, so the pass count is
+unestablished — do not quote a number here or anywhere else** ([`CLAUDE.md`](../../CLAUDE.md)
+§ the hard constraint). The argument below does not depend on the count.
 We then tested the obvious hypothesis — "they fail only because the demo universe
 is too small" — directly, on larger and strategy-appropriate universes, and it is
 **false**: bigger universes do not flip any verdict and often make things worse

--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -13,9 +13,12 @@ Purpose: one card per session instead of a 45k-token plan re-read.
 
 Cards are committed (`16324bd`, PR #1238) and indexed in [`docs/README.md`](../README.md).
 The Aug-16 State section this replaces claimed *"zero sprint work has landed"* and listed four
-PRs as still open. Both were already wrong when written and are thoroughly wrong now: four
-sprint commits landed 2026-08-16 (`5c601fb`, `d7073f1`, `ba102c3`, `5327dbf`), and #1224
-(`1f3788d`), #1226 (`0d22af7`), #1201 (`ddd21fc`) and #1095 (`8abf1cd`) are all merged.
+PRs as still open. **Both were accurate when written** — the card was authored 2026-08-16
+00:18 +0300, and the four sprint commits (`5327dbf` 00:27, `5c601fb` 00:39, `d7073f1` 00:46,
+`ba102c3` 01:09) were written later that same night on sibling branches, reaching `main` only on
+2026-08-18 via #1238 and #1242. They are stale now, not wrong then: that work is in, #1224
+(`1f3788d`), #1226 (`0d22af7`), #1201 (`ddd21fc`) and #1095 (`8abf1cd`) are all merged, and the
+2026-08-20 frontend series landed on top.
 
 ### Four things a session must know before picking up any card
 
@@ -54,12 +57,15 @@ sprint commits landed 2026-08-16 (`5c601fb`, `d7073f1`, `ba102c3`, `5327dbf`), a
 
 Verified against source at `0057518`, 2026-08-21, by an 11-way item-level audit. Fractions are
 that audit's own decomposition (acceptance clauses, anti-goals and test asks counted
-separately) — a shape, not a score. Adversarial re-verification of the DONE claims was still
-running when this was written; treat single-source DONEs as strong-but-unconfirmed.
+separately) — a shape, not a score. Adversarial re-verification reached 3 of 11 cards before
+running out of budget and **overturned 16 claims, every one in the less-complete direction**
+(including this section's own first draft, which wrongly called the Aug-16 State section
+inaccurate). Treat the un-reverified cards' DONEs as strong-but-unconfirmed, and read every
+fraction here as an upper bound on completeness.
 
 | Session | Card | Status | What is actually left |
 |---|---|---|---|
-| 1 | [cluster-0](cluster-0-unblock.md) | **code done, asks open** (23/37) | Asks to Dan ~1 of 7 · PyPI `archimedes-cli` unreserved · `PAYMENTS_DRY_RUN` pinned in `ecs.tf` only, still unset in all three compose files and `setup-ssm-secrets.sh`. A6 is **no longer blocked** — diagnosed 2026-08-18, do not re-run it |
+| 1 | [cluster-0](cluster-0-unblock.md) | **code done, asks unmet** (23/37) | **Ask 1 did not just go unsent — it was overtaken.** #1129 and #1200 both changed `contracts/src/Vault.sol` (fee caps; NAV decimals + performance-fee share mint) and merged 2026-08-19/20 with **zero human reviews** — every review on #1129 is `copilot-pull-request-reviewer[bot]`, state `COMMENTED`, none `APPROVED`. `CLAUDE.md` makes Dan the sole required approver for contract changes. Raise this before any further contract merge. Also: PyPI `archimedes-cli` unreserved · `PAYMENTS_DRY_RUN` pinned in `ecs.tf` only, still unset in all three compose files and `infra/scripts/setup-ssm-secrets.sh`. A6 is **no longer blocked** — diagnosed 2026-08-18, do not re-run it |
 | 2 | [cluster-1](cluster-1-cost-ssot.md) | **2 of 3 engines** (12/21) | All three code edits landed in `5c601fb`. Engine C untouched, so "identical floor everywhere" is not yet true. 3 of 6 test asks unwritten |
 | 2 | [cluster-3](cluster-3-backtest-models.md) | **mostly done** (13/20) | A7 shipped in full — the sprint's cleanest win. `cost_model_id` still persists NULL from two of three writers, so the Done-when clause fails; provenance fields are declared on `StrategyResponse` but never assigned, and absent from `leaderboard_schemas.py` and all UI |
 | 3 | [cluster-2](cluster-2-fusion-engine.md) | **barely started** (9/21) | A1c, A4, the whole A8 label, all three tests. Only A7-adapter is satisfied — and it already was when the card was written. **Highest-leverage remaining work in the sprint** |
@@ -97,7 +103,9 @@ running when this was written; treat single-source DONEs as strong-but-unconfirm
 7. **Merge discipline — breached; settle it with Dan before relying on it.** The rule reads max
    2 merges/day, ≥40 min apart, `/health` verified between. Actual: 21 merges 2026-08-18, 34 on
    08-19, 58 on 08-20 (`git log --merges --since=2026-08-16 --format=%ad --date=short | sort |
-   uniq -c`). Either it is dead or the sprint is running blind on deploy verification — and
+   uniq -c`; a `Merge pull request` subject count agrees within 2, so the order of magnitude
+   holds even though CI clones here are shallow with grafted roots). Either it is dead or the
+   sprint is running blind on deploy verification — and
    #1346 (deploy starvation from a fast merge train) and #1309 (~2-minute 502 per deploy) are
    exactly the failure modes it existed to prevent. Both still open.
 

--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -1,64 +1,142 @@
 # Arc mainnet sprint — session cards
 
 Working cards sharded from `arc-goes-mainnet-sleepy-marble.md` (2026-08-10 measurement).
-Purpose: **one card per session, ~50 lines instead of a 45k-token plan re-read.**
+Purpose: one card per session instead of a 45k-token plan re-read.
 
-> Not committed by default. `git status` will show this directory untracked — commit it or
-> add to `.gitignore`, your call. New subdirectory, so collision risk with #1225's docs
-> restructure is low.
+> **The source doc is not in this repo** — it lives in the private `docs` repo per
+> [`CLAUDE.md`](../../CLAUDE.md). Every `Doc items` label below (A1, A7-surgical, B0–B5, D1)
+> dereferences against it and cannot be resolved from here. The cards themselves are
+> self-contained; the labels are provenance only. Cards run 64–133 lines, not the ~50 the
+> original intent stated.
 
-## State — 2026-08-16
+## State — 2026-08-21
 
-Zero sprint work has landed. `origin/main` since Aug 8 = 20 commits, all dependabot (10 PRs
-merged as a batch, including #1229/#1233/#1234 which the plan told us to hold). #1224, #1226,
-#1201, #1095 — all marked "merge now" — still open.
+Cards are committed (`16324bd`, PR #1238) and indexed in [`docs/README.md`](../README.md).
+The Aug-16 State section this replaces claimed *"zero sprint work has landed"* and listed four
+PRs as still open. Both were already wrong when written and are thoroughly wrong now: four
+sprint commits landed 2026-08-16 (`5c601fb`, `d7073f1`, `ba102c3`, `5327dbf`), and #1224
+(`1f3788d`), #1226 (`0d22af7`), #1201 (`ddd21fc`) and #1095 (`8abf1cd`) are all merged.
 
-**All doc anchors re-verified 6/6 fresh on 2026-08-16.** Trust them.
+### Four things a session must know before picking up any card
 
-Path corrections vs the source doc:
-- `spend_cap.py` → `backend/archimedes/marketplace/spend_cap.py` (not `services/`)
-- `Architecture.jsx` → `ui/src/components/Architecture.jsx` (not `pages/`)
+1. **The re-run already happened, ahead of its own gate — and nobody decided to run it.**
+   [cluster-1](cluster-1-cost-ssot.md) makes a passing cost-parity test the sole authorisation
+   for [the re-run](a6-rerun.md) ("do not run it anyway"). The real A6 blocker turned out to be
+   none of the card's three hypotheses — it was `PermissionError` on a read-only packaged
+   artifact dir on Fargate, at the artifact write that *precedes* the DB insert, so every
+   computed backtest was being discarded. Fixed 2026-08-18 (`8e6554c`), after which **the armed
+   in-app scheduler self-healed the leaderboard** (`backtest_scheduler.py`, default on, 168h max
+   age). Fresh curated rows reached prod 2026-08-19/20 with **Engine C still charging commission
+   only** — the cost floor is identical across two of three engines. Nobody overrode the gate;
+   automation nobody disarmed walked past it. [cluster-2](cluster-2-fusion-engine.md)'s A1c is
+   what closes it, and it is unstarted. **This is the sprint's open honesty debt.**
+2. **`POST /api/rigor/verify` can answer `passes: true` on four bars.** Shipped via #1305
+   (2026-08-19), ahead of and overlapping [cluster-8](cluster-8-returns-csv.md). `passes` is
+   `all(...)` over *evaluable* legs only, and PBO plus look-ahead are hard-coded
+   `not_evaluable` **always**, while DSR needs only ≥4 bars and OOS needs ~70. So a short series
+   whose DSR passes returns `passes: true` on one of four legs — and `archimedes verify` exits
+   `OK` on that boolean, which is what a script or CI branches on. The full body is honest
+   (every leg carries a status and reason) and the nothing-evaluable case is explicitly guarded
+   ("vacuous truth is not honesty", `test_rigor_verify_routes.py:174`). The scalar and the exit
+   code are not. Worth an issue; do not build on `passes` until it is qualified.
+3. **Do not trust this directory's anchors.** Follow session rule 1 without exception. Two are
+   not stale but fictional: cluster-0 records `ui/src/siwe.js:15` as a *verified* day-0 finding
+   and **that file has never existed** — `grep -rn VITE_ARC_CHAIN_ID .` matches only the card.
+   The chain id is hardcoded with no override seam in `ui/src/circle-wallet.js:36`,
+   `linked-wallets.js:13`, `api.js:16`, `AuthenticatedApp.jsx:71`, which is worse than the card
+   says. Four acceptance commands name files that do not exist (see Corrections).
+4. **Two big items shipped by a different design than their card specifies.** #1194's quota
+   rebuild closed cluster-5's headline bug without building the meter; #1266's
+   `VITE_ROADMAP_SURFACES` flag closed cluster-7's nav work while *reversing* two of its
+   decisions. Both are disclosed in code. Read the card for intent, the tree for state.
 
-~20 working days remain to Sept 16 against a 24-day estimate. See the re-cut at the bottom.
+### Per-card status
+
+Verified against source at `0057518`, 2026-08-21, by an 11-way item-level audit. Fractions are
+that audit's own decomposition (acceptance clauses, anti-goals and test asks counted
+separately) — a shape, not a score. Adversarial re-verification of the DONE claims was still
+running when this was written; treat single-source DONEs as strong-but-unconfirmed.
+
+| Session | Card | Status | What is actually left |
+|---|---|---|---|
+| 1 | [cluster-0](cluster-0-unblock.md) | **code done, asks open** (23/37) | Asks to Dan ~1 of 7 · PyPI `archimedes-cli` unreserved · `PAYMENTS_DRY_RUN` pinned in `ecs.tf` only, still unset in all three compose files and `setup-ssm-secrets.sh`. A6 is **no longer blocked** — diagnosed 2026-08-18, do not re-run it |
+| 2 | [cluster-1](cluster-1-cost-ssot.md) | **2 of 3 engines** (12/21) | All three code edits landed in `5c601fb`. Engine C untouched, so "identical floor everywhere" is not yet true. 3 of 6 test asks unwritten |
+| 2 | [cluster-3](cluster-3-backtest-models.md) | **mostly done** (13/20) | A7 shipped in full — the sprint's cleanest win. `cost_model_id` still persists NULL from two of three writers, so the Done-when clause fails; provenance fields are declared on `StrategyResponse` but never assigned, and absent from `leaderboard_schemas.py` and all UI |
+| 3 | [cluster-2](cluster-2-fusion-engine.md) | **barely started** (9/21) | A1c, A4, the whole A8 label, all three tests. Only A7-adapter is satisfied — and it already was when the card was written. **Highest-leverage remaining work in the sprint** |
+| 4 | [cluster-4](cluster-4-strategies-route.md) | **partial** (9/19) | Both A3 items landed 2026-08-20 (`757341a`, `14db21d`) by a different design — there is no `metrics_source` field anywhere. §3 TODO markers and §4 the unmetered generate endpoint untouched |
+| 5 | [a6-rerun](a6-rerun.md) | **executed, prerequisites skipped** (12/26) | The A4 read-path fix was not taken and its stated window ("the one moment in the year") has closed; the A5 fetch memo was never threaded (`run_backtests.py` passes no `fetcher`); **the before/after table — the card's named deliverable — does not exist**; rejection-rate copy never written |
+| 6–8 | [cluster-5](cluster-5-meter.md) | **barely started** (9/48) | No `metering.py`, `Principal`, SKUs, reserve/commit/release, or `METER_ENFORCE`. #1199 was closed independently by #1194 — which breaches this card's first anti-goal, since `GenerationQuota.peek` now backs the CLI's `meter` on the same one-way INCR. B5's silent model downgrade is **still live** (`generate_routes.py:193`) |
+| 6–8 | [cluster-6](cluster-6-boot-paywall.md) | **barely started** (7/31) | An x402 generation paywall **shipped** 2026-08-19 (`ab712a1`), flag-off in prod — so the card's premise that no route emits a satisfiable 402 is false. **Neither boot assertion exists**, and `GATEWAY_CHAIN` still silently falls back to `arcTestnet` in three places. A live paywall with no mainnet-chain guard is the dangerous half of this card. No `/api/v1/`, no manifest-honesty edits |
+| 9 | [cluster-8](cluster-8-returns-csv.md) | **barely started** (11/53) | None of the specified deliverable: no `returns_import.py`, no `/api/v1/rigor/verdict`, no CSV transport, none of the eight validations, no test file. #1305's overlapping endpoint breaches two prohibitions — see item 2 above and A1 (gate compute runs on the event loop, not `asyncio.to_thread`) |
+| 10 | [cluster-7](cluster-7-ui-surface.md) | **barely started** (14/38) | `sitemap.xml` is the one clean win. A9/A10 are **product reversals**: the card says keep /portfolio and /marketplace live with a banner; #1266 hid them instead. All five orphan deletions untouched — `FusionResult.jsx` (198L) is being *actively maintained while orphaned*, `PortfolioAdvisor.jsx` (477L) leaves `/api/strategies/advisor` with no consumer. No `WorkInProgress.jsx`, so A4/A8/A10 have no banner to render. All three check scripts missing |
 
 ## Session rules — apply to every card
 
-1. **Anchor-trust.** Re-anchor with `grep -n "<symbol>" <file>` (~200 tok), then `Read` with
-   `offset`/`limit` for a ±40-line window. Never `Read` a file whole to "get oriented."
-2. **Never read whole** — ~8,400 lines ≈ 105k tokens:
-   `strategies_routes.py` (2357) · `_rigor_helpers.py` (1328) · `portfolio_backtester.py` (1180)
-   · `rigor_evaluator.py` (956) · `Architecture.jsx` (896) · `fusion_evaluator.py` (864)
-   · `main.py` (821)
+1. **Anchor-trust — inverted.** Re-anchor with `grep -n "<symbol>" <file>`, then `Read` a ±40-line
+   window. Never `Read` a file whole to get oriented. **This rule overrides every line number in
+   this directory.** The Aug-16 note claiming the anchors were "re-verified 6/6 fresh — trust
+   them" was retired 2026-08-21: every rule-2 count had drifted and two anchors named a file
+   that has never existed.
+2. **Never read whole** — counts as of 2026-08-21: `strategies_routes.py` (2547) ·
+   `Architecture.jsx` (1322) · `rigor_evaluator.py` (1246) · `_rigor_helpers.py` (1176, under
+   `services/`, not `api/`) · `main.py` (861) · `fusion_evaluator.py` (856).
+   **`portfolio_backtester.py` has left this list** — `c02d5fa` (2026-08-18) cut it 1180 → 683,
+   so it is readable whole and cluster-1's "window-read only" note on it is moot.
 3. **One cluster per session.** Do not drift into an adjacent item because it is nearby.
 4. **Test narrow:** `pytest backend/tests/test_<module>.py -q`. Full suite once, pre-merge.
 5. **No subagents, no workflows.** No discovery left to parallelize.
-6. **Universal anti-goals** (from the source doc's "Explicitly not doing"): no vitest/playwright
-   · no `React.lazy` · no `python-multipart` · no server-side user Python · no DSL-JSON upload
-   · don't delete `_run_fusion_job` · don't repair QuantLab's mocks · no KB pipeline · no
-   distributed meter reaper · don't un-pin `circlekit` · no vectorbt · don't rewrite
-   `Architecture.jsx`. **Never weaken a rigor threshold.**
-7. **Merge discipline is a token rule too.** Max 2 merges/day, ≥40 min apart, never during a
-   deploy, verify `/health` version matches the SHA before the next. A killed deploy costs a
-   ~50k-token diagnosis session.
+6. **Universal anti-goals:** no vitest/playwright · no `python-multipart` · no server-side user
+   Python · no DSL-JSON upload · don't delete `_run_fusion_job` · don't repair QuantLab's mocks ·
+   no KB pipeline · no distributed meter reaper · don't un-pin `circlekit` · no vectorbt.
+   **Never weaken a rigor threshold.** All verified still held except two, both breached by
+   post-card work and both **superseding rather than violating** the intent — but cluster-7's
+   premise rests on them, so restate it before using that card: `React.lazy` is now in
+   `ui/src/App.jsx:13` (the #1194 auth boundary, `e76c1c7`), and `Architecture.jsx` was
+   effectively rewritten (896 → 1322 lines, +750/−324 whitespace-insensitive) by eight
+   claim-integrity commits on 2026-08-19/20.
+7. **Merge discipline — breached; settle it with Dan before relying on it.** The rule reads max
+   2 merges/day, ≥40 min apart, `/health` verified between. Actual: 21 merges 2026-08-18, 34 on
+   08-19, 58 on 08-20 (`git log --merges --since=2026-08-16 --format=%ad --date=short | sort |
+   uniq -c`). Either it is dead or the sprint is running blind on deploy verification — and
+   #1346 (deploy starvation from a fast merge train) and #1309 (~2-minute 502 per deploy) are
+   exactly the failure modes it existed to prevent. Both still open.
 
-## Order — by value-per-token, not workstream letter
+## Corrections to the cards
 
-| Session | Card | Doc items | Est. |
-|---|---|---|---|
-| 1 | [cluster-0-unblock](cluster-0-unblock.md) | D1 asks · merges · B0 checks · A6 diagnostic | 0.5d, ~0 code tokens |
-| 2 | [cluster-1-cost-ssot](cluster-1-cost-ssot.md) + [cluster-3-backtest-models](cluster-3-backtest-models.md) | A1 · A7-surgical · A2-lite · A3/A4 mapper | 1.5d — **best ratio in the sprint** |
-| 3 | [cluster-2-fusion-engine](cluster-2-fusion-engine.md) | A1c · A4 · A8 label | 0.75d |
-| 4 | [cluster-4-strategies-route](cluster-4-strategies-route.md) | A3 fixture kill · DEGENERATE | 1.5d |
-| 5 | [a6-rerun](a6-rerun.md) | A5 memo · A6 re-run + before/after table | 1.25d |
-| 6–8 | [cluster-5-meter](cluster-5-meter.md), [cluster-6-boot-paywall](cluster-6-boot-paywall.md) | B2 · B5 · B0-boot · B3 | 4.0d |
-| 9 | [cluster-8-returns-csv](cluster-8-returns-csv.md) | B4 | 1.5d |
-| 10 | [cluster-7-ui-surface](cluster-7-ui-surface.md) | B1 (re-cut) | 0.4d sprint / 0.85d buffer |
+Substantive errors only. Line drift is pervasive and rule 1 handles it.
+
+| Card | Claim | Correction |
+|---|---|---|
+| cluster-0 | `ui/src/siwe.js:15` hardcodes `5042002` / is `VITE_ARC_CHAIN_ID ?? '5042002'`, recorded as an executed result | **The file has never existed** and no override seam exists anywhere. Check 2's conclusion stands; its evidence does not |
+| cluster-0 | "Zero code. Bash and `gh` only." | Contradicted by the card's own two-bug-fix section, which shipped +14/−1 in PR #1239 |
+| cluster-1 | `cd analytics-engine && uv run pytest tests/test_cost_parity.py` | Never created; the analytics half went into `tests/test_costs.py:287-378`. The command cannot pass |
+| cluster-2 | `pytest backend/tests/test_fusion_evaluator.py` | Path is `backend/tests/services/test_fusion_evaluator.py` |
+| cluster-2 | `CostModel.apply_to_broker(cerebro)` is a one-liner per site | Real signature is `apply_to_broker(self, cerebro, feed_names)` — the literal call does not compile |
+| cluster-2 | "DSL rows always get `backtest_start=None`" | Overbroad — real-data fusion runs thread real dates. And `:430` is worse than dead: it fabricates a hard-coded `date(2004, 1, 2)` |
+| cluster-2 | A8 rename to `dsl-fusion-sleeves` | `_SEARCH_TRACKED_ENGINES` (`selection_bias_routes.py:605`) matches the literal `"dsl-fusion"`; a bare rename breaks num-trials attribution |
+| cluster-3 | `look_ahead_audit_passed` is the OR of a real AST audit and a broker-config check | **Neither leg is the AST audit.** `cli.py:378` reduces the same field with `all(...)`, so the OR compares a value against a reduction of itself. The real AST audit is never invoked on this path. Shipped as disclosure (`look_ahead_audit_source`), flag flip deferred to the re-run — which has now passed |
+| cluster-3 | Done-when: `grep passes_rigor_gate models/backtest.py` is empty | Contradicts the card's own ask for a retraction comment containing that string. Trust `test_gate_equivalence.py` instead |
+| cluster-3 | A4-part ends fabricated `0.0` correlations | Fixed at the mapper (`:271-272`), but `generation_pipeline.py:1625-1626` hard-codes both and `portfolio_backtester.py:473` hard-codes `correlation_to_btc`. Worse, `:442` initialises `correlation_to_spy = 0.0` before the `:452` compute, so a failed computation is indistinguishable from a measured zero |
+| cluster-4 | `pytest backend/tests/test_live_rigor_gate.py` | No such file. Coverage is in `test_gate_equivalence.py`, `test_live_gate_returns.py`, `test_rigor_evaluator.py`, `test_strategies_routes.py` |
+| cluster-5 | `enforce_generation_quota()` opens `if wallet: return`, so the cap never applies | Inverted. Rebuilt for #1194: `(request, user_id)`, no bypass, stacked user+IP day caps (10/20). `WALLET_LESS_GENERATION_DAILY_CAP` no longer exists |
+| cluster-5 | Proof test: an N+1 route test reads as unlimited today | `generate_routes.py:144` skips enforcement when `TESTING` is set, so such a test passes against unfixed code — the exact trap CLAUDE.md § *a test that passes against the unfixed code proves nothing* warns about |
+| cluster-6 | No route emits a satisfiable 402 | False since 2026-08-19: `POST /api/generate/start` emits one with a real circlekit `PAYMENT-REQUIRED` header |
+| cluster-6 | Delete "Arc has no mainnet yet" from `llms.txt` | Never in that file. It is at `README.md:28` and, in variant form, `docs/user-stories.md:20`. Retarget the edit |
+| cluster-6 | The CLI's `login`/`meter` depend on keys, so keys come first | The CLI shipped without keys — `meter` runs against `GET /api/account/usage` with a cached Better Auth session |
+| cluster-7 | "`App.jsx` statically imports all 20 page components (25 imports, zero `React.lazy`)" | The 25 imports moved to `AuthenticatedApp.jsx`; `App.jsx` has 9 and one `lazy()`. The conclusion (a `VITE_*` flag is a policy selector, not a code-elimination device) holds; the premise does not |
+| cluster-7 | Delete `assets/logo_old.svg` "(zero importers, verified)" | The file did not exist when the card was written, so that cannot have been verified |
+| cluster-7 | The picker offers 281 assets | 252 unique tickers in `assetUniverse.js` `ASSET_GROUPS` |
+| cluster-8 | "Mostly a new pure module — cheap to write" | Stale: #1305 shipped an overlapping `POST /api/rigor/verify` + `archimedes verify` on 2026-08-19. Rescope the card against what exists rather than writing beside it |
+| a6-rerun | "Rollback is free — the gate can be pinned to a `run_id`" | Only half implemented. `run_id` is persisted (`backtest_repository.py:59`, `:115`) but no reader consumes it — `get_daily_returns` resolves by `created_at desc` and takes no `run_id`. Rollback is add-only survival, not pinning |
+| README | "~20 working days remain against a 24-day estimate" | On 2026-08-16 it was 23 business days (22 excluding Labor Day, Sep 7). As of 2026-08-21, ~18 |
 
 ## Re-cut vs the source doc
 
-- **B1 splits.** Claim-honesty subset in-sprint (~0.4d); the `routes.js` 6-way consolidation +
-  3 check scripts to buffer. #1237 already fixes CRUMB_MAP #1219 — coordinate, don't collide.
-- **A2 stays lite.** `backtest_engine` surfaced + `cost_model_id` only. The 9-column migration
-  to buffer.
-- **A7 surgical only.** Full unification (`cohort_results`, golden vectors) to buffer.
+- **B1 splits.** The claim-honesty *outcome* landed via #1354/#1266, but not as cluster-7 specs
+  it — see that row. The `routes.js` consolidation and three check scripts stay in buffer;
+  #1237 merged 2026-08-18, so the `Breadcrumbs.jsx` coordination window is closed.
+- **A2 stays lite.** `backtest_engine` + `cost_model_id` surfaced; the 9-column migration stays
+  in buffer. Not fully closed — see cluster-3's row.
+- **A7 surgical only.** Landed. Full unification (`cohort_results`, golden vectors) stays buffer;
+  the badge/number cohort divergence in cluster-4 §3 is still live and still unmarked.
 - Everything already on the doc's cut list stays cut.

--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -58,7 +58,9 @@ PRs as still open. **Both were accurate when written** — the card was authored
    `OK` on that boolean, which is what a script or CI branches on. The full body is honest
    (every leg carries a status and reason) and the nothing-evaluable case is explicitly guarded
    ("vacuous truth is not honesty", `test_rigor_verify_routes.py:174`). The scalar and the exit
-   code are not. Worth an issue; do not build on `passes` until it is qualified.
+   code are not. **Tracked as [#1481](https://github.com/a-apin/archimedes/issues/1481)** with a
+   machine-checkable acceptance set and the `verdict_from_returns` reuse that cluster-8's U1 item
+   already wanted. Do not build on `passes` until it is qualified.
 3. **Do not trust this directory's anchors.** Follow session rule 1 without exception. Two are
    not stale but fictional: cluster-0 records `ui/src/siwe.js:15` as a *verified* day-0 finding
    and **that file has never existed** — `grep -rn VITE_ARC_CHAIN_ID .` matches only the card.
@@ -93,7 +95,7 @@ a row.
 | 5 | [a6-rerun](a6-rerun.md) | **executed, prerequisites skipped** (12/26) | The A4 read-path fix was not taken and its stated window ("the one moment in the year") has closed; the A5 fetch memo was never threaded (`run_backtests.py` passes no `fetcher`); **the before/after table — the card's named deliverable — does not exist**; rejection-rate copy never written |
 | 6–8 | [cluster-5](cluster-5-meter.md) | **retired, with one live tail** (9/48) | #1442 retires this card (#1194 + #1296/#1300 rebuilt the space; refund/release is now #1441) and that reading is right about the metering design. **One item it does not cover: B5's silent model downgrade is still live** at `generate_routes.py:335` — an entitled premium request is still downgraded to the env default, and #1441 is about refund/release, not this. Either fix it or track it before the card is closed |
 | 6–8 | [cluster-6](cluster-6-boot-paywall.md) | **barely started** (7/31) | An x402 generation paywall **shipped** 2026-08-19 (`ab712a1`), flag-off in prod — so the card's premise that no route emits a satisfiable 402 is false. **Neither boot assertion exists**, and `GATEWAY_CHAIN` still silently falls back to `arcTestnet` in three places. A live paywall with no mainnet-chain guard is the dangerous half of this card. No `/api/v1/`, no manifest-honesty edits |
-| 9 | [cluster-8](cluster-8-returns-csv.md) | **barely started** (11/53) | None of the specified deliverable: no `returns_import.py`, no `/api/v1/rigor/verdict`, no CSV transport, none of the eight validations, no test file. #1305's overlapping endpoint breaches two prohibitions — see item 2 above and A1 (gate compute runs on the event loop, not `asyncio.to_thread`) |
+| 9 | [cluster-8](cluster-8-returns-csv.md) | **barely started** (11/53) | None of the specified deliverable: no `returns_import.py`, no `/api/v1/rigor/verdict`, no CSV transport, none of the eight validations, no test file. #1305's overlapping endpoint breaches two prohibitions: the `passes` scalar (now [#1481](https://github.com/a-apin/archimedes/issues/1481)) and A1 — gate compute runs on the event loop, not `asyncio.to_thread`. Rescope this card against what #1305 shipped rather than writing beside it |
 | 10 | [cluster-7](cluster-7-ui-surface.md) | **barely started** (14/38) | `sitemap.xml` is the one clean win. A9/A10 are **product reversals**: the card says keep /portfolio and /marketplace live with a banner; #1266 hid them instead. All five orphan deletions untouched — `FusionResult.jsx` (198L) is being *actively maintained while orphaned*, `PortfolioAdvisor.jsx` (477L) leaves `/api/strategies/advisor` with no consumer. No `WorkInProgress.jsx`, so A4/A8/A10 have no banner to render. All three check scripts missing |
 
 ## Session rules — apply to every card

--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -20,19 +20,33 @@ PRs as still open. **Both were accurate when written** — the card was authored
 (`1f3788d`), #1226 (`0d22af7`), #1201 (`ddd21fc`) and #1095 (`8abf1cd`) are all merged, and the
 2026-08-20 frontend series landed on top.
 
+> **Scope of this section vs [#1442](https://github.com/a-apin/archimedes/pull/1442).** Dan's
+> #1442 is the **dispatch state**: which work packages are out, which PRs close which partials
+> (#1379, #1401, #1439, #1441), and which cards are retired outright. This section is the
+> **verification layer**: what a `grep` finds in the tree today, and where a card's own text is
+> wrong. Read #1442 for what is being worked; read this for what is true. Where they disagree,
+> re-run the command — and one disagreement is flagged in the table below (cluster-5).
+>
+> **This section decays in days, not weeks.** `main` took 170 commits between this doc's first
+> draft and its rebase, which closed three findings outright (Engine C's cost floor,
+> `cost_model_id`-NULL, fabricated `0.0` correlations). Re-verify before acting on any row.
+
 ### Four things a session must know before picking up any card
 
-1. **The re-run already happened, ahead of its own gate — and nobody decided to run it.**
+1. **The re-run happened ahead of its gate; the gate has since closed behind it.**
    [cluster-1](cluster-1-cost-ssot.md) makes a passing cost-parity test the sole authorisation
-   for [the re-run](a6-rerun.md) ("do not run it anyway"). The real A6 blocker turned out to be
-   none of the card's three hypotheses — it was `PermissionError` on a read-only packaged
-   artifact dir on Fargate, at the artifact write that *precedes* the DB insert, so every
-   computed backtest was being discarded. Fixed 2026-08-18 (`8e6554c`), after which **the armed
-   in-app scheduler self-healed the leaderboard** (`backtest_scheduler.py`, default on, 168h max
-   age). Fresh curated rows reached prod 2026-08-19/20 with **Engine C still charging commission
-   only** — the cost floor is identical across two of three engines. Nobody overrode the gate;
-   automation nobody disarmed walked past it. [cluster-2](cluster-2-fusion-engine.md)'s A1c is
-   what closes it, and it is unstarted. **This is the sprint's open honesty debt.**
+   for [the re-run](a6-rerun.md) ("do not run it anyway"). The real A6 blocker was none of the
+   card's three hypotheses — it was `PermissionError` on a read-only packaged artifact dir on
+   Fargate, at the artifact write that *precedes* the DB insert, so every computed backtest was
+   discarded. Fixed 2026-08-18 (`8e6554c`), after which the armed in-app scheduler self-healed
+   the leaderboard: fresh curated rows reached prod 2026-08-19/20 with Engine C still charging
+   commission only. **`4f60971` (2026-08-20) then put Engine C on the cost floor** — slippage at
+   `fusion_evaluator.py:230-232` and `:393-395`, `cost_model_id` stamped on fusion rows, and
+   `test_cost_parity.py` now exercises engine C directly. So the floor is complete now, but it
+   completed *after* those rows published. **The residual is whether the curated rows on the
+   board predate `4f60971`** — if they do, they were graded on a two-of-three floor and need a
+   re-grade or a re-run. That cannot be settled from this repo; check
+   `backtest_results.cost_model_id` on prod against the post-`4f60971` fingerprint.
 2. **`POST /api/rigor/verify` can answer `passes: true` on four bars.** Shipped via #1305
    (2026-08-19), ahead of and overlapping [cluster-8](cluster-8-returns-csv.md). `passes` is
    `all(...)` over *evaluable* legs only, and PBO plus look-ahead are hard-coded
@@ -66,12 +80,12 @@ fraction here as an upper bound on completeness.
 | Session | Card | Status | What is actually left |
 |---|---|---|---|
 | 1 | [cluster-0](cluster-0-unblock.md) | **code done, asks unmet** (23/37) | **Ask 1 did not just go unsent — it was overtaken.** #1129 and #1200 both changed `contracts/src/Vault.sol` (fee caps; NAV decimals + performance-fee share mint) and merged 2026-08-19/20 with **zero human reviews** — every review on #1129 is `copilot-pull-request-reviewer[bot]`, state `COMMENTED`, none `APPROVED`. `CLAUDE.md` makes Dan the sole required approver for contract changes. Raise this before any further contract merge. Also: PyPI `archimedes-cli` unreserved · `PAYMENTS_DRY_RUN` pinned in `ecs.tf` only, still unset in all three compose files and `infra/scripts/setup-ssm-secrets.sh`. A6 is **no longer blocked** — diagnosed 2026-08-18, do not re-run it |
-| 2 | [cluster-1](cluster-1-cost-ssot.md) | **2 of 3 engines** (12/21) | All three code edits landed in `5c601fb`. Engine C untouched, so "identical floor everywhere" is not yet true. 3 of 6 test asks unwritten |
-| 2 | [cluster-3](cluster-3-backtest-models.md) | **mostly done** (13/20) | A7 shipped in full — the sprint's cleanest win. `cost_model_id` still persists NULL from two of three writers, so the Done-when clause fails; provenance fields are declared on `StrategyResponse` but never assigned, and absent from `leaderboard_schemas.py` and all UI |
-| 3 | [cluster-2](cluster-2-fusion-engine.md) | **barely started** (9/21) | A1c, A4, the whole A8 label, all three tests. Only A7-adapter is satisfied — and it already was when the card was written. **Highest-leverage remaining work in the sprint** |
+| 2 | [cluster-1](cluster-1-cost-ssot.md) | **done** | Code edits landed in `5c601fb`; `4f60971` closed the Engine C leg and the test gap. "Identical floor everywhere" is now true. Audited at 12/21 before that commit — re-read the row above, not the fraction |
+| 2 | [cluster-3](cluster-3-backtest-models.md) | **done at the DB, open at the surface** | A7 shipped in full — the sprint's cleanest win. `4f60971` closed the `cost_model_id`-NULL and fabricated-`0.0`-correlation gaps (both now `None`, with `portfolio_backtester.py:447` no longer defaulting `correlation_to_spy` to `0.0`). What remains is surfacing: provenance fields are declared on `StrategyResponse` but never assigned, and absent from `leaderboard_schemas.py` and all UI |
+| 3 | [cluster-2](cluster-2-fusion-engine.md) | **A1c done, rest open** | `4f60971` landed A1c. Still open: A4 (the dead `backtest_start` condition at `:277`, and `:430` fabricating `date(2004, 1, 2)`) and the whole A8 sleeve label — `dsl-fusion-sleeves` / `n_independent_sleeves_equal_weight` are still absent tree-wide, so an "inverse-vol 5-asset" generated strategy is still graded as N independent 100%-long sleeves with no disclosure on the row |
 | 4 | [cluster-4](cluster-4-strategies-route.md) | **partial** (9/19) | Both A3 items landed 2026-08-20 (`757341a`, `14db21d`) by a different design — there is no `metrics_source` field anywhere. §3 TODO markers and §4 the unmetered generate endpoint untouched |
 | 5 | [a6-rerun](a6-rerun.md) | **executed, prerequisites skipped** (12/26) | The A4 read-path fix was not taken and its stated window ("the one moment in the year") has closed; the A5 fetch memo was never threaded (`run_backtests.py` passes no `fetcher`); **the before/after table — the card's named deliverable — does not exist**; rejection-rate copy never written |
-| 6–8 | [cluster-5](cluster-5-meter.md) | **barely started** (9/48) | No `metering.py`, `Principal`, SKUs, reserve/commit/release, or `METER_ENFORCE`. #1199 was closed independently by #1194 — which breaches this card's first anti-goal, since `GenerationQuota.peek` now backs the CLI's `meter` on the same one-way INCR. B5's silent model downgrade is **still live** (`generate_routes.py:193`) |
+| 6–8 | [cluster-5](cluster-5-meter.md) | **retired, with one live tail** (9/48) | #1442 retires this card (#1194 + #1296/#1300 rebuilt the space; refund/release is now #1441) and that reading is right about the metering design. **One item it does not cover: B5's silent model downgrade is still live** at `generate_routes.py:335` — an entitled premium request is still downgraded to the env default, and #1441 is about refund/release, not this. Either fix it or track it before the card is closed |
 | 6–8 | [cluster-6](cluster-6-boot-paywall.md) | **barely started** (7/31) | An x402 generation paywall **shipped** 2026-08-19 (`ab712a1`), flag-off in prod — so the card's premise that no route emits a satisfiable 402 is false. **Neither boot assertion exists**, and `GATEWAY_CHAIN` still silently falls back to `arcTestnet` in three places. A live paywall with no mainnet-chain guard is the dangerous half of this card. No `/api/v1/`, no manifest-honesty edits |
 | 9 | [cluster-8](cluster-8-returns-csv.md) | **barely started** (11/53) | None of the specified deliverable: no `returns_import.py`, no `/api/v1/rigor/verdict`, no CSV transport, none of the eight validations, no test file. #1305's overlapping endpoint breaches two prohibitions — see item 2 above and A1 (gate compute runs on the event loop, not `asyncio.to_thread`) |
 | 10 | [cluster-7](cluster-7-ui-surface.md) | **barely started** (14/38) | `sitemap.xml` is the one clean win. A9/A10 are **product reversals**: the card says keep /portfolio and /marketplace live with a banner; #1266 hid them instead. All five orphan deletions untouched — `FusionResult.jsx` (198L) is being *actively maintained while orphaned*, `PortfolioAdvisor.jsx` (477L) leaves `/api/strategies/advisor` with no consumer. No `WorkInProgress.jsx`, so A4/A8/A10 have no banner to render. All three check scripts missing |
@@ -83,14 +97,19 @@ fraction here as an upper bound on completeness.
    this directory.** The Aug-16 note claiming the anchors were "re-verified 6/6 fresh — trust
    them" was retired 2026-08-21: every rule-2 count had drifted and two anchors named a file
    that has never existed.
-2. **Never read whole** — counts as of 2026-08-21: `strategies_routes.py` (2547) ·
-   `Architecture.jsx` (1322) · `rigor_evaluator.py` (1246) · `_rigor_helpers.py` (1176, under
-   `services/`, not `api/`) · `main.py` (861) · `fusion_evaluator.py` (856).
-   **`portfolio_backtester.py` has left this list** — `c02d5fa` (2026-08-18) cut it 1180 → 683,
+2. **Never read whole** — counts at `f3d4103` (2026-08-21): `strategies_routes.py` (2621) ·
+   `Architecture.jsx` (1329) · `rigor_evaluator.py` (1246) · `_rigor_helpers.py` (1176, under
+   `services/`, not `api/`) · `main.py` (928) · `fusion_evaluator.py` (884).
+   **`portfolio_backtester.py` has left this list** — `c02d5fa` (2026-08-18) cut it 1180 → 694,
    so it is readable whole and cluster-1's "window-read only" note on it is moot.
+   These drift by tens of lines per day; re-measure rather than cite.
 3. **One cluster per session.** Do not drift into an adjacent item because it is nearby.
 4. **Test narrow:** `pytest backend/tests/test_<module>.py -q`. Full suite once, pre-merge.
-5. **No subagents, no workflows.** No discovery left to parallelize.
+5. ~~**No subagents, no workflows.**~~ **Superseded** by the owner's execution-style call
+   (Dan, 2026-08-20, recorded in [#1442](https://github.com/a-apin/archimedes/pull/1442)):
+   rules 5 and 7 were written for a solo token-constrained session and do not bind sessions
+   running the repo's parallel-agent pipeline (CLAUDE.md § parallel agent fan-out). Rule 6's
+   anti-goals stay in force.
 6. **Universal anti-goals:** no vitest/playwright · no `python-multipart` · no server-side user
    Python · no DSL-JSON upload · don't delete `_run_fusion_job` · don't repair QuantLab's mocks ·
    no KB pipeline · no distributed meter reaper · don't un-pin `circlekit` · no vectorbt.
@@ -100,14 +119,12 @@ fraction here as an upper bound on completeness.
    `ui/src/App.jsx:13` (the #1194 auth boundary, `e76c1c7`), and `Architecture.jsx` was
    effectively rewritten (896 → 1322 lines, +750/−324 whitespace-insensitive) by eight
    claim-integrity commits on 2026-08-19/20.
-7. **Merge discipline — breached; settle it with Dan before relying on it.** The rule reads max
-   2 merges/day, ≥40 min apart, `/health` verified between. Actual: 21 merges 2026-08-18, 34 on
-   08-19, 58 on 08-20 (`git log --merges --since=2026-08-16 --format=%ad --date=short | sort |
-   uniq -c`; a `Merge pull request` subject count agrees within 2, so the order of magnitude
-   holds even though CI clones here are shallow with grafted roots). Either it is dead or the
-   sprint is running blind on deploy verification — and
-   #1346 (deploy starvation from a fast merge train) and #1309 (~2-minute 502 per deploy) are
-   exactly the failure modes it existed to prevent. Both still open.
+7. ~~**Merge discipline: max 2 merges/day.**~~ **Superseded by the same 2026-08-20 call** — see
+   rule 5. For the record of what it was measuring: 21 merges landed 2026-08-18, 34 on 08-19,
+   58 on 08-20, and `main` took 170 commits in the day to 2026-08-21 alone. The two failure
+   modes the rule was written against are still open issues — #1346 (deploy starvation from a
+   fast merge train) and #1309 (~2-minute 502 window per deploy) — so the *risk* it named is
+   real even though the *rule* is retired; treat those as issues to fix, not a cadence to obey.
 
 ## Corrections to the cards
 
@@ -124,7 +141,6 @@ Substantive errors only. Line drift is pervasive and rule 1 handles it.
 | cluster-2 | A8 rename to `dsl-fusion-sleeves` | `_SEARCH_TRACKED_ENGINES` (`selection_bias_routes.py:605`) matches the literal `"dsl-fusion"`; a bare rename breaks num-trials attribution |
 | cluster-3 | `look_ahead_audit_passed` is the OR of a real AST audit and a broker-config check | **Neither leg is the AST audit.** `cli.py:378` reduces the same field with `all(...)`, so the OR compares a value against a reduction of itself. The real AST audit is never invoked on this path. Shipped as disclosure (`look_ahead_audit_source`), flag flip deferred to the re-run — which has now passed |
 | cluster-3 | Done-when: `grep passes_rigor_gate models/backtest.py` is empty | Contradicts the card's own ask for a retraction comment containing that string. Trust `test_gate_equivalence.py` instead |
-| cluster-3 | A4-part ends fabricated `0.0` correlations | Fixed at the mapper (`:271-272`), but `generation_pipeline.py:1625-1626` hard-codes both and `portfolio_backtester.py:473` hard-codes `correlation_to_btc`. Worse, `:442` initialises `correlation_to_spy = 0.0` before the `:452` compute, so a failed computation is indistinguishable from a measured zero |
 | cluster-4 | `pytest backend/tests/test_live_rigor_gate.py` | No such file. Coverage is in `test_gate_equivalence.py`, `test_live_gate_returns.py`, `test_rigor_evaluator.py`, `test_strategies_routes.py` |
 | cluster-5 | `enforce_generation_quota()` opens `if wallet: return`, so the cap never applies | Inverted. Rebuilt for #1194: `(request, user_id)`, no bypass, stacked user+IP day caps (10/20). `WALLET_LESS_GENERATION_DAILY_CAP` no longer exists |
 | cluster-5 | Proof test: an N+1 route test reads as unlimited today | `generate_routes.py:144` skips enforcement when `TESTING` is set, so such a test passes against unfixed code — the exact trap CLAUDE.md § *a test that passes against the unfixed code proves nothing* warns about |

--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -40,13 +40,16 @@ PRs as still open. **Both were accurate when written** — the card was authored
    Fargate, at the artifact write that *precedes* the DB insert, so every computed backtest was
    discarded. Fixed 2026-08-18 (`8e6554c`), after which the armed in-app scheduler self-healed
    the leaderboard: fresh curated rows reached prod 2026-08-19/20 with Engine C still charging
-   commission only. **`4f60971` (2026-08-20) then put Engine C on the cost floor** — slippage at
-   `fusion_evaluator.py:230-232` and `:393-395`, `cost_model_id` stamped on fusion rows, and
-   `test_cost_parity.py` now exercises engine C directly. So the floor is complete now, but it
-   completed *after* those rows published. **The residual is whether the curated rows on the
-   board predate `4f60971`** — if they do, they were graded on a two-of-three floor and need a
-   re-grade or a re-run. That cannot be settled from this repo; check
-   `backtest_results.cost_model_id` on prod against the post-`4f60971` fingerprint.
+   commission only. **`4f60971`, in #1379 (2026-08-20), then put Engine C on the cost floor** —
+   slippage at `fusion_evaluator.py:230-232` and `:393-395`, `cost_model_id` stamped on fusion
+   rows, and `test_cost_parity.py` now exercising engine C directly. So the floor is complete,
+   but it completed *after* those rows published. Two residuals, and only one is tracked:
+   #1449 covers the **paper-trading** side (a full-history replay under the new floor will
+   register drift on every past date of every open deployment, and the ledger is append-only by
+   design). Nothing covers the **curated leaderboard** side: whether the rows now on the board
+   were graded before or after `4f60971`, and so whether they need a re-grade. Settle it by
+   checking `backtest_results.cost_model_id` on prod against the post-`4f60971` fingerprint —
+   it cannot be answered from this repo.
 2. **`POST /api/rigor/verify` can answer `passes: true` on four bars.** Shipped via #1305
    (2026-08-19), ahead of and overlapping [cluster-8](cluster-8-returns-csv.md). `passes` is
    `all(...)` over *evaluable* legs only, and PBO plus look-ahead are hard-coded

--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -74,11 +74,14 @@ PRs as still open. **Both were accurate when written** — the card was authored
 
 Verified against source at `0057518`, 2026-08-21, by an 11-way item-level audit. Fractions are
 that audit's own decomposition (acceptance clauses, anti-goals and test asks counted
-separately) — a shape, not a score. Adversarial re-verification reached 3 of 11 cards before
-running out of budget and **overturned 16 claims, every one in the less-complete direction**
-(including this section's own first draft, which wrongly called the Aug-16 State section
-inaccurate). Treat the un-reverified cards' DONEs as strong-but-unconfirmed, and read every
-fraction here as an upper bound on completeness.
+separately) — a shape, not a score. Adversarial re-verification **covered 3 of 11 cards and
+stopped there** (two resume attempts wedged; not retried again). Over 88 claims attacked it
+**overturned 16, every one in the less-complete direction** — including this section's own
+first draft, which wrongly called the Aug-16 State section inaccurate. So: the three
+re-verified cards (this one, cluster-0, cluster-1) are twice-checked; the other eight are
+single-source. Treat their DONEs as strong-but-unconfirmed and read every fraction here as an
+upper bound on completeness. Re-verification is the cheapest thing to extend if anyone doubts
+a row.
 
 | Session | Card | Status | What is actually left |
 |---|---|---|---|

--- a/docs/sprint/a6-rerun.md
+++ b/docs/sprint/a6-rerun.md
@@ -66,18 +66,20 @@ last 40 lines when it finishes.
 
 ## Set the expectation before you publish
 
-`docs/specs/second-wave-universe-experiment.md` already tested whether a bigger universe rescues
-failing strategies. **The answer is no** — no verdict flips, several get worse, 7 of 9 had
-negative Sharpe after costs. `docs/specs/quant-roadmap.md` concludes strategy count is a vanity
-metric.
+[`second-wave-universe-experiment.md`](../quant/second-wave-universe-experiment.md) already tested
+whether a bigger universe rescues failing strategies. **The answer is no** — no verdict flips,
+several get worse, 7 of 9 had negative Sharpe after costs.
+[`quant-roadmap.md`](../plans/quant-roadmap.md) concludes strategy count is a vanity metric.
 
-**Fixing the backtests will make more strategies fail, not fewer.** Today 3 of 34 pass, and the
-three are a T-bill proxy, buy-and-hold, and risk parity. Correct routing plus real slippage on
-Engine C will very likely push that down. **That is the gate working, and it is the product: we
-sell the verdict, not the alpha.**
+**Fixing the backtests will make more strategies fail, not fewer.** The handful of rows that read
+as passing today are a T-bill proxy, buy-and-hold, and risk parity — and the count itself is
+**unestablished** per [`CLAUDE.md`](../../CLAUDE.md) § the hard constraint, so publish it as
+"unestablished", never as a number. Correct routing plus real slippage on Engine C will very
+likely push it down further. **That is the gate working, and it is the product: we sell the
+verdict, not the alpha.**
 
 Have the copy ready **before** the run, not after. Reframe the headline from scoreboard to
-**rejection rate** — "34 candidates, 3 clear the bar" *is* the thesis; a board that passes
+**rejection rate** — "most candidates do not clear the bar" *is* the thesis; a board that passes
 everything is marketing.
 
 ## No threshold moves. A `FeedArityError` is a loud honest failure, not a regression.


### PR DESCRIPTION
Docs-only, rebased onto `baa173a`. **Complementary to #1442, not competing with it** — see Scope below.

## Scope vs #1442

#1442 is the **dispatch state**: which work packages are out, which PRs close which partials, which cards are retired. This PR is the **verification layer**: what a `grep` finds in the tree today, and where a card's own text is wrong. The README now says so explicitly, so the two can both land. **#1442 should go first** — it carries the owner's ruling and the in-flight picture; I'll rebase onto it and drop anything it covers.

**Where they disagree, one item:** #1442 retires cluster-5, correctly on the metering design (#1194 + #1296/#1300 rebuilt the space; refund/release is #1441). But **B5's silent model downgrade is still live** at `generate_routes.py:335` — an entitled premium request is still downgraded to the env default, and #1441 covers refund/release, not that. Flagged rather than silently reconciled.

## Retractions (the rebase earned its keep)

The branch was 170 commits behind at one point. Re-verifying against current `main` killed the loudest thing this PR originally said. `4f60971`, in **#1379**, closed three findings:

- **"Engine C still charges commission only"** — false now. Slippage at `fusion_evaluator.py:230-232` and `:393-395`; `TestEngineCFloor` in `test_cost_parity.py` pins both call sites. The re-run's authorising gate is met.
- **"`cost_model_id` persists NULL from two of three writers"** — closed.
- **"Fabricated `0.0` correlations"** — closed; all serve `None`, and `portfolio_backtester.py:447` is now typed `float | None = None`, so the fail-soft default is gone too.

What survives is narrower and split by tracking status: #1449 already covers the **paper-trading** consequence (full-history replay under the new floor drifts every open deployment; append-only ledger). Nothing covers the **curated leaderboard** one — whether the rows now published were graded before or after `4f60971`. Both need a prod read.

Session rules 5 and 7 are struck through rather than argued with: Dan's 2026-08-20 execution-style call, recorded in #1442, supersedes both. The previous revision asked him to settle rule 7; he already had. Rule 6's anti-goals stay in force.

## What's still standing

All re-checked against `baa173a`, which `main` has sat on since 2026-08-21:

- **`POST /api/rigor/verify` can answer `passes: true` on four bars** — PBO and look-ahead are hard-coded `not_evaluable` *always*; DSR needs ≥4 bars, OOS ~70. One leg of four decides it, and `archimedes verify` exits `OK` on that boolean. Body is honest; scalar and exit code are not. **Now filed as #1481** with a machine-checkable acceptance set, and the fix it recommends (reuse `verdict_from_returns`) closes cluster-8's own U1 item rather than adding work beside it.
- **#1129 and #1200 changed `contracts/src/Vault.sol` and merged with zero human reviews** — every review on #1129 is `copilot-pull-request-reviewer[bot]`, state `COMMENTED`, none `APPROVED`. `CLAUDE.md` makes Dan the sole required approver. This is cluster-0's Ask 1, which went unsent while the PRs merged anyway. **This is the item I'd most want a second pair of eyes on.**
- **`ui/src/siwe.js` has never existed** — cited twice in cluster-0's *executed results* as verified. The conclusion holds; the evidence is fictional and reality is worse (no override seam, chain id hardcoded in four places).
- Boot assertions still absent (`GATEWAY_CHAIN` unguarded in `main.py`, `arcTestnet` default live) — #1401 is draft.
- `metrics_source` and the A8 sleeve label still absent tree-wide.
- Four acceptance commands name files that don't exist; the look-ahead OR premise is wrong (neither leg is the AST audit).

Commit 1 is independent of all of this: it de-numbers two pass-count claims that `CLAUDE.md` § the hard constraint forbids, and converts three code-span doc refs that broke silently in #1225 into real links.

## Verification

- `make docs-check` → links 0 broken (1183 scanned), index 143/143.
- Every claim written into the docs was checked with a literal command, and each still-standing finding was re-checked by hand after all three rebases.
- **Adversarial re-verification is concluded at 3 of 11 cards, not pending.** Two resume attempts wedged, so it was not retried. Over 88 claims attacked it overturned **16, every one toward less-complete** — including this PR's own first draft, which wrongly called the Aug-16 State section inaccurate. Three cards are twice-checked (README, cluster-0, cluster-1); the other eight are single-source and the doc labels their fractions as upper bounds. **Read every fraction as a ceiling on completeness, not a measurement.**
- No code touched. `git diff --check` clean.

## Reviewer note

The heads-up worth having before this lands: #1469 (draft) is a 60-file UI rebrand that rewrites `sitemap.xml`, `routes.js`, `Architecture.jsx` and `Leaderboard.jsx` — i.e. most of what cluster-7's rows describe. It touches none of the eight files the still-standing findings rest on, so nothing here is wrong today, but cluster-7's status will need re-verifying after that merges.