### PR TITLE
[backend] DSR-significant tile counts the least-confident picks, not the most

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1034,17 +1034,33 @@ async def get_portfolio_advisor(
         }
 
     def _build_rigor_summary(active_rows: list[dict]) -> dict:
+        # dsr_p_value reads "higher = more confident" throughout this codebase
+        # (RigorExplainer.jsx "confidence ≥ 0.90 (badge)", RigorStrictnessControl.jsx
+        # "DSR confidence ≥ dsr_p_min", RejectedCandidates.jsx's dsrBad = dsr_p_value
+        # < 0.95) — the SAME badge floor rigor_profiles.py uses at STRICTEST_LEVEL
+        # (level 1, the Archimedes Verified bar). This tile must use the identical
+        # floor+direction: a `< 0.05` comparator here previously counted the LOWEST-
+        # confidence strategies (round-2 review, #1358) — the opposite of what the
+        # PortfolioAdvisor.jsx "DSR conf<threshold" label (this same PR) claims.
+        from archimedes.services.rigor_profiles import STRICTEST_LEVEL, get_profile
+
+        dsr_badge_floor = get_profile(STRICTEST_LEVEL).dsr_p_min
+
         n = len(active_rows)
         if n == 0:
             return {
                 "total_picks": 0,
                 "passes_rigor_gate": 0,
                 "dsr_significant": 0,
+                "dsr_significant_threshold": dsr_badge_floor,
                 "pbo_acceptable": 0,
+                "pbo_acceptable_threshold": 0.50,
                 "oos_positive": 0,
             }
         passes = sum(1 for r in active_rows if r.get("passes_rigor_gate"))
