### PR TITLE
[rigor][cli] /api/rigor/verify: passes is a quorum over runnable legs (#1481)

### DIFF
--- a/backend/archimedes/api/agent_manifest_routes.py
+++ b/backend/archimedes/api/agent_manifest_routes.py
@@ -163,9 +163,18 @@ async def get_agent_manifest():
             # checks over a bare returns series the caller submits. Only DSR and
             # walk-forward OOS are evaluable from a bare series — PBO and the
             # look-ahead audit report `not_evaluable`, never a silent pass.
+            # #1481: `passes` is a quorum over the two RUNNABLE legs, so an agent
+            # reading the scalar alone cannot mistake it for the passport gate.
             "rigor": {
                 "status": "live",
                 "auth_required": True,
+                "verdict_note": (
+                    "`passes` requires BOTH runnable legs (DSR, OOS consistency) to have run "
+                    "and passed. PBO and look-ahead can never run on a bare returns series, so "
+                    "the verdict is capped: it is NOT equivalent to the strategy passport gate. "
+                    "The response carries legs_evaluated / legs_runnable / legs_total / "
+                    "verdict_capped so the scalar is qualifiable without re-deriving leg statuses."
+                ),
                 "routes": {
                     "verify": "POST /api/rigor/verify",
                 },

--- a/backend/archimedes/api/rigor_verify_routes.py
+++ b/backend/archimedes/api/rigor_verify_routes.py
@@ -32,9 +32,23 @@ returns series can only ever support two of them:
     Archimedes never executes or uploads strategy code server-side (the
     README's hard boundary) — this endpoint accepts only numbers, on purpose.
 
-``passes`` is ``True`` iff no EVALUABLE check failed AND at least one check
-was evaluable — a request where every check is ``not_evaluable`` (e.g. a
-too-short series) must not report ``passes=True`` by vacuous truth.
+**The verdict is CAPPED, and ``passes`` is a quorum, not a majority (#1481).**
+Two of the four legs above are structurally ``not_evaluable`` on a bare
+series — always, for every request. So this endpoint can never reproduce the
+full passport gate, and a caller must not read ``passes`` as "cleared the
+rigor gate."
+
+``passes`` is ``True`` iff **every RUNNABLE leg actually ran and passed** —
+that is, both DSR and OOS consistency. Computing it over "whichever legs
+happened to be evaluable" is the #1481 defect: OOS needs ~70 bars while DSR
+needs only 4, so a 4-bar series had exactly one evaluable leg and returned
+``passes=True`` on one leg of four. The zero-evaluable case was already
+guarded ("vacuous truth is not honesty"); the one-evaluable case was not.
+
+``legs_evaluated`` / ``legs_runnable`` / ``legs_total`` and
+``verdict_capped`` are on the response so ``passes`` is qualifiable by a
+consumer without re-deriving the leg statuses itself. ``legs_total`` is the
+real gate's four; ``legs_runnable`` is the two this transport can support.
 
 Account-session-gated (Better Auth) + rate-limited ``5/minute`` per the issue
 spec, mirroring ``paper_routes.py`` / ``selection_bias_routes.py`` style.
@@ -58,6 +72,16 @@ from archimedes.services.rigor_evaluator import (
 from archimedes.services.rigor_profiles import DSR_P_FLOOR, OOS_ABS_FLOOR
 
 rigor_verify_router = APIRouter(prefix="/api/rigor", tags=["rigor"])
+
+# Legs that can ever be evaluated against a bare return series. PBO needs a
+# selection set and the look-ahead audit needs inspectable source; neither
+# exists on this transport, so both are structurally not_evaluable on every
+# request (see the module docstring's honesty contract). `passes` is a quorum
+# over RUNNABLE legs — never over "whichever legs happened to be evaluable",
+# which is what let a 4-bar series pass on one leg of four (#1481).
+_RUNNABLE_LEGS: tuple[str, ...] = ("dsr", "oos_consistency")
+_STRUCTURALLY_NOT_RUN_LEGS: tuple[str, ...] = ("pbo", "look_ahead")
+_LEGS_TOTAL = len(_RUNNABLE_LEGS) + len(_STRUCTURALLY_NOT_RUN_LEGS)
 
 CheckStatus = Literal["pass", "fail", "not_evaluable"]
 
@@ -109,6 +133,13 @@ class RigorVerifyResponse(BaseModel):
     trials: int
     self_attested: bool = True
     n_bars: int
+    # #1481: `passes` alone overstated the evidence. These make the scalar
+    # qualifiable without the caller re-deriving leg statuses.
+    legs_evaluated: int
+    legs_runnable: int
+    legs_total: int
+    legs_not_run: list[str]
+    verdict_capped: bool
     dsr: DsrCheckResult
     pbo: RigorCheck
     oos_consistency: OosConsistencyResult
@@ -199,15 +230,35 @@ async def verify_rigor(
     pbo_check = RigorCheck(status="not_evaluable", reason=_PBO_NOT_EVALUABLE_REASON)
     look_ahead_check = RigorCheck(status="not_evaluable", reason=_LOOK_AHEAD_NOT_EVALUABLE_REASON)
 
-    statuses = [dsr_check.status, pbo_check.status, oos_check.status, look_ahead_check.status]
-    evaluable = [s for s in statuses if s != "not_evaluable"]
-    passes = bool(evaluable) and all(s == "pass" for s in evaluable)
+    leg_status = {
+        "dsr": dsr_check.status,
+        "pbo": pbo_check.status,
+        "oos_consistency": oos_check.status,
+        "look_ahead": look_ahead_check.status,
+    }
+    runnable_statuses = [leg_status[leg] for leg in _RUNNABLE_LEGS]
+    legs_evaluated = sum(1 for st in runnable_statuses if st != "not_evaluable")
+
+    # QUORUM over runnable legs, not "all evaluable legs" (#1481). Every
+    # runnable leg must actually have run AND passed. A partially-evaluated
+    # series (DSR at 4 bars, OOS still short) is not a pass — it is an
+    # incomplete evaluation, and `passes` must not launder it into a verdict.
+    passes = legs_evaluated == len(_RUNNABLE_LEGS) and all(st == "pass" for st in runnable_statuses)
+
+    legs_not_run = [leg for leg, st in leg_status.items() if st == "not_evaluable"]
 
     return RigorVerifyResponse(
         passes=passes,
         trials=body.trials,
         self_attested=True,
         n_bars=len(daily_returns),
+        legs_evaluated=legs_evaluated,
+        legs_runnable=len(_RUNNABLE_LEGS),
+        legs_total=_LEGS_TOTAL,
+        legs_not_run=legs_not_run,
+        # Always true on this transport: PBO and look-ahead can never run
+        # here, so the verdict can never stand in for the passport gate.
+        verdict_capped=True,
         dsr=dsr_check,
         pbo=pbo_check,
         oos_consistency=oos_check,

--- a/backend/tests/test_rigor_verify_routes.py
+++ b/backend/tests/test_rigor_verify_routes.py
@@ -10,9 +10,11 @@ Covers the honesty contract this endpoint exists to enforce:
   3. PBO and look-ahead are ALWAYS ``not_evaluable`` for a bare returns series
      — never silently passed, never defaulted, never reported as a FAIL they
      were never evaluated for;
-  4. ``passes`` is true only when no evaluable check failed AND at least one
-     check was evaluable (a request where nothing was evaluable must not read
-     as passing by vacuous truth);
+  4. ``passes`` is true only when EVERY RUNNABLE leg (DSR + OOS consistency)
+     actually ran and passed — a quorum, not "no evaluable check failed"
+     (#1481). Neither the zero-evaluable case (vacuous truth) nor the
+     one-evaluable case (a 4-bar series where only DSR could run) may read as
+     passing;
   5. ``trials`` is self-attested, `>= 1` enforced at the schema (0 is a 422,
      not a silently-accepted degenerate deflation);
   6. the ADVERSARIAL demonstration the repo's guard-review rule requires: a
@@ -42,6 +44,13 @@ from fastapi import FastAPI
 _STRONG_SERIES = np.random.default_rng(7).normal(0.0015, 0.004, 300).tolist()  # DSR PASS, OOS PASS
 _WEAK_SERIES = np.random.default_rng(11).normal(-0.002, 0.01, 300).tolist()  # DSR FAIL, OOS FAIL
 _SHORT_SERIES = [0.01, -0.02, 0.015]  # T=3: DSR needs T>=4, OOS needs T>=10 -> both not_evaluable
+
+# #1481: the ONE-evaluable window. DSR becomes evaluable at T>=4; the OOS split
+# needs >=21 OOS bars, i.e. ~70 total at 70/30. So for 4 <= T < ~70 exactly one
+# runnable leg can run. At T=4 / seed 7 the DSR p-value is 0.6494 >= DSR_P_FLOOR
+# (0.50), so DSR PASSES while OOS is structurally not_evaluable — the precise
+# shape that used to return passes=true on one leg of four.
+_PARTIAL_SERIES = np.random.default_rng(7).normal(0.0015, 0.004, 4).tolist()
 
 
 def _returns_body(series: list[float], trials: int = 1) -> dict:
@@ -222,3 +231,67 @@ async def test_empty_returns_rejected_422(app, monkeypatch):
     async with _client(app) as client:
         resp = await client.post("/api/rigor/verify", json={"returns": [], "trials": 1})
     assert resp.status_code == 422
+
+
+# ── #1481: `passes` is a quorum over runnable legs ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_four_bar_series_with_passing_dsr_does_not_pass(app, monkeypatch):
+    """#1481 REGRESSION. One evaluable leg of four must not produce a pass.
+
+    DSR is evaluable at 4 bars and passes here; the OOS split needs ~70 bars so
+    it cannot run; PBO and look-ahead never run on a bare series. The old rule
+    ("no evaluable check failed AND at least one was evaluable") returned
+    ``passes: true`` on this exact body, and ``archimedes verify`` exited 0 on
+    it. Reverting the quorum in ``rigor_verify_routes`` makes this test fail.
+    """
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_PARTIAL_SERIES))
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # The precondition that makes this the one-evaluable case, asserted rather
+    # than assumed — if DSR stopped passing here the test would still be green
+    # for the wrong reason.
+    assert body["dsr"]["status"] == "pass"
+    assert body["oos_consistency"]["status"] == "not_evaluable"
+    assert body["pbo"]["status"] == "not_evaluable"
+    assert body["look_ahead"]["status"] == "not_evaluable"
+
+    assert body["passes"] is False
+    assert body["legs_evaluated"] == 1
+    assert body["legs_runnable"] == 2
+
+
+@pytest.mark.asyncio
+async def test_response_qualifies_the_scalar(app, monkeypatch):
+    """`passes` must be qualifiable without the caller re-deriving leg statuses:
+    the quorum counts and the structural cap are on every response."""
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_STRONG_SERIES))
+    body = resp.json()
+
+    assert body["legs_total"] == 4
+    assert body["legs_runnable"] == 2
+    # Always capped on this transport — PBO and look-ahead can never run here,
+    # so the verdict can never stand in for the passport gate.
+    assert body["verdict_capped"] is True
+    assert sorted(body["legs_not_run"]) == ["look_ahead", "pbo"]
+
+
+@pytest.mark.asyncio
+async def test_full_length_series_clearing_every_runnable_leg_still_passes(app, monkeypatch):
+    """The quorum must not make the endpoint permanently unable to pass: a
+    series long enough for both runnable legs, clearing both, still passes."""
+    _sign_in(monkeypatch)
+    async with _client(app) as client:
+        resp = await client.post("/api/rigor/verify", json=_returns_body(_STRONG_SERIES))
+    body = resp.json()
+
+    assert body["dsr"]["status"] == "pass"
+    assert body["oos_consistency"]["status"] == "pass"
+    assert body["legs_evaluated"] == body["legs_runnable"] == 2
+    assert body["passes"] is True

--- a/cli/src/archimedes_cli/cli.py
+++ b/cli/src/archimedes_cli/cli.py
@@ -375,6 +375,34 @@ _CHECK_LABELS = (
 _STATUS_TAG = {"pass": "PASS", "fail": "FAIL", "not_evaluable": "N/A"}
 
 
+def _verify_verdict(body: dict) -> str:
+    """Classify a verify response as ``"pass"``, ``"fail"`` or ``"incomplete"``.
+
+    Never trusts ``passes`` on its own (#1481). The server computes it as a
+    quorum over runnable legs, but ``--api-url`` can point at any host,
+    including one predating that fix — which returns ``passes: true`` on a
+    4-bar series and carries no ``legs_*`` fields at all. So when the quorum
+    fields are absent we re-derive the quorum from the leg statuses rather
+    than assuming the evaluation was complete.
+    """
+    leg_statuses = [(body.get(key) or {}).get("status") for _name, key in _CHECK_LABELS]
+    if any(st == "fail" for st in leg_statuses):
+        return "fail"
+
+    evaluated = body.get("legs_evaluated")
+    runnable = body.get("legs_runnable")
+    if isinstance(evaluated, int) and isinstance(runnable, int):
+        complete = evaluated == runnable and runnable > 0
+    else:
+        # Older server: no quorum reported. Fail closed — an unreported
+        # quorum is an unproven one, not an assumed-complete one.
+        complete = bool(leg_statuses) and all(st == "pass" for st in leg_statuses)
+
+    if not complete:
+        return "incomplete"
+    return "pass" if body.get("passes") else "fail"
+
+
 def _render_verify(body: dict) -> None:
     click.echo(f"n_bars={body.get('n_bars')}  trials={body.get('trials')} (self-attested)")
     for name, key in _CHECK_LABELS:
@@ -386,7 +414,22 @@ def _render_verify(body: dict) -> None:
         if reason:
             line += f" — {reason}"
         click.echo(line)
-    click.echo("PASSES" if body.get("passes") else "FAILS")
+
+    evaluated, runnable = body.get("legs_evaluated"), body.get("legs_runnable")
+    total = body.get("legs_total")
+    if isinstance(evaluated, int) and isinstance(runnable, int):
+        suffix = f" of {total} in the full gate" if isinstance(total, int) else ""
+        click.echo(f"legs evaluated: {evaluated}/{runnable} runnable here{suffix}")
+
+    verdict = _verify_verdict(body)
+    if verdict == "pass":
+        # Never an unqualified "PASSES": PBO and the look-ahead audit cannot
+        # run on a bare returns series, so this is not the passport gate.
+        click.echo("PASSES (capped — PBO and look-ahead cannot be evaluated on a returns series)")
+    elif verdict == "incomplete":
+        click.echo("INCOMPLETE — not every runnable leg could be evaluated; this is not a verdict")
+    else:
+        click.echo("FAILS")
 
 
 @main.command()
@@ -483,7 +526,10 @@ def verify(returns_csv: str, run_local: bool, trials: int, api_url: str | None, 
         click.echo(json.dumps({"ok": True, **body}))
     else:
         _render_verify(body)
-    sys.exit(exits.OK if body.get("passes") else exits.GATE_FAILED)
+    # Not a bare `passes` read (#1481): an incomplete evaluation exits with its
+    # own code so a CI job cannot read "too few bars" as "strategy rejected".
+    _verdict = _verify_verdict(body)
+    sys.exit(exits.OK if _verdict == "pass" else exits.GATE_FAILED if _verdict == "fail" else exits.INCOMPLETE)
 
 
 @main.command()

--- a/cli/src/archimedes_cli/exits.py
+++ b/cli/src/archimedes_cli/exits.py
@@ -30,9 +30,19 @@ real answer about a strategy the way ``GATE_FAILED`` is. Kept as a separate name
 than spelling ``USAGE`` at every auth call site) purely so the reason is legible in the
 code that raises it."""
 
+INCOMPLETE = 4
+"""``verify`` reached the server and got an answer, but not every runnable leg of
+the gate could be evaluated — typically too few bars for the walk-forward OOS
+split (~70) while DSR only needs 4.
+
+A new code rather than ``GATE_FAILED`` on purpose, per this module's own split:
+an incomplete evaluation is not a verdict about the strategy, so collapsing it
+into 1 would report "not enough data" as "strategy rejected" — precisely the
+confusion the header warns about. See #1481."""
+
 NOT_IMPLEMENTED = 3
 """The subcommand exists in the command tree but has no implementation in this
 release. 0.0.1 returned this for every subcommand; 0.1.0 narrows it to ``backtest``
 and ``verify --local``, which still need the not-yet-published local execution engine."""
 
-__all__ = ["AUTH", "GATE_FAILED", "NOT_IMPLEMENTED", "OK", "USAGE"]
+__all__ = ["AUTH", "GATE_FAILED", "INCOMPLETE", "NOT_IMPLEMENTED", "OK", "USAGE"]

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -23,7 +23,7 @@ import httpx
 import pytest
 from archimedes_cli import __version__
 from archimedes_cli.cli import main
-from archimedes_cli.exits import AUTH, GATE_FAILED, NOT_IMPLEMENTED, OK, USAGE
+from archimedes_cli.exits import AUTH, GATE_FAILED, INCOMPLETE, NOT_IMPLEMENTED, OK, USAGE
 from archimedes_cli.session import SESSION_COOKIE_NAME, save_session, session_path
 from click.testing import CliRunner
 
@@ -122,6 +122,12 @@ _VERIFY_PASS_BODY = {
     "trials": 1,
     "self_attested": True,
     "n_bars": 300,
+    # #1481: the server qualifies `passes` with the quorum it was computed over.
+    "legs_evaluated": 2,
+    "legs_runnable": 2,
+    "legs_total": 4,
+    "legs_not_run": ["pbo", "look_ahead"],
+    "verdict_capped": True,
     "dsr": {
         "status": "pass",
         "reason": "self-attested trials=1: DSR p-value 0.9997 >= floor 0.50 (Newey-West HAC standard error)",
@@ -149,6 +155,11 @@ _VERIFY_FAIL_BODY = {
     "trials": 1,
     "self_attested": True,
     "n_bars": 300,
+    "legs_evaluated": 2,
+    "legs_runnable": 2,
+    "legs_total": 4,
+    "legs_not_run": ["pbo", "look_ahead"],
+    "verdict_capped": True,
     "dsr": {
         "status": "fail",
         "reason": "self-attested trials=1: DSR p-value 0.0002 < floor 0.50 (Newey-West HAC standard error)",
@@ -170,6 +181,11 @@ _VERIFY_NOT_EVALUABLE_BODY = {
     "trials": 1,
     "self_attested": True,
     "n_bars": 3,
+    "legs_evaluated": 0,
+    "legs_runnable": 2,
+    "legs_total": 4,
+    "legs_not_run": ["dsr", "pbo", "oos_consistency", "look_ahead"],
+    "verdict_capped": True,
     "dsr": {"status": "not_evaluable", "reason": "return series too short or degenerate for DSR (need >= 4 bars)"},
     "pbo": {"status": "not_evaluable", "reason": "PBO requires a trial matrix."},
     "oos_consistency": {"status": "not_evaluable", "reason": "insufficient data for a walk-forward OOS split"},
@@ -482,7 +498,10 @@ class TestVerify:
         assert "[PASS] OOS consistency" in result.stdout
         assert "[N/A] PBO" in result.stdout
         assert "[N/A] Look-ahead" in result.stdout
-        assert "PASSES" in result.stdout
+        # Never an unqualified "PASSES" (#1481): two of the four gate legs cannot
+        # run on a bare returns series, so the verdict is reported as capped.
+        assert "PASSES (capped" in result.stdout
+        assert "legs evaluated: 2/2 runnable here of 4 in the full gate" in result.stdout
 
     def test_json_on_a_lookahead_free_strong_oos_series_exits_0(self, runner, monkeypatch):
         """The issue's literal acceptance check, second half: `--json` on a series with
@@ -511,18 +530,65 @@ class TestVerify:
         assert payload["pbo"]["status"] == "not_evaluable"  # issue's literal acceptance check
 
     def test_not_evaluable_rendering_when_nothing_could_run(self, runner, monkeypatch):
-        """The honesty-contract case from the issue's acceptance criteria: every check
-        not_evaluable must render as such (never a silent pass) and still exit 1."""
+        """Every check not_evaluable must render as such (never a silent pass).
+
+        Exit code changed deliberately in #1481: this used to exit GATE_FAILED(1).
+        But `exits.py` reserves 1 for "the gate ran and the answer was no" — a real
+        verdict about the strategy — and a 3-bar series produced no verdict at all.
+        Collapsing it into 1 reported "too few bars" as "strategy rejected", which
+        is the exact confusion that module's docstring warns against. It now exits
+        INCOMPLETE(4)."""
         _seed_session()
         _install_transport(
             monkeypatch, _route({("POST", "/api/rigor/verify"): httpx.Response(200, json=_VERIFY_NOT_EVALUABLE_BODY)})
         )
         result = runner.invoke(main, ["verify", "returns.csv"])
-        assert result.exit_code == GATE_FAILED
+        assert result.exit_code == INCOMPLETE
         assert result.stdout.count("[N/A]") == 4
         assert "[PASS]" not in result.stdout
         assert "[FAIL]" not in result.stdout
-        assert "FAILS" in result.stdout
+        assert "INCOMPLETE" in result.stdout
+        assert "PASSES" not in result.stdout
+
+    def test_partially_evaluated_series_exits_incomplete_not_ok(self, runner, monkeypatch):
+        """#1481 REGRESSION, CLI half. A 4-bar series where DSR passed but the OOS
+        split could not run is one leg of four — `archimedes verify && deploy` used
+        to succeed on it. It must not exit OK, and must not print PASSES."""
+        _seed_session()
+        body = {
+            **_VERIFY_PASS_BODY,
+            "passes": False,
+            "n_bars": 4,
+            "legs_evaluated": 1,
+            "legs_runnable": 2,
+            "legs_not_run": ["pbo", "oos_consistency", "look_ahead"],
+            "oos_consistency": {
+                "status": "not_evaluable",
+                "reason": "insufficient data for a walk-forward OOS split",
+            },
+        }
+        _install_transport(monkeypatch, _route({("POST", "/api/rigor/verify"): httpx.Response(200, json=body)}))
+        result = runner.invoke(main, ["verify", "returns.csv"])
+        assert result.exit_code == INCOMPLETE
+        assert "PASSES" not in result.stdout
+        assert "INCOMPLETE" in result.stdout
+
+    def test_server_without_quorum_fields_fails_closed(self, runner, monkeypatch):
+        """Defence in depth: `--api-url` can point at a host predating the #1481 fix,
+        which returns `passes: true` on a partial evaluation and carries no `legs_*`
+        fields at all. An unreported quorum is an unproven one, so the CLI must not
+        exit OK on it — it re-derives the quorum from the leg statuses and fails
+        closed."""
+        _seed_session()
+        legacy = {k: v for k, v in _VERIFY_PASS_BODY.items() if not k.startswith("legs_")}
+        legacy.pop("verdict_capped", None)
+        legacy["passes"] = True
+        legacy["n_bars"] = 4
+        legacy["oos_consistency"] = {"status": "not_evaluable", "reason": "too short"}
+        _install_transport(monkeypatch, _route({("POST", "/api/rigor/verify"): httpx.Response(200, json=legacy)}))
+        result = runner.invoke(main, ["verify", "returns.csv"])
+        assert result.exit_code == INCOMPLETE
+        assert "PASSES" not in result.stdout
 
     def test_trials_option_is_sent_to_the_api(self, runner, monkeypatch):
         _seed_session()

--- a/ui/public/.well-known/agent.json
+++ b/ui/public/.well-known/agent.json
@@ -90,7 +90,7 @@
       "routes": {
         "verify": "POST /api/rigor/verify"
       },
-      "note": "Runs the gate's admission checks over a bare returns series you submit. DSR and walk-forward OOS are evaluable; PBO and the look-ahead audit report not_evaluable rather than a silent pass. Backs the CLI's `verify`. Rate limited 5/minute."
+      "note": "Runs the gate's admission checks over a bare returns series you submit. DSR and walk-forward OOS are evaluable; PBO and the look-ahead audit report not_evaluable rather than a silent pass. `passes` is a QUORUM over the two runnable legs -- true only when DSR and OOS both ran and passed -- and because PBO and look-ahead can never run here the verdict is CAPPED, not equivalent to the strategy passport gate. Read legs_evaluated / legs_runnable / legs_total / verdict_capped alongside it. Backs the CLI's `verify`. Rate limited 5/minute."
     },
     "paper": {
       "status": "live",

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -46,6 +46,10 @@ operations. Circle wallet passkeys control Circle wallets; they do not log in to
   submit: `{ "returns": [{ "date": "...", "daily_return": ... }], "trials": N }`. Rate
   limited `5/minute`. DSR and walk-forward OOS are evaluable; PBO and look-ahead audit
   always report `not_evaluable` — bare series carries no selection set and no code.
+  `passes` is a QUORUM over the two runnable legs: true only when DSR and OOS both ran
+  and passed. Since PBO and look-ahead can never run here the verdict is CAPPED and is
+  not the strategy passport's gate. Read `legs_evaluated` / `legs_runnable` /
+  `legs_total` / `verdict_capped` alongside it; `passes` alone overstates the evidence.
   `passes` is true only when at least one check was evaluable and none failed.
 
 ## Optional wallet link (EIP-4361)


### PR DESCRIPTION
Closes #1481.

## The defect

`passes` was computed over whichever legs turned out to be *evaluable*, and two of the four legs are hard-coded `not_evaluable` on every request. DSR becomes evaluable at 4 bars; the walk-forward OOS split needs ~70. So for roughly `4 <= n_bars < 70` exactly one leg could run:

```
:203  evaluable = [s for s in statuses if s != "not_evaluable"]
:204  passes = bool(evaluable) and all(s == "pass" for s in evaluable)
```

A DSR p-value >= 0.50 on a 4-bar series returned `passes: true` with three legs `not_evaluable`, and `archimedes verify short.csv && deploy` exited 0 on it.

Measured at `baa173a6`, 4 bars / seed 7: `dsr_p = 0.6494 >= DSR_P_FLOOR (0.50)` -> DSR pass, `compute_oos_sharpe -> None`.

The body was already honest; the **scalar and the exit code** were not. The zero-evaluable case was guarded ("vacuous truth is not honesty") — it stopped one case short.

## The fix

`passes` requires **every runnable leg** (DSR + OOS consistency) to have run and passed. Response gains `legs_evaluated` / `legs_runnable` / `legs_total` / `legs_not_run` / `verdict_capped`, so the scalar is qualifiable without re-deriving leg statuses.

`verdict_capped` is always `true` here — PBO needs a selection set, look-ahead needs inspectable source, neither can ever run on a bare series. This endpoint cannot stand in for the passport gate and now says so.

**Why not reuse `verdict_from_returns`** (the issue's recommended option): with `strategy_code=None` the always-on look-ahead floor fails at every strictness level, so the endpoint could never pass at all. That is cluster-8's look-ahead item, and its stated answer is the one taken here — report the leg NOT_RUN and cap the verdict. Landing it here settles that decision rather than deferring it.

## CLI

- `exits.INCOMPLETE = 4`. A new code, not `GATE_FAILED`, per that module's own rule: 1 means the gate ran and the answer was no — a real verdict. Reporting "too few bars" as "strategy rejected" is the confusion its docstring warns about.
- `_verify_verdict` never trusts `passes` alone. `--api-url` can point at a host predating this fix, which returns `passes: true` with no `legs_*` fields; an unreported quorum is re-derived from leg statuses and **fails closed**.
- The terminal word names the cap instead of printing a bare `PASSES`.

**Behaviour change worth flagging:** the all-`not_evaluable` case used to exit 1 / print `FAILS`. It now exits 4 / prints `INCOMPLETE`. A 3-bar series produced no verdict, so 1 was the wrong code.

## Claim surfaces

The endpoint is advertised to agents in three places (`agent_manifest_routes.py`, `llms.txt`, `.well-known/agent.json`). All three described the legs honestly but not that `passes` is capped. Fixed — an agent reading the scalar alone was getting an unqualified "cleared the rigor gate."

## Verification

```
pytest backend/tests/test_rigor_verify_routes.py -q   ->  12 passed
cd cli && pytest tests/ -q                            ->  45 passed
pytest backend/tests/test_agent_manifest.py -q        ->  passed
grep -n "exits.OK if body.get" cli/src/archimedes_cli/cli.py  ->  empty
```

**The guard is demonstrated, not asserted.** Reverting only the `passes` line and re-running gives:

```
FAILED test_four_bar_series_with_passing_dsr_does_not_pass - assert True is False
1 failed, 11 passed
```

The regression test also asserts its own precondition (`dsr.status == "pass"`), so it cannot go green for the wrong reason if the DSR math shifts.

Baseline on `main` @ `baa173a6` measured in a pristine worktree before starting: **3688 passed, 2 skipped, 0 failed**.

## Anti-goals respected

No threshold moved. No second minimum-length constant. `verdict_from_returns` untouched. No new deps. Existing exit codes not redefined.