### PR TITLE
[frontend] Honest guard: Circle passkey wallets can't sign the x402 nanopayments rail !minor

### DIFF
--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -8,7 +8,7 @@ import { apiGet, apiPostWithMeta } from "../api";
 import { getAddress } from "../config";
 import { listLinkedWallets } from "../linked-wallets";
 import { GENERATION_QUOTE_ENABLED } from "../featureFlags";
-import { depositToGateway, getGatewayBalance, parseUsdcAmount, signGatewayPayment, walletSupportsPayment } from "../x402";
+import { depositToGateway, getGatewayBalance, parseUsdcAmount, paymentWalletKind, signGatewayPayment, walletSupportsPayment } from "../x402";
 import {
 	DEPTH_OPTIONS,
 	PAYMENT_STATUS,
@@ -1026,6 +1026,33 @@ export default function Generate({ onNavigate, onStageChange }) {
 											onClick={() => window.dispatchEvent(new Event("open-wallet-modal"))}
 										>
 											Connect wallet →
+										</button>
+									</div>
+								) : paymentWalletKind() === "circle" ? (
+									// Circle's nanopayments rail validates burn intents as EOA
+									// (ERC-3009) signatures ONLY — "Nanopayments require an EOA
+									// wallet. Smart contract account (SCA) wallets are not
+									// supported" (Circle buyer quickstart), and the ERC-1271
+									// path is explicitly excluded from nanopayments (Circle
+									// ERC-1271 reference). Field-proven 2026-08-21: a passkey
+									// smart-account signature reaches the facilitator and dies
+									// with invalid_signature. Until the delegate design ships
+									// (registered session-EOA signing on the SCA's behalf),
+									// offering the pay button to a passkey wallet is a trap
+									// that ends in a cryptic error AFTER a deposit.
+									<div style={{ marginTop: 6 }}>
+										<p className="caption mb-1">
+											Your Circle passkey wallet can hold and deposit USDC, but
+											Circle's payment rail can't verify passkey signatures on
+											x402 payments yet — payments need a standard wallet
+											(MetaMask, Coinbase, Brave, Phantom) for now.
+										</p>
+										<button
+											type="button"
+											className="btn btn-outline btn-sm"
+											onClick={() => window.dispatchEvent(new Event("open-wallet-modal"))}
+										>
+											Connect a payment wallet →
 										</button>
 									</div>
 								) : (

--- a/ui/test/passkey-rail-guard.test.js
+++ b/ui/test/passkey-rail-guard.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Field-proven 2026-08-21 (Dan's iPad, prod): a Circle passkey smart-account
+// signature clears the WebAuthn ceremony and the validity window, reaches
+// Circle's facilitator, and dies with `invalid_signature` — because the
+// nanopayments rail validates burn intents as EOA (ERC-3009) signatures
+// only. Circle's own docs are explicit: "Nanopayments require an EOA
+// wallet. Smart contract account (SCA) wallets are not supported" (buyer
+// quickstart), and ERC-1271 is excluded from nanopayments (ERC-1271
+// reference). Offering the pay button to a passkey wallet is therefore a
+// trap that can take a deposit and then fail every payment. These pins
+// hold the honest guard until the delegate design ships.
+
+const generate = readFileSync(new URL("../src/components/Generate.jsx", import.meta.url), "utf8");
+
+test("passkey wallets get the honest no-rail notice, not the pay button", () => {
+	// The circle-kind branch exists in the pay panel…
+	assert.match(generate, /paymentWalletKind\(\) === "circle" \? \(/);
+	// …says plainly why, in user words…
+	assert.match(generate, /can't verify passkey signatures/);
+	// …and offers the wallet modal as the way forward.
+	const branch = generate.match(/paymentWalletKind\(\) === "circle" \? \(([\s\S]*?)\) : \(/);
+	assert.ok(branch, "circle-kind branch missing");
+	assert.match(branch[1], /open-wallet-modal/);
+	assert.match(branch[1], /Connect a payment wallet/);
+	// The guard must sit BEFORE the pay control so a passkey wallet can
+	// never reach handlePayAndGenerate (which would deposit first, then
+	// fail signature verification — money in, nothing out).
+	assert.ok(
+		generate.indexOf('paymentWalletKind() === "circle" ? (') <
+			generate.indexOf("onClick={handlePayAndGenerate}"),
+		"circle guard must precede the pay button",
+	);
+});


### PR DESCRIPTION
## Why (the final layer of tonight's payment-failure ladder)

Dan's iPad tap now clears the WebAuthn ceremony (#1464) and the validity window (#1465), reaches Circle's facilitator — and dies with `Payment verification failed: invalid_signature`. Root cause is Circle-side, documented, and not fixable by us tonight:

- Circle buyer quickstart: **"Nanopayments require an EOA wallet. Smart contract account (SCA) wallets are not supported."**
- Circle ERC-1271 reference: **"Nanopayments … isn't available through ERC-1271. Nanopayment burn intents are batched and submitted through ERC-3009 requests, which use a different validation path."**
- Our EOA probe (same wire code, secp256k1 signature) passes verification end-to-end; the passkey smart account (deployed, ERC-1967 proxy — plain ERC-1271, no 6492) fails it. Exactly the doc's split.

So the pay button was a trap for passkey wallets: deposit succeeds (user-op rail), then every payment fails after the prompt. This PR replaces the pay control for `paymentWalletKind() === "circle"` with an honest notice + "Connect a payment wallet →" (opens the existing modal).

## The real fix (follow-up issue, filed separately)

Gateway supports **delegates** at the contract level (`addDelegate` / `isAuthorizedForBalance`): a one-time user-op from the passkey account registering a browser-held session EOA, which then signs ERC-3009 burn intents — zero prompts per payment, allowance bounded by the Gateway deposit. Needs verification that the nanopayments validation path honors delegate signatures (contract interface says yes at burn level; the facilitator wire format needs a spike).

## Verification

Pin test fails on pre-guard source (adversarial); full ui suite **400/400**; ESLint clean. Dan's $20 already in the Gateway under the passkey account stays withdrawable via user-op (noted in the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7