### PR TITLE
[backtest] Make the DSL row describe the run that happened (A4, A8)

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -483,6 +483,13 @@ def _rigor_verdict_dict(ev: Any) -> dict[str, Any]:
         "calmar_ratio": bt.calmar_ratio,
         "win_rate": bt.win_rate,
         "total_trades": bt.total_trades,
+        # A8: which runner produced this row and how it combined assets. The
+        # sleeve runner grades N independent single-asset backtests and
+        # equal-weights them, so a multi-asset spec is NOT a cross-sectionally
+        # allocated portfolio. Carried here rather than re-derived downstream —
+        # the runner is the only place that knows.
+        "backtest_engine": getattr(bt, "backtest_engine", None),
+        "portfolio_construction": getattr(bt, "portfolio_construction", None),
     }
 
 

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1594,7 +1594,7 @@ async def _persist_real_returns(c: _CandidateResult, strategy_id: str, emit: _Em
             SOURCE_PIPELINE_DSL_FUSION,
             insert_backtest_if_missing,
         )
-        from archimedes.services.fusion_evaluator import DEFAULT_COST_MODEL_ID
+        from archimedes.services.fusion_evaluator import DEFAULT_COST_MODEL_ID, ENGINE_SINGLE_FEED
         from archimedes.services.live_rigor_gate import verdict_from_returns
 
         returns = list(c.return_series)