-        dsr_sig = sum(1 for r in active_rows if r.get("dsr_p_value") is not None and r["dsr_p_value"] < 0.05)
+        dsr_sig = sum(
+            1 for r in active_rows if r.get("dsr_p_value") is not None and r["dsr_p_value"] >= dsr_badge_floor
+        )
         pbo_ok = sum(1 for r in active_rows if r.get("pbo_score") is not None and r["pbo_score"] < 0.5)
         oos_pos = sum(
             1 for r in active_rows if r.get("out_of_sample_sharpe") is not None and r["out_of_sample_sharpe"] > 0
@@ -1055,7 +1071,7 @@ async def get_portfolio_advisor(
             "total_picks": n,
             "passes_rigor_gate": passes,
             "dsr_significant": dsr_sig,
-            "dsr_significant_threshold": 0.05,
+            "dsr_significant_threshold": dsr_badge_floor,
             "pbo_acceptable": pbo_ok,
             "pbo_acceptable_threshold": 0.50,
             "oos_positive": oos_pos,

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1041,7 +1041,15 @@ async def get_portfolio_advisor(
         # (level 1, the Archimedes Verified bar). This tile must use the identical
         # floor+direction: a `< 0.05` comparator here previously counted the LOWEST-
         # confidence strategies (round-2 review, #1358) — the opposite of what the
-        # PortfolioAdvisor.jsx "DSR conf<threshold" label (this same PR) claims.
+        # "DSR significant" name claims. `dsr_p_value` is `norm.cdf(z)` in
+        # `_rigor_helpers._dsr_from_stats`, i.e. Prob(true SR > best-of-N null) —
+        # the Bailey-LdP DSR itself, not a frequentist p-value — so higher IS
+        # better and `>=` is the correct direction.
+        #
+        # No UI reads this today: PortfolioAdvisor.jsx, the tile's only consumer,
+        # was deleted as dead code in 2fccecf6. `GET /api/strategies/advisor` is
+        # still live and still emits these fields, so the wire value has to be
+        # honest regardless of whether anything renders it.
         from archimedes.services.rigor_profiles import STRICTEST_LEVEL, get_profile
 
         dsr_badge_floor = get_profile(STRICTEST_LEVEL).dsr_p_min

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -974,6 +974,90 @@ class TestAdvisorRoutes:
         assert "plain" in captured
         assert captured["plain"][-1] == statuses
 
+    def test_advisor_rigor_summary_dsr_threshold_matches_badge_floor_direction(self, client, seeded_db):
+        """#1358 round-2 review: ``dsr_significant``/``dsr_significant_threshold``
+        must count HIGH-confidence strategies (>= the STRICTEST_LEVEL badge
+        floor — 0.90 today, rigor_profiles.py) — the SAME direction
+        RigorExplainer.jsx ("confidence >= 0.90 (badge)") and
+        RigorStrictnessControl.jsx ("DSR confidence >= dsr_p_min") already use.
+        Pre-fix, a ``< 0.05`` comparator counted the WORST (lowest-confidence)
+        strategies under this positive-sounding stat, self-contradicting the
+        PortfolioAdvisor.jsx "DSR conf" tile this same PR renamed."""
+        from archimedes.api import strategies_routes as sr
+        from archimedes.services.rigor_evaluator import RigorGateResult
+        from archimedes.services.rigor_profiles import STRICTEST_LEVEL, get_profile
+
+        badge_floor = get_profile(STRICTEST_LEVEL).dsr_p_min
+
+        def fake_batch(strategies):
+            results = {}
+            for i, s in enumerate(strategies):
+                # Alternate: even index confidently ABOVE the badge floor,
+                # odd index confidently BELOW it.
+                dsr_p = badge_floor + 0.02 if i % 2 == 0 else max(badge_floor - 0.30, 0.0)
+                results[s.id] = RigorGateResult(
+                    strategy_id=s.id,
+                    deflated_sharpe=1.0,
+                    dsr_p_value=dsr_p,
+                    num_trials=1,
+                    pbo_score=0.1,
+                    oos_sharpe=0.5,
+                    look_ahead_passed=True,
+                )
+            return results
+
+        with patch.object(sr, "_live_rigor_results_for_strategies", side_effect=fake_batch):
+            resp = client.get("/api/strategies/advisor?risk_profile=moderate")
+        assert resp.status_code == 200
+        body = resp.json()
+        summary = body["rigor_summary"]
+        allocations = body["allocations"]
+        assert allocations, "advisor returned no allocations to check"
+
+        assert summary["dsr_significant_threshold"] == pytest.approx(badge_floor)
+        expected = sum(1 for a in allocations if a.get("dsr_p_value") is not None and a["dsr_p_value"] >= badge_floor)
+        assert expected > 0, "fixture must produce >=1 above-floor allocation for this test to be meaningful"
+        assert summary["dsr_significant"] == expected
+
+    def test_build_rigor_summary_empty_branch_carries_same_keys_as_populated_branch(self):
+        """#1358 round-2 review: ``_build_rigor_summary``'s ``n == 0`` early
+        return must carry the SAME key set as its populated-case return, so
+        every consumer that reads ``dsr_significant_threshold`` /
+        ``pbo_acceptable_threshold`` unconditionally (``rigor_summary`` is
+        built unconditionally at both call sites in this route; the one
+        current UI consumer, ``PortfolioAdvisor.jsx``, happens to guard on
+        ``total_picks > 0`` today, but the API contract itself must not
+        depend on that guard existing) gets the honest floor value rather
+        than ``undefined``/a ``KeyError``.
+
+        Source-text assertion (not a live route call): every reachable path
+        through ``get_portfolio_advisor`` short-circuits to a *different*,
+        ``rigor_summary``-free error shape (``if not scored: return
+        {"error": ..., "allocations": []}``) before ``_build_rigor_summary``
+        is ever called with an empty list, so the ``n == 0`` branch is
+        currently unreachable via the live endpoint — this test guards the
+        function's internal key-symmetry contract directly, the same way
+        ``ui/test/rigor-tristate.test.js`` guards JSX branches via source
+        text rather than a full render.
+        """
+        import inspect
+
+        from archimedes.api import strategies_routes as sr
+
+        src = inspect.getsource(sr)
+        fn_start = src.index("def _build_rigor_summary(")
+        n0_start = src.index("if n == 0:", fn_start)
+        n0_body_start = src.index("return {", n0_start)
+        n0_body_end = src.index("}", n0_body_start)
+        n0_body = src[n0_body_start : n0_body_end + 1]
+
+        assert '"dsr_significant_threshold"' in n0_body, (
+            f"n==0 branch is missing dsr_significant_threshold — got: {n0_body}"
+        )
+        assert '"pbo_acceptable_threshold"' in n0_body, (
+            f"n==0 branch is missing pbo_acceptable_threshold — got: {n0_body}"
+        )
+
 
 class TestFusionEvaluatorIntegration:
     """Tests for fusion_evaluator wiring in _run_fusion_job.

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -981,8 +981,10 @@ class TestAdvisorRoutes:
         RigorExplainer.jsx ("confidence >= 0.90 (badge)") and
         RigorStrictnessControl.jsx ("DSR confidence >= dsr_p_min") already use.
         Pre-fix, a ``< 0.05`` comparator counted the WORST (lowest-confidence)
-        strategies under this positive-sounding stat, self-contradicting the
-        PortfolioAdvisor.jsx "DSR conf" tile this same PR renamed."""
+        strategies under this positive-sounding stat. ``dsr_p_value`` is
+        ``norm.cdf(z)`` in ``_rigor_helpers._dsr_from_stats`` — Prob(true SR >
+        best-of-N null), the Bailey-LdP DSR itself rather than a frequentist
+        p-value — so higher is better and ``>=`` is the correct direction."""
         from archimedes.api import strategies_routes as sr
         from archimedes.services.rigor_evaluator import RigorGateResult
         from archimedes.services.rigor_profiles import STRICTEST_LEVEL, get_profile
@@ -1024,11 +1026,11 @@ class TestAdvisorRoutes:
         return must carry the SAME key set as its populated-case return, so
         every consumer that reads ``dsr_significant_threshold`` /
         ``pbo_acceptable_threshold`` unconditionally (``rigor_summary`` is
-        built unconditionally at both call sites in this route; the one
-        current UI consumer, ``PortfolioAdvisor.jsx``, happens to guard on
-        ``total_picks > 0`` today, but the API contract itself must not
-        depend on that guard existing) gets the honest floor value rather
-        than ``undefined``/a ``KeyError``.
+        built unconditionally at both call sites in this route) gets the
+        honest floor value rather than ``undefined``/a ``KeyError``. There is
+        no UI consumer at all on ``main`` — ``PortfolioAdvisor.jsx`` was
+        deleted as dead code in 2fccecf6 — which makes the wire contract the
+        only thing holding this shape, not a guard in some component.
 
         Source-text assertion (not a live route call): every reachable path
         through ``get_portfolio_advisor`` short-circuits to a *different*,
@@ -1036,9 +1038,7 @@ class TestAdvisorRoutes:
         {"error": ..., "allocations": []}``) before ``_build_rigor_summary``
         is ever called with an empty list, so the ``n == 0`` branch is
         currently unreachable via the live endpoint — this test guards the
-        function's internal key-symmetry contract directly, the same way
-        ``ui/test/rigor-tristate.test.js`` guards JSX branches via source
-        text rather than a full render.
+        function's internal key-symmetry contract directly.
         """
         import inspect
 


### PR DESCRIPTION
## Summary

Extracts `288dbfdc` out of PR #1390 into its own PR, per #1421. #1390 bundles ~6-7 logical
changes; this is the one that changes a live API's wire semantics, so it is the one a future
bisect wants isolated from the tri-state rendering work.

Two commits:

- `c3587702` — Dan's commit, cherry-picked with `-x` so the provenance line survives.
  Authorship left as his.
- `0685c0c4` — mine, comments and docstrings only. The original text argued the direction
  from a UI consumer that no longer exists (see "Dropped" below), so I replaced that
  argument with the producer-side one and removed three now-false statements.

## The bug, as production serves it right now

`GET /api/strategies/advisor?risk_profile=moderate` against the live site, this morning:

```json
"rigor_summary": {
  "total_picks": 6,
  "passes_rigor_gate": 2,
  "dsr_significant": 1,
  "dsr_significant_threshold": 0.05,
  ...
}
```

The six allocations' actual `dsr_p_value`s: `[0.978903, 0.143614, 0.614395, 0.944019, 0.183225, 0.0]`

| Comparator | Counts | Which strategies |
| --- | --- | --- |
| `< 0.05` (shipped today) | 1 | the `0.0` one, i.e. the least confident pick in the set |
| `>= 0.90` (badge floor, this PR) | 2 | the `0.9789` and `0.9440` picks |

So the tile labelled "DSR significant" is currently reporting a count of 1 whose single
member is the *worst* strategy in the portfolio, and is excluding both strategies that
actually clear the bar. The field directly beside it already disagrees: `passes_rigor_gate: 2`
matches the corrected count exactly, because the gate uses the same 0.90 floor.

## Why `>=` is the correct direction

`dsr_p_value` is not a frequentist p-value despite the name. From
`_rigor_helpers._dsr_from_stats`:

```python
z = (SR_hat - SR_zero) * math.sqrt(T - 1) / math.sqrt(denom_sq)
dsr_p_value = float(norm.cdf(z))
```

That is Prob(true SR > best-of-N null) — the Deflated Sharpe Ratio as Bailey & López de
Prado define it. Higher is more confident, and the correct floor is the one the Archimedes
Verified badge already uses: `get_profile(STRICTEST_LEVEL).dsr_p_min`, 0.90 today.

The original commit argued this from consumer agreement (three JSX files plus
`rigor_profiles.py` all treating the field as "higher is better"). That is true but it
establishes consistent usage, not what the producer computes. The `norm.cdf` above is what
settles it, which is why I moved the comment onto it.

## What changed on the wire

`GET /api/strategies/advisor` → `rigor_summary`:

- `dsr_significant` — now counts picks at or above the badge floor.
- `dsr_significant_threshold` — now reports that floor (0.90) instead of the stale 0.05.
- the `n == 0` branch now carries both `*_threshold` keys, so a consumer reading them
  unconditionally cannot get a `KeyError`.

## Dropped from the original commit

The `ui/src/components/PortfolioAdvisor.jsx` hunk (a `DSR conf<` → `DSR conf≥` label
rename). That file was deleted as dead code in `2fccecf6`, and nothing on `main` reads
`dsr_significant` at all now. The endpoint is still live and still serves the number, so the
backend half stands on its own.

## Verify

```bash
pytest backend/tests/test_api_routes.py -q          # 42 passed
pytest -m "not integration" -q                      # 3690 passed, 0 failed
ruff format --check && ruff check                    # clean on both changed files
```

Both guards were mutation-proven independently rather than taken from the original commit
message:

- restoring `< 0.05` + `threshold: 0.05` → `test_advisor_rigor_summary_dsr_threshold_matches_badge_floor_direction`
  fails.
- deleting `dsr_significant_threshold` from the `n == 0` branch →
  `test_build_rigor_summary_empty_branch_carries_same_keys_as_populated_branch` fails with
  `n==0 branch is missing dsr_significant_threshold`.

## Anti-goals

- No change to how `dsr_p_value` is computed, and no gate threshold touched. This is a
  reporting comparator only.
- No UI work. The consumer is gone; re-wiring an advisor surface is out of scope.
- Does not close #1358 or supersede #1390.

## Note for whoever rebases #1390

`288dbfdc` is now on `main` (assuming this merges first), so that commit needs dropping from
#1390 during its rebase. #1390 is already conflicting for an unrelated reason: it also
modifies `PortfolioAdvisor.jsx`, which `main` deleted.

Closes #1421.
