### PR TITLE
[payments] Hold back Circle's fee when sweeping a Gateway balance (#1486)

### DIFF
--- a/backend/archimedes/marketplace/config.py
+++ b/backend/archimedes/marketplace/config.py
@@ -4,7 +4,13 @@ Single source of truth for chain-name defaults so that payment charging,
 Gateway withdrawal, and settlement all read from the same constant.
 """
 
+from __future__ import annotations
+
+import logging
 import os
+from decimal import Decimal
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_GATEWAY_CHAIN = "arcTestnet"
 
@@ -28,3 +34,77 @@ def gateway_chain() -> str:
     chain is to ask for it.
     """
     return os.getenv("GATEWAY_CHAIN", DEFAULT_GATEWAY_CHAIN).strip()
+
+
+_USDC = Decimal(10) ** 6
+
+# Circle's Gateway withdrawal fee is charged ON TOP of the burn amount, not
+# deducted from it. Asking to withdraw the entire available balance therefore
+# always fails — observed in prod 2026-08-26 sweeping the revenue DCW:
+#
+#   POST /v1/transfer -> 400
+#   "Insufficient balance for depositor 0xffa7abba...56c1:
+#    available 36.000000, required 36.0035"
+#
+# So a full sweep must hold back at least the fee (0.0035 USDC on that
+# withdrawal). We reserve 0.05 — ~14x observed headroom, and still under two
+# thousandths of a $36 sweep — and pass the same number as the burn intent's
+# ``maxFee``. That second half matters: circlekit's default maxFee is
+# 2_010_000 (2.01 USDC), so an unbounded withdrawal authorises Circle to take
+# a 5.6% haircut off a $36 sweep without complaint. Bounding it means an
+# unexpectedly large fee fails loudly instead of being paid silently.
+DEFAULT_GATEWAY_FEE_RESERVE_USDC = "0.05"
+
+
+def gateway_fee_reserve_raw() -> int:
+    """Raw 6-decimal USDC held back from a Gateway withdrawal to cover Circle's
+    fee. Override via ``GATEWAY_WITHDRAW_FEE_RESERVE_USDC`` if Circle's fee
+    schedule moves; a bad value falls back to the default rather than risking
+    a zero reserve (which is the bug this exists to prevent)."""
+    raw = os.getenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", "").strip()
+    if not raw:
+        raw = DEFAULT_GATEWAY_FEE_RESERVE_USDC
+    try:
+        value = Decimal(raw)
+    except Exception:
+        logger.warning(
+            "invalid GATEWAY_WITHDRAW_FEE_RESERVE_USDC=%r — using %s",
+            raw,
+            DEFAULT_GATEWAY_FEE_RESERVE_USDC,
+        )
+        value = Decimal(DEFAULT_GATEWAY_FEE_RESERVE_USDC)
+    if value <= 0:
+        logger.warning(
+            "GATEWAY_WITHDRAW_FEE_RESERVE_USDC=%r is not positive — using %s "
+            "(a zero reserve makes every full sweep fail)",
+            raw,
+            DEFAULT_GATEWAY_FEE_RESERVE_USDC,
+        )
+        value = Decimal(DEFAULT_GATEWAY_FEE_RESERVE_USDC)
+    return int(value * _USDC)
+
+
+def format_usdc(raw: int) -> str:
+    """Raw 6-decimal USDC → the fixed-point decimal string circlekit parses."""
+    return f"{Decimal(raw) / _USDC:.6f}"
+
+
+def gateway_sweep_amount(available_raw: int) -> tuple[str, int]:
+    """Plan a full sweep of ``available_raw``.
+
+    Returns ``(amount, fee_reserve_raw)`` where ``amount`` is the decimal
+    string to pass to ``GatewayClient.withdraw`` and ``fee_reserve_raw`` is
+    the ``max_fee`` to pass alongside it. ``amount + fee <= available`` holds
+    for any fee at or under the reserve, which is what Circle actually checks.
+
+    Raises ``ValueError`` when the balance cannot cover the reserve — callers
+    treat that as "nothing to sweep", never as an amount to clamp to zero.
+    """
+    reserve = gateway_fee_reserve_raw()
+    amount_raw = available_raw - reserve
+    if amount_raw <= 0:
+        raise ValueError(
+            f"available {format_usdc(available_raw)} USDC does not cover the "
+            f"{format_usdc(reserve)} withdrawal fee reserve"
+        )
+    return format_usdc(amount_raw), reserve

