### PR TITLE
[frontend] One-tap payment: WebAuthn ceremony inside the tap's activation, one button !minor

### DIFF
--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -141,6 +141,12 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// option) — see ../generateQuote.js's derivePaymentRequirements. Null
 	// until a 402 lands.
 	const [paymentRequirements, setPaymentRequirements] = useState(null);
+	// When the active requirements were parsed. WebKit refuses a WebAuthn
+	// ceremony after any await chain, so the pay tap must sign with HELD
+	// requirements, not refetched ones — this timestamp bounds how old a
+	// held set may be before we refetch anyway (the server window is 7
+	// days, #1452; the cap only guards a config change under an idle tab).
+	const [paymentRequirementsAt, setPaymentRequirementsAt] = useState(0);
 	// The 402 body's OWN quote ({price, asset, chain, dry_run, ...}) —
 	// captured independently of the upfront GET /api/generate/quote fetch so
 	// the payment step can show a price even when GENERATION_QUOTE_ENABLED
@@ -268,6 +274,20 @@ export default function Generate({ onNavigate, onStageChange }) {
 		};
 	}, [paymentRequirements, walletAddr, payerMismatch]);
 
+	// True exactly when the payment panel renders its own pay button — the
+	// main submit button hides then, so precisely ONE button is on screen
+	// (Dan's 2026-08-21 field report: "Pay & generate" next to "Approve &
+	// Generate" is redundant and confusing). Every other panel branch keeps
+	// the main button as the retry control after the user fixes the
+	// connect/link condition it describes.
+	const payPanelReady =
+		(paymentStatus === PAYMENT_STATUS.DRY_RUN ||
+			paymentStatus === PAYMENT_STATUS.LIVE_UNAVAILABLE) &&
+		!paymentRequirements?.error &&
+		!!walletAddr &&
+		!payerMismatch &&
+		walletSupportsPayment();
+
 	// ── Build the /start request body. No payment field on it anywhere —
 	// the ratified contract (#1296) gates entirely via status codes/headers,
 	// not a request-body field (the PROPOSED contract's quote_id is dead). ──
@@ -306,6 +326,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 		setPaymentStatus(PAYMENT_STATUS.NONE);
 		setPaymentMessage("");
 		setPaymentRequirements(null);
+		setPaymentRequirementsAt(0);
 		setPaywallQuoteRaw(null);
 		setGatewayBalance(null);
 		setDepositError("");
@@ -344,6 +365,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 					// IS the human version of that instruction; rendering both was
 					// pure noise (Dan's 2026-08-21 field report).
 					setPaymentRequirements(derivePaymentRequirements(extractPaymentRequiredHeader(e.headers)));
+					setPaymentRequirementsAt(Date.now());
 				} else {
 					setPaymentMessage(paymentErrorMessage(e));
 				}
@@ -356,10 +378,12 @@ export default function Generate({ onNavigate, onStageChange }) {
 	};
 
 	// One-click pay step ("idle" | "refreshing" | "approving" | "depositing"
-	// | "signing" | "starting") — drives the single button's label so the
-	// user watches ONE control narrate the whole flow instead of juggling a
-	// deposit button and a pay button (Dan's 2026-08-21 field report:
-	// "redundant, confusing" — this is the fix).
+	// | "signing" | "starting" | "confirm") — drives the single button's
+	// label so the user watches ONE control narrate the whole flow instead
+	// of juggling a deposit button and a pay button (Dan's 2026-08-21 field
+	// report: "redundant, confusing" — this is the fix). "confirm" = a
+	// signature is ready to be requested but the browser needs a fresh tap
+	// to open the prompt (WebKit activation rules, or the user cancelled).
 	const [payStep, setPayStep] = useState("idle");
 
 	// Re-fetch a FRESH 402 at click time. Requirements parsed from an earlier
@@ -380,20 +404,79 @@ export default function Generate({ onNavigate, onStageChange }) {
 			const fresh = derivePaymentRequirements(extractPaymentRequiredHeader(e.headers));
 			if (!fresh?.requirements) throw e;
 			setPaymentRequirements(fresh);
+			setPaymentRequirementsAt(Date.now());
 			setPaywallQuoteRaw(e?.detail?.quote ?? null);
 			return fresh;
 		}
 	};
 
