### PR TITLE
[ci] Stop dependabot rewriting the torch floor with a +cpu local label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,20 @@ updates:
       - backend
     commit-message:
       prefix: "[deps][backend]"
+    ignore:
+      # torch resolves through the `--extra-index-url .../whl/cpu` in
+      # backend/requirements.txt, so the *installed* version reads `2.13.0+cpu`
+      # and dependabot rewrites the floor to match: `torch>=2.13.0+cpu,<3.0`.
+      # That is not a valid PEP 440 requirement — a local version label is only
+      # permitted on `==` or `!=` — so import-guard rejects every such PR. See
+      # #1478, and the trailing comment on the torch line in requirements.txt.
+      # Selecting the CPU wheel is the index's job, not the specifier's.
+      # Only version bumps are suppressed; security advisories still open PRs.
+      - dependency-name: torch
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   # Analytics engine — pip
   - package-ecosystem: pip


### PR DESCRIPTION
Follow-up to #1478, which I closed rather than merged.

Dependabot has been rewriting the torch floor to `torch>=2.13.0+cpu,<3.0`. That isn't a valid PEP 440 requirement — a local version label (`+cpu`) is only permitted on `==` or `!=` — so `backend/requirements.txt` stops parsing entirely and import-guard fails the PR:

```
packaging.requirements.InvalidRequirement: Local version label can only be used with `==` or `!=` operators
    torch>=2.13.0+cpu,<3.0
         ~~~~~~~~^
```

Reproduces identically in CI (run `32684118943`) and locally against the repo's own `packaging`.

## Why it happens

Two lines above the torch pin:

```
--extra-index-url https://download.pytorch.org/whl/cpu
torch>=2.13.0,<3.0  # CPU-only wheel via pytorch whl index ...; no +cpu here, pip rejects a local version label on a >= specifier
```

That index resolves torch to the CPU-variant wheel, so the *installed* version reports as `2.13.0+cpu`. Dependabot reads the installed version and copies it into the floor. The line's own trailing comment already warned about this — dependabot just doesn't read comments.

Left alone, it regenerates on every torch release. #1478 was at least the second occurrence.

## What changed

One `ignore` entry on the `pip` / `/backend` block, listing all three `version-update:semver-*` types. That suppresses version bumps for torch and nothing else — **security advisories still open PRs**, which is the property that made me comfortable adding an ignore at all rather than closing the PR by hand each month.

The comment in the config explains the mechanism so the next person doesn't remove it as unexplained cruft.

## Verification

- `yaml.safe_load` on the edited file parses, and the `ignore` block lands on the `/backend` pip entry (not one of the other four ecosystems).
- No change to `backend/requirements.txt`; the torch floor stays bare, which is the correct form. Picking the CPU wheel is the index's job, not the specifier's.

Narrow scope on purpose — this is CI wiring, so it's a PR rather than a direct push, and it's split from #1493 (the `environment.yml` alignment) because they're separate changes that happen to share an afternoon.
