### PR TITLE
[backend][infra] Platform revenue sweep: Gateway → DCW tokens (CLI + opt-in scheduler) !minor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -230,6 +230,13 @@ GENERATION_PAYMENT_REQUIRED=false
 # Generation-scoped dry-run: set false to really verify+settle generation
 # payments while the global PAYMENTS_DRY_RUN stays true (marketplace stays
 # dry, #975). Unset inherits PAYMENTS_DRY_RUN.
+# Platform revenue sweep (services/revenue_sweep.py): Gateway balance -> the
+# recipient DCW's token balance. REVENUE_WALLET_ID = that DCW's Circle wallet
+# id. The scheduler loop arms ONLY on the literal "true"; the CLI
+# (python -m archimedes.services.revenue_sweep --check|--sweep) always works.
+REVENUE_WALLET_ID=
+REVENUE_SWEEP_ENABLED=
+REVENUE_SWEEP_MIN_USDC=10.0
 GENERATION_PAYMENTS_DRY_RUN=
 GENERATION_PRICE_USD=2.00
 GENERATION_PAYMENT_RECIPIENT=

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -359,6 +359,21 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     except Exception as exc:
         _logger.warning("startup: backtest scheduler failed to arm (non-fatal): %s", exc)
 
+    # Platform revenue sweep (services/revenue_sweep.py): opt-in Gateway →
+    # DCW-token withdrawal loop. Money-switch convention: only the literal
+    # REVENUE_SWEEP_ENABLED=true arms it; unset/anything-else stays off and
+    # says so. Same RUF006 app.state reference rule as the loops above.
+    try:
+        from archimedes.services.revenue_sweep import revenue_sweep_loop, sweep_enabled
+
+        if sweep_enabled():
+            _app.state.revenue_sweep_task = asyncio.create_task(revenue_sweep_loop())
+            _logger.info("startup: revenue sweep scheduler armed")
+        else:
+            _logger.info("startup: revenue sweep scheduler disabled (REVENUE_SWEEP_ENABLED != 'true')")
+    except Exception as exc:
+        _logger.warning("startup: revenue sweep failed to arm (non-fatal): %s", exc)
+
     yield  # ── app is now running ────────────────────────────────────────
 
     # ── SHUTDOWN ─────────────────────────────────────────────────────────