-	// ── One-click: fresh 402 → deposit if short → sign → start ──
+	// True when the browser refused to OPEN the signing prompt because the
+	// tap's transient user activation was already consumed by earlier awaits
+	// (ox Authentication.SignFailedError, surfaced verbatim as "Failed to
+	// request credential." in Dan's 2026-08-21 field test — the deposit
+	// prompt, close to the tap, succeeded; the payment prompt after the
+	// deposit's confirmation wait was refused every time, iPad and Mac
+	// alike). Not a wallet failure: the fix is a fresh tap that reaches the
+	// ceremony first.
+	const isActivationRefusal = (e) =>
+		e?.name === "Authentication.SignFailedError" ||
+		/failed to request credential/i.test(e?.message || "") ||
+		/failed to request credential/i.test(e?.cause?.message || "");
+
+	// Requirements already held in page state are signable without a
+	// click-time refetch while younger than this — the refetch was #1459's
+	// staleness guard, but awaiting it before the signature is exactly what
+	// kills the WebAuthn ceremony on WebKit. 10 minutes is far inside the
+	// 7-day validity window (#1452) while still bounding how long a server
+	// config change can sit unnoticed under an idle tab.
+	const REQUIREMENTS_FRESH_MS = 10 * 60 * 1000;
+	const heldSignableRequirements = () => {
+		const held = paymentRequirements;
+		if (!held?.requirements) return null;
+		if (Date.now() - paymentRequirementsAt > REQUIREMENTS_FRESH_MS) return null;
+		return held;
+	};
+
+	const finishStart = async (header) => {
+		setPayStep("starting");
+		const { receipt: settledReceipt } = await submitStart({ "Payment-Signature": header });
+		resetPaymentStepState();
+		setNoSettlementNotice(!settledReceipt);
+		if (GENERATION_QUOTE_ENABLED) fetchQuote();
+	};
+
+	// ── One tap when funded: the signing ceremony runs FIRST, inside the
+	// tap's activation, against held requirements and the held balance.
+	// Deposit-needed taps run refetch → deposit (its prompt is close enough
+	// to the tap to survive), then TRY to finish; a browser that refuses
+	// the second ceremony arms payStep "confirm" so the next tap gives the
+	// payment signature its own activation. ──
 	const handlePayAndGenerate = async () => {
 		setPaying(true);
 		setPaymentMessage("");
 		setDepositError("");
 		try {
+			const held = heldSignableRequirements();
+			const funded =
+				held != null &&
+				requiredAmountRaw != null &&
+				gatewayBalance != null &&
+				gatewayBalance >= requiredAmountRaw;
+			if (funded) {
+				// NOTHING may be awaited between the tap and this call.
+				setPayStep("signing");
+				const header = await signGatewayPayment({
+					requirements: held.requirements,
+					resource: held.resource,
+					x402Version: held.x402Version,
+					payerAddress: walletAddr,
+				});
+				await finishStart(header);
+				return;
+			}
 			setPayStep("refreshing");
-			const fresh = await refreshPaymentRequirements();
-			if (!fresh) return; // started without payment
+			const fresh = held ?? (await refreshPaymentRequirements());
+			if (!fresh) return; // started without payment (paywall off)
 			const req = fresh.requirements;
 			const need = BigInt(req.amount);
 			let bal = await getGatewayBalance(req, walletAddr);
@@ -409,24 +492,35 @@ export default function Generate({ onNavigate, onStageChange }) {
 				setGatewayBalance(bal);
 			}
 			setPayStep("signing");
-			const header = await signGatewayPayment({
-				requirements: req,
-				resource: fresh.resource,
-				x402Version: fresh.x402Version,
-				payerAddress: walletAddr,
-			});
-			setPayStep("starting");
-			const { receipt: settledReceipt } = await submitStart({ "Payment-Signature": header });
-			resetPaymentStepState();
-			setNoSettlementNotice(!settledReceipt);
-			if (GENERATION_QUOTE_ENABLED) fetchQuote();
+			let header;
+			try {
+				header = await signGatewayPayment({
+					requirements: req,
+					resource: fresh.resource,
+					x402Version: fresh.x402Version,
+					payerAddress: walletAddr,
+				});
+			} catch (e) {
+				if (isActivationRefusal(e)) {
+					// Deposit landed; the browser just needs a fresh tap for
+					// the payment prompt. Not an error state.
+					setPayStep("confirm");
+					return;
+				}
+				throw e;
+			}
+			await finishStart(header);
 		} catch (e) {
-			setPaymentMessage(
-				paymentErrorMessage(e, e?.shortMessage || e?.message || "Payment failed — try again."),
-			);
+			if (isActivationRefusal(e)) {
+				setPayStep("confirm");
+			} else {
+				setPaymentMessage(
+					paymentErrorMessage(e, e?.shortMessage || e?.message || "Payment failed — try again."),
+				);
+			}
 		} finally {
 			setPaying(false);
-			setPayStep("idle");
+			setPayStep((s) => (s === "confirm" ? s : "idle"));
 		}
 	};
 