@@ -1635,7 +1635,12 @@ async def _persist_real_returns(c: _CandidateResult, strategy_id: str, emit: _Em
             pbo_score=_of("pbo"),
             out_of_sample_sharpe=_of("oos_sharpe"),
             look_ahead_audit_passed=bool(rv.get("lookahead_audit_passed", False)),
-            backtest_engine="dsl-fusion",
+            # A8: the runner's own label, not a hardcoded "dsl-fusion". The
+            # sleeve runner reports "dsl-fusion-sleeves" so a row graded as N
+            # independent equal-weighted single-asset backtests is
+            # distinguishable from a genuine single-feed run. Falls back to the
+            # single-feed label for verdict blobs written before A8.
+            backtest_engine=(rv.get("backtest_engine") or ENGINE_SINGLE_FEED),
             # Fixed cost basis every fusion/DSL backtest is charged — tx_cost_bps
             # and slippage_bps are never overridden by a caller on this path today
             # (see fusion_evaluator.DEFAULT_COST_MODEL_ID). Matches the mapper's

--- a/backend/archimedes/services/_fusion_helpers.py
+++ b/backend/archimedes/services/_fusion_helpers.py
@@ -264,9 +264,31 @@ def _build_analyzers():
     class _EquityCurve(bt.Analyzer):
         def start(self):
             self._values: list[float] = []
+            # First/last bar dates of the feed actually consumed by this run.
+            # Captured here rather than passed in: the caller's notion of the
+            # requested window and the bars backtrader really iterated can
+            # differ (short feeds, warmup trimming), and the persisted row has
+            # to describe the run that happened. See fusion_evaluator's
+            # backtest_start/backtest_end stamping.
+            self._first_date = None
+            self._last_date = None
 
         def next(self):
             self._values.append(float(self.strategy.broker.getvalue()))
+            bar_date = self._current_bar_date()
+            if bar_date is not None:
+                if self._first_date is None:
+                    self._first_date = bar_date
+                self._last_date = bar_date
+
+        def _current_bar_date(self):
+            try:
+                return self.strategy.datas[0].datetime.date(0)
+            except (AttributeError, IndexError, ValueError, TypeError):
+                # A feed without a usable datetime line yields no date rather
+                # than aborting the run; the caller then persists None, which
+                # is the honest answer.
+                return None
 
         def stop(self):
             # Capture the final value once after the last bar so the curve
@@ -276,7 +298,11 @@ def _build_analyzers():
                 self._values.append(final)
 
         def get_analysis(self):
-            return {"values": list(self._values)}
+            return {
+                "values": list(self._values),
+                "first_bar_date": self._first_date,
+                "last_bar_date": self._last_date,
+            }
 
     class _TradeStats(bt.Analyzer):
         """Trade-level stats: total trades, win rate, average holding period."""

--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -54,6 +54,16 @@ _PBO_S_PARTITIONS = 16
 # ── Result types ──────────────────────────────────────────────────────
 
 
+# Engine / construction labels stamped on every row this module produces (A8).
+# `backtest_engine` is an existing persisted column, so distinguishing the two
+# runners here is what surfaces the sleeve limitation on the passport without a
+# schema change.
+ENGINE_SINGLE_FEED = "dsl-fusion"
+ENGINE_SLEEVES = "dsl-fusion-sleeves"
+CONSTRUCTION_SINGLE_ASSET = "single_asset"
+CONSTRUCTION_SLEEVES = "n_independent_sleeves_equal_weight"
+
+
 @dataclass(frozen=True)
 class BacktestMetrics:
     """Metrics from a DSL-interpreted strategy backtest."""
@@ -74,6 +84,16 @@ class BacktestMetrics:
     # means random.gauss noise (dev/test only); "csv:<name>" / "provided" mean
     # real OHLCV. Rigor metrics from a "synthetic" run are NOT admissible.
     data_source: str = "synthetic"
+    # WHICH runner produced these numbers, and how it combined assets (A8).
+    # `run_dsl_backtest_portfolio` runs the same single-asset spec once per
+    # asset on initial_cash/N and sums the sleeves, so an "inverse-vol 5-asset"
+    # strategy is really five independent 100%-long single-asset backtests,
+    # equal-weighted — there is no cross-sectional allocation step and no
+    # rebalance between sleeves. Stamping it is what makes that a disclosed
+    # limitation instead of a silent one; the multi-feed interpreter that would
+    # remove the limitation is deliberately out of scope.
+    backtest_engine: str = ENGINE_SINGLE_FEED
+    portfolio_construction: str = CONSTRUCTION_SINGLE_ASSET
 
 
 @dataclass(frozen=True)
@@ -243,9 +263,17 @@ def run_dsl_backtest(
 
     strat = results[0] if results else None
     equity_curve: list[float]
+    bar_start: date | None = None
+    bar_end: date | None = None
     if strat is not None:
         ec = strat.analyzers.equity_curve.get_analysis()
         equity_curve = list(ec.get("values", [])) or [initial_cash]
+        # Real first/last bar of the feed this run actually consumed. Was a
+        # pair of sentinels keyed on a variable reassigned above, so the
+        # condition was dead and every DSL row persisted a null (or, on the
+        # variant path, a fabricated 2004-01-02) window.
+        bar_start = ec.get("first_bar_date")
+        bar_end = ec.get("last_bar_date")
     else:
         equity_curve = [initial_cash]
 
@@ -291,8 +319,8 @@ def run_dsl_backtest(
         ),
         equity_curve=[round(e, 2) for e in equity_curve],
         monthly_returns=[round(m, 4) for m in monthly_returns],
-        backtest_start=date(2004, 1, 2) if data_feed is None else None,
-        backtest_end=date(2026, 4, 30) if data_feed is None else None,
+        backtest_start=bar_start,
+        backtest_end=bar_end,
         data_source=data_source,
     )
 
@@ -403,9 +431,17 @@ def _run_variant_backtest(
 
     strat = results[0] if results else None
     equity_curve: list[float]
+    bar_start: date | None = None
+    bar_end: date | None = None
     if strat is not None:
         ec = strat.analyzers.equity_curve.get_analysis()
         equity_curve = list(ec.get("values", [])) or [initial_cash]
+        # Real first/last bar of the feed this run actually consumed. Was a
+        # pair of sentinels keyed on a variable reassigned above, so the
+        # condition was dead and every DSL row persisted a null (or, on the
+        # variant path, a fabricated 2004-01-02) window.
+        bar_start = ec.get("first_bar_date")
+        bar_end = ec.get("last_bar_date")
     else:
         equity_curve = [initial_cash]
 
@@ -450,8 +486,8 @@ def _run_variant_backtest(
         ),
         equity_curve=[round(e, 2) for e in equity_curve],
         monthly_returns=[round(m, 4) for m in monthly_returns],
-        backtest_start=date(2004, 1, 2) if data_csv_path is None else None,
-        backtest_end=date(2026, 4, 30) if data_csv_path is None else None,
+        backtest_start=bar_start,
+        backtest_end=bar_end,
         data_source=data_source,
     )
 
@@ -525,6 +561,8 @@ def _aggregate_portfolio_metrics(
         backtest_start=backtest_start,
         backtest_end=backtest_end,
         data_source=label,
+        backtest_engine=ENGINE_SLEEVES,
+        portfolio_construction=CONSTRUCTION_SLEEVES,
     )
 
 

--- a/backend/tests/services/test_fusion_evaluator.py
+++ b/backend/tests/services/test_fusion_evaluator.py
@@ -15,14 +15,21 @@ separate piece of work).
 from __future__ import annotations
 
 import random
+from datetime import date
 from pathlib import Path
 
 from archimedes.services.fusion_evaluator import (
+    CONSTRUCTION_SINGLE_ASSET,
+    CONSTRUCTION_SLEEVES,
+    ENGINE_SINGLE_FEED,
+    ENGINE_SLEEVES,
     BacktestMetrics,
+    _run_variant_backtest,
     apply_rigor_gate,
     evaluate_fusion_spec,
     is_admissible_source,
     run_dsl_backtest,
+    run_dsl_backtest_portfolio,
 )
 from archimedes.services.strategy_dsl import FABER_2007_SPEC, validate_strategy_spec
 
