### PR TITLE
[backend][frontend] Payment receipts: persist settled generation payments + user-facing list !minor

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -179,6 +179,62 @@ def _require_job_access(job: dict, user_id: str, job_id: str, linked_wallet: str
         raise HTTPException(status_code=404, detail=f"job {job_id} not found or expired")
 
 
+# USDC's on-chain decimal precision — matches marketplace.payments._USDC_DECIMALS.
+# PaymentInfo.amount (circlekit) is a string of raw base units, e.g. "2000000"
+# for $2.00; this is the sole place generate_routes converts that into a
+# display dollar string for the receipt (see models/payment_receipt.py).
+_RECEIPT_USDC_DECIMALS = 6
+
+
+def _format_receipt_usd(amount_base_units: int) -> str:
+    from decimal import Decimal
+
+    return f"${Decimal(amount_base_units) / Decimal(10**_RECEIPT_USDC_DECIMALS):.2f}"
+
+
+def _write_payment_receipt(*, user_id: str, payment, job_id: str) -> None:
+    """The persistence boundary — no try/except here. The caller
+    (``_persist_payment_receipt``) wraps this; tests patch this exact name to
+    exercise the fail-safe path without reaching into the DB layer."""
+    from archimedes.db import get_session
+    from archimedes.models.payment_receipt import record_payment_receipt
+
+    amount_base_units = int(payment.amount)
+    with get_session() as session:
+        record_payment_receipt(
+            session,
+            user_id=user_id,
+            payer_wallet=payment.payer,
+            amount_base_units=amount_base_units,
+            price_usd=_format_receipt_usd(amount_base_units),
+            network=payment.network,
+            settlement_ref=payment.transaction,
+            job_id=job_id,
+        )
+        session.commit()
+
+
+def _persist_payment_receipt(*, user_id: str, payment, job_id: str) -> None:
+    """Persist one settled generation payment as a receipt (Dan's directive:
+    "we must provide people with their receipts").
+
+    FAIL-SAFE, deliberately: the payment already cleared by the time this
+    runs — the user already paid. A receipt-write failure must never fail or
+    delay the paid generation, so every exception is swallowed here and only
+    logged. This is the ONE place in this module that name is true; every
+    other write on the happy path (job enqueue, funnel, identity event) is
+    allowed to matter to the response.
+    """
+    try:
+        _write_payment_receipt(user_id=user_id, payment=payment, job_id=job_id)
+    except Exception:
+        logger.warning(
+            "payment receipt write failed for job %s (payment already settled — no user impact)",
+            sanitize_log_value(job_id),
+            exc_info=True,
+        )
+
+
 @generate_public_router.get("/quote")
 async def get_generation_quote():
     """The upfront generation cost estimate — public, so a human can see the
@@ -231,6 +287,11 @@ async def start_generation(
     # BEFORE entitlement/enqueue (no work is burned for an unpaid request).
     # The 402 carries the full x402 requirements — that response IS the
     # quote-approval flow for humans and agents alike. Paper trading stays free.
+    # None under flag-off / dry-run (see enforce_generation_payment); a real
+    # settled PaymentInfo only when the flag is on and the payment cleared —
+    # that is also the ONLY case a payment receipt is persisted (below, once
+    # job_id exists).
+    payment = None
     if generation_payment.payment_required():
         if not linked_wallet:
             # The wallet-connection precondition. 409 (not 402): the blocker is
@@ -291,6 +352,13 @@ async def start_generation(
             "model": selected_model,
         },
     )
+
+    # Payment receipt (Dan's directive: "we must provide people with their
+    # receipts"). Only when a real settled PaymentInfo exists — flag-off and
+    # dry-run leave `payment` None and nothing is written. Deliberately AFTER
+    # enqueue succeeds, so the receipt carries a real job_id.
+    if payment is not None:
+        _persist_payment_receipt(user_id=user.id, payment=payment, job_id=job_id)
 
     # Fire-and-forget; the SSE stream tails events. User ownership is threaded
     # from this authenticated request, never client-supplied.

--- a/backend/archimedes/api/payment_routes.py
+++ b/backend/archimedes/api/payment_routes.py
@@ -1,0 +1,58 @@
+"""``GET /api/payments/receipts`` — the CALLER's own settled generation-payment
+receipts (Dan's directive, 2026-08-21: "we must provide people with their
+receipts").
+
+Reads the durable ``payment_receipts`` table written at settle time by
+``generate_routes.start_generation`` (fail-safe there: a write failure never
+fails or delays the paid generation, so this list can in principle be
+incomplete for a given user during a genuine DB outage — an honest gap, not a
+fabricated empty result masquerading as "no payments").
+
+Account-session-gated (Better Auth, ``require_current_user``) — mirrors
+``account_usage_routes.py``'s per-route ``Depends`` style. Owner-scoped by
+construction: the query is always filtered to the CALLER's own ``user.id``,
+so one account can never see another's charges. No pagination yet — capped at
+``PaymentReceiptRecord.MAX_RECEIPTS`` (200), noted in the response docstring.
+
+**Honesty note** (mirrors ``models/payment_receipt.py``): ``settlement_ref``
+is a Circle facilitator reference id, NOT an on-chain transaction hash. It is
+returned as a plain string; nothing here (or in the UI) may render it as an
+arcscan link.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from archimedes.api.account_auth import CurrentUser, require_current_user
+
+payment_router = APIRouter(prefix="/api/payments", tags=["payments"])
+
+
+class PaymentReceiptResponse(BaseModel):
+    id: int
+    created_at: str | None
+    price_usd: str
+    amount_base_units: int
+    payer_wallet: str
+    # Circle facilitator reference id — NOT an on-chain tx hash. Never link
+    # this to a block explorer (see module docstring's honesty note).
+    settlement_ref: str | None
+    job_id: str | None
+    network: str
+
+
+@payment_router.get("/receipts", response_model=list[PaymentReceiptResponse])
+async def list_receipts(user: CurrentUser = Depends(require_current_user)) -> list[PaymentReceiptResponse]:
+    """The caller's own settled generation-payment receipts, newest-first.
+
+    Capped at 200 rows — no pagination yet. If a payer somehow has more than
+    200 settled generation payments, only the most recent 200 are returned.
+    """
+    from archimedes.db import get_session
+    from archimedes.models.payment_receipt import MAX_RECEIPTS, list_payment_receipts
+
+    with get_session() as session:
+        rows = list_payment_receipts(session, user.id, limit=MAX_RECEIPTS)
+    return [PaymentReceiptResponse(**row) for row in rows]

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -35,6 +35,7 @@ from archimedes.models.marketplace import (
     SubscriberLiability,
     SubscriberTickLog,
 )
+from archimedes.models.payment_receipt import PaymentReceiptRecord
 from archimedes.models.request_snapshot import RequestCountSnapshot
 from archimedes.models.strategy_generators import StrategyGenerator
 from archimedes.models.strategy_proposal import StrategyProposal
@@ -62,6 +63,7 @@ __all__ = [
     "LinkedWallet",
     "MarketplaceAgent",
     "PaperRecord",
+    "PaymentReceiptRecord",
     "RequestCountSnapshot",
     "SettlementIntent",
     "StrategyBacktestFixture",

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -49,6 +49,7 @@ from archimedes.api.generate_routes import generate_public_router, generate_rout
 from archimedes.api.leaderboard_routes import leaderboard_router
 from archimedes.api.limiter import limiter
 from archimedes.api.paper_routes import paper_router
+from archimedes.api.payment_routes import payment_router
 
 # FAIL-SOFT import: marketplace_routes → service → payments imports circlekit
 # (the circle-titanoboa-sdk VCS dependency). If that dependency fails to IMPORT
@@ -512,6 +513,7 @@ app.include_router(portfolio_router, dependencies=[Depends(require_current_user)
 app.include_router(selection_bias_router)
 app.include_router(rigor_verify_router)
 app.include_router(account_usage_router)
+app.include_router(payment_router)
 app.include_router(papers_router)
 app.include_router(user_router, dependencies=[Depends(require_current_user)])
 app.include_router(wallet_router)

--- a/backend/archimedes/models/payment_receipt.py
+++ b/backend/archimedes/models/payment_receipt.py
@@ -1,0 +1,135 @@
+"""Durable per-generation payment receipt (Dan's directive, 2026-08-21: "we
+must provide people with their receipts").
+
+The $2/generation x402 paywall (``services/generation_payment.py``) settles
+through Circle's facilitator and hands the route a
+``circlekit.x402.PaymentInfo`` — ``verified``/``payer``/``amount``/``network``/
+``transaction``/``response_headers`` — then forgets it. Nothing survived the
+request: a payer had no way to look back at what they were charged. This
+table is where the settled fact survives, and ``GET /api/payments/receipts``
+(``api/payment_routes.py``) is what reads it back.
+
+**Honesty note, load-bearing:** ``settlement_ref`` is ``PaymentInfo.transaction``
+— a Circle facilitator reference id, NOT an on-chain transaction hash. Circle
+batches and settles on-chain later; this codebase does not run that
+settlement logic (see ``marketplace/payments.py``'s module docstring). Never
+render ``settlement_ref`` as a clickable arcscan link — a dead arcscan link
+for a non-hash is worse than no link at all.
+
+One row per settled payment, keyed to the account that paid
+(``user_id`` — canonical Better Auth id, matching every other owner-scoped
+table in this codebase, e.g. ``paper_deployments.owner_user_id``).
+``job_id`` is nullable: it names the generation the payment funded, but the
+receipt is a record of the CHARGE, not of the job succeeding, so a future
+call site that cannot resolve a job id yet must still be able to write one.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Index, Integer, String
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from archimedes.models.chat import Base
+
+logger = logging.getLogger(__name__)
+
+#: No pagination yet (Dan's spec) — a hard cap keeps one query bounded and
+#: keeps a runaway payer's list from becoming an unbounded read.
+MAX_RECEIPTS = 200
+
+
+class PaymentReceiptRecord(Base):
+    """One settled x402 generation payment, durably kept for the payer."""
+
+    __tablename__ = "payment_receipts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    payer_wallet: Mapped[str] = mapped_column(String(64), nullable=False)
+    amount_base_units: Mapped[int] = mapped_column(Integer, nullable=False)
+    price_usd: Mapped[str] = mapped_column(String(32), nullable=False)
+    network: Mapped[str] = mapped_column(String(64), nullable=False)
+    # The Circle facilitator reference id — see module docstring's honesty
+    # note. Nullable: a settle can complete without one in principle, and an
+    # absent reference must render as absent, never as a fabricated value.
+    settlement_ref: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    job_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (Index("ix_payment_receipts_user_id", "user_id"),)
+
+    def to_payload(self) -> dict[str, Any]:
+        """The API shape — matches the fields ``GET /api/payments/receipts``
+        promises, in the same order."""
+        return {
+            "id": self.id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "price_usd": self.price_usd,
+            "amount_base_units": self.amount_base_units,
+            "payer_wallet": self.payer_wallet,
+            "settlement_ref": self.settlement_ref,
+            "job_id": self.job_id,
+            "network": self.network,
+        }
+
+
+def record_payment_receipt(
+    session: Session,
+    *,
+    user_id: str,
+    payer_wallet: str,
+    amount_base_units: int,
+    price_usd: str,
+    network: str,
+    settlement_ref: str | None,
+    job_id: str | None = None,
+) -> PaymentReceiptRecord:
+    """Insert one receipt row. Raises ``ValueError`` on a missing identity
+    field — a receipt with no owner or no payer is not a receipt anyone could
+    ever read back.
+
+    Callers (``api/generate_routes.py``) are expected to wrap this in a
+    try/except: the payment already settled by the time this runs, so a
+    write failure here must never surface to the paying user.
+    """
+    if not user_id:
+        raise ValueError("record_payment_receipt requires a user_id")
+    if not payer_wallet:
+        raise ValueError("record_payment_receipt requires a payer_wallet")
+
+    record = PaymentReceiptRecord(
+        user_id=user_id,
+        payer_wallet=payer_wallet,
+        amount_base_units=int(amount_base_units),
+        price_usd=str(price_usd),
+        network=str(network),
+        settlement_ref=settlement_ref,
+        job_id=job_id,
+        created_at=datetime.now(UTC),
+    )
+    session.add(record)
+    session.flush()
+    return record
+
+
+def list_payment_receipts(session: Session, user_id: str, *, limit: int = MAX_RECEIPTS) -> list[dict[str, Any]]:
+    """Newest-first receipts owned by *user_id*, capped at *limit*.
+
+    Owner-scoped by construction — a caller can only ever pass their own
+    ``user_id`` (see ``api/payment_routes.py``), so this never leaks another
+    payer's charges.
+    """
+    if not user_id:
+        return []
+    records = (
+        session.query(PaymentReceiptRecord)
+        .filter_by(user_id=user_id)
+        .order_by(PaymentReceiptRecord.created_at.desc(), PaymentReceiptRecord.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return [r.to_payload() for r in records]

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -62,6 +62,7 @@ from archimedes.models.marketplace import (  # noqa: E402
     SubscriberLiability,
     SubscriberTickLog,
 )
+from archimedes.models.payment_receipt import PaymentReceiptRecord  # noqa: E402
 from archimedes.models.request_snapshot import RequestCountSnapshot  # noqa: E402
 from archimedes.models.strategy_generators import StrategyGenerator  # noqa: E402
 from archimedes.models.strategy_passport_record import (  # noqa: E402
@@ -97,6 +98,7 @@ __all__ = [
     "MarketplaceAgent",
     "PaperRecord",
     "PassportPaperRef",
+    "PaymentReceiptRecord",
     "RequestCountSnapshot",
     "SettlementIntent",
     "StrategyBacktestFixture",

--- a/backend/migrations/versions/1752121b8d7c_add_payment_receipts.py
+++ b/backend/migrations/versions/1752121b8d7c_add_payment_receipts.py
@@ -1,0 +1,75 @@
+"""add payment_receipts — durable per-generation payment receipts
+
+Dan's directive (2026-08-21): "we must provide people with their receipts."
+The $2/generation x402 paywall is live on testnet and settles through
+Circle's facilitator, but nothing survived the request — a payer had no way
+to look back at what they were charged. This table is where the settled
+``PaymentInfo`` (``verified``/``payer``/``amount``/``network``/``transaction``/
+``response_headers``) survives, written at the settle site
+(``api/generate_routes.py``'s ``start_generation``, fail-safe: a write
+failure there never fails or delays the paid generation) and read back by
+``GET /api/payments/receipts``.
+
+``settlement_ref`` stores ``PaymentInfo.transaction`` — a Circle facilitator
+reference id, NOT an on-chain transaction hash (Circle batches and settles
+on-chain later). The read surface must never render it as an arcscan link.
+
+BACKFILL (migrations-ship-with-their-data rule): **none, and none is
+possible.** The table is new; every generation payment settled before this
+revision has no recoverable receipt record — there is nothing to backfill
+from, since the settled ``PaymentInfo`` was never persisted anywhere. Those
+earlier payments simply predate the receipts list.
+
+Revision ID: 1752121b8d7c
+Revises: f0ab58339d55
+Create Date: 2026-08-21 00:00:00.000000
+
+SEQUENCING: chained onto ``f0ab58339d55``, the chain head at authoring time.
+If another migration lands on main first, re-point ``down_revision`` at the
+new head — ``.github/scripts/migration_chain_guard.py`` catches a fork.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1752121b8d7c"
+down_revision: str | Sequence[str] | None = "f0ab58339d55"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "payment_receipts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("payer_wallet", sa.String(length=64), nullable=False),
+        sa.Column("amount_base_units", sa.Integer(), nullable=False),
+        sa.Column("price_usd", sa.String(length=32), nullable=False),
+        sa.Column("network", sa.String(length=64), nullable=False),
+        sa.Column("settlement_ref", sa.String(length=128), nullable=True),
+        sa.Column("job_id", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_payment_receipts_user_id", "payment_receipts", ["user_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Dropping the table discards every receipt recorded while this revision
+    was live. There is nowhere else they are kept — this table is the sole
+    durable record of a settled generation payment — so a downgrade is a
+    deliberate loss of receipts, not a reversible move.
+    """
+    op.drop_index("ix_payment_receipts_user_id", table_name="payment_receipts")
+    op.drop_table("payment_receipts")

--- a/backend/tests/test_payment_receipts.py
+++ b/backend/tests/test_payment_receipts.py
@@ -1,0 +1,290 @@
+"""``payment_receipts`` — persistence + list surface for settled generation
+payments (Dan's directive, 2026-08-21: "we must provide people with their
+receipts").
+
+Covers:
+
+  1. the model: round-trip write/read, newest-first ordering, owner-scoped
+     list (another user's receipts are invisible — their list is empty), and
+     refusal on a missing identity field;
+  2. the route: a settled payment on ``POST /api/generate/start`` produces a
+     receipt the SAME payer can read back via ``GET /api/payments/receipts``
+     — and it is invisible to a different payer;
+  3. auth: the receipts endpoint requires a Better Auth session, and a
+     flag-off/dry-run request (no settled ``PaymentInfo``) writes nothing;
+  4. FAIL-SAFE (ADVERSARIAL): a receipt-write failure must never fail or
+     delay the paid generation. Demonstrated by patching the exact
+     persistence boundary (``generate_routes._write_payment_receipt``) to
+     raise — the ``/start`` response is still 202, and no receipt row lands.
+
+Hermetic: tmp-file SQLite (``redirect_to_tmp_sqlite`` — the ``_use_tmp_db``
+precedent from ``test_api_routes.py``), mocked job store + backgrounded task
+(mirrors ``test_generate_payment_gate.py``'s harness), no live Redis/
+Postgres/Circle facilitator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.db import get_session
+from archimedes.models.payment_receipt import (
+    PaymentReceiptRecord,
+    list_payment_receipts,
+    record_payment_receipt,
+)
+from archimedes.services import generation_payment
+from fastapi.testclient import TestClient
+
+from tests.auth_helpers import auth_cookies
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+RECIPIENT = "0x00000000000000000000000000000000000000a1"
+PAYER_A = "0x" + "12" * 20  # matches tests.auth_helpers.TEST_WALLET
+PAYER_B = "0x" + "34" * 20
+
+_BODY = {"brief": {"intent": "low-vol treasury alternative", "risk_appetite": "moderate"}}
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _mock_store(job_id: str = "job-pay") -> MagicMock:
+    store = MagicMock()
+    store.enqueue = AsyncMock(return_value=job_id)
+    return store
+
+
+def _close_background_coroutine(coro):
+    coro.close()
+    return MagicMock()
+
+
+def _harness(store):
+    return (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        patch("archimedes.api.generate_routes.asyncio.create_task", side_effect=_close_background_coroutine),
+    )
+
+
+@dataclass
+class _FakePaymentInfo:
+    """Mirrors circlekit.x402.PaymentInfo's fields exactly: verified / payer /
+    amount / network / transaction / response_headers. ``amount`` is raw base
+    units as a string (server.py's ``_build_payment_info``), never a dollar
+    figure."""
+
+    verified: bool = True
+    payer: str = PAYER_A
+    amount: str = "2000000"  # $2.00 at USDC's 6 decimals
+    network: str = "eip155:5042002"
+    transaction: str | None = "831aaaf1-f110-47f7-8faf-c76aa8f841cb"
+    response_headers: dict = field(default_factory=dict)
+
+
+def _settled(monkeypatch, *, payer: str = PAYER_A) -> None:
+    """Configure the paywall as ON and make ``enforce_generation_payment``
+    return a real settled ``PaymentInfo`` — the ONLY case a receipt is
+    written. Patches the module attribute directly (not via string dotted
+    path) so the same object ``generate_routes.py`` calls is affected."""
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+    monkeypatch.setattr(
+        generation_payment, "enforce_generation_payment", AsyncMock(return_value=_FakePaymentInfo(payer=payer))
+    )
+
+
+# ── 1. The model ─────────────────────────────────────────────────────────
+
+
+class TestRecordPaymentReceipt:
+    def test_round_trips(self):
+        with get_session() as session:
+            record_payment_receipt(
+                session,
+                user_id="user-a",
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="eip155:5042002",
+                settlement_ref="ref-123",
+                job_id="job-1",
+            )
+            session.commit()
+            rows = list_payment_receipts(session, "user-a")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["price_usd"] == "$2.00"
+        assert row["amount_base_units"] == 2_000_000
+        assert row["payer_wallet"] == PAYER_A
+        assert row["settlement_ref"] == "ref-123"
+        assert row["job_id"] == "job-1"
+        assert row["network"] == "eip155:5042002"
+        assert row["created_at"]
+
+    def test_owner_scoped_another_users_list_is_empty(self):
+        with get_session() as session:
+            record_payment_receipt(
+                session,
+                user_id="user-a",
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="eip155:5042002",
+                settlement_ref="ref-a",
+                job_id="job-a",
+            )
+            session.commit()
+            assert list_payment_receipts(session, "user-b") == []
+            assert len(list_payment_receipts(session, "user-a")) == 1
+
+    def test_newest_first(self):
+        with get_session() as session:
+            record_payment_receipt(
+                session,
+                user_id="user-a",
+                payer_wallet=PAYER_A,
+                amount_base_units=1,
+                price_usd="$0.000001",
+                network="n",
+                settlement_ref="old",
+                job_id="job-old",
+            )
+            record_payment_receipt(
+                session,
+                user_id="user-a",
+                payer_wallet=PAYER_A,
+                amount_base_units=2,
+                price_usd="$0.000002",
+                network="n",
+                settlement_ref="new",
+                job_id="job-new",
+            )
+            session.commit()
+            rows = list_payment_receipts(session, "user-a")
+            capped = list_payment_receipts(session, "user-a", limit=1)
+        assert [r["settlement_ref"] for r in rows] == ["new", "old"]
+        assert [r["settlement_ref"] for r in capped] == ["new"]
+
+    def test_missing_identity_is_refused(self):
+        with get_session() as session:
+            with pytest.raises(ValueError, match="user_id"):
+                record_payment_receipt(
+                    session,
+                    user_id="",
+                    payer_wallet=PAYER_A,
+                    amount_base_units=1,
+                    price_usd="$0.00",
+                    network="n",
+                    settlement_ref=None,
+                )
+            with pytest.raises(ValueError, match="payer_wallet"):
+                record_payment_receipt(
+                    session,
+                    user_id="user-a",
+                    payer_wallet="",
+                    amount_base_units=1,
+                    price_usd="$0.00",
+                    network="n",
+                    settlement_ref=None,
+                )
+            assert session.query(PaymentReceiptRecord).count() == 0
+
+
+# ── 2 & 3. The route: settle -> persist -> the SAME payer reads it back ──
+
+
+def test_a_settled_payment_produces_a_receipt_the_payer_can_read_back(monkeypatch):
+    _settled(monkeypatch)
+    store = _mock_store("job-receipt-1")
+    p1, p2 = _harness(store)
+    cookies = auth_cookies(PAYER_A)
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=cookies)
+    assert resp.status_code == 202
+    assert resp.json()["job_id"] == "job-receipt-1"
+
+    list_resp = _client().get("/api/payments/receipts", cookies=cookies)
+    assert list_resp.status_code == 200
+    receipts = list_resp.json()
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["job_id"] == "job-receipt-1"
+    assert receipt["amount_base_units"] == 2_000_000
+    assert receipt["price_usd"] == "$2.00"
+    assert receipt["payer_wallet"] == PAYER_A
+    assert receipt["settlement_ref"] == "831aaaf1-f110-47f7-8faf-c76aa8f841cb"
+    assert receipt["network"] == "eip155:5042002"
+    assert receipt["created_at"]
+
+
+def test_another_users_receipts_list_does_not_see_this_payment(monkeypatch):
+    _settled(monkeypatch)
+    store = _mock_store("job-receipt-2")
+    p1, p2 = _harness(store)
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=auth_cookies(PAYER_A))
+    assert resp.status_code == 202
+
+    other_resp = _client().get("/api/payments/receipts", cookies=auth_cookies(PAYER_B))
+    assert other_resp.status_code == 200
+    assert other_resp.json() == []
+
+
+def test_receipts_endpoint_requires_a_session():
+    resp = _client().get("/api/payments/receipts")
+    assert resp.status_code == 401
+
+
+def test_flag_off_writes_no_receipt(monkeypatch):
+    """No settled PaymentInfo (flag off) -> `payment` stays None -> nothing
+    is ever written. Mirrors test_generate_payment_gate's flag-off case."""
+    monkeypatch.delenv("GENERATION_PAYMENT_REQUIRED", raising=False)
+    store = _mock_store("job-no-pay")
+    p1, p2 = _harness(store)
+    cookies = auth_cookies(PAYER_A)
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=cookies)
+    assert resp.status_code == 202
+
+    list_resp = _client().get("/api/payments/receipts", cookies=cookies)
+    assert list_resp.json() == []
+
+
+# ── 4. FAIL-SAFE — the adversarial demonstration ──────────────────────────
+
+
+def test_a_receipt_write_failure_never_fails_the_paid_generation(monkeypatch):
+    """The input that SHOULD break a naive implementation: the persistence
+    boundary raises. The user already paid — /start must still succeed, and
+    no receipt is written (the failure is swallowed, not silently forged)."""
+    _settled(monkeypatch)
+    store = _mock_store("job-boom")
+    p1, p2 = _harness(store)
+    cookies = auth_cookies(PAYER_A)
+    with (
+        p1,
+        p2,
+        patch(
+            "archimedes.api.generate_routes._write_payment_receipt",
+            side_effect=RuntimeError("database is on fire"),
+        ),
+    ):
+        resp = _client().post("/api/generate/start", json=_BODY, cookies=cookies)
+    assert resp.status_code == 202
+    store.enqueue.assert_awaited_once()
+
+    list_resp = _client().get("/api/payments/receipts", cookies=cookies)
+    assert list_resp.status_code == 200
+    assert list_resp.json() == []

--- a/docs/api-surface-status.md
+++ b/docs/api-surface-status.md
@@ -68,6 +68,7 @@ per-surface reference doc yet (a real gap, not an oversight to paper over).
 | `/api/selection-bias` | `archimedes.api.selection_bias_routes.selection_bias_router` | public | live | [`api/strategies-and-rigor.md`](api/strategies-and-rigor.md) |
 | `/api/rigor` | `archimedes.api.rigor_verify_routes.rigor_verify_router` | session | live | — |
 | `/api/account` | `archimedes.api.account_usage_routes.account_usage_router` | session | live | — |
+| `/api/payments` | `archimedes.api.payment_routes.payment_router` | session | live | [`api/generation.md`](api/generation.md) |
 | `/api/papers` | `archimedes.api.papers_routes.papers_router` | public | live | — |
 | `/api/user` | `archimedes.api.user_routes.user_router` | session | live | — |
 | `/api/wallets` | `archimedes.api.wallet_routes.wallet_router` | session | live | [`api/wallets.md`](api/wallets.md) |

--- a/docs/api/generation.md
+++ b/docs/api/generation.md
@@ -134,6 +134,25 @@ Errors: 404 `job {job_id} not found or expired` (unknown, or not owned).
 curl -s -b /tmp/session.jar https://archimedes-arc.com/api/generate/jobs/<job_id>/candidates
 ```
 
+### GET /api/payments/receipts
+The caller's own settled generation-payment receipts, newest-first (Dan's
+directive, 2026-08-21: "we must provide people with their receipts"). Written
+at settle time inside `/start` — fail-safe: a receipt-write failure never
+fails or delays the paid generation, so this list can in principle be
+incomplete during a genuine DB outage. Owner-scoped server-side; no
+pagination yet (capped at 200 rows). | **Auth**: account-session
+
+Request: none.
+Response: `[{id: int, created_at: str|null, price_usd: str, amount_base_units: int, payer_wallet: str, settlement_ref: str|null, job_id: str|null, network: str}]`.
+`settlement_ref` is `PaymentInfo.transaction` — a **Circle facilitator
+reference id, not an on-chain transaction hash** (Circle batches and settles
+on-chain later); it must never be rendered as a block-explorer link.
+Errors: none beyond the global 401.
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/payments/receipts
+```
+
 ## The payment-gate status-code flow (POST /api/generate/start)
 
 The paywall carries no payment fields in the request body — it is entirely a

--- a/ui/src/components/PaymentReceipts.jsx
+++ b/ui/src/components/PaymentReceipts.jsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react'
+import { apiGet } from '../api'
+
+// GET /api/payments/receipts — the caller's own settled generation-payment
+// receipts (Dan's directive, 2026-08-21: "we must provide people with their
+// receipts"). Account-session-gated (Better Auth); apiGet sends
+// credentials:'include' so the session cookie reaches the endpoint and the
+// backend scopes the list to the CALLER's own payments — one payer never
+// sees another's charges.
+//
+// HONESTY (load-bearing, do not "fix"): `settlement_ref` is a Circle
+// facilitator reference id, NOT an on-chain transaction hash — Circle
+// batches and settles on-chain later (see
+// backend/archimedes/marketplace/payments.py's module docstring and
+// backend/archimedes/models/payment_receipt.py). It is rendered here as
+// plain labelled text, never as a clickable arcscan link: a dead arcscan
+// link for a value that was never a tx hash is worse than no link at all.
+
+function formatReceiptDate(iso) {
+	if (!iso) return "—";
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return "—";
+	return d.toLocaleString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+export default function PaymentReceipts() {
+	const [receipts, setReceipts] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState("");
+
+	useEffect(() => {
+		let cancelled = false;
+		apiGet("/api/payments/receipts")
+			.then((data) => {
+				if (!cancelled) setReceipts(Array.isArray(data) ? data : []);
+			})
+			.catch((e) => {
+				if (!cancelled) setError(e.message || "Failed to load receipts");
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (loading) {
+		return <div className="caption">Loading payment receipts…</div>;
+	}
+
+	if (error) {
+		return (
+			<div className="card" style={{ padding: 18 }}>
+				<p className="caption" style={{ color: "var(--negative, #ef4444)" }}>
+					Could not load payment receipts: {error}
+				</p>
+			</div>
+		);
+	}
+
+	if (receipts.length === 0) {
+		return (
+			<div className="card" style={{ padding: 18 }}>
+				<p className="body" style={{ marginBottom: 6 }}>
+					No payment receipts yet.
+				</p>
+				<p className="caption">
+					When you pay for a generation, the receipt appears here.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2">
+			{receipts.map((r) => (
+				<div key={r.id} className="trace-card">
+					<div className="flex justify-between items-center gap-3 flex-wrap">
+						<strong style={{ fontSize: "0.9rem" }}>{r.price_usd}</strong>
+						<span className="caption">{formatReceiptDate(r.created_at)}</span>
+					</div>
+					<div
+						className="caption mt-1.5 flex gap-3 flex-wrap"
+						style={{ color: "var(--text-3)" }}
+					>
+						{r.job_id && <span>job {r.job_id}</span>}
+						{/* Honesty rule: labelled plain text, never an arcscan link —
+						    this is a Circle facilitator reference id, not a tx hash. */}
+						<span>
+							Circle settlement reference:{" "}
+							<span className="mono">{r.settlement_ref || "—"}</span>
+						</span>
+						{r.network && <span>{r.network}</span>}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -6,6 +6,7 @@ import {
 	NEW_CONTRACTS,
 	getUsdcBalance,
 } from "../config";
+import PaymentReceipts from "./PaymentReceipts";
 import RegimePanel from "./RegimePanel";
 import StressScenarioPanel from "./StressScenarioPanel";
 
@@ -776,6 +777,14 @@ export default function Portfolio({
 								</>
 							);
 						})()}
+				</section>
+
+				{/* Payment receipts — settled generation payments (Dan's directive:
+				    "we must provide people with their receipts"). Own records only;
+				    GET /api/payments/receipts is owner-scoped server-side. */}
+				<section className="portfolio-payments">
+					<div className="label mb-3">Payment Receipts</div>
+					<PaymentReceipts />
 				</section>
 			</div>
 		</div>

--- a/ui/test/payment-receipts.test.js
+++ b/ui/test/payment-receipts.test.js
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Source-regex pins on PaymentReceipts.jsx (Dan's directive, 2026-08-21: "we
+// must provide people with their receipts"). Same shape as
+// ui/test/trace-binding.test.js's "Source-regex pins" section: readFileSync +
+// substring/regex assertions on the rendered source, confirming the honesty
+// contract and the owner-scoped fetch actually landed in the component. This
+// is a brand-new component with no pre-fix tree of its own to fail against
+// (mirrors trace-binding.test.js's blockOrderCopy note); the anti-goal check
+// on Portfolio.jsx below exists to catch a *future* PR breaking the wiring.
+
+const receiptsSrc = readFileSync(
+	new URL("../src/components/PaymentReceipts.jsx", import.meta.url),
+	"utf8",
+);
+
+// ── Owner-scoped fetch path ──────────────────────────────────────────────
+
+test("fetches the owner-scoped receipts endpoint via the shared apiGet helper", () => {
+	// apiGet (src/api.js) sends credentials:'include', which is what makes the
+	// request owner-scoped server-side (require_current_user reads the Better
+	// Auth session cookie). A bare fetch() with no credentials would silently
+	// 401 rather than leak another user's receipts, but pin the real helper
+	// call so this stays wired to the session-carrying path, not a copy/paste
+	// bare fetch.
+	assert.ok(
+		receiptsSrc.includes('apiGet("/api/payments/receipts")'),
+		"must call apiGet on the exact /api/payments/receipts path",
+	);
+});
+
+test("imports apiGet from the shared API helper, not a bare fetch", () => {
+	assert.ok(
+		/from ['"]\.\.\/api['"]/.test(receiptsSrc),
+		"must import from ../api (the credentials:'include' helper), not roll its own fetch",
+	);
+	assert.ok(
+		!receiptsSrc.includes("fetch("),
+		"must not call the global fetch() directly — apiGet is the one credentialed path",
+	);
+});
+
+// ── Honesty: settlement_ref is a Circle reference, never an arcscan link ──
+
+test("labels settlement_ref honestly as a Circle facilitator reference, not a tx hash", () => {
+	assert.ok(
+		receiptsSrc.includes("Circle settlement reference"),
+		"the honest label text must be present verbatim",
+	);
+});
+
+test("never renders settlement_ref as an arcscan link", () => {
+	// Checks for the actual hazard (a live link to the block explorer), not
+	// the word "arcscan" in prose — the component's own honesty-rule comments
+	// legitimately name arcscan while explaining why it must not appear as a
+	// link, so a bare substring ban would false-positive on those comments.
+	assert.ok(
+		!receiptsSrc.includes("testnet.arcscan.app"),
+		"settlement_ref is a Circle facilitator reference id, not an on-chain tx hash — it must never be linked to the block explorer",
+	);
+	assert.ok(
+		!/href=.*arcscan/i.test(receiptsSrc),
+		"no href in this component may point at arcscan",
+	);
+});
+
+test("settlement_ref is rendered as plain text, never inside an anchor tag", () => {
+	const labelIdx = receiptsSrc.indexOf("Circle settlement reference");
+	assert.ok(labelIdx !== -1, "the honest label must exist to anchor this check");
+	const refIdx = receiptsSrc.indexOf("settlement_ref", labelIdx);
+	assert.ok(refIdx !== -1, "settlement_ref must actually be rendered near its label");
+	const between = receiptsSrc.slice(labelIdx, refIdx + "settlement_ref".length + 10);
+	assert.ok(
+		!between.includes("<a "),
+		"the settlement_ref value must not be wrapped in a clickable <a> element",
+	);
+});
+
+// ── Portfolio.jsx wiring (anti-goal pin — this PR must not skip it) ──────
+
+const portfolioSrc = readFileSync(
+	new URL("../src/components/Portfolio.jsx", import.meta.url),
+	"utf8",
+);
+
+test("Portfolio.jsx imports and renders PaymentReceipts", () => {
+	assert.ok(
+		/import PaymentReceipts from ['"]\.\/PaymentReceipts['"]/.test(portfolioSrc),
+		"Portfolio.jsx must import the PaymentReceipts component",
+	);
+	assert.ok(
+		portfolioSrc.includes("<PaymentReceipts"),
+		"Portfolio.jsx must actually render <PaymentReceipts />",
+	);
+});
+
+test("Portfolio.jsx does not touch Generate.jsx or AccountSettings.jsx conventions (anti-goal)", () => {
+	// This feature's spec explicitly forbids touching Generate.jsx and
+	// AccountSettings.jsx (parallel work owns them) — pin that the payments
+	// section landed in Portfolio.jsx itself, not smuggled elsewhere.
+	assert.ok(portfolioSrc.includes("portfolio-payments"));
+});


### PR DESCRIPTION
Dan's directive: "we must provide people with their receipts." Every settled generation payment is now persisted server-side and listed to the paying user.

- **`payment_receipts` table** (migration `1752121b8d7c`, chained on current head, upgrade+downgrade cycle verified) — user_id, payer wallet, amount, network, Circle settlement reference, job_id.
- **Persist at the one honest moment**: in /start, only when a real settled PaymentInfo exists (flag-off and dry-run write nothing), after enqueue so the receipt carries the job id, and **fail-safe** — the user already paid, so a receipt-write failure logs loudly but can never fail the paid generation (adversarially demonstrated: guard removed → the paid-path test 500s; restored → green).
- **`GET /api/payments/receipts`** — caller-scoped, newest-first (cap 200).
- **UI**: `PaymentReceipts` card in Portfolio. Honesty rule enforced by test: the Circle settlement reference renders as **labelled plain text, never an arcscan link** — it's a facilitator reference id, not an on-chain hash, and a dead explorer link is worse than none. (On-chain deposit txs are the client's own hashes and can link later.)

Verification (agent-built, personally vetted): full backend suite 3680/0 + ui 387/0 by the builder; I re-ran the new suites + payment/concurrency neighbors (26/26, 7/7) and eslint on a 0-behind branch; migration chain confirmed against origin/main's head; hook placement re-read line-by-line in generate_routes.py (my own heavily-worked file). Docs drift-gate rows updated.

Related: #1298 (paid rail), #1441 (refunds — receipts are the observability half; refund flow stays separately gated). Revenue-sweep engineering lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7