@@ -953,14 +1047,16 @@ export default function Generate({ onNavigate, onStageChange }) {
 											{payStep === "refreshing"
 												? "Checking price…"
 												: payStep === "approving"
-													? "Step 1 of 3 — approve USDC in your wallet…"
+													? "Approve USDC in your wallet…"
 													: payStep === "depositing"
-														? "Step 2 of 3 — depositing into Gateway…"
+														? "Depositing into Gateway…"
 														: payStep === "signing"
-															? "Step 3 of 3 — sign the payment…"
+															? "Sign the payment in your wallet…"
 															: payStep === "starting"
 																? "Starting generation…"
-																: `Pay ${fmtUsd(effectiveQuoteView?.price) ?? ""} & generate →`}
+																: payStep === "confirm"
+																	? `Tap to approve the ${fmtUsd(effectiveQuoteView?.price) ?? ""} payment →`
+																	: `Pay ${fmtUsd(effectiveQuoteView?.price) ?? ""} & generate →`}
 										</button>
 										{(gatewayBalance == null ||
 											(requiredAmountRaw != null && gatewayBalance < requiredAmountRaw)) && (
@@ -1018,20 +1114,22 @@ export default function Generate({ onNavigate, onStageChange }) {
 							<div />
 						)}
 						</div>
-						<button
-							className="btn btn-primary"
-							onClick={startJob}
-							disabled={starting || !intent.trim() || !quoteReady}
-							aria-describedby={
-								!intent.trim() ? "generate-submit-hint" : undefined
-							}
-						>
-							{starting
-								? "Starting…"
-								: GENERATION_QUOTE_ENABLED
-									? "Approve & Generate →"
-									: "Generate →"}
-						</button>
+						{!payPanelReady && (
+							<button
+								className="btn btn-primary"
+								onClick={startJob}
+								disabled={starting || !intent.trim() || !quoteReady}
+								aria-describedby={
+									!intent.trim() ? "generate-submit-hint" : undefined
+								}
+							>
+								{starting
+									? "Starting…"
+									: GENERATION_QUOTE_ENABLED
+										? "Approve & Generate →"
+										: "Generate →"}
+							</button>
+						)}
 					</div>
 					{/* The submit button is disabled until a brief exists; state the
 					    cause rather than leaving the form looking stuck (3.3.1). */}

--- a/ui/test/generate-quote.test.js
+++ b/ui/test/generate-quote.test.js
@@ -558,11 +558,13 @@ test("Generate.jsx: the no-receipt success copy is honest — never claims settl
 
 test("Generate.jsx: one-click payment — deposit folds into the single pay flow (2026-08-21 UX fix)", () => {
 	// The separate "Approve & deposit" button is retired: ONE control runs
-	// fresh-402 → deposit-if-short → sign → start, narrating each step.
+	// the whole flow, narrating each step. (The click-time refetch moved to
+	// the not-yet-funded branch only — the funded tap signs with held
+	// requirements so WebKit's activation survives; see
+	// webauthn-activation.test.js.)
 	assert.doesNotMatch(generate, /Approve & deposit/);
 	assert.match(generate, /handlePayAndGenerate/);
-	assert.match(generate, /const fresh = await refreshPaymentRequirements\(\)/);
-	assert.match(generate, /Step 1 of 3/);
+	assert.match(generate, /const fresh = held \?\? \(await refreshPaymentRequirements\(\)\)/);
 	assert.match(generate, /one-time\s+deposit covers many generations/);
 });
 

--- a/ui/test/webauthn-activation.test.js
+++ b/ui/test/webauthn-activation.test.js
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Field report (Dan, 2026-08-21, iPad + MacBook): passkey payments died with
+// "Failed to request credential." on REAL taps. WebKit refuses to open a
+// WebAuthn prompt once the tap's transient user activation has been consumed
+// by earlier awaits — and the one-click flow awaited a fresh 402, a balance
+// read, a deposit user-op, and its confirmation before requesting the
+// payment signature. The deposit's own prompt (close to the tap) succeeded;
+// the payment prompt never did. These pins hold the contract that fixed it.
+
+const generate = readFileSync(new URL("../src/components/Generate.jsx", import.meta.url), "utf8");
+const x402 = readFileSync(new URL("../src/x402.js", import.meta.url), "utf8");
+
+test("funded tap signs FIRST — no await between the tap and the ceremony", () => {
+	// The funded branch exists, keyed on held requirements + held balance…
+	assert.match(generate, /heldSignableRequirements/);
+	assert.match(generate, /gatewayBalance >= requiredAmountRaw/);
+	// …and inside it the signature call uses the HELD requirements, with the
+	// no-await contract stated where the next editor will see it.
+	assert.match(generate, /NOTHING may be awaited between the tap and this call/);
+	assert.match(generate, /requirements: held\.requirements/);
+	// The old shape — unconditional click-time refetch before signing — is
+	// gone: the refetch survives only behind the held ?? fallback.
+	assert.doesNotMatch(generate, /const fresh = await refreshPaymentRequirements\(\)/);
+});
+
+test("a refused ceremony arms a fresh-tap confirm state, not a raw error", () => {
+	// ox's refusal (and a user cancel) is recognised…
+	assert.match(generate, /isActivationRefusal/);
+	assert.match(generate, /Authentication\.SignFailedError/);
+	assert.match(generate, /failed to request credential/i);
+	// …and lands in payStep "confirm" whose button asks for one more tap.
+	assert.match(generate, /setPayStep\("confirm"\)/);
+	assert.match(generate, /Tap to approve the/);
+	// The confirm state survives the finally-reset that returns to idle.
+	assert.match(generate, /s === "confirm" \? s : "idle"/);
+});
+
+test("held requirements have a bounded age before a refetch is forced", () => {
+	assert.match(generate, /REQUIREMENTS_FRESH_MS/);
+	assert.match(generate, /paymentRequirementsAt/);
+});
+
+test("exactly one button: main submit hides when the pay panel is armed", () => {
+	assert.match(generate, /payPanelReady/);
+	assert.match(generate, /\{!payPanelReady && \(/);
+});
+
+test("the circle signing path itself stays await-free before the prompt", () => {
+	// signGatewayPayment's circle branch must go straight from sync typed-data
+	// assembly to smartAccount.signTypedData — an ensureArcChain/getWalletClient
+	// hop before the passkey ceremony would reintroduce the refusal class.
+	const circleBranch = x402.match(/if \(kind === "circle"\) \{([\s\S]*?)\} else \{/);
+	assert.ok(circleBranch, "circle signing branch missing");
+	assert.doesNotMatch(circleBranch[1], /ensureArcChain|getWalletClient/);
+	assert.match(circleBranch[1], /smartAccount\.signTypedData/);
+});


### PR DESCRIPTION
## The failure (Dan's field report, iPad + MacBook, all browsers)

Real taps on **Pay & generate** died with `Failed to request credential.` — ox's `SignFailedError`, i.e. the browser refused to OPEN the passkey prompt. Root cause: WebKit only allows a WebAuthn ceremony while the tap's transient user activation is alive, and the one-click flow consumed it with awaits before the signature: fresh-402 refetch → RPC balance read → (first run) deposit user-op + confirmation wait → then `credentials.get()`. Field evidence nails it: the **deposit's own prompt — close to the tap — succeeded** (0x512b…9596 now holds $20.00 in the Gateway, verified on-chain), while the payment prompt after the waits was refused every time.

## The fix

- **Funded tap = one tap.** If requirements are held (≤10 min old — the server validity window is 7 days, #1452, so held requirements sign identically to refetched ones) and the held balance covers the price, the tap's FIRST await is `signGatewayPayment` — nothing runs before the ceremony. Then start.
- **First-time tap = deposit, then a clean second tap.** The not-yet-funded path refetches, deposits (that prompt survives, field-proven), then *tries* to finish; a browser that refuses the second ceremony lands in `payStep: "confirm"` — the button reads "Tap to approve the \$2.00 payment →" and that tap signs first-thing with its own activation. Browsers with laxer rules just complete in one tap. A user-cancelled prompt lands in the same honest state instead of a raw error.
- **Exactly one button.** The main "Approve & Generate" submit hides whenever the pay panel is armed (`payPanelReady`) — Dan's screenshot showed both on screen.
- Step labels de-numbered ("Approve USDC in your wallet…", "Sign the payment in your wallet…") since the funded path has a single step.

## Why the deposit exists at all (Dan's question, for the record)

Circle Gateway/x402: the facilitator settles from the payer's **Gateway balance** against a signed EIP-712 authorization — it cannot pull straight from wallet USDC. Deposit once → every generation is a single signature. The gateway→revenue-wallet leg IS automatic at settle (the DCW's $6.00 accrued proves it).

## Guards demonstrated to reject

New `webauthn-activation.test.js` run against the PRE-fix `Generate.jsx`: **4/5 fail** (the 5th pins the unchanged x402 circle branch staying await-free before the prompt, labeled as such). Post-fix: 5/5. Stale #1459 pin re-pointed. Full ui suite **399/399**, ESLint clean.

## Field verification

After deploy: iPad tap on "Pay \$2.00 & generate →" should open the passkey prompt immediately (funded path). Desktop Safari/Chrome/Firefox retests follow; errors still render verbatim if anything else surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7