--- a/backend/archimedes/services/revenue_sweep.py
+++ b/backend/archimedes/services/revenue_sweep.py
@@ -1,0 +1,169 @@
+"""Platform revenue sweep: the generation-payment DCW's Gateway balance → real tokens.
+
+Why this exists (Dan, 2026-08-21): x402 generation payments settle into the
+platform DCW's balance INSIDE the Circle Gateway contract — attributed to the
+address, invisible to any wallet token view. Realizing revenue is a Circle
+Gateway withdrawal (burn-intent signed by the DCW via Circle's API →
+attestation → on-chain gatewayMint), after which USDC appears as ordinary
+tokens in the wallet (console/arcscan visible). "It's important to show we can
+collect revenue into our DCW all the way."
+
+This module is the thin platform-revenue twin of the marketplace's
+settlement.py Stage A — the SAME circlekit machinery (CircleWalletSigner +
+CircleTxExecutor + GatewayClient.withdraw), pointed at the revenue wallet.
+
+Two entry points:
+
+  * CLI (explicit operator action — works regardless of the scheduler flag)::
+
+        python -m archimedes.services.revenue_sweep --check          # read-only
+        python -m archimedes.services.revenue_sweep --sweep          # threshold-gated
+        python -m archimedes.services.revenue_sweep --sweep --min 5  # override
+
+  * Scheduler loop, wired in main.py behind ``REVENUE_SWEEP_ENABLED`` —
+    default **off** (an always-on funds-moving loop is opt-in, never a
+    surprise). Interval ``REVENUE_SWEEP_INTERVAL_S`` (default 3600).
+
+Config (all env): ``GENERATION_PAYMENT_RECIPIENT`` (the DCW address — same
+value the paywall pays to), ``REVENUE_WALLET_ID`` (that DCW's Circle wallet
+id, needed for API signing), ``REVENUE_SWEEP_MIN_USDC`` (default "10.0" —
+must stay several multiples of Circle's ~2.01 USDC withdrawal fee, same
+rationale as settlement.SWEEP_WITHDRAW_THRESHOLD_USDC).
+
+Deliberately independent of PAYMENTS_DRY_RUN / GENERATION_PAYMENTS_DRY_RUN:
+those gate CHARGING USERS; this moves the platform's own already-settled
+funds between the platform's own venues (Gateway balance → the same DCW's
+token balance) under the accepted DCW-custodial-INTERIM posture (#958).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from decimal import Decimal
+
+from circlekit.client import GatewayClient
+from circlekit.wallets import CircleTxExecutor, CircleWalletSigner
+
+from archimedes.marketplace.config import DEFAULT_GATEWAY_CHAIN
+
+logger = logging.getLogger(__name__)
+
+_USDC = Decimal(10) ** 6
+
+
+def _recipient() -> str:
+    return os.getenv("GENERATION_PAYMENT_RECIPIENT", "").strip()
+
+
+def _wallet_id() -> str:
+    return os.getenv("REVENUE_WALLET_ID", "").strip()
+
+
+def _min_usdc() -> Decimal:
+    raw = os.getenv("REVENUE_SWEEP_MIN_USDC", "10.0").strip() or "10.0"
+    try:
+        value = Decimal(raw)
+    except Exception:
+        logger.warning("invalid REVENUE_SWEEP_MIN_USDC=%r — using 10.0", raw)
+        return Decimal("10.0")
+    return value if value > 0 else Decimal("10.0")
+
+
+def _client() -> GatewayClient:
+    recipient, wallet_id = _recipient(), _wallet_id()
+    if not recipient or not wallet_id:
+        # Loud absence, not a silent no-op: a sweep that can't sign is a
+        # configuration outage the operator must see (fail-soft principle —
+        # this is a load-bearing credential pair for the revenue path).
+        raise RuntimeError(
+            "revenue sweep is not configured: GENERATION_PAYMENT_RECIPIENT and "
+            "REVENUE_WALLET_ID must both be set (the paywall recipient DCW and "
+            "its Circle wallet id)."
+        )
+    signer = CircleWalletSigner(wallet_id=wallet_id, wallet_address=recipient)
+    executor = CircleTxExecutor(wallet_id=wallet_id, wallet_address=recipient)
+    return GatewayClient(chain=DEFAULT_GATEWAY_CHAIN, signer=signer, tx_executor=executor)
+
+
+async def check_revenue() -> dict:
+    """Read-only: the revenue DCW's Gateway balance, in USDC decimal strings."""
+    client = _client()
+    balances = await client.get_gateway_balance()
+    return {
+        "recipient": _recipient(),
+        "available_usdc": balances.formatted_available,
+        "total_usdc": balances.formatted_total,
+        "min_sweep_usdc": str(_min_usdc()),
+    }
+
+
+async def sweep_revenue(min_usdc: Decimal | None = None) -> dict:
+    """Withdraw the full available Gateway balance to the DCW's token balance
+    when it meets the threshold. Returns a structured outcome either way —
+    callers log it; the scheduler loop never raises out of a tick."""
+    threshold = min_usdc if min_usdc is not None else _min_usdc()
+    client = _client()
+    balances = await client.get_gateway_balance()
+    available = Decimal(balances.available) / _USDC
+    if available < threshold:
+        return {
+            "swept": False,
+            "reason": f"available {available} USDC below threshold {threshold}",
+            "available_usdc": str(available),
+        }
+    amount = balances.formatted_available
+    result = await client.withdraw(amount=amount)
+    logger.info(
+        "revenue sweep: withdrew %s USDC Gateway → wallet %s; mint tx=%s",
+        amount,
+        _recipient(),
+        getattr(result, "mint_tx_hash", result),
+    )
+    return {
+        "swept": True,
+        "amount_usdc": amount,
+        "mint_tx_hash": getattr(result, "mint_tx_hash", None),
+    }
+
+
+def sweep_enabled() -> bool:
+    """Scheduler gate — only the literal "true" enables (mirrors the repo's
+    money-switch convention: an unset money switch must mean OFF)."""
+    return os.getenv("REVENUE_SWEEP_ENABLED", "").strip().lower() == "true"
+
+
+async def revenue_sweep_loop() -> None:
+    """The opt-in scheduler loop main.py starts behind sweep_enabled()."""
+    interval = int(os.getenv("REVENUE_SWEEP_INTERVAL_S", "3600"))
+    logger.info("revenue sweep loop started (interval=%ds, min=%s USDC)", interval, _min_usdc())
+    while True:
+        try:
+            outcome = await sweep_revenue()
+            if outcome.get("swept"):
+                logger.info("revenue sweep tick: %s", outcome)
+        except Exception:
+            logger.exception("revenue sweep tick failed — will retry next interval")
+        await asyncio.sleep(interval)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Platform revenue sweep (Gateway → DCW tokens)")
+    group = ap.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true", help="read-only balance check")
+    group.add_argument("--sweep", action="store_true", help="withdraw if >= threshold")
+    ap.add_argument("--min", type=Decimal, default=None, help="threshold override (USDC)")
+    args = ap.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    if args.check:
+        print(asyncio.run(check_revenue()))
+        return 0
+    outcome = asyncio.run(sweep_revenue(args.min))
+    print(outcome)
+    return 0 if outcome.get("swept") or "below threshold" in str(outcome.get("reason", "")) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/services/test_revenue_sweep.py
+++ b/backend/tests/services/test_revenue_sweep.py
@@ -1,0 +1,103 @@
+"""Laws of the platform revenue sweep (services/revenue_sweep.py).
+
+Hermetic: circlekit's GatewayClient is mocked at the module boundary — no
+Circle API, no chain. The guard demonstrations (repo rule 4): the
+disabled-by-default scheduler gate, the loud-unconfigured failure, and the
+threshold refusing a below-minimum sweep are each shown rejecting their
+inputs, not assumed.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.services import revenue_sweep as rs
+
+RECIPIENT = "0xffa7abba5f17cb8471ebf150bf808bd6fb8856c1"
+WALLET_ID = "af3e1cf6-76a3-55db-911a-b356860058e4"
+
+
+def _balances(available_units: int):
+    b = MagicMock()
+    b.available = available_units
+    b.formatted_available = f"{available_units / 10**6:.6f}"
+    b.formatted_total = b.formatted_available
+    return b
+
+
+def _mock_client(available_units: int):
+    client = MagicMock()
+    client.get_gateway_balance = AsyncMock(return_value=_balances(available_units))
+    client.withdraw = AsyncMock(return_value=MagicMock(mint_tx_hash="0xmint"))
+    return client
+
+
+class TestSchedulerGate:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("REVENUE_SWEEP_ENABLED", raising=False)
+        assert rs.sweep_enabled() is False
+
+    def test_only_literal_true_arms(self, monkeypatch):
+        for bad in ("1", "yes", "TRUE ", "on", ""):
+            monkeypatch.setenv("REVENUE_SWEEP_ENABLED", bad)
+            # "TRUE " strips+lowers to "true" — that one IS armed; the rest not.
+            expected = bad.strip().lower() == "true"
+            assert rs.sweep_enabled() is expected
+        monkeypatch.setenv("REVENUE_SWEEP_ENABLED", "true")
+        assert rs.sweep_enabled() is True
+
+
+class TestConfigurationIsLoud:
+    async def test_unconfigured_raises_not_noop(self, monkeypatch):
+        monkeypatch.delenv("REVENUE_WALLET_ID", raising=False)
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        with pytest.raises(RuntimeError, match="not configured"):
+            await rs.check_revenue()
+
+
+class TestSweep:
+    async def test_below_threshold_refuses(self, monkeypatch):
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
+        client = _mock_client(4_000_000)  # $4 < default $10
+        with patch.object(rs, "_client", return_value=client):
+            out = await rs.sweep_revenue()
+        assert out["swept"] is False
+        client.withdraw.assert_not_awaited()
+
+    async def test_at_threshold_withdraws_full_available(self, monkeypatch):
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
+        client = _mock_client(12_500_000)  # $12.50
+        with patch.object(rs, "_client", return_value=client):
+            out = await rs.sweep_revenue()
+        assert out["swept"] is True and out["mint_tx_hash"] == "0xmint"
+        client.withdraw.assert_awaited_once_with(amount="12.500000")
+
+    async def test_min_override(self, monkeypatch):
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
+        client = _mock_client(4_000_000)
+        with patch.object(rs, "_client", return_value=client):
+            out = await rs.sweep_revenue(Decimal("2"))
+        assert out["swept"] is True
+
+    async def test_check_is_read_only(self, monkeypatch):
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
+        client = _mock_client(12_500_000)
+        with patch.object(rs, "_client", return_value=client):
+            out = await rs.check_revenue()
+        assert out["available_usdc"] == "12.500000"
+        client.withdraw.assert_not_awaited()
+
+
+def test_threshold_parse_defensive(monkeypatch):
+    monkeypatch.setenv("REVENUE_SWEEP_MIN_USDC", "garbage")
+    assert rs._min_usdc() == Decimal("10.0")
+    monkeypatch.setenv("REVENUE_SWEEP_MIN_USDC", "-3")
+    assert rs._min_usdc() == Decimal("10.0")
+    monkeypatch.setenv("REVENUE_SWEEP_MIN_USDC", "5.5")
+    assert rs._min_usdc() == Decimal("5.5")

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -567,6 +567,11 @@ resource "aws_ecs_task_definition" "backend" {
         # docs repo, business-model refresh §3a).
         { name = "GENERATION_PRICE_USD", value = "2.00" },
         { name = "GENERATION_PAYMENT_RECIPIENT", value = var.generation_payment_recipient },
+        # The recipient DCW's Circle wallet id — an identifier (the API key +
+        # entity secret in SSM are the credentials), needed so the revenue
+        # sweep (services/revenue_sweep.py) can sign Gateway withdrawals.
+        # Sweep stays OFF until REVENUE_SWEEP_ENABLED=true is added here.
+        { name = "REVENUE_WALLET_ID", value = "af3e1cf6-76a3-55db-911a-b356860058e4" },
         # KNOWN GAP #2 (see file header): these three paths have no Fargate
         # equivalent of the docker-compose host bind mount yet.
         { name = "ARCHIMEDES_STRATEGIES_DIR", value = "/app/analytics-engine/strategies" },


### PR DESCRIPTION
Dan: "I don't want to defer the sweep step to mainnet, I want to architect that in now… it's important to show we can collect revenue into our DCW all the way."

Settled $2 generation payments accrue as the DCW's **Gateway-contract balance** — real, on-chain, but invisible to wallet token views (verified live: $2 settled and readable via `availableBalance`, console shows nothing). This PR adds `services/revenue_sweep.py`, the platform-revenue twin of `settlement.py`'s Stage A, reusing the identical circlekit machinery (DCW signs the burn intent via Circle's API → attestation → `gatewayMint`; USDC lands as ordinary tokens in the wallet, console/arcscan-visible).

**Two entry points**: a CLI (`python -m archimedes.services.revenue_sweep --check | --sweep [--min N]`) for explicit operator runs — usable the moment this deploys — and a scheduler loop wired in main.py that arms ONLY on the literal `REVENUE_SWEEP_ENABLED=true` (unset money switch = OFF, per the repo convention), interval + threshold configurable (default $10 ≥ several multiples of Circle's ~$2.01 withdrawal fee, same rationale as settlement's threshold). Deliberately independent of PAYMENTS_DRY_RUN/generation dry-run: those gate charging *users*; this moves the platform's own settled funds between its own venues under the #958 custodial-INTERIM posture.

`REVENUE_WALLET_ID` (the DCW's Circle wallet id — an identifier; credentials stay in SSM) plumbed in ecs.tf + .env.example.

**Guards shown rejecting**: off-by-default + literal-true-only gate; unconfigured → loud RuntimeError, never a silent no-op; below-threshold → refuses with `withdraw` never awaited. 8/8 hermetic tests (GatewayClient mocked at boundary), ruff/fmt clean.

**After merge**: apply (picks up REVENUE_WALLET_ID) + deploy roll; then `--check`/`--sweep` work from any shell with the Circle env, and the scheduler stays off until Dan flips the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7