### PR TITLE
[frontend] 24h validity margin over the facilitator minimum — fixes authorization_validity_too_short on real devices !minor

### DIFF
--- a/ui/src/generateQuote.js
+++ b/ui/src/generateQuote.js
@@ -297,10 +297,25 @@ export function requirementChainId(requirements) {
  * domain is the #1 way a naive implementation of this flow produces a hash
  * the Gateway contract rejects.
  */
+// Margin ADDED to the server-advertised maxTimeoutSeconds when computing
+// validBefore. The facilitator enforces its validity minimum against ITS OWN
+// clock at verification time with essentially zero grace — probed live
+// 2026-08-21 against the testnet facilitator with byte-identical browser
+// payloads: a client clock a mere 30 SECONDS behind real time fails
+// `authorization_validity_too_short`; correct clock passes; with this
+// 24-hour margin even a clock 10 minutes behind passes (and the facilitator
+// accepts the longer window). Signing exactly the advertised minimum from
+// the CLIENT clock therefore bricks payments for every consumer device
+// whose clock runs behind — Dan's iPad, field report 2026-08-21. The
+// authorization is single-nonce and for the exact amount/recipient, so the
+// longer window adds no spend exposure.
+export const VALIDITY_SKEW_MARGIN_SECONDS = 86_400;
+
 export function buildTransferAuthorizationTypedData(requirements, { from, nowSec, nonceHex }) {
 	const chainId = requirementChainId(requirements);
 	const validAfter = nowSec - 600; // 10 min clock-skew buffer, matches circlekit
-	const validBefore = nowSec + Number(requirements?.maxTimeoutSeconds ?? 0);
+	const validBefore =
+		nowSec + Number(requirements?.maxTimeoutSeconds ?? 0) + VALIDITY_SKEW_MARGIN_SECONDS;
 	const to = requirements?.payTo;
 	const value = String(requirements?.amount ?? "0");
 	return {

--- a/ui/test/generate-quote.test.js
+++ b/ui/test/generate-quote.test.js
@@ -378,7 +378,10 @@ test("buildTransferAuthorizationTypedData: message uses bigints for uint256 fiel
 	assert.equal(message.value, 2_000_000n);
 	assert.equal(typeof message.value, "bigint");
 	assert.equal(message.validAfter, 1_000_000n - 600n);
-	assert.equal(message.validBefore, 1_000_000n + 345_600n);
+	// maxTimeoutSeconds + the 24h skew margin — the facilitator measures
+	// remaining validity against ITS clock with zero grace (probed live
+	// 2026-08-21: a client clock 30s behind fails without the margin).
+	assert.equal(message.validBefore, 1_000_000n + 345_600n + 86_400n);
 	assert.equal(message.nonce, nonceHex);
 	assert.equal(message.to, fixtureRequirement.payTo);
 });
@@ -394,7 +397,7 @@ test("buildTransferAuthorizationTypedData: authorization (the wire payload) uses
 	assert.equal(authorization.to, fixtureRequirement.payTo);
 	assert.equal(authorization.value, "2000000");
 	assert.equal(authorization.validAfter, String(1_000_000 - 600));
-	assert.equal(authorization.validBefore, String(1_000_000 + 345_600));
+	assert.equal(authorization.validBefore, String(1_000_000 + 345_600 + 86_400));
 	assert.equal(authorization.nonce, nonceHex);
 	for (const key of ["from", "to", "value", "validAfter", "validBefore", "nonce"]) {
 		assert.equal(typeof authorization[key], "string", `authorization.${key} must be a string`);


### PR DESCRIPTION
## The failure

Dan's iPad tap (first browser-signed payment ever to reach verification, right after #1464 fixed the WebAuthn activation) died with `Payment verification failed: authorization_validity_too_short`.

## Live bisection (smoke wallet, $0 Gateway balance — validity passing safely dead-ends at insufficient_balance, nothing can settle)

Byte-identical browser payloads (the probe imports `ui/src/generateQuote.js` itself), signed with controlled clock offsets against prod:

| clock offset | validBefore construction | facilitator verdict |
|---|---|---|
| 0 | `now + 604800` (old code) | passes → `insufficient_balance` |
| **−30 s** | `now + 604800` (old code) | **`authorization_validity_too_short`** — Dan's exact error |
| −120 s | `now + 604800` (old code) | `authorization_validity_too_short` |
| −600 s | `now + 604800 + 86400` (this PR) | passes → `insufficient_balance` |

So the facilitator checks remaining validity against **its own clock with zero grace**, and we signed exactly the advertised minimum from the **client** clock. Any consumer device ≥30 s behind fails deterministically; NTP-tight machines (the agent path signs on the server) pass — exactly the observed agent-works/browser-fails split's second layer.

## The fix

`VALIDITY_SKEW_MARGIN_SECONDS = 86400` added to `validBefore` in `buildTransferAuthorizationTypedData`. The authorization is single-nonce, exact-amount, exact-recipient — the longer window adds no spend exposure. `validAfter`'s existing 600 s backdate already covers clocks running fast.

Optional server-side hardening (not in this PR, one logical change): advertise `maxTimeoutSeconds = 604800 + margin` in `payments.py` so third-party agent clients signing exactly the advertised value also clear the floor.

## Verification

- Behavioral tests updated; **adversarial: the old builder fails them 2/48**; full ui suite 399/399, ESLint clean.
- Live: the fixed builder signed with a clock **10 minutes behind** passes prod verification (table above).

After deploy Dan re-taps on the iPad: passkey prompt (fixed in #1464) → signature → verification should now pass → settle → generation starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7