### PR TITLE
[frontend] Wallet split-brain fix: announce wallet-changed on every connect/reconnect/disconnect !minor

### DIFF
--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -41,17 +41,27 @@ let _lastSeenChainId = null
 // (Rabby/Brave/…) whose object is NOT window.ethereum (#921). Every handler
 // no-ops unless the event's provider is the one connectWallet selected
 // (_provider), so an announced-but-inactive wallet can't hijack the session.
+// Announce the module-level wallet state to the app. Components that copy
+// the connected address into their own state (Generate's payment panel:
+// getAddress() at mount + this event) can NOT see page-level setters like
+// AuthenticatedApp's onConnect — this event is their only resync. EVERY
+// transition of _address must fire it, or any panel mounted before the
+// transition keeps the stale address forever ("top bar says connected,
+// pay panel says connect wallet" split-brain).
+function announceWalletChanged() {
+  window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: _address } }))
+}
+
 function _onAccountsChanged(provider, accounts) {
   if (provider !== _provider) return
   if (!accounts?.length) {
-    disconnectWallet()
-    window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: null } }))
+    disconnectWallet() // announces the null address itself
     return
   }
   _address = accounts[0]
   if (_providerId) saveWalletMeta(_providerId, _address)
   _walletClient = createWalletClient({ account: _address, chain: arcTestnet, transport: custom(provider) })
-  window.dispatchEvent(new CustomEvent('wallet-changed', { detail: { address: _address } }))
+  announceWalletChanged()
 }
 
 function _onChainChanged(provider, newChainId) {
@@ -326,6 +336,7 @@ export async function reconnectWallet() {
       _smartAccount = restored.smartAccount
       _smartAccountClient = restored.client
       saveWalletMeta(CIRCLE_PROVIDER_ID, _address)
+      announceWalletChanged()
       return { address: _address, provider: _providerId }
     } catch {
       // If rehydration fails (corrupted credential, SDK error, etc.)
@@ -358,6 +369,7 @@ export async function reconnectWallet() {
     })
 
     saveWalletMeta(_providerId, _address)
+    announceWalletChanged()
     return { address: _address, provider: _providerId }
   } catch {
     clearWalletMeta()
@@ -450,6 +462,7 @@ export async function connectCircleWallet({ mode = 'login', walletName } = {}) {
   // discoverable so no name comes back; any previously stored name for this
   // address is left intact for getStoredWalletName().
   saveWalletMeta(CIRCLE_PROVIDER_ID, _address, result.walletName)
+  announceWalletChanged()
   return { address: _address, provider: CIRCLE_PROVIDER_ID }
 }
 
@@ -494,6 +507,7 @@ export async function connectWallet(providerId, opts) {
   })
 
   saveWalletMeta(providerId, _address)
+  announceWalletChanged()
   return { address: _address, provider: providerId }
 }
 
