### PR TITLE
[payments] Route every Gateway chain read through one helper (#1495)

### DIFF
--- a/backend/archimedes/marketplace/config.py
+++ b/backend/archimedes/marketplace/config.py
@@ -4,4 +4,27 @@ Single source of truth for chain-name defaults so that payment charging,
 Gateway withdrawal, and settlement all read from the same constant.
 """
 
+import os
+
 DEFAULT_GATEWAY_CHAIN = "arcTestnet"
+
+
+def gateway_chain() -> str:
+    """The Circle Gateway chain every money-path caller must settle on.
+
+    Centralised because the default being shared was not enough. Three call
+    sites read ``GATEWAY_CHAIN`` and applied this default; a fourth
+    (``services/revenue_sweep.py``) passed the constant straight through as a
+    keyword argument and never consulted the environment at all, so pointing
+    the deployment at mainnet moved the paywall and left the revenue sweep on
+    testnet (#1495).
+
+    That divergence was invisible: a sweep querying an empty testnet balance
+    logs "below threshold — skip", which on day one of mainnet is exactly what
+    a working system looks like.
+
+    Reading the environment through one function means a new call site cannot
+    reintroduce the split by forgetting a ``getenv``; the only way to obtain the
+    chain is to ask for it.
+    """
+    return os.getenv("GATEWAY_CHAIN", DEFAULT_GATEWAY_CHAIN).strip()

--- a/backend/archimedes/marketplace/payments.py
+++ b/backend/archimedes/marketplace/payments.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from decimal import Decimal
 
 import circlekit.server as _circlekit_server
@@ -26,7 +25,7 @@ from circlekit.server import GatewayMiddleware
 from circlekit.wallets import CircleWalletSigner
 from circlekit.x402 import create_payment_header, get_payment_required
 
-from archimedes.marketplace.config import DEFAULT_GATEWAY_CHAIN
+from archimedes.marketplace.config import gateway_chain
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +78,7 @@ def get_gateway_middleware(seller_address: str) -> GatewayMiddleware:
     if not seller_address or int(seller_address, 16) == 0:
         raise RuntimeError(f"refusing to charge into zero address ({seller_address})")
 
-    chain = os.getenv("GATEWAY_CHAIN", DEFAULT_GATEWAY_CHAIN).strip()
+    chain = gateway_chain()
     mw = create_gateway_middleware(
         seller_address=seller_address,
         chain=chain,

--- a/backend/archimedes/marketplace/settlement.py
+++ b/backend/archimedes/marketplace/settlement.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 from circlekit.client import GatewayClient
 from circlekit.wallets import CircleTxExecutor, CircleWalletSigner
 
-from archimedes.marketplace.config import DEFAULT_GATEWAY_CHAIN
+from archimedes.marketplace.config import gateway_chain
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ SWEEP_WITHDRAW_THRESHOLD_USDC = os.getenv(
     "10.0",  # must exceed several multiples of the ~2.01 USDC withdrawal fee
 )
 SWEEP_MIN_DEPOSIT_RAW = int(os.getenv("SWEEP_MIN_DEPOSIT_RAW", "1000000"))  # 1 USDC, raw 6-dec
-GATEWAY_CHAIN = os.getenv("GATEWAY_CHAIN", DEFAULT_GATEWAY_CHAIN)
+GATEWAY_CHAIN = gateway_chain()
 
 _THRESHOLD_RAW = int(Decimal(SWEEP_WITHDRAW_THRESHOLD_USDC) * 10**6)
 

--- a/backend/archimedes/services/generation_payment.py
+++ b/backend/archimedes/services/generation_payment.py
@@ -93,14 +93,14 @@ def quote() -> dict:
     per-generation budget replaces the internals of this function (and bumps
     the model name) without changing the paywall flow around it.
     """
-    from archimedes.marketplace.config import DEFAULT_GATEWAY_CHAIN
+    from archimedes.marketplace.config import gateway_chain
 
     return {
         "payment_required": payment_required(),
         "pricing_model": "flat_v1",
         "price": _price(),
         "asset": "USDC",
-        "chain": os.getenv("GATEWAY_CHAIN", DEFAULT_GATEWAY_CHAIN).strip(),
+        "chain": gateway_chain(),
         "recipient": _recipient() or None,
         "dry_run": _payments_dry_run(),
         "how": (

--- a/backend/archimedes/services/revenue_sweep.py
+++ b/backend/archimedes/services/revenue_sweep.py
@@ -47,7 +47,7 @@ from decimal import Decimal
 from circlekit.client import GatewayClient
 from circlekit.wallets import CircleTxExecutor, CircleWalletSigner
 
-from archimedes.marketplace.config import DEFAULT_GATEWAY_CHAIN
+from archimedes.marketplace.config import gateway_chain
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ def _client() -> GatewayClient:
         )
     signer = CircleWalletSigner(wallet_id=wallet_id, wallet_address=recipient)
     executor = CircleTxExecutor(wallet_id=wallet_id, wallet_address=recipient)
-    return GatewayClient(chain=DEFAULT_GATEWAY_CHAIN, signer=signer, tx_executor=executor)
+    return GatewayClient(chain=gateway_chain(), signer=signer, tx_executor=executor)
 
 
 async def check_revenue() -> dict:

--- a/backend/tests/marketplace/test_gateway_chain.py
+++ b/backend/tests/marketplace/test_gateway_chain.py
@@ -1,0 +1,157 @@
+"""Every money-path caller must settle on one Gateway chain (#1495).
+
+Three call sites read ``GATEWAY_CHAIN`` from the environment and applied
+``DEFAULT_GATEWAY_CHAIN`` as the fallback. A fourth — ``revenue_sweep._client``
+— passed the constant through as a keyword argument and never consulted the
+environment, so setting ``GATEWAY_CHAIN=arcMainnet`` moved the paywall, the
+quote and settlement while leaving the revenue sweep on testnet.
+
+The divergence had no visible symptom. A sweep pointed at an empty testnet
+balance logs "below threshold — skip" and returns cleanly, which on the first
+day of mainnet is indistinguishable from "no revenue yet".
+
+Hermetic: circlekit is mocked at the module boundary. No Circle API, no chain.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from archimedes.marketplace import payments
+from archimedes.marketplace.config import DEFAULT_GATEWAY_CHAIN, gateway_chain
+from archimedes.services import generation_payment, revenue_sweep
+
+RECIPIENT = "0xffa7abba5f17cb8471ebf150bf808bd6fb8856c1"
+WALLET_ID = "af3e1cf6-76a3-55db-911a-b356860058e4"
+MAINNET = "arcMainnet"
+
+
+@pytest.fixture
+def sweep_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The credentials `_client` refuses to run without."""
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("REVENUE_WALLET_ID", WALLET_ID)
+
+
+def _sweep_chain() -> str:
+    """The chain `revenue_sweep._client` hands to circlekit."""
+    seen: dict[str, str] = {}
+
+    class CapturingGatewayClient:
+        def __init__(self, chain: str, **_kwargs: object) -> None:
+            seen["chain"] = chain
+
+    with (
+        patch.object(revenue_sweep, "GatewayClient", CapturingGatewayClient),
+        patch.object(revenue_sweep, "CircleWalletSigner", MagicMock()),
+        patch.object(revenue_sweep, "CircleTxExecutor", MagicMock()),
+    ):
+        revenue_sweep._client()
+    return seen["chain"]
+
+
+def _charge_chain() -> str:
+    """The chain `payments.get_gateway_middleware` builds against."""
+    seen: dict[str, str] = {}
+
+    def _capture(*, seller_address: str, chain: str, description: str) -> MagicMock:
+        seen["chain"] = chain
+        return MagicMock()
+
+    payments._middleware_cache.clear()
+    try:
+        with patch.object(payments, "create_gateway_middleware", _capture):
+            payments.get_gateway_middleware(RECIPIENT)
+    finally:
+        payments._middleware_cache.clear()
+    return seen["chain"]
+
+
+class TestRevenueSweepFollowsTheEnvironment:
+    def test_sweep_follows_gateway_chain(self, monkeypatch: pytest.MonkeyPatch, sweep_env: None) -> None:
+        """The regression. Fails on the pre-#1495 code, which returned arcTestnet."""
+        monkeypatch.setenv("GATEWAY_CHAIN", MAINNET)
+        assert _sweep_chain() == MAINNET
+
+    def test_sweep_defaults_to_testnet_when_unset(self, monkeypatch: pytest.MonkeyPatch, sweep_env: None) -> None:
+        monkeypatch.delenv("GATEWAY_CHAIN", raising=False)
+        assert _sweep_chain() == DEFAULT_GATEWAY_CHAIN
+
+
+class TestEveryCallSiteAgrees:
+    """The property that actually matters: no site can diverge from the others.
+
+    Asserted against each other rather than against a literal, so the test
+    keeps holding if the default changes at the mainnet cutover.
+    """
+
+    def test_all_call_time_sites_report_one_chain(self, monkeypatch: pytest.MonkeyPatch, sweep_env: None) -> None:
+        monkeypatch.setenv("GATEWAY_CHAIN", MAINNET)
+        chains = {
+            "revenue_sweep": _sweep_chain(),
+            "payments": _charge_chain(),
+            "quote": generation_payment.quote()["chain"],
+            "helper": gateway_chain(),
+        }
+        assert len(set(chains.values())) == 1, f"money path split across chains: {chains}"
+        assert chains["helper"] == MAINNET
+
+    def test_they_agree_on_the_default_too(self, monkeypatch: pytest.MonkeyPatch, sweep_env: None) -> None:
+        monkeypatch.delenv("GATEWAY_CHAIN", raising=False)
+        chains = {_sweep_chain(), _charge_chain(), generation_payment.quote()["chain"]}
+        assert chains == {DEFAULT_GATEWAY_CHAIN}
+
+
+class TestHelperSemantics:
+    def test_surrounding_whitespace_is_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An env var set from a here-doc or a task-def JSON blob can carry a newline."""
+        monkeypatch.setenv("GATEWAY_CHAIN", f"  {MAINNET}\n")
+        assert gateway_chain() == MAINNET
+
+    def test_settlement_constant_comes_from_the_helper(self) -> None:
+        """`settlement.GATEWAY_CHAIN` is import-time by design — assert the source.
+
+        It is a module-level constant that other modules import, so it is read
+        once at import and a later `monkeypatch.setenv` cannot move it. Checking
+        the value at runtime would therefore prove nothing about which code path
+        produced it; checking the assignment does.
+        """
+        source = Path(revenue_sweep.__file__).parent.parent / "marketplace" / "settlement.py"
+        assert "GATEWAY_CHAIN = gateway_chain()" in source.read_text()
+
+
+class TestNoFifthCallSite:
+    def test_default_constant_is_referenced_only_where_it_is_defined(self) -> None:
+        """The structural half: a new caller cannot reintroduce the split.
+
+        `revenue_sweep` diverged by importing the default and using it directly
+        instead of reading the environment. Nothing stopped it. Confining the
+        constant to `config.py` means the only way to obtain the chain elsewhere
+        is `gateway_chain()`, which cannot forget the `getenv`.
+        """
+        package_root = Path(revenue_sweep.__file__).resolve().parents[1]
+        offenders = {
+            str(path.relative_to(package_root))
+            for path in package_root.rglob("*.py")
+            if path.name != "config.py" and re.search(r"\bDEFAULT_GATEWAY_CHAIN\b", path.read_text())
+        }
+        assert not offenders, (
+            "DEFAULT_GATEWAY_CHAIN is referenced outside config.py by "
+            f"{sorted(offenders)}. Call gateway_chain() instead — using the "
+            "constant directly is how #1495 skipped the environment read."
+        )
+
+    def test_the_scan_actually_reaches_the_money_path_modules(self) -> None:
+        """Guard on the guard: prove the rglob sees the files it is policing."""
+        package_root = Path(revenue_sweep.__file__).resolve().parents[1]
+        scanned = {str(p.relative_to(package_root)) for p in package_root.rglob("*.py")}
+        for expected in (
+            "services/revenue_sweep.py",
+            "marketplace/payments.py",
+            "marketplace/settlement.py",
+            "services/generation_payment.py",
+        ):
+            assert expected in scanned, f"{expected} not scanned — the guard is blind"


### PR DESCRIPTION
Closes #1495.

`revenue_sweep._client()` handed `DEFAULT_GATEWAY_CHAIN` to `GatewayClient` as a keyword argument and never read `GATEWAY_CHAIN`. The three other money-path sites did read it. Setting `GATEWAY_CHAIN=arcMainnet` at the Sept 16 cutover would have moved the paywall, the quote and settlement, and left the revenue sweep on testnet.

## The shape of the failure

It wouldn't have thrown. `sweep_revenue` queries the balance, finds a testnet account holding nothing, logs `below threshold — skip`, and returns `{"swept": False}`. On the first day of mainnet that is indistinguishable from *"no revenue yet"* — which is the reading anyone would take. Revenue would sit unswept on mainnet with a green log line under it.

This is the fail-soft pattern from `architectural-principles.md`: the degraded state has to be a loud absence, and a quiet "nothing to sweep" isn't one. `_client()` already gets that right for its other load-bearing config — it raises when `GENERATION_PAYMENT_RECIPIENT` or `REVENUE_WALLET_ID` is missing, with a comment citing the principle. The chain just wasn't covered.

## Fix

The issue asked for a `getenv` on line 88. I went one step further, because a fourth site drifting is a symptom rather than the disease — `config.py`'s docstring already claimed to be the "single source of truth… so that payment charging, Gateway withdrawal, and settlement all read from the same constant", but only the *default* was shared. Every caller was still expected to remember its own `os.getenv`, and one didn't.

So `config.gateway_chain()` now owns the read, and all four sites call it:

| site | before | after |
|---|---|---|
| `services/revenue_sweep.py:88` | `chain=DEFAULT_GATEWAY_CHAIN` — **the bug** | `chain=gateway_chain()` |
| `marketplace/payments.py:82` | `os.getenv(...).strip()` | `gateway_chain()` |
| `services/generation_payment.py:103` | `os.getenv(...).strip()` | `gateway_chain()` |
| `marketplace/settlement.py:34` | `os.getenv(...)` | `gateway_chain()` |

`DEFAULT_GATEWAY_CHAIN` is now referenced only inside `config.py`, and a test enforces that — the only way to get the chain elsewhere is to ask for it, and asking cannot forget the `getenv`.

Two incidental changes worth naming rather than burying:

- **`settlement.GATEWAY_CHAIN` now strips its value.** It was the one site that didn't. Same direction as the other three, so a task-def value carrying a trailing newline stops silently producing an unknown chain name.
- **`payments.py` no longer imports `os`** — it was left unused, and `F401` is inside the blocking `ruff-gate` subset, so leaving it would have failed CI.

`settlement.GATEWAY_CHAIN` stays a module-level constant read at import, because other modules import the name. I didn't convert it to a call.

## Shown to reject

Four mutations, each run against the new tests:

| mutation | result |
|---|---|
| restore the exact #1495 bug (`chain=DEFAULT_GATEWAY_CHAIN`) | **3 failed** |
| make `gateway_chain()` ignore the environment | **3 failed** |
| revert settlement to its own `getenv` | **1 failed** |
| blind the structural scan's `rglob` | **1 failed** — *"the guard is blind"* |

The first one's diagnostic is the one I'd want to read at 3am:

```
AssertionError: money path split across chains:
  {'revenue_sweep': 'arcTestnet', 'payments': 'arcMainnet',
   'quote': 'arcMainnet', 'helper': 'arcMainnet'}
```

Two notes on what the mutations show. The default-case tests **correctly keep passing** under mutation 1 — the bug only manifests when the environment differs from the default, which is exactly why it survived on testnet where the two agree. And mutation 4 exists because the structural test is a source scan: if its `rglob` ever stopped matching, it would pass vacuously forever. `test_the_scan_actually_reaches_the_money_path_modules` fails in that case by name.

## The cross-site test asserts agreement, not a literal

`test_all_call_time_sites_report_one_chain` compares the four sites against **each other**, not against `"arcMainnet"`. The property that matters is that they can't diverge; it should keep holding after the cutover changes what the right answer is.

## Verification

- New file: 8 passed. Hermetic gate (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend`): 8 passed.
- Directly affected existing suites (`test_settlement`, `test_payments`, `test_revenue_sweep`, `test_settlement_idempotency`): 50 passed.
- Full unit suite: **3727 passed, 2 skipped** — the 3719 on `main` plus these 8, no regressions.
- `ruff format --check .` and the blocking `--select E9,F63,F7,F40,F82` subset: clean.

## Not in scope

#1495 suggested a startup assertion that the sweep's chain matches settlement's. I've left that out — #1401 is already adding mainnet-gate startup assertions and that's the right home for it. With all four reads behind one function, the assertion has much less to check now anyway.

**#1463 is still open and still required.** It reports that the sweep can't run in the web tier at all, because the Circle credentials are absent from the backend task definition. Both need to be true before a mainnet sweep works — this PR makes it point at the right chain, not that it can run.