@@ -594,3 +601,104 @@ class TestFusionGateUsesRealTrialCount:
         variants = {f"v{i}": _metrics_from_curve(base) for i in range(30)}
         verdict = apply_rigor_gate(base_metrics, num_trials=10, variants_metrics=variants)
         assert verdict.num_trials == 30
+
+
+# ── A8 / A4: the persisted DSL row must describe the run that happened ──
+
+
+class TestBacktestWindowIsReal:
+    """`backtest_start`/`backtest_end` came from two dead sentinel conditions.
+
+    In ``run_dsl_backtest`` the sentinel keyed on ``data_feed is None``, but
+    ``data_feed`` is unconditionally assigned a few lines above, so it was never
+    None and EVERY DSL row persisted a null window — un-auditable. In
+    ``_run_variant_backtest`` the sentinel keyed on ``data_csv_path is None``,
+    which IS reachable, so a run over a real feed factory persisted a fabricated
+    2004-01-02 -> 2026-04-30 window instead.
+
+    The dates now come from the bars backtrader actually iterated, so they can be
+    checked against the feed. The fixture spans 2004-01-02..2026-02-06 — note the
+    old sentinel's end date (2026-04-30) was not even the file's last bar.
+    """
+
+    _TRUE_FIRST_BAR = date(2004, 1, 2)
+    _TRUE_LAST_BAR = date(2026, 2, 6)
+    _FABRICATED_END = date(2026, 4, 30)
+
+    def _factory(self):
+        from archimedes.services._fusion_helpers import _csv_data_feed
+
+        return lambda: _csv_data_feed(_SPY_FIXTURE)
+
+    def test_single_feed_run_reports_the_real_window(self):
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = run_dsl_backtest(spec, data_csv_path=_SPY_FIXTURE)
+
+        # Previously None on this path, for every DSL row ever written.
+        assert metrics.backtest_start == self._TRUE_FIRST_BAR
+        assert metrics.backtest_end == self._TRUE_LAST_BAR
+
+    def test_variant_run_over_a_real_feed_does_not_fabricate_a_window(self):
+        """The worse half of the bug: real data, invented dates."""
+        from archimedes.services.dsl_to_backtrader import interpret_spec
+
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = _run_variant_backtest(
+            interpret_spec(spec),
+            data_feed_factory=self._factory(),
+            data_source_label="csv:spy_ohlcv_2004_2026.csv",
+        )
+
+        assert metrics.backtest_end != self._FABRICATED_END
+        assert metrics.backtest_start == self._TRUE_FIRST_BAR
+        assert metrics.backtest_end == self._TRUE_LAST_BAR
+
+
+class TestSleeveConstructionIsLabelled:
+    """A8. ``run_dsl_backtest_portfolio`` runs the same single-asset spec once per
+    asset on ``initial_cash/N`` and sums the sleeves — there is no
+    cross-sectional allocation and no rebalance between them. The multi-feed
+    interpreter that would fix that is out of scope; labelling the row is what
+    turns a silent lie into a disclosed limitation."""
+
+    def _factory(self):
+        from archimedes.services._fusion_helpers import _csv_data_feed
+
+        return lambda: _csv_data_feed(_SPY_FIXTURE)
+
+    def test_single_feed_rows_are_labelled_single_asset(self):
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = run_dsl_backtest(spec, data_csv_path=_SPY_FIXTURE)
+        assert metrics.backtest_engine == ENGINE_SINGLE_FEED == "dsl-fusion"
+        assert metrics.portfolio_construction == CONSTRUCTION_SINGLE_ASSET == "single_asset"
+
+    def test_sleeve_rows_are_labelled_as_independent_sleeves(self):
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = run_dsl_backtest_portfolio(
+            spec,
+            {"SPY": self._factory(), "SPY2": self._factory()},
+            label="csv:spy_ohlcv_2004_2026.csv",
+        )
+        # The label must distinguish this from a genuine single-feed run, so a
+        # reader of the passport can tell the two apart.
+        assert metrics.backtest_engine == ENGINE_SLEEVES == "dsl-fusion-sleeves"
+        assert metrics.backtest_engine != ENGINE_SINGLE_FEED
+        assert metrics.portfolio_construction == CONSTRUCTION_SLEEVES == "n_independent_sleeves_equal_weight"
+
+    def test_the_label_reaches_the_canonical_rigor_verdict_dict(self):
+        """The label is useless if it dies at the debate/pipeline boundary — that
+        boundary is exactly where `backtest_engine` used to be hardcoded."""
+        from archimedes.agents.debate_engine import _rigor_verdict_dict
+
+        spec = validate_strategy_spec(FABER_2007_SPEC)
+        metrics = run_dsl_backtest_portfolio(
+            spec,
+            {"SPY": self._factory(), "SPY2": self._factory()},
+            label="csv:spy_ohlcv_2004_2026.csv",
+        )
+        ev = evaluate_fusion_spec(FABER_2007_SPEC)
+        ev = ev.__class__(spec=ev.spec, backtest=metrics, rigor=ev.rigor)
+
+        verdict = _rigor_verdict_dict(ev)
+        assert verdict["backtest_engine"] == "dsl-fusion-sleeves"
+        assert verdict["portfolio_construction"] == "n_independent_sleeves_equal_weight"