@@ -508,6 +522,7 @@ export function disconnectWallet() {
   _smartAccount = null
   _smartAccountClient = null
   clearWalletMeta()
+  announceWalletChanged()
 }
 
 export async function getWalletClient() {

--- a/ui/test/wallet-changed-announce.test.js
+++ b/ui/test/wallet-changed-announce.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Browser-payments split-brain (field report Dan, 2026-08-21, all three
+// browsers): the top-bar chip showed a connected wallet while Generate's
+// pay panel said "Connect your wallet to pay" forever. Root cause:
+// Generate copies the connected address into local state (getAddress() at
+// mount + the 'wallet-changed' event), but the ONLY dispatcher of that
+// event was the EOA accountsChanged runtime listener — connectWallet(),
+// reconnectWallet() (both branches), and disconnectWallet() all mutated
+// _address silently. Page-load reconnect resolves AFTER Generate mounts,
+// so the panel never engaged the one-click pay path in ANY browser flow.
+// These pins reject any build where an _address transition doesn't
+// announce.
+
+const config = readFileSync(new URL("../src/config.js", import.meta.url), "utf8");
+const generate = readFileSync(new URL("../src/components/Generate.jsx", import.meta.url), "utf8");
+
+test("every wallet-state transition announces wallet-changed", () => {
+	// The single announcer helper exists and carries the module address.
+	assert.match(
+		config,
+		/function announceWalletChanged\(\) \{\s*window\.dispatchEvent\(new CustomEvent\('wallet-changed', \{ detail: \{ address: _address \} \}\)\)/,
+	);
+	// Circle passkey connect announces after persisting.
+	assert.match(
+		config,
+		/saveWalletMeta\(CIRCLE_PROVIDER_ID, _address, result\.walletName\)\s*\n\s*announceWalletChanged\(\)/,
+	);
+	// EOA connect announces after persisting.
+	assert.match(
+		config,
+		/saveWalletMeta\(providerId, _address\)\s*\n\s*announceWalletChanged\(\)/,
+	);
+	// Silent page-load reconnect announces on BOTH branches — this is the
+	// exact transition Generate was blind to (chip connected, panel not).
+	assert.match(
+		config,
+		/saveWalletMeta\(CIRCLE_PROVIDER_ID, _address\)\s*\n\s*announceWalletChanged\(\)/,
+	);
+	assert.match(
+		config,
+		/saveWalletMeta\(_providerId, _address\)\s*\n\s*announceWalletChanged\(\)/,
+	);
+	// Disconnect announces the cleared (null) address.
+	assert.match(config, /clearWalletMeta\(\)\s*\n\s*announceWalletChanged\(\)\s*\n\}/);
+});
+
+test("accountsChanged path uses the shared announcer, no double dispatch", () => {
+	// The empty-accounts branch relies on disconnectWallet()'s announce —
+	// a second inline dispatch there would fire the event twice per revoke.
+	assert.doesNotMatch(
+		config,
+		/disconnectWallet\(\).*\n\s*window\.dispatchEvent\(new CustomEvent\('wallet-changed'/,
+	);
+	// And no raw dispatches remain outside the helper.
+	const rawDispatches = config.match(/dispatchEvent\(new CustomEvent\('wallet-changed'/g) ?? [];
+	assert.equal(rawDispatches.length, 1, "wallet-changed must only be dispatched by announceWalletChanged()");
+});
+
+test("Generate resyncs from the announcement (consumer side of the pin)", () => {
+	assert.match(generate, /useState\(\(\) => getAddress\(\)\)/);
+	assert.match(generate, /addEventListener\("wallet-changed"/);
+});


### PR DESCRIPTION
## The bug (root cause of Dan's browser-payment failures in ALL three browsers)

Live-driven repro on prod Safari tonight (post-#1459 deploy): top bar shows the connected wallet chip (`Test_Wallet · 0x512b…9596`), but clicking **Approve & Generate** takes the *plain submit* path → 402 → the panel says **"Connect your wallet to pay"** — and clicking its Connect button can never fix it.

Why, verified in source:

- `Generate` copies the connected address into local state: `getAddress()` at mount + the `wallet-changed` event (`Generate.jsx:124,190-192`).
- The ONLY dispatcher of `wallet-changed` was `_onAccountsChanged` — the EOA runtime listener (`config.js`). `connectWallet()`, `connectCircleWallet()`, both `reconnectWallet()` branches, and `disconnectWallet()` all mutate `_address` silently.
- On page load, `reconnectWallet()` resolves AFTER Generate mounts → Generate's `walletAddr` is null forever. A manual connect via the modal calls `onConnect={setWalletAddr}` — AuthenticatedApp state only; Generate never hears about it either.

So the one-click pay path (#1459) never engages in a browser: not for Circle passkey (Safari), not for MetaMask (Firefox), not for Coinbase (Chrome). The agent/headless path never touches this component — exactly the observed split of "agent path proven end-to-end, every browser fails."

## The fix

One announcer helper in `config.js` dispatching `wallet-changed` with the module address; called at all five state transitions (EOA connect, passkey connect, both reconnect branches, disconnect). `_onAccountsChanged` reuses it; its revoke branch now relies on `disconnectWallet()`'s announce instead of double-dispatching.

Consumers already in place: `Generate.jsx` resyncs via its existing listener; `AuthenticatedApp`'s listener re-checks linkage on the same event (idempotent with its own reconnect `.then()`).

## Guard demonstrated to reject (per CLAUDE.md rule 3/4)

New pin test run against the PRE-fix `config.js` (stashed): **2/3 tests fail**. Against the fixed file: 3/3 pass. (The third is a consumer-side pin that holds both ways by design.) Full ui suite: **394/394**. ESLint clean.

## Field verification plan

After deploy: hard-reload the prod Generate tab in Safari → the pay panel should engage the one-click flow with the passkey wallet without any Connect prompt; then Dan retests MetaMask/Firefox and Coinbase/Chrome (errors render verbatim on-screen since #1454).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7