### PR TITLE
[frontend][infra] Wallet-matrix payment unlock: connect flow, passkey signing, caps 100/200 !minor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -212,8 +212,8 @@ MARKETPLACE_SPEND_CAP_USDC=50
 # ships). <= 0 disables a layer individually. Fail-closed on Redis errors —
 # deliberate: the generate path's job queue needs the same Redis, so failing
 # open would only uncap spend in exactly the degraded state.
-GENERATION_DAILY_CAP_PER_USER=10
-GENERATION_DAILY_CAP_PER_IP=20
+GENERATION_DAILY_CAP_PER_USER=100
+GENERATION_DAILY_CAP_PER_IP=200
 # Admission control: how many generation pipelines may RUN at once (one
 # pipeline ≈ 65% of the prod task's vCPU, so raise only with task CPU) and
 # how many more may WAIT in queue before /start refuses 429 pre-payment.

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -551,8 +551,8 @@ resource "aws_ecs_task_definition" "backend" {
         # code default because it was never added to the task definition is a
         # config-drift failure this file has already had (see KNOWN GAP list).
         # Not secrets. Both layers must pass; <= 0 disables a layer.
-        { name = "GENERATION_DAILY_CAP_PER_USER", value = "10" },
-        { name = "GENERATION_DAILY_CAP_PER_IP", value = "20" },
+        { name = "GENERATION_DAILY_CAP_PER_USER", value = "100" },
+        { name = "GENERATION_DAILY_CAP_PER_IP", value = "200" },
         # Generation payment gate (flip-list #834): flag stays "false" until
         # Dan flips it deliberately — and GENERATION_PAYMENT_RECIPIENT (the
         # platform wallet that receives x402 settlements) MUST be set first;

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -394,7 +394,11 @@ export default function Generate({ onNavigate, onStageChange }) {
 			setNoSettlementNotice(!settledReceipt);
 			if (GENERATION_QUOTE_ENABLED) fetchQuote();
 		} catch (e) {
-			setPaymentMessage(paymentErrorMessage(e, e?.message || "Payment failed — try again."));
+			// Surface the wallet/backend's OWN words — a generic "failed" here
+			// cost a full manual test cycle per wallet (#1298 field report).
+			setPaymentMessage(
+				paymentErrorMessage(e, e?.shortMessage || e?.message || "Payment failed — try again."),
+			);
 		} finally {
 			setPaying(false);
 		}
@@ -889,10 +893,19 @@ export default function Generate({ onNavigate, onStageChange }) {
 										one below.
 									</p>
 								) : !walletSupportsPayment() ? (
-									<p className="caption mb-0" style={{ marginTop: 6 }}>
-										Pay with a browser wallet (e.g. MetaMask) — this wallet type isn't
-										supported for payments yet.
-									</p>
+									<div style={{ marginTop: 6 }}>
+										<p className="caption mb-1">
+											Connect the wallet you linked to pay — MetaMask, Coinbase, Brave,
+											Phantom, or your Circle passkey wallet.
+										</p>
+										<button
+											type="button"
+											className="btn btn-outline btn-sm"
+											onClick={() => window.dispatchEvent(new Event("open-wallet-modal"))}
+										>
+											Connect wallet →
+										</button>
+									</div>
 								) : checkingBalance ? (
 									<p className="caption mb-0" style={{ marginTop: 6 }}>
 										Checking your Gateway balance…

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -402,7 +402,11 @@ export async function ensureArcChain(ethereum) {
           chainName: 'Arc Testnet',
           nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 18 },
           rpcUrls: ['https://rpc.testnet.arc.network'],
-          blockExplorerUrls: [],
+          // MetaMask-family validation REJECTS an empty array here (EIP-3085:
+          // null or a non-empty HTTPS list) — `[]` made wallet_addEthereumChain
+          // throw for every wallet without Arc pre-added, killing the deposit
+          // and signing flows before any prompt appeared (#1298 field bug).
+          blockExplorerUrls: ['https://testnet.arcscan.app'],
         }],
       })
     } else if (isAlreadyPendingError(switchError)) {

--- a/ui/src/x402.js
+++ b/ui/src/x402.js
@@ -6,25 +6,28 @@
 // mirroring the DepositFlow.jsx / circle-tx-executor.js split already
 // established for vault deposits.
 //
-// EOA / injected-wallet path ONLY (MetaMask, Coinbase Wallet, any EIP-6963
-// wallet). The Circle passkey smart-account path is explicitly out of scope
-// for payments (Dan's directive): it has no viem WalletClient and can't sign
-// EIP-712 today — config.js's getWalletClient() already throws a clear error
-// for that path. walletSupportsPayment() below lets Generate.jsx show an
-// honest "use a browser wallet" message instead of a broken pay button,
-// rather than letting the throw surface as a crash.
+// Full wallet matrix (#1298, Dan's 2026-08-21 directive): EOA/injected
+// wallets (MetaMask, Coinbase, Brave, Phantom — anything EIP-6963) sign via
+// the viem WalletClient; the Circle passkey smart account signs typed data
+// through its viem SmartAccount (ERC-1271/6492) and transacts through the
+// bundler executor. paymentWalletKind() below is the branch point, and
+// 'none' means the session has no connected wallet yet — the UI must offer
+// the CONNECT flow there, never a dead-end message.
 //
 // No new dependency: viem is already a dependency (see config.js), and the
 // two ABIs below follow this repo's established "minimal inline ABI, just
 // what's needed" convention (config.js's USDC_ABI / VAULT_ABI).
 
 import { parseUnits } from "viem";
+import { encodeCall, executeUserOp } from "./circle-tx-executor";
 import {
 	CIRCLE_PROVIDER_ID,
 	USDC_DECIMALS,
 	ensureArcChain,
 	getConnectedProvider,
 	getRawProvider,
+	getSmartAccount,
+	getSmartAccountClient,
 	getWalletClient,
 	publicClient,
 } from "./config";
@@ -75,17 +78,25 @@ const USDC_APPROVE_ABI = [
 ];
 
 /**
- * True only when the connected wallet can sign EIP-712 typed data — any
- * EOA/injected path (MetaMask, Coinbase Wallet, EIP-6963 wallets). False
- * when nothing is connected, or the connected wallet is the Circle passkey
- * smart account (CIRCLE_PROVIDER_ID), which signs via Circle's bundler and
- * has no viem WalletClient. Generate.jsx checks this BEFORE offering a pay
- * button so an unsupported wallet gets an honest message instead of a click
- * that throws.
+ * Which kind of payment-capable wallet is connected right now (#1298 wallet
+ * matrix): 'eoa' — any injected/EIP-6963 wallet (MetaMask, Coinbase, Brave,
+ * Phantom, …) with a viem WalletClient; 'circle' — the Circle passkey smart
+ * account, which signs typed data through its viem SmartAccount and
+ * transacts through the bundler executor; 'none' — nothing connected in this
+ * session. Generate.jsx branches on this to offer the CONNECT flow for
+ * 'none' (the prior build dead-ended there: it told MetaMask users to "use a
+ * browser wallet" while giving them no connect button — the exact failure
+ * Dan hit in all three browsers).
  */
-export function walletSupportsPayment() {
+export function paymentWalletKind() {
 	const provider = getConnectedProvider();
-	return Boolean(provider) && provider !== CIRCLE_PROVIDER_ID;
+	if (!provider) return "none";
+	return provider === CIRCLE_PROVIDER_ID ? "circle" : "eoa";
+}
+
+/** Back-compat boolean: any connected wallet can now attempt payment. */
+export function walletSupportsPayment() {
+	return paymentWalletKind() !== "none";
 }
 
 /**
@@ -137,6 +148,25 @@ export async function depositToGateway(requirements, amountRaw, onProgress = () 
 	const token = requirements?.asset;
 	if (!gateway || !token) throw new Error("Missing Gateway contract or asset address in the payment requirements.");
 
+	// Circle passkey path: approve + deposit as ONE batched user operation
+	// through the bundler — same executor DepositFlow.jsx's vault path uses.
+	if (paymentWalletKind() === "circle") {
+		const smartAccount = getSmartAccount();
+		const client = getSmartAccountClient();
+		if (!smartAccount || !client) {
+			throw new Error("Passkey wallet session expired — reconnect your Circle wallet and retry.");
+		}
+		onProgress("approving");
+		const calls = [
+			encodeCall({ address: token, abi: USDC_APPROVE_ABI, functionName: "approve", args: [gateway, amountRaw] }),
+			encodeCall({ address: gateway, abi: GATEWAY_ABI, functionName: "deposit", args: [token, amountRaw] }),
+		];
+		onProgress("depositing");
+		const out = await executeUserOp({ smartAccount, client, calls, onStateChange: () => {} });
+		onProgress("deposited", { userOp: out });
+		return { userOp: out };
+	}
+
 	await ensureArcChain(getRawProvider());
 	const walletClient = await getWalletClient();
 
@@ -179,13 +209,10 @@ export async function depositToGateway(requirements, amountRaw, onProgress = () 
  * rather than letting getWalletClient()'s passkey error surface raw.
  */
 export async function signGatewayPayment({ requirements, resource, x402Version, payerAddress }) {
-	if (!walletSupportsPayment()) {
-		throw new Error(
-			"This wallet type can't sign payments yet — connect a browser wallet (e.g. MetaMask) to pay.",
-		);
+	const kind = paymentWalletKind();
+	if (kind === "none") {
+		throw new Error("No wallet connected — use Connect Wallet, then retry the payment.");
 	}
-	await ensureArcChain(getRawProvider());
-	const walletClient = await getWalletClient();
 
 	const nowSec = Math.floor(Date.now() / 1000);
 	const nonceBytes = crypto.getRandomValues(new Uint8Array(32));
@@ -196,7 +223,22 @@ export async function signGatewayPayment({ requirements, resource, x402Version, 
 		{ from: payerAddress, nowSec, nonceHex },
 	);
 
-	const signature = await walletClient.signTypedData({ domain, types, primaryType, message });
+	let signature;
+	if (kind === "circle") {
+		// Circle passkey smart account: viem SmartAccount.signTypedData returns
+		// the ERC-1271 (or ERC-6492-wrapped while counterfactual) signature in
+		// the wire format Circle's own stack verifies — do NOT wrap it again
+		// (the #870/#871 double-wrap lesson from the SIWE path applies here).
+		const smartAccount = getSmartAccount();
+		if (!smartAccount?.signTypedData) {
+			throw new Error("Passkey wallet session expired — reconnect your Circle wallet and retry.");
+		}
+		signature = await smartAccount.signTypedData({ domain, types, primaryType, message });
+	} else {
+		await ensureArcChain(getRawProvider());
+		const walletClient = await getWalletClient();
+		signature = await walletClient.signTypedData({ domain, types, primaryType, message });
+	}
 
 	return buildPaymentSignatureHeader({ x402Version, resource, requirements, authorization, signature });
 }

--- a/ui/test/generate-quote.test.js
+++ b/ui/test/generate-quote.test.js
@@ -562,10 +562,11 @@ test("Generate.jsx: the deposit step's copy names the two on-chain steps (approv
 	assert.match(generate, /depositStep/);
 });
 
-test("Generate.jsx: an unsupported wallet type (e.g. the Circle passkey path) gets an honest message, not a broken pay button", () => {
-	// \s+ tolerates the source's own line wrap inside the JSX text node —
-	// JSX collapses it to a single space at render time either way.
-	assert.match(generate, /isn't\s+supported for payments yet/);
+test("Generate.jsx: the no-wallet state offers the connect flow (#1298 supersedes the old unsupported-wallet dead end)", () => {
+	// The #1427-era "isn't supported for payments yet" message is RETIRED:
+	// passkey wallets now sign via their smart account, and the no-connection
+	// state must offer the connect modal (see wallet-matrix.test.js).
+	assert.doesNotMatch(generate, /isn't\s+supported for payments yet/);
 	assert.match(generate, /walletSupportsPayment\(\)/);
 });
 

--- a/ui/test/wallet-matrix.test.js
+++ b/ui/test/wallet-matrix.test.js
@@ -9,6 +9,7 @@ import test from "node:test";
 
 const x402 = readFileSync(new URL("../src/x402.js", import.meta.url), "utf8");
 const generate = readFileSync(new URL("../src/components/Generate.jsx", import.meta.url), "utf8");
+const config = readFileSync(new URL("../src/config.js", import.meta.url), "utf8");
 
 test("no-wallet branch offers the connect flow, not a dead end (#1298)", () => {
 	// The old copy told users to use a wallet without offering one — gone.
@@ -35,4 +36,11 @@ test("circle passkey wallets sign and deposit instead of being refused (#1298)",
 
 test("payment errors surface the wallet's own words (#1298)", () => {
 	assert.match(generate, /e\?\.shortMessage \|\| e\?\.message/);
+});
+
+test("wallet_addEthereumChain declares a non-empty block explorer (#1298 MetaMask validation)", () => {
+	// MetaMask/Brave reject blockExplorerUrls: [] outright — the add-chain
+	// call must carry the real explorer or omit the key entirely.
+	assert.doesNotMatch(config, /blockExplorerUrls:\s*\[\s*\]/);
+	assert.match(config, /blockExplorerUrls:\s*\['https:\/\/testnet\.arcscan\.app'\]/);
 });

--- a/ui/test/wallet-matrix.test.js
+++ b/ui/test/wallet-matrix.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// #1298 wallet-matrix unlock: the pay panel must never dead-end. Field
+// report (Dan, 2026-08-21): with no in-session wallet connection the panel
+// said "use a browser wallet" with NO connect affordance — MetaMask, Circle
+// passkey, and Coinbase users were all stuck. These pins reject that build.
+
+const x402 = readFileSync(new URL("../src/x402.js", import.meta.url), "utf8");
+const generate = readFileSync(new URL("../src/components/Generate.jsx", import.meta.url), "utf8");
+
+test("no-wallet branch offers the connect flow, not a dead end (#1298)", () => {
+	// The old copy told users to use a wallet without offering one — gone.
+	assert.doesNotMatch(generate, /isn't\s*\n?\s*supported for payments yet/);
+	// The replacement branch must dispatch the app's existing connect modal.
+	const branch = generate.match(/!walletSupportsPayment\(\) \? \(([\s\S]*?)\) : checkingBalance/);
+	assert.ok(branch, "no-wallet branch missing");
+	assert.match(branch[1], /open-wallet-modal/);
+	assert.match(branch[1], /Connect wallet/);
+});
+
+test("circle passkey wallets sign and deposit instead of being refused (#1298)", () => {
+	// Kind-based branching exists and covers all three states.
+	assert.match(x402, /paymentWalletKind/);
+	// Passkey signing goes through the smart account's typed-data signer…
+	assert.match(x402, /smartAccount\.signTypedData\(\{ domain, types, primaryType, message \}\)/);
+	// …and passkey deposits go through the bundler executor as a batched op.
+	assert.match(x402, /executeUserOp\(\{ smartAccount, client, calls/);
+	// The signature must NOT be re-wrapped (the #870/#871 double-ERC-6492 class).
+	assert.doesNotMatch(x402, /wrap6492|erc6492Wrap/i);
+	// The old blanket refusal copy is gone from the signer.
+	assert.doesNotMatch(x402, /can't sign payments yet/);
+});
+
+test("payment errors surface the wallet's own words (#1298)", () => {
+	assert.match(generate, /e\?\.shortMessage \|\| e\?\.message/);
+});


### PR DESCRIPTION
Addresses #1298's field failures (Dan: MetaMask/Firefox, Circle Passkey/Safari, Coinbase/Chrome all unable to pay).

**Root cause 1 — the dead end**: with no in-session wallet connection, the pay panel said "use a browser wallet" with NO connect button (`getWalletClient()` only returns a client the in-app connect flow built). The no-wallet state now renders **Connect wallet →** dispatching the existing `open-wallet-modal` (EIP-6963 discovery — Brave and Phantom work through the same door).

**Root cause 2 — passkey guarded off**: the Circle smart account now signs the EIP-712 authorization via its viem `SmartAccount.signTypedData` (ERC-1271/6492 wire format, NOT re-wrapped — the #870/#871 lesson) and funds Gateway with approve+deposit as ONE batched userop through the existing `executeUserOp` bundler path. Facilitator acceptance of 1271 sigs is the remaining unknown — if it refuses, the exact facilitator error now surfaces verbatim in the UI (fix 3: `shortMessage`/`message` passthrough), so the next field test is diagnostic rather than mute.

**Also**: `GENERATION_DAILY_CAP_PER_USER` 10→100 and `_PER_IP` 20→200 (testing directive; per-IP must move too or the user cap is unreachable behind one IP).

Verification: 383/383 ui tests (3 new matrix guards + 1 repointed #1427-era pin whose behavior this supersedes); eslint clean; adversarial revert → 3/3 guards fail. **After merge**: UI rides the merge deploy; the caps need `apply.sh --apply` + the next deploy roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7