--- a/backend/archimedes/marketplace/settlement.py
+++ b/backend/archimedes/marketplace/settlement.py
@@ -1,7 +1,9 @@
 """Settlement sweep: Gateway balance → agent wallet → PaymentSplitter.depositToPool → withdraw.
 
 Three cadences:
-  Stage A — Gateway → wallet (threshold-based, ~2.01 USDC fee per withdrawal).
+  Stage A — Gateway → wallet (threshold-based; Circle's fee is charged on top
+            of the burn amount, so the request holds back a reserve — see
+            ``marketplace.config``).
   Stage B — wallet USDC → depositToPool (per tick interval, 1 USDC min).
   Stage C — PaymentSplitter.withdraw(pool_id, amount) — creator/platform payout.
 
@@ -21,14 +23,18 @@ from decimal import Decimal
 from circlekit.client import GatewayClient
 from circlekit.wallets import CircleTxExecutor, CircleWalletSigner
 
-from archimedes.marketplace.config import gateway_chain
+from archimedes.marketplace.config import (
+    format_usdc,
+    gateway_chain,
+    gateway_sweep_amount,
+)
 
 logger = logging.getLogger(__name__)
 
 # Config
 SWEEP_WITHDRAW_THRESHOLD_USDC = os.getenv(
     "SWEEP_WITHDRAW_THRESHOLD_USDC",
-    "10.0",  # must exceed several multiples of the ~2.01 USDC withdrawal fee
+    "10.0",  # enough that a withdrawal is worth its own transaction
 )
 SWEEP_MIN_DEPOSIT_RAW = int(os.getenv("SWEEP_MIN_DEPOSIT_RAW", "1000000"))  # 1 USDC, raw 6-dec
 GATEWAY_CHAIN = gateway_chain()
@@ -123,12 +129,22 @@ class SettlementSweeper:
                 )
                 return
 
-            amount = balances.formatted_available  # decimal string e.g. "12.50"
-            result = await client.withdraw(amount=amount)
+            # NOT the whole balance: Circle charges its withdrawal fee on top
+            # of the burn amount, so requesting all of it is always rejected
+            # with "available X, required X+fee" (see marketplace.config).
+            try:
+                amount, fee_reserve_raw = gateway_sweep_amount(balances.available)
+            except ValueError as exc:
+                logger.info("[%s] Stage A: %s — skip withdraw", pub.strategy_id, exc)
+                return
+
+            result = await client.withdraw(amount=amount, max_fee=fee_reserve_raw)
             logger.info(
-                "[%s] Stage A: withdrew %s USDC from Gateway → wallet; tx=%s",
+                "[%s] Stage A: withdrew %s of %s USDC available (%s held for fee) from Gateway → wallet; tx=%s",
                 pub.strategy_id,
                 amount,
+                balances.formatted_available,
+                format_usdc(fee_reserve_raw),
                 result.mint_tx_hash,
             )
         except Exception:

--- a/backend/archimedes/services/revenue_sweep.py
+++ b/backend/archimedes/services/revenue_sweep.py
@@ -27,8 +27,16 @@ Two entry points:
 Config (all env): ``GENERATION_PAYMENT_RECIPIENT`` (the DCW address — same
 value the paywall pays to), ``REVENUE_WALLET_ID`` (that DCW's Circle wallet
 id, needed for API signing), ``REVENUE_SWEEP_MIN_USDC`` (default "10.0" —
-must stay several multiples of Circle's ~2.01 USDC withdrawal fee, same
-rationale as settlement.SWEEP_WITHDRAW_THRESHOLD_USDC).
+enough that the sweep is worth a transaction), and
+``GATEWAY_WITHDRAW_FEE_RESERVE_USDC`` (default "0.05", shared with
+settlement — see ``marketplace.config``).
+
+A sweep withdraws the available balance **less the fee reserve**, never the
+whole thing: Circle charges its withdrawal fee on top of the burn amount, so
+``/v1/transfer`` rejects a full-balance request outright (measured in prod
+2026-08-26 — "available 36.000000, required 36.0035"). The 2.01 USDC figure
+that used to appear in these comments is circlekit's default *maxFee cap*,
+not the fee; the real fee on that withdrawal was 0.0035.
 
 Deliberately independent of PAYMENTS_DRY_RUN / GENERATION_PAYMENTS_DRY_RUN:
 those gate CHARGING USERS; this moves the platform's own already-settled
@@ -47,7 +55,11 @@ from decimal import Decimal
 from circlekit.client import GatewayClient
 from circlekit.wallets import CircleTxExecutor, CircleWalletSigner
 
-from archimedes.marketplace.config import gateway_chain
+from archimedes.marketplace.config import (
+    format_usdc,
+    gateway_chain,
+    gateway_sweep_amount,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,9 +113,10 @@ async def check_revenue() -> dict:
 
 
 async def sweep_revenue(min_usdc: Decimal | None = None) -> dict:
-    """Withdraw the full available Gateway balance to the DCW's token balance
-    when it meets the threshold. Returns a structured outcome either way —
-    callers log it; the scheduler loop never raises out of a tick."""
+    """Withdraw the available Gateway balance, less Circle's fee reserve, to
+    the DCW's token balance when it meets the threshold. Returns a structured
+    outcome either way — callers log it; the scheduler loop never raises out
+    of a tick."""
     threshold = min_usdc if min_usdc is not None else _min_usdc()
     client = _client()
     balances = await client.get_gateway_balance()
@@ -114,17 +127,30 @@ async def sweep_revenue(min_usdc: Decimal | None = None) -> dict:
             "reason": f"available {available} USDC below threshold {threshold}",
             "available_usdc": str(available),
         }
-    amount = balances.formatted_available
-    result = await client.withdraw(amount=amount)
+    # NOT the whole balance: Circle charges its fee on top of the burn amount,
+    # so asking for all of it is always rejected (see marketplace.config).
+    try:
+        amount, fee_reserve_raw = gateway_sweep_amount(balances.available)
+    except ValueError as exc:
+        return {
+            "swept": False,
+            "reason": str(exc),
+            "available_usdc": str(available),
+        }
+    result = await client.withdraw(amount=amount, max_fee=fee_reserve_raw)
     logger.info(
-        "revenue sweep: withdrew %s USDC Gateway → wallet %s; mint tx=%s",
+        "revenue sweep: withdrew %s of %s USDC available (%s held for fee) Gateway → wallet %s; mint tx=%s",
         amount,
+        balances.formatted_available,
+        format_usdc(fee_reserve_raw),
         _recipient(),
         getattr(result, "mint_tx_hash", result),
     )
     return {
         "swept": True,
         "amount_usdc": amount,
+        "available_usdc": balances.formatted_available,
+        "fee_reserve_usdc": format_usdc(fee_reserve_raw),
         "mint_tx_hash": getattr(result, "mint_tx_hash", None),
     }
 

--- a/backend/tests/gateway_fake.py
+++ b/backend/tests/gateway_fake.py
@@ -1,0 +1,99 @@
+"""A Circle Gateway fake that enforces the rule Circle actually enforces.
+
+Why this exists: both sweep paths (services/revenue_sweep.py Stage A and
+marketplace/settlement.py Stage A) shipped asking Circle to withdraw the
+*entire* available Gateway balance, and both were covered by tests using a
+bare ``AsyncMock`` for ``withdraw`` — a mock that accepts every argument and
+therefore cannot fail. The bug surfaced only in production, on the first real
+sweep::
+
+    POST /v1/transfer -> 400
+    {"success": false, "message": "Insufficient balance for depositor
+     0xffa7abba...56c1: available 36.000000, required 36.0035"}
+
+Circle charges its withdrawal fee **on top of** the burn amount. The real
+constraint is ``amount + fee <= available``, and a fake that does not model it
+is worse than no fake at all, because it certifies the broken behaviour.
+
+``FakeGatewayClient`` models it, so a caller that asks for the whole balance
+raises exactly the way prod did.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+# The fee Circle charged on the 36.000000 USDC revenue withdrawal measured on
+# Arc testnet, 2026-08-26. Tests may override to probe other schedules.
+OBSERVED_FEE_RAW = 3_500
+
+_USDC = Decimal(10) ** 6
+
+
+def raw_to_str(raw: int) -> str:
+    return f"{Decimal(raw) / _USDC:.6f}"
+
+
+def make_balances(available_raw: int) -> MagicMock:
+    b = MagicMock()
+    b.available = available_raw
+    b.formatted_available = raw_to_str(available_raw)
+    b.formatted_total = b.formatted_available
+    return b
+
+
+class FakeGatewayClient:
+    """Stands in for ``circlekit.client.GatewayClient``.
+
+    Records the arguments of every ``withdraw`` call, and rejects the ones
+    Circle rejects:
+
+    * ``amount + fee > available`` -> the production 400 message;
+    * ``fee > max_fee`` -> Circle refusing an under-authorised burn intent.
+    """
+
+    def __init__(
+        self,
+        available_raw: int,
+        fee_raw: int = OBSERVED_FEE_RAW,
+        depositor: str = "0xffa7abba5f17cb8471ebf150bf808bd6fb8856c1",
+        mint_tx_hash: str = "0xmint",
+    ) -> None:
+        self.available_raw = available_raw
+        self.fee_raw = fee_raw
+        self.depositor = depositor
+        self.mint_tx_hash = mint_tx_hash
+        self.withdraw_calls: list[dict] = []
+
+    async def get_gateway_balance(self):
+        return make_balances(self.available_raw)
+
+    async def withdraw(self, amount: str, max_fee: int | None = None, **kwargs):
+        self.withdraw_calls.append({"amount": amount, "max_fee": max_fee, **kwargs})
+        amount_raw = int(Decimal(amount) * _USDC)
+
+        # circlekit defaults maxFee to 2.01 USDC when the caller passes none.
+        authorised = 2_010_000 if max_fee is None else max_fee
+        if self.fee_raw > authorised:
+            raise ValueError(
+                f"Withdrawal failed (status 400): fee {raw_to_str(self.fee_raw)} "
+                f"exceeds maxFee {raw_to_str(authorised)}"
+            )
+
+        if amount_raw + self.fee_raw > self.available_raw:
+            raise ValueError(
+                f"Withdrawal failed (status 400): "
+                f'{{"success":false,"message":"Insufficient balance for depositor '
+                f"{self.depositor}: available {raw_to_str(self.available_raw)}, "
+                f'required {Decimal(amount_raw + self.fee_raw) / _USDC}"}}'
+            )
+
+        self.available_raw -= amount_raw + self.fee_raw
+        return MagicMock(mint_tx_hash=self.mint_tx_hash)
+
+    # convenience for assertions
+    @property
+    def last_withdraw(self) -> dict:
+        assert self.withdraw_calls, "withdraw was never called"
+        return self.withdraw_calls[-1]

--- a/backend/tests/marketplace/test_gateway_fee_reserve.py
+++ b/backend/tests/marketplace/test_gateway_fee_reserve.py
@@ -1,0 +1,68 @@
+"""Laws of the Gateway withdrawal fee reserve (marketplace/config.py).
+
+Both sweep paths withdraw ``available - reserve``, never ``available``,
+because Circle charges its fee on top of the burn amount. These tests pin the
+arithmetic and show the defensive parses rejecting bad input rather than
+silently producing a zero reserve — which is exactly the state that caused the
+production failure of 2026-08-26.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.marketplace import config as mc
+
+
+class TestReserveParsing:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", raising=False)
+        assert mc.gateway_fee_reserve_raw() == 50_000  # $0.05
+
+    def test_override_is_honoured(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", "0.25")
+        assert mc.gateway_fee_reserve_raw() == 250_000
+
+    @pytest.mark.parametrize("bad", ["garbage", "", "   ", "-1", "0", "0.0"])
+    def test_bad_values_fall_back_never_to_zero(self, monkeypatch, bad):
+        """A zero or unparseable reserve is the bug this module prevents, so
+        no input may produce one."""
+        monkeypatch.setenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", bad)
+        assert mc.gateway_fee_reserve_raw() == 50_000
+
+
+class TestSweepAmount:
+    def test_holds_back_the_reserve(self, monkeypatch):
+        monkeypatch.delenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", raising=False)
+        amount, reserve = mc.gateway_sweep_amount(36_000_000)
+        assert amount == "35.950000"
+        assert reserve == 50_000
+
+    def test_the_production_case_would_now_be_affordable(self, monkeypatch):
+        """The exact prod numbers: available 36.000000, Circle's fee 0.0035.
+
+        Old behaviour asked for 36.000000 and Circle computed required
+        36.0035 > 36.000000. The reserved request clears it with room.
+        """
+        monkeypatch.delenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", raising=False)
+        available_raw = 36_000_000
+        observed_fee_raw = 3_500
+        amount, reserve = mc.gateway_sweep_amount(available_raw)
+        amount_raw = int(float(amount) * 10**6)
+
+        assert amount_raw + observed_fee_raw <= available_raw
+        assert observed_fee_raw <= reserve, "reserve must cover the observed fee"
+        # and the old behaviour genuinely did not clear it
+        assert available_raw + observed_fee_raw > available_raw
+
+    def test_balance_at_or_under_the_reserve_raises(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", "0.05")
+        for available in (0, 1, 49_999, 50_000):
+            with pytest.raises(ValueError, match="does not cover"):
+                mc.gateway_sweep_amount(available)
+
+    def test_amount_is_exact_six_decimals(self, monkeypatch):
+        """circlekit re-parses this string; a float-ish repr would drift."""
+        monkeypatch.delenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", raising=False)
+        amount, _ = mc.gateway_sweep_amount(10_000_001)
+        assert amount == "9.950001"
+        assert len(amount.split(".")[1]) == 6

--- a/backend/tests/marketplace/test_settlement.py
+++ b/backend/tests/marketplace/test_settlement.py
@@ -12,6 +12,7 @@ from archimedes.marketplace.settlement import (
     SWEEP_MIN_DEPOSIT_RAW,
     SettlementSweeper,
 )
+from tests.gateway_fake import FakeGatewayClient
 
 
 @pytest.fixture
@@ -116,27 +117,44 @@ async def test_stage_a_below_threshold_does_not_withdraw(sweeper, pub):
 
 
 @pytest.mark.asyncio
-async def test_stage_a_above_threshold_withdraws(sweeper, pub):
-    """Available balance above threshold => withdraw called once."""
-    mock_balance = MagicMock()
-    mock_balance.available = _THRESHOLD_RAW + 5000000  # above threshold
-    mock_balance.formatted_available = "15.00"
+async def test_stage_a_above_threshold_withdraws_less_fee_reserve(sweeper, pub, monkeypatch):
+    """Available balance above threshold => withdraw called once, for an
+    amount Circle will actually accept.
 
-    mock_result = MagicMock()
-    mock_result.mint_tx_hash = "0xminttx"
+    Guard demonstration for the fee-reserve fix. ``FakeGatewayClient``
+    enforces Circle's real ``amount + fee <= available`` rule, so the previous
+    ``amount = balances.formatted_available`` raises here rather than passing
+    against an AsyncMock that accepts anything.
+    """
+    monkeypatch.delenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", raising=False)
+    available = _THRESHOLD_RAW + 5_000_000  # $15.00
+    fake = FakeGatewayClient(available, mint_tx_hash="0xminttx")
 
     with (
         patch("archimedes.marketplace.settlement.CircleWalletSigner"),
         patch("archimedes.marketplace.settlement.CircleTxExecutor"),
-        patch("archimedes.marketplace.settlement.GatewayClient") as MockGW,
+        patch("archimedes.marketplace.settlement.GatewayClient", return_value=fake),
     ):
-        instance = MockGW.return_value
-        instance.get_gateway_balance = AsyncMock(return_value=mock_balance)
-        instance.withdraw = AsyncMock(return_value=mock_result)
-
         await sweeper._stage_a_gateway_to_wallet(pub)
 
-        instance.withdraw.assert_awaited_once_with(amount="15.00")
+    assert fake.last_withdraw["amount"] == "14.950000"  # $15.00 - $0.05 reserve
+    assert fake.last_withdraw["max_fee"] == 50_000
+
+
+@pytest.mark.asyncio
+async def test_stage_a_swallows_the_circle_rejection_and_lets_stage_b_run(sweeper, pub):
+    """Stage A already catches its own exceptions — confirm the Circle 400
+    path stays inside that contract rather than escaping the sweeper."""
+    fake = FakeGatewayClient(_THRESHOLD_RAW + 5_000_000, fee_raw=9_000_000)
+
+    with (
+        patch("archimedes.marketplace.settlement.CircleWalletSigner"),
+        patch("archimedes.marketplace.settlement.CircleTxExecutor"),
+        patch("archimedes.marketplace.settlement.GatewayClient", return_value=fake),
+    ):
+        await sweeper._stage_a_gateway_to_wallet(pub)  # must not raise
+
+    assert fake.withdraw_calls, "withdraw should have been attempted"
 
 
 # ── Stage B: wallet balance below min deposit → no action ───────────────

--- a/backend/tests/services/test_revenue_sweep.py
+++ b/backend/tests/services/test_revenue_sweep.py
@@ -1,10 +1,17 @@
 """Laws of the platform revenue sweep (services/revenue_sweep.py).
 
-Hermetic: circlekit's GatewayClient is mocked at the module boundary — no
+Hermetic: circlekit's GatewayClient is replaced at the module boundary — no
 Circle API, no chain. The guard demonstrations (repo rule 4): the
-disabled-by-default scheduler gate, the loud-unconfigured failure, and the
-threshold refusing a below-minimum sweep are each shown rejecting their
-inputs, not assumed.
+disabled-by-default scheduler gate, the loud-unconfigured failure, the
+threshold refusing a below-minimum sweep, and the fee reserve keeping the
+request affordable are each shown rejecting their inputs, not assumed.
+
+Note on the fake: withdrawal semantics use ``tests.gateway_fake``, which
+enforces Circle's real ``amount + fee <= available`` rule. The bare
+``AsyncMock`` this suite used to withdraw against accepted any argument, and
+so certified the full-balance request that failed on the first production
+sweep (2026-08-26). ``_mock_client`` remains only for the paths that never
+reach ``withdraw``.
 """
 
 from __future__ import annotations
@@ -14,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from archimedes.services import revenue_sweep as rs
+from tests.gateway_fake import FakeGatewayClient
 
 RECIPIENT = "0xffa7abba5f17cb8471ebf150bf808bd6fb8856c1"
 WALLET_ID = "af3e1cf6-76a3-55db-911a-b356860058e4"
@@ -67,22 +75,70 @@ class TestSweep:
         assert out["swept"] is False
         client.withdraw.assert_not_awaited()
 
-    async def test_at_threshold_withdraws_full_available(self, monkeypatch):
+    async def test_at_threshold_withdraws_available_less_fee_reserve(self, monkeypatch):
+        """The amount requested must leave room for Circle's fee.
+
+        This is the guard demonstration for the prod bug of 2026-08-26: the
+        fake enforces Circle's real rule (amount + fee <= available), so the
+        old ``amount = balances.formatted_available`` cannot pass it.
+        """
         monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
         monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
-        client = _mock_client(12_500_000)  # $12.50
+        monkeypatch.delenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", raising=False)
+        client = FakeGatewayClient(12_500_000)  # $12.50
         with patch.object(rs, "_client", return_value=client):
             out = await rs.sweep_revenue()
+
         assert out["swept"] is True and out["mint_tx_hash"] == "0xmint"
-        client.withdraw.assert_awaited_once_with(amount="12.500000")
+        # $12.50 available - $0.05 reserve
+        assert client.last_withdraw["amount"] == "12.450000"
+        assert out["amount_usdc"] == "12.450000"
+        assert out["available_usdc"] == "12.500000"
+        assert out["fee_reserve_usdc"] == "0.050000"
+
+    async def test_requesting_the_whole_balance_is_what_circle_rejects(self, monkeypatch):
+        """Pin the failure mode itself, so the fake is proven to have teeth.
+
+        If this test ever stops raising, the fake has gone slack and the guard
+        demonstration above is worthless.
+        """
+        client = FakeGatewayClient(36_000_000)
+        with pytest.raises(ValueError, match="Insufficient balance for depositor"):
+            await client.withdraw(amount="36.000000", max_fee=2_010_000)
+
+    async def test_reserve_bounds_what_circle_may_charge(self, monkeypatch):
+        """max_fee is pinned to the reserve, so an outsized fee fails loudly
+        instead of being quietly paid out of revenue."""
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
+        monkeypatch.delenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", raising=False)
+        # A wildly out-of-band fee — under circlekit's 2.01 default this would
+        # silently take 5.6% of a $36 sweep.
+        client = FakeGatewayClient(36_000_000, fee_raw=2_000_000)
+        with patch.object(rs, "_client", return_value=client):
+            with pytest.raises(ValueError, match="exceeds maxFee"):
+                await rs.sweep_revenue()
+        assert client.last_withdraw["max_fee"] == 50_000
+
+    async def test_balance_under_the_reserve_is_not_swept(self, monkeypatch):
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
+        monkeypatch.setenv("GATEWAY_WITHDRAW_FEE_RESERVE_USDC", "0.05")
+        client = FakeGatewayClient(40_000)  # $0.04 — under the reserve
+        with patch.object(rs, "_client", return_value=client):
+            out = await rs.sweep_revenue(Decimal("0.01"))  # threshold cleared
+        assert out["swept"] is False
+        assert "does not cover" in out["reason"]
+        assert client.withdraw_calls == []
 
     async def test_min_override(self, monkeypatch):
         monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
         monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
-        client = _mock_client(4_000_000)
+        client = FakeGatewayClient(4_000_000)
         with patch.object(rs, "_client", return_value=client):
             out = await rs.sweep_revenue(Decimal("2"))
         assert out["swept"] is True
+        assert client.last_withdraw["amount"] == "3.950000"
 
     async def test_check_is_read_only(self, monkeypatch):
         monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)


### PR DESCRIPTION
Closes #1486.

## The bug, in production

The first real platform revenue sweep failed tonight:

```
POST https://gateway-api-testnet.circle.com/v1/transfer "HTTP/1.1 400 Bad Request"
ValueError: Withdrawal failed (status 400): {"success":false,
  "message":"Insufficient balance for depositor 0xffa7abba…56c1:
             available 36.000000, required 36.0035"}
```

**Circle charges its withdrawal fee on top of the burn amount.** The real
constraint is `amount + fee <= available`, and both sweep paths asked for the
entire available balance — which can never satisfy it.

It is not a revenue-only bug. `marketplace/settlement.py` Stage A carries the
same line and would have failed identically on its first real withdrawal.

Behind it sits a quieter problem: neither call site passed `max_fee`, so both
inherited circlekit's `DEFAULT_WITHDRAW_MAX_FEE = 2_010_000` — authorising
Circle to take **2.01 USDC, 5.6% of a $36 sweep**, without complaint. The
"~2.01 USDC withdrawal fee" comments in both modules had mistaken that *cap*
for the fee. The fee actually charged was **0.0035**. Comments corrected.

## Fix

`gateway_sweep_amount()` in `marketplace/config.py` — one helper, both call
sites, so the two paths cannot drift apart again:

```python
amount, fee_reserve_raw = gateway_sweep_amount(balances.available)
result = await client.withdraw(amount=amount, max_fee=fee_reserve_raw)
```

Passing the reserve as `max_fee` is the half that isn't obvious: it means an
out-of-band fee **fails loudly instead of being paid quietly out of revenue**.

Reserve defaults to **0.05 USDC** — 14x the observed fee, under 0.2% of a $36
sweep — overridable via `GATEWAY_WITHDRAW_FEE_RESERVE_USDC`. No input can drive
it to zero (garbage, empty, negative, and `0` all fall back), because a zero
reserve reproduces exactly this bug.

## Why CI was green through all of it

Both suites asserted `withdraw` against a bare `AsyncMock`, which accepts any
argument and therefore certifies whatever the code happens to do:

```python
client.withdraw.assert_awaited_once_with(amount="12.500000")   # revenue
instance.withdraw.assert_awaited_once_with(amount="15.00")     # settlement
```

That is repo rule 3 in its purest form — *a test that passes against the unfixed
code proves nothing*. The mock could not fail, so it locked the bug in and made
it look covered.

`tests/gateway_fake.py` replaces it with a fake that enforces Circle's actual
rule and reproduces its rejection messages, including the `maxFee` one.

## Guard demonstration (repo rule 4)

Fix stashed (call sites only), tests re-run against the old sources:

```
FAILED test_revenue_sweep.py::test_at_threshold_withdraws_available_less_fee_reserve
  ValueError: … "available 12.500000, required 12.5035"
FAILED test_revenue_sweep.py::test_min_override
  ValueError: … "available 4.000000, required 4.0035"
FAILED test_revenue_sweep.py::test_balance_under_the_reserve_is_not_swept
  ValueError: … "available 0.040000, required 0.0435"
FAILED test_settlement.py::test_stage_a_above_threshold_withdraws_less_fee_reserve
  AssertionError: assert '15.000000' == '14.950000'
FAILED test_revenue_sweep.py::test_reserve_bounds_what_circle_may_charge
  ValueError: … "available 36.000000, required 38"    ← the unbounded maxFee

5 failed, 39 passed
```

Restored: **44 passed**, and identically under `env -i HOME=$HOME PATH=$PATH
PYTHONPATH=backend` (hermetic gate).

`test_requesting_the_whole_balance_is_what_circle_rejects` pins the failure mode
itself, so if the fake ever goes slack the guard demonstration fails loudly
rather than silently becoming decorative.

## Measured on Arc testnet, 2026-08-26

| | |
|---|---|
| Fee on the 36.000000 withdrawal | **0.0035 USDC** |
| Comparable Gateway ops | `submitBatch` 132,245 / 177,075 gas · `gatewayBurn` 162,667 |
| Effective gas price | 26–35 gwei |
| Cost of the DCW's `gatewayMint` | **~$0.011** (USDC is the native gas token on Arc) |

## Not in this PR

`REVENUE_SWEEP_ENABLED` stays off, and #1463 (Circle creds absent from
`ecs.tf`) is untouched — the scheduler should not arm until a manual sweep has
succeeded once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