### PR DESCRIPTION
Two sprint items from `docs/sprint/cluster-2-fusion-engine.md`: A4 (the dead date condition) and A8 (the sleeve label). Both are about the persisted DSL row misdescribing its own run.

## A4 — the window came from two dead sentinels

`run_dsl_backtest:294` stamped `backtest_start=date(2004,1,2) if data_feed is None else None`. `data_feed` is unconditionally assigned ~70 lines above (`:223-226`), so it was never `None` and **every DSL row persisted a null window**. A row with no window can't be audited — you can't say what period produced the numbers.

`_run_variant_backtest:453` keyed its sentinel on `data_csv_path is None`, which **is** reachable: a run over a real feed factory (the live path) passes no CSV path, so it stamped a **fabricated `2004-01-02 → 2026-04-30` window over real data**. That's the worse half, and the card didn't have it.

Detail worth noting: the fixture those dates were cribbed from (`spy_ohlcv_2004_2026.csv`) actually spans `2004-01-02..2026-02-06`. The fabricated end date wasn't even correct for the file it came from.

Both sites now report the first and last bar backtrader actually iterated, captured in `_EquityCurveAnalyzer` — which already walks every bar, so this costs nothing. **Captured, not passed in:** the caller's requested window and the bars really iterated can differ (short feeds, warmup), and the row must describe the run rather than the intent.

## A8 — sleeve construction was silent

`run_dsl_backtest_portfolio` runs the same single-asset spec once per asset on `initial_cash/N` and sums the sleeves. No cross-sectional allocation, no rebalance between sleeves — so an "inverse-vol 5-asset" strategy is really five independent 100%-long single-asset backtests, equal-weighted. That's the pattern #1203 ripped out of Engine A as wrong. Every such row persisted `backtest_engine="dsl-fusion"`, indistinguishable from a real single-feed run.

The multi-feed interpreter is **cut** (card anti-goal). What ships is the label:

| Runner | `backtest_engine` | `portfolio_construction` |
|---|---|---|
| `run_dsl_backtest` / `_run_variant_backtest` | `dsl-fusion` | `single_asset` |
| `run_dsl_backtest_portfolio` | `dsl-fusion-sleeves` | `n_independent_sleeves_equal_weight` |

**Scope call:** `backtest_engine` is an existing persisted column that already reaches `api/schemas.py:242`, so the sleeve fact reaches the passport **with no migration**. `portfolio_construction` rides in the `rigor_verdict` blob rather than becoming a column — that column is on cluster-3's A2-full deferred list and stays there. Flagging it since the card's wording implies a column.

`generation_pipeline:1638` stops hardcoding `backtest_engine="dsl-fusion"` and reads the runner's own label (falling back to the single-feed label for verdict blobs written before this). `debate_engine._rigor_verdict_dict` carries both fields across the exact boundary the hardcode sat on.

## Verification

```
pytest backend/tests/services/test_fusion_evaluator.py -q   ->  31 passed
pytest backend/tests/test_cost_parity.py -q                 ->  passed (Engine C floor intact)
pytest -m "not integration" -q                              ->  3693 passed, 0 failed
```

Baseline on `main` @ `baa173a6`, measured in a pristine worktree before starting: **3688 passed**. +5 = the five tests added here.

**Guards demonstrated, not asserted.** Reverting both sentinels and the sleeve labels and re-running:

```
4 failed, 27 passed
```

The window tests assert against the fixture's true first/last bar (read from the CSV) rather than a restated constant, so they can't pass by echoing the code. One test covers the label surviving the debate→pipeline boundary, since a label that dies at that boundary is worthless.

## Anti-goals respected

No multi-feed interpreter. No threshold moved. `_MAX_ASSETS` untouched. `strategy_dsl.py` validation and `debate_engine._dsl_conformance_ok` untouched. No migration, no new column, no new deps.