### PR TITLE
[payments] A settled generation payment always buys something (#1441) !minor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 > **Where things live:** [`docs/README.md`](docs/README.md) — the doc index (a doc not
 > listed there does not exist) · [`docs/user-stories.md`](docs/user-stories.md) — canonical
 > product spine · [`docs/architecture.md`](docs/architecture.md) — architecture map ·
-> [`docs/adr/`](docs/adr/README.md) — 18 decision records. Current status comes from
+> [`docs/adr/`](docs/adr/README.md) — 19 decision records. Current status comes from
 > the live system, not a doc: `/health`, `GET /api/config/contracts`, and the
 > deploy history. (The README's dated Status section was retired 2026-08-20.)
 

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -42,7 +42,7 @@ from archimedes.api.generate_schemas import (
 )
 from archimedes.api.limiter import limiter
 from archimedes.api.wallet_routes import get_linked_wallet_address
-from archimedes.services import generation_payment
+from archimedes.services import generation_credits, generation_payment
 from archimedes.services.generation_quota import enforce_generation_quota
 from archimedes.services.identity_events import emit_identity_event
 from archimedes.services.job_queue import EVENT_LOG_TTL, get_job_store
@@ -235,6 +235,83 @@ def _persist_payment_receipt(*, user_id: str, payment, job_id: str) -> None:
         )
 
 
+async def _paywall_with_credit(request: Request, linked_wallet: str, user_id: str):
+    """Run the paywall so that money taken is always money accounted for (#1441).
+
+    Returns ``(payment, credit_id)``. ``credit_id`` names the credit this run
+    spends once it is safely enqueued; ``payment`` is the settled
+    ``PaymentInfo`` only when this request is what settled it.
+
+    The ordering below is the fix. The charge used to settle and the job to be
+    enqueued afterwards, with the entitlement gate in between — so a 402 from
+    that gate, an enqueue error, or a worker crash left the money taken and
+    nothing delivered. Now the charge buys a durable credit first, and only a
+    job that actually reaches the queue spends it.
+    """
+    # An unspent credit from an earlier paid-but-undelivered run pays for this
+    # one. Checked BEFORE the paywall, so a payer whose last generation died is
+    # never asked for money twice.
+    existing = generation_credits.take_credit(user_id)
+    if existing is not None:
+        logger.info("generation covered by unspent credit %s — no new charge", existing)
+        return None, existing
+
+    if not generation_payment.settles_real_value():
+        # Flag off or dry-run: the paywall still quotes and still exercises the
+        # 402 approval flow, but no value moves. Nothing to owe and nothing to
+        # record, so the ledger stays entirely out of the way.
+        settled = await generation_payment.enforce_generation_payment(request, linked_wallet)
+        return settled, None
+
+    idempotency_key = (request.headers.get("Idempotency-Key") or "").strip() or None
+    outcome, credit_id = generation_credits.claim(user_id, idempotency_key)
+
+    if outcome == "already_settled":
+        # This key already paid and the credit is still unspent. Spend it.
+        return None, credit_id
+    if outcome == "already_consumed":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "reason": "idempotency_key_already_used",
+                "message": (
+                    "This Idempotency-Key already paid for a generation that started. "
+                    "Use a new key to start another. No second charge was taken."
+                ),
+            },
+        )
+    if outcome == "in_flight":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "reason": "payment_in_flight",
+                "message": (
+                    "A payment with this Idempotency-Key is still settling. Wait for it to "
+                    "finish rather than retrying — a retry signs a fresh authorization and "
+                    "would charge you twice."
+                ),
+            },
+        )
+
+    try:
+        settled = await generation_payment.enforce_generation_payment(request, linked_wallet)
+    except BaseException:
+        # Includes the 402 the paywall raises when no payment was presented. The
+        # claim must not outlive the attempt: a `pending` row left behind reads
+        # as `in_flight` forever and locks that key out.
+        generation_credits.void(credit_id)
+        raise
+
+    if settled is None:
+        # settles_real_value() said otherwise, so this is a configuration race
+        # rather than an expected path. No value moved; release the claim.
+        generation_credits.void(credit_id)
+        return None, None
+
+    generation_credits.settle(credit_id, settled)
+    return settled, credit_id
+
+
 @generate_public_router.get("/quote")
 async def get_generation_quote():
     """The upfront generation cost estimate — public, so a human can see the
@@ -292,6 +369,7 @@ async def start_generation(
     # that is also the ONLY case a payment receipt is persisted (below, once
     # job_id exists).
     payment = None
+    credit_id = None
     if generation_payment.payment_required():
         if not linked_wallet:
             # The wallet-connection precondition. 409 (not 402): the blocker is
@@ -310,7 +388,7 @@ async def start_generation(
                     ),
                 },
             )
-        payment = await generation_payment.enforce_generation_payment(request, linked_wallet)
+        payment, credit_id = await _paywall_with_credit(request, linked_wallet, user.id)
         if payment is not None:
             # Surface the settlement receipt (PAYMENT-RESPONSE) to the payer.
             for name, value in (payment.response_headers or {}).items():
@@ -359,6 +437,11 @@ async def start_generation(
     # enqueue succeeds, so the receipt carries a real job_id.
     if payment is not None:
         _persist_payment_receipt(user_id=user.id, payment=payment, job_id=job_id)
+
+    # The credit is spent only now, once the job is queued — that is what makes
+    # every failure before this point cost the payer nothing (#1441).
+    if credit_id is not None:
+        generation_credits.consume(credit_id, job_id=job_id)
 
     # Fire-and-forget; the SSE stream tails events. User ownership is threaded
     # from this authenticated request, never client-supplied.
@@ -432,6 +515,41 @@ async def _heartbeat_loop(job_id: str, store) -> None:
             logger.exception("heartbeat: touch failed for job %s", sanitize_log_value(job_id))
 
 
+async def _release_credit_if_undelivered(job_id: str, store) -> None:
+    """Give the credit back unless the job actually delivered (#1441).
+
+    The charge bought a credit and the enqueue spent it. If the run then died —
+    worker crash, LLM failure, a container roll, or the payer cancelling — the
+    payer holds nothing, so the credit goes back and their next generation
+    spends it instead of asking for money again.
+
+    Terminal states other than ``done`` all restore. Cancellation is included
+    deliberately: a cancelled run produced no strategy, and charging for it
+    would make the paywall a fee on trying rather than a price for delivery.
+
+    A job whose Redis record has already expired reads as undelivered, which is
+    the safe direction to be wrong in — the alternative silently keeps money for
+    a run nobody can prove finished. ``restore_credit_for_job`` only ever moves
+    a ``consumed`` credit, so a second call cannot mint a second credit.
+
+    Fail-safe: this runs in a background task's ``finally`` with nobody to
+    report to, so it logs and returns.
+    """
+    try:
+        job = await store.get(job_id)
+        status = (job or {}).get("status")
+        if status == "done":
+            return
+        if generation_credits.restore_for_job(job_id):
+            logger.warning(
+                "job %s ended as %s — generation credit restored, the payer owes nothing",
+                sanitize_log_value(job_id),
+                sanitize_log_value(str(status)),
+            )
+    except Exception:
+        logger.exception("could not evaluate credit release for job %s", sanitize_log_value(job_id))
+
+
 async def _run_with_cleanup(
     job_id: str,
     brief: GenerateBrief,
@@ -477,6 +595,7 @@ async def _run_with_cleanup(
         heartbeat_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await heartbeat_task
+        await _release_credit_if_undelivered(job_id, store)
 
 
 @generate_router.get("/stream/{job_id}")

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -28,6 +28,7 @@ from archimedes.models.chat import Base
 from archimedes.models.corpus_store import CorpusMetaRecord, PaperRecord
 from archimedes.models.daily_returns_store import StrategyDailyReturn
 from archimedes.models.generation_cost import GenerationCostRecord
+from archimedes.models.generation_credit import GenerationCreditRecord
 from archimedes.models.identity import ControlledWallet, IdentityEvent, WalletIdentity
 from archimedes.models.marketplace import (
     MarketplaceAgent,
@@ -59,6 +60,7 @@ __all__ = [
     "ControlledWallet",
     "CorpusMetaRecord",
     "GenerationCostRecord",
+    "GenerationCreditRecord",
     "IdentityEvent",
     "LinkedWallet",
     "MarketplaceAgent",

--- a/backend/archimedes/models/generation_credit.py
+++ b/backend/archimedes/models/generation_credit.py
@@ -1,0 +1,268 @@
+"""Durable generation credits — the accounting record behind a settled payment (#1441).
+
+The x402 generation paywall settles the charge and *then* enqueues the job
+(``api/generate_routes.py``'s ``start_generation``). Everything between those
+two points, and everything the job does afterwards, could fail with the money
+already taken: the entitlement gate raising 402, the enqueue erroring, the
+worker crashing, the LLM failing, a container roll mid-run. Nothing released
+the charge and nothing recorded that the payer was owed anything.
+
+**The decision, written down** (the issue asked for one): a settled payment
+buys a *credit*, and the credit — not the payment — is what a generation
+spends. A refund was the alternative and was rejected: settling runs one way
+through Circle's facilitator, so refunding means a fresh outbound transfer out
+of the recipient DCW. That needs the Circle signer on the money path and rides
+on #975's unfinished custody migration. A refund path we cannot execute today
+would be a promise the code does not keep, and this repo's first rule is that
+claims must be true. A credit is local, durable, and needs no value to move.
+
+Lifecycle, one row per logical charge::
+
+    pending ──settle ok──> available ──enqueue ok──> consumed
+       │                        ▲                        │
+       │                        └────job did not finish──┘
+       └──settle failed/refused──> void
+
+``pending`` is claimed BEFORE the settle call, mirroring
+``marketplace/service.py``'s ``_claim_settlement_intent``: x402 is not
+crash-retry-idempotent (a retry signs a fresh EIP-3009 nonce, which settles as
+a brand-new payment), so the only way a retry can be recognised is a logical
+key claimed ahead of the charge. That key is the caller's ``Idempotency-Key``.
+
+``void`` rather than ``failed``: nothing went wrong with the money — the
+settle was refused or never attempted, so no value moved. Keeping it distinct
+from a *failed job* keeps the ledger readable.
+
+A credit carries no expiry. One is owed until it is spent.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Index, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from archimedes.models.chat import Base
+
+logger = logging.getLogger(__name__)
+
+CREDIT_PENDING = "pending"
+CREDIT_AVAILABLE = "available"
+CREDIT_CONSUMED = "consumed"
+CREDIT_VOID = "void"
+
+#: Bound on one payer's ledger read. Matches ``payment_receipt.MAX_RECEIPTS``.
+MAX_CREDITS = 200
+
+
+class GenerationCreditRecord(Base):
+    """One logical generation charge, from claim through to the job it funded."""
+
+    __tablename__ = "generation_credits"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # The caller's Idempotency-Key. NULL when the client sent none — and NULLs
+    # do not collide under a UNIQUE constraint in either Postgres or SQLite, so
+    # a caller who never sends one can still hold several credits at once.
+    idempotency_key: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default=CREDIT_PENDING)
+
+    # Everything below is unknown until the settle returns, so all of it is
+    # nullable: a `pending` row exists precisely because we do not yet know
+    # whether there will be a payment to describe.
+    payer_wallet: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    amount_base_units: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    price_usd: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    network: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    settlement_ref: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    #: The generation this credit was spent on. Set when the credit is
+    #: consumed, and deliberately KEPT when it is restored, so the ledger shows
+    #: which run failed rather than quietly reverting to a blank row.
+    job_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    settled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "idempotency_key", name="uq_generation_credits_user_key"),
+        Index("ix_generation_credits_user_status", "user_id", "status"),
+    )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "settled_at": self.settled_at.isoformat() if self.settled_at else None,
+            "consumed_at": self.consumed_at.isoformat() if self.consumed_at else None,
+            "price_usd": self.price_usd,
+            "amount_base_units": self.amount_base_units,
+            "payer_wallet": self.payer_wallet,
+            "settlement_ref": self.settlement_ref,
+            "job_id": self.job_id,
+            "network": self.network,
+        }
+
+
+def claim_credit(session: Session, *, user_id: str, idempotency_key: str | None) -> tuple[str, GenerationCreditRecord]:
+    """Claim the right to charge, BEFORE the money moves.
+
+    Returns ``(outcome, row)`` where outcome is one of:
+
+    ``claimed``
+        A fresh ``pending`` row. The caller may settle.
+    ``in_flight``
+        Another request holds this key and has not finished settling. The
+        caller must NOT settle — that is the double-charge this exists to stop.
+    ``already_settled``
+        This key already bought a credit that is still unspent.
+    ``already_consumed``
+        This key already bought a credit and a generation already spent it.
+
+    Ordering matters and is the whole point: claiming after the settle would
+    leave the window (settle returns, process dies before the write) wide open,
+    which is exactly the window a client retry lands in.
+    """
+    if not user_id:
+        raise ValueError("claim_credit requires a user_id")
+
+    if idempotency_key:
+        existing = (
+            session.query(GenerationCreditRecord)
+            .filter_by(user_id=user_id, idempotency_key=idempotency_key)
+            .one_or_none()
+        )
+        if existing is not None:
+            if existing.status == CREDIT_PENDING:
+                return "in_flight", existing
+            if existing.status == CREDIT_AVAILABLE:
+                return "already_settled", existing
+            if existing.status == CREDIT_CONSUMED:
+                return "already_consumed", existing
+            # A voided key is a charge that never happened; let it be retried.
+            existing.status = CREDIT_PENDING
+            existing.created_at = datetime.now(UTC)
+            session.flush()
+            return "claimed", existing
+
+    record = GenerationCreditRecord(
+        user_id=user_id,
+        idempotency_key=idempotency_key or None,
+        status=CREDIT_PENDING,
+        created_at=datetime.now(UTC),
+    )
+    session.add(record)
+    session.flush()
+    return "claimed", record
+
+
+def mark_credit_settled(
+    session: Session,
+    credit_id: int,
+    *,
+    payer_wallet: str,
+    amount_base_units: int,
+    price_usd: str,
+    network: str,
+    settlement_ref: str | None,
+) -> GenerationCreditRecord | None:
+    """Money moved: the claim becomes a spendable credit."""
+    record = session.get(GenerationCreditRecord, credit_id)
+    if record is None:
+        return None
+    record.status = CREDIT_AVAILABLE
+    record.payer_wallet = payer_wallet
+    record.amount_base_units = int(amount_base_units)
+    record.price_usd = str(price_usd)
+    record.network = str(network)
+    record.settlement_ref = settlement_ref
+    record.settled_at = datetime.now(UTC)
+    session.flush()
+    return record
+
+
+def void_credit(session: Session, credit_id: int) -> None:
+    """No value moved — release the claim so the key is usable again.
+
+    Called when the settle was refused, or when the paywall returned without
+    charging at all (flag off, dry-run). Leaving the row ``pending`` would
+    poison the idempotency key permanently: every later retry would read
+    ``in_flight`` and refuse to charge for a payment that never happened.
+    """
+    record = session.get(GenerationCreditRecord, credit_id)
+    if record is None:
+        return
+    if record.status == CREDIT_PENDING:
+        record.status = CREDIT_VOID
+        session.flush()
+
+
+def take_available_credit(session: Session, user_id: str) -> GenerationCreditRecord | None:
+    """The oldest unspent credit for *user_id*, or None.
+
+    Oldest-first so a payer's ledger drains in the order they paid.
+    """
+    if not user_id:
+        return None
+    return (
+        session.query(GenerationCreditRecord)
+        .filter_by(user_id=user_id, status=CREDIT_AVAILABLE)
+        .order_by(GenerationCreditRecord.created_at.asc(), GenerationCreditRecord.id.asc())
+        .first()
+    )
+
+
+def consume_credit(session: Session, credit_id: int, *, job_id: str) -> GenerationCreditRecord | None:
+    """Spend a credit on *job_id*. Only an ``available`` credit can be spent."""
+    record = session.get(GenerationCreditRecord, credit_id)
+    if record is None or record.status != CREDIT_AVAILABLE:
+        return None
+    record.status = CREDIT_CONSUMED
+    record.job_id = job_id
+    record.consumed_at = datetime.now(UTC)
+    session.flush()
+    return record
+
+
+def restore_credit_for_job(session: Session, job_id: str) -> GenerationCreditRecord | None:
+    """Give the credit back because *job_id* did not deliver.
+
+    ``job_id`` is left in place: the ledger should show which run burned and
+    gave the credit back, not silently rewind to a blank row. ``consumed_at``
+    is cleared, since the credit is once again unspent.
+
+    Idempotent — restoring an already-restored credit is a no-op, so a retried
+    or duplicated terminal-state callback cannot mint a second credit out of
+    one payment.
+    """
+    if not job_id:
+        return None
+    record = session.query(GenerationCreditRecord).filter_by(job_id=job_id, status=CREDIT_CONSUMED).one_or_none()
+    if record is None:
+        return None
+    record.status = CREDIT_AVAILABLE
+    record.consumed_at = None
+    session.flush()
+    return record
+
+
+def list_credits(session: Session, user_id: str, *, limit: int = MAX_CREDITS) -> list[dict[str, Any]]:
+    """Newest-first credits owned by *user_id*, capped at *limit*."""
+    if not user_id:
+        return []
+    records = (
+        session.query(GenerationCreditRecord)
+        .filter_by(user_id=user_id)
+        .order_by(GenerationCreditRecord.created_at.desc(), GenerationCreditRecord.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return [r.to_payload() for r in records]

--- a/backend/archimedes/services/generation_credits.py
+++ b/backend/archimedes/services/generation_credits.py
@@ -1,0 +1,174 @@
+"""Session-owning wrapper around the generation credit ledger (#1441).
+
+``models/generation_credit.py`` is pure persistence and takes a ``Session``.
+This module owns the sessions and decides, for each step, whether a failure is
+allowed to reach the caller. That split is the whole point of the file, because
+the answer changes at exactly one moment: **when the money moves.**
+
+- **Before the settle, failures are loud.** Claiming the idempotency key is
+  what makes a double-charge impossible. If the claim cannot be written, the
+  request must not proceed to take money — running the paywall anyway would
+  buy a charge with no protection behind it.
+
+- **After the settle, failures are quiet.** The payer's funds are already gone.
+  Raising here would hand them a 500 *and* keep their money, which is strictly
+  worse than the ledger inconsistency it would be reporting. These paths log at
+  ``error`` — they are real defects, not noise — but never surface.
+
+The asymmetry is deliberate and is the fail-soft principle applied honestly:
+fail-soft is wrong for anything a claim depends on, and right when the
+alternative harms the person the claim was meant to protect.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+from archimedes.models.generation_credit import (
+    claim_credit,
+    consume_credit,
+    mark_credit_settled,
+    restore_credit_for_job,
+    take_available_credit,
+    void_credit,
+)
+
+logger = logging.getLogger(__name__)
+
+#: USDC base units per dollar. Mirrors ``generate_routes._RECEIPT_USDC_DECIMALS``
+#: so a credit and the receipt written for the SAME payment render the same
+#: price string. ``test_credit_and_receipt_agree_on_the_price`` pins that.
+_USDC_DECIMALS = 6
+
+
+def _format_usd(amount_base_units: int) -> str:
+    return f"${Decimal(amount_base_units) / Decimal(10**_USDC_DECIMALS):.2f}"
+
+
+def _session():
+    from archimedes.db import get_session
+
+    return get_session()
+
+
+def take_credit(user_id: str) -> int | None:
+    """The id of an unspent credit for *user_id*, or None.
+
+    Quiet on failure: a ledger read that errors must not block a generation the
+    caller is about to pay for anyway. The cost of missing a credit here is
+    that the payer is charged again and ends up holding two — recoverable, and
+    strictly better than refusing them service over a read error.
+    """
+    try:
+        with _session() as session:
+            credit = take_available_credit(session, user_id)
+            if credit is None:
+                return None
+            credit_id = credit.id
+            session.commit()
+            return credit_id
+    except Exception:
+        logger.exception("generation credit lookup failed for user %s — treating as no credit", user_id)
+        return None
+
+
+def claim(user_id: str, idempotency_key: str | None) -> tuple[str, int | None]:
+    """Claim the right to charge. Raises on failure — see the module docstring.
+
+    Returns ``(outcome, credit_id)``; outcomes are those of
+    ``models.generation_credit.claim_credit``.
+    """
+    with _session() as session:
+        outcome, credit = claim_credit(session, user_id=user_id, idempotency_key=idempotency_key)
+        credit_id, job_id = credit.id, credit.job_id
+        session.commit()
+    if outcome != "claimed":
+        logger.info(
+            "generation credit claim for user %s returned %s (credit=%s job=%s)",
+            user_id,
+            outcome,
+            credit_id,
+            job_id,
+        )
+    return outcome, credit_id
+
+
+def settle(credit_id: int, payment) -> None:
+    """Record that the money moved. Quiet on failure — the funds are gone."""
+    try:
+        with _session() as session:
+            amount_base_units = int(payment.amount)
+            mark_credit_settled(
+                session,
+                credit_id,
+                payer_wallet=str(payment.payer),
+                amount_base_units=amount_base_units,
+                price_usd=_format_usd(amount_base_units),
+                network=str(payment.network),
+                settlement_ref=payment.transaction,
+            )
+            session.commit()
+    except Exception:
+        logger.error(
+            "generation credit %s could not be marked settled — the payment CLEARED but is "
+            "not recorded as owed. Manual reconciliation needed.",
+            credit_id,
+            exc_info=True,
+        )
+
+
+def void(credit_id: int) -> None:
+    """Release a claim that never became a charge. Quiet: no value moved.
+
+    Loud enough to matter, though — a claim left ``pending`` poisons that
+    idempotency key for every later retry.
+    """
+    try:
+        with _session() as session:
+            void_credit(session, credit_id)
+            session.commit()
+    except Exception:
+        logger.error(
+            "generation credit claim %s could not be voided — that idempotency key will read "
+            "as in-flight on retry until it is cleared.",
+            credit_id,
+            exc_info=True,
+        )
+
+
+def consume(credit_id: int, *, job_id: str) -> None:
+    """Spend the credit on *job_id*. Quiet on failure.
+
+    A credit that fails to be marked consumed stays ``available``, so the payer
+    could spend it a second time. That errs toward the payer, which is the
+    correct direction for an accounting bug on a paywall.
+    """
+    try:
+        with _session() as session:
+            consume_credit(session, credit_id, job_id=job_id)
+            session.commit()
+    except Exception:
+        logger.error(
+            "generation credit %s could not be marked consumed for job %s — it stays spendable.",
+            credit_id,
+            job_id,
+            exc_info=True,
+        )
+
+
+def restore_for_job(job_id: str) -> bool:
+    """Give a credit back because *job_id* did not deliver. Quiet on failure."""
+    try:
+        with _session() as session:
+            restored = restore_credit_for_job(session, job_id)
+            session.commit()
+            return restored is not None
+    except Exception:
+        logger.error(
+            "generation credit for job %s could not be restored — a payer may be owed a "
+            "generation with nothing recording it.",
+            job_id,
+            exc_info=True,
+        )
+        return False

--- a/backend/archimedes/services/generation_payment.py
+++ b/backend/archimedes/services/generation_payment.py
@@ -72,6 +72,17 @@ def _recipient() -> str:
     return os.getenv("GENERATION_PAYMENT_RECIPIENT", "").strip()
 
 
+def settles_real_value() -> bool:
+    """True only when a presented payment will actually be verified and settled.
+
+    The generation credit ledger (#1441) hangs off this. Under flag-off or
+    dry-run no value moves, so there is nothing to owe anybody and no claim
+    worth writing — the ledger stays completely inert, which is what keeps this
+    change a no-op in production until the payment stack is flipped on.
+    """
+    return payment_required() and not _payments_dry_run()
+
+
 def _price() -> str:
     """The circlekit "$X.XXXXXX" price string. Fails SAFE to the default on a
     malformed env value (a typo must not turn the paywall free or absurd)."""

--- a/backend/migrations/versions/a3f19c7d2e84_add_generation_credits.py
+++ b/backend/migrations/versions/a3f19c7d2e84_add_generation_credits.py
@@ -1,0 +1,91 @@
+"""add generation_credits — a settled payment survives a failed job (#1441)
+
+The x402 generation paywall settles the charge and then enqueues the job.
+Between those points the entitlement gate can raise 402 and the enqueue can
+error; after them the worker can crash, the LLM can fail, or a container roll
+can take the run down. In every one of those cases the money was taken and
+nothing released it, and there was no record that the payer was owed anything.
+
+This table is that record. A settled payment buys a credit; a generation spends
+the credit. If the run does not deliver, the credit goes back to ``available``
+and the payer's next attempt spends it instead of paying again.
+
+A refund was the alternative and was rejected: settling runs one way through
+Circle's facilitator, so refunding means a fresh outbound transfer out of the
+recipient DCW — the money path, gated on #975's custody migration. See
+``docs/adr/generation-payment-credit-not-refund.md``.
+
+The ``pending`` state is claimed BEFORE the settle call, mirroring
+``marketplace/service.py``'s ``_claim_settlement_intent``. x402 is not
+crash-retry-idempotent — a retry signs a fresh EIP-3009 nonce and settles as a
+new payment — so a logical key claimed ahead of the charge is the only thing
+that can recognise a retry. ``uq_generation_credits_user_key`` is what makes
+that claim atomic.
+
+BACKFILL (migrations-ship-with-their-data rule): **none, and none is needed.**
+``PAYMENTS_DRY_RUN`` has held in production for the whole life of the paywall,
+so no generation payment has ever settled real value — there is no historical
+charge that is owed a credit. Every row in ``payment_receipts`` predating this
+revision was written on a path where no value moved.
+
+Revision ID: a3f19c7d2e84
+Revises: 1752121b8d7c
+Create Date: 2026-08-29 00:00:00.000000
+
+SEQUENCING: chained onto ``1752121b8d7c``, the chain head at authoring time.
+If another migration lands on main first, re-point ``down_revision`` at the
+new head — ``.github/scripts/migration_chain_guard.py`` catches a fork.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f19c7d2e84"
+down_revision: str | Sequence[str] | None = "1752121b8d7c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "generation_credits",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("payer_wallet", sa.String(length=64), nullable=True),
+        sa.Column("amount_base_units", sa.Integer(), nullable=True),
+        sa.Column("price_usd", sa.String(length=32), nullable=True),
+        sa.Column("network", sa.String(length=64), nullable=True),
+        sa.Column("settlement_ref", sa.String(length=128), nullable=True),
+        sa.Column("job_id", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("settled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        # The atomic half of the idempotency claim. NULL keys do not collide
+        # under UNIQUE in either Postgres or SQLite, so a caller who sends no
+        # Idempotency-Key can still hold several credits at once.
+        sa.UniqueConstraint("user_id", "idempotency_key", name="uq_generation_credits_user_key"),
+    )
+    op.create_index("ix_generation_credits_user_status", "generation_credits", ["user_id", "status"])
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Dropping the table discards every unspent credit. Those represent payments
+    that settled and were never delivered against — money owed to real payers,
+    kept nowhere else. A downgrade is a deliberate write-off, not a reversible
+    move.
+    """
+    op.drop_index("ix_generation_credits_user_status", table_name="generation_credits")
+    op.drop_table("generation_credits")

--- a/backend/tests/test_generation_credits.py
+++ b/backend/tests/test_generation_credits.py
@@ -1,0 +1,562 @@
+"""A settled generation payment always buys something (#1441).
+
+The paywall settled the charge and enqueued the job afterwards, with the
+premium-model entitlement gate sitting between them. Anything that failed in
+that window — the gate raising 402, the enqueue erroring — and anything that
+failed after it — worker crash, LLM failure, container roll, the payer
+cancelling — kept the money with nothing delivered and nothing recording that
+the payer was owed a generation.
+
+A settled payment now buys a durable *credit*, and only a job that reaches the
+queue spends it. A run that does not deliver hands the credit back.
+
+Covers:
+
+  1. the ledger: claim/settle/consume/restore transitions, the idempotency key
+     as a unique claim, and oldest-first draining;
+  2. the window this issue is about: enqueue failure and entitlement-gate 402
+     after a settled charge both leave a spendable credit;
+  3. the payoff: the payer's NEXT attempt spends that credit and is not
+     charged again;
+  4. idempotency: a retry against an in-flight key is refused rather than
+     settling a second EIP-3009 authorization;
+  5. inertness: under flag-off and under dry-run the ledger writes nothing at
+     all, so this is a no-op in production until the payment stack is flipped.
+
+Hermetic: tmp-file SQLite (``redirect_to_tmp_sqlite``), mocked job store and
+backgrounded task — the harness from ``test_payment_receipts.py``. No live
+Redis, Postgres or Circle facilitator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.api import generate_routes
+from archimedes.db import get_session
+from archimedes.models.generation_credit import (
+    CREDIT_AVAILABLE,
+    CREDIT_CONSUMED,
+    CREDIT_PENDING,
+    CREDIT_VOID,
+    GenerationCreditRecord,
+    claim_credit,
+    consume_credit,
+    mark_credit_settled,
+    restore_credit_for_job,
+    take_available_credit,
+    void_credit,
+)
+from archimedes.services import generation_payment
+from fastapi.testclient import TestClient
+
+from tests.auth_helpers import auth_cookies
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+RECIPIENT = "0x00000000000000000000000000000000000000a1"
+PAYER_A = "0x" + "12" * 20  # matches tests.auth_helpers.TEST_WALLET
+USER = "user-a"
+
+_BODY = {"brief": {"intent": "low-vol treasury alternative", "risk_appetite": "moderate"}}
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@dataclass
+class _FakePaymentInfo:
+    """Mirrors circlekit.x402.PaymentInfo exactly; ``amount`` is raw base units."""
+
+    verified: bool = True
+    payer: str = PAYER_A
+    amount: str = "2000000"  # $2.00 at USDC's 6 decimals
+    network: str = "eip155:5042002"
+    transaction: str | None = "831aaaf1-f110-47f7-8faf-c76aa8f841cb"
+    response_headers: dict = field(default_factory=dict)
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _mock_store(job_id: str = "job-credit") -> MagicMock:
+    store = MagicMock()
+    store.enqueue = AsyncMock(return_value=job_id)
+    return store
+
+
+def _close_background_coroutine(coro):
+    coro.close()
+    return MagicMock()
+
+
+def _harness(store):
+    return (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        patch(
+            "archimedes.api.generate_routes.asyncio.create_task",
+            side_effect=_close_background_coroutine,
+        ),
+    )
+
+
+def _paywall_on(monkeypatch) -> AsyncMock:
+    """Flag on, dry-run off, and a settle that succeeds. Returns the mock so a
+    test can assert how many times a charge was actually taken."""
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+    monkeypatch.delenv("GENERATION_PAYMENTS_DRY_RUN", raising=False)
+    settle = AsyncMock(return_value=_FakePaymentInfo())
+    monkeypatch.setattr(generation_payment, "enforce_generation_payment", settle)
+    return settle
+
+
+def _route_owner_id(settle) -> str:
+    """The owner id ``/api/generate/start`` writes credits under.
+
+    Derived by running one real paid generation and reading the row back,
+    rather than hard-coding a literal that would silently stop matching if the
+    route's identity source ever changed. The credit it creates is consumed by
+    that run, so it does not affect a later ``take_credit``.
+    """
+    store_patch, task_patch = _harness(_mock_store("job-probe"))
+    with store_patch, task_patch, _client() as client:
+        resp = client.post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+    assert resp.status_code == 202, resp.text
+    rows = _credits()
+    assert len(rows) == 1 and rows[0].status == CREDIT_CONSUMED
+    return rows[0].user_id
+
+
+def _credits() -> list[GenerationCreditRecord]:
+    with get_session() as session:
+        return list(session.query(GenerationCreditRecord).order_by(GenerationCreditRecord.id).all())
+
+
+# ── 1. The ledger ────────────────────────────────────────────────────────
+
+
+class TestLedgerTransitions:
+    def test_a_fresh_claim_is_pending_and_carries_no_payment_yet(self):
+        with get_session() as session:
+            outcome, credit = claim_credit(session, user_id=USER, idempotency_key="k1")
+            session.commit()
+            assert outcome == "claimed"
+            assert credit.status == CREDIT_PENDING
+            assert credit.settlement_ref is None
+            assert credit.amount_base_units is None
+
+    def test_settle_then_consume_then_restore(self):
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key=None)
+            mark_credit_settled(
+                session,
+                credit.id,
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="eip155:5042002",
+                settlement_ref="ref-1",
+            )
+            assert credit.status == CREDIT_AVAILABLE
+            assert credit.settled_at is not None
+
+            consume_credit(session, credit.id, job_id="job-1")
+            assert credit.status == CREDIT_CONSUMED
+            assert credit.consumed_at is not None
+
+            restore_credit_for_job(session, "job-1")
+            session.commit()
+            assert credit.status == CREDIT_AVAILABLE
+            assert credit.consumed_at is None
+            # job_id is deliberately kept — the ledger should show which run
+            # burned and handed the credit back, not rewind to a blank row.
+            assert credit.job_id == "job-1"
+
+    def test_restoring_twice_cannot_mint_a_second_credit(self):
+        """A duplicated terminal-state callback must not double-credit."""
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key=None)
+            mark_credit_settled(
+                session,
+                credit.id,
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="net",
+                settlement_ref="ref",
+            )
+            consume_credit(session, credit.id, job_id="job-1")
+            assert restore_credit_for_job(session, "job-1") is not None
+            assert restore_credit_for_job(session, "job-1") is None
+            session.commit()
+        assert len(_credits()) == 1
+
+    def test_only_an_available_credit_can_be_spent(self):
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key=None)
+            session.commit()
+            # Still pending — the money has not moved, so there is nothing to spend.
+            assert consume_credit(session, credit.id, job_id="job-1") is None
+
+    def test_voiding_cannot_destroy_a_credit_the_payer_already_bought(self):
+        """``void`` releases an unstarted claim. It must never erase money taken.
+
+        No current caller reaches ``void_credit`` with a settled credit — both
+        call sites hold a ``pending`` one. This pins the guard that keeps that
+        true, because the failure it prevents is unrecoverable: the charge
+        cleared, and the only record that the payer is owed anything is this row.
+        """
+        with get_session() as session:
+            for terminal, expected in (("settle", CREDIT_AVAILABLE), ("consume", CREDIT_CONSUMED)):
+                _, credit = claim_credit(session, user_id=USER, idempotency_key=None)
+                mark_credit_settled(
+                    session,
+                    credit.id,
+                    payer_wallet=PAYER_A,
+                    amount_base_units=2_000_000,
+                    price_usd="$2.00",
+                    network="net",
+                    settlement_ref=f"ref-{terminal}",
+                )
+                if terminal == "consume":
+                    consume_credit(session, credit.id, job_id=f"job-{terminal}")
+                void_credit(session, credit.id)
+                session.commit()
+                assert credit.status == expected, f"void() destroyed a {expected} credit"
+
+    def test_credits_drain_oldest_first(self):
+        with get_session() as session:
+            ids = []
+            for ref in ("ref-1", "ref-2"):
+                _, credit = claim_credit(session, user_id=USER, idempotency_key=None)
+                mark_credit_settled(
+                    session,
+                    credit.id,
+                    payer_wallet=PAYER_A,
+                    amount_base_units=2_000_000,
+                    price_usd="$2.00",
+                    network="net",
+                    settlement_ref=ref,
+                )
+                ids.append(credit.id)
+            session.commit()
+            assert take_available_credit(session, USER).id == ids[0]
+
+    def test_credits_are_owner_scoped(self):
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key=None)
+            mark_credit_settled(
+                session,
+                credit.id,
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="net",
+                settlement_ref="ref",
+            )
+            session.commit()
+            assert take_available_credit(session, "someone-else") is None
+
+
+class TestIdempotencyKeyClaim:
+    def test_a_second_claim_on_a_live_key_reads_in_flight(self):
+        with get_session() as session:
+            claim_credit(session, user_id=USER, idempotency_key="k1")
+            session.commit()
+            outcome, _ = claim_credit(session, user_id=USER, idempotency_key="k1")
+            assert outcome == "in_flight"
+
+    def test_a_key_whose_credit_is_unspent_reads_already_settled(self):
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key="k1")
+            mark_credit_settled(
+                session,
+                credit.id,
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="net",
+                settlement_ref="ref",
+            )
+            session.commit()
+            assert claim_credit(session, user_id=USER, idempotency_key="k1")[0] == "already_settled"
+
+    def test_a_key_whose_credit_was_spent_reads_already_consumed(self):
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key="k1")
+            mark_credit_settled(
+                session,
+                credit.id,
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="net",
+                settlement_ref="ref",
+            )
+            consume_credit(session, credit.id, job_id="job-1")
+            session.commit()
+            assert claim_credit(session, user_id=USER, idempotency_key="k1")[0] == "already_consumed"
+
+    def test_a_voided_key_becomes_reusable(self):
+        """A claim that never became a charge must not lock the key forever."""
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key="k1")
+            void_credit(session, credit.id)
+            session.commit()
+            assert credit.status == CREDIT_VOID
+            outcome, again = claim_credit(session, user_id=USER, idempotency_key="k1")
+            session.commit()
+            assert outcome == "claimed"
+            assert again.id == credit.id
+        assert len(_credits()) == 1
+
+    def test_keyless_claims_do_not_collide(self):
+        """NULL keys are distinct under UNIQUE, so a client that sends none can
+        still hold several credits."""
+        with get_session() as session:
+            claim_credit(session, user_id=USER, idempotency_key=None)
+            claim_credit(session, user_id=USER, idempotency_key=None)
+            session.commit()
+        assert len(_credits()) == 2
+
+
+# ── 2. The window the issue is about ─────────────────────────────────────
+
+
+class TestMoneyTakenIsAlwaysAccountedFor:
+    def test_enqueue_failure_leaves_a_spendable_credit(self, monkeypatch):
+        """The charge cleared; the job never queued. The payer keeps a credit."""
+        _paywall_on(monkeypatch)
+        store = _mock_store()
+        store.enqueue = AsyncMock(side_effect=RuntimeError("redis is down"))
+        store_patch, task_patch = _harness(store)
+        with store_patch, task_patch, _client() as client, pytest.raises(RuntimeError):
+            client.post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+
+        rows = _credits()
+        assert len(rows) == 1
+        assert rows[0].status == CREDIT_AVAILABLE
+        assert rows[0].settlement_ref == "831aaaf1-f110-47f7-8faf-c76aa8f841cb"
+        assert rows[0].job_id is None
+
+    def test_entitlement_gate_402_after_settling_leaves_a_spendable_credit(self, monkeypatch):
+        """The sharpest window: pay, then get 402'd for a premium model."""
+        from fastapi import HTTPException
+
+        _paywall_on(monkeypatch)
+        monkeypatch.setattr(
+            generate_routes,
+            "enforce_model_entitlement",
+            MagicMock(side_effect=HTTPException(status_code=402, detail="premium not entitled")),
+        )
+        store_patch, task_patch = _harness(_mock_store())
+        with store_patch, task_patch, _client() as client:
+            resp = client.post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+        assert resp.status_code == 402
+
+        rows = _credits()
+        assert len(rows) == 1
+        assert rows[0].status == CREDIT_AVAILABLE
+
+    def test_the_next_attempt_spends_the_credit_and_is_not_charged_again(self, monkeypatch):
+        """The payoff. This is what makes the credit worth anything."""
+        settle = _paywall_on(monkeypatch)
+        store = _mock_store()
+        store.enqueue = AsyncMock(side_effect=RuntimeError("redis is down"))
+        store_patch, task_patch = _harness(store)
+        with store_patch, task_patch, _client() as client, pytest.raises(RuntimeError):
+            client.post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+        assert settle.await_count == 1
+
+        # Second attempt, everything healthy.
+        store2 = _mock_store("job-second")
+        store_patch2, task_patch2 = _harness(store2)
+        with store_patch2, task_patch2, _client() as client:
+            resp = client.post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+        assert resp.status_code == 202
+
+        # No second charge was taken...
+        assert settle.await_count == 1
+        # ...and the one credit was spent on the run that actually started.
+        rows = _credits()
+        assert len(rows) == 1
+        assert rows[0].status == CREDIT_CONSUMED
+        assert rows[0].job_id == "job-second"
+
+    def test_a_delivered_generation_spends_its_credit(self, monkeypatch):
+        _paywall_on(monkeypatch)
+        store_patch, task_patch = _harness(_mock_store("job-ok"))
+        with store_patch, task_patch, _client() as client:
+            assert client.post("/api/generate/start", json=_BODY, cookies=auth_cookies()).status_code == 202
+        rows = _credits()
+        assert len(rows) == 1
+        assert rows[0].status == CREDIT_CONSUMED
+        assert rows[0].job_id == "job-ok"
+
+
+class TestIdempotencyOverTheRoute:
+    def test_a_retry_against_an_in_flight_key_is_refused_not_charged(self, monkeypatch):
+        """x402 is not crash-retry-idempotent: a retry signs a FRESH EIP-3009
+        authorization, so an unguarded retry settles a second real payment."""
+        settle = _paywall_on(monkeypatch)
+
+        # The route derives its own owner id from the session, so learn it from
+        # a real request rather than asserting against a guessed literal.
+        owner = _route_owner_id(settle)
+        with get_session() as session:
+            claim_credit(session, user_id=owner, idempotency_key="retry-me")
+            session.commit()
+        charges_before = settle.await_count
+
+        store_patch, task_patch = _harness(_mock_store())
+        with store_patch, task_patch, _client() as client:
+            resp = client.post(
+                "/api/generate/start",
+                json=_BODY,
+                cookies=auth_cookies(),
+                headers={"Idempotency-Key": "retry-me"},
+            )
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["reason"] == "payment_in_flight"
+        assert settle.await_count == charges_before  # no second charge
+
+    def test_a_spent_key_is_refused_without_a_second_charge(self, monkeypatch):
+        """End to end: the same key twice buys one generation, not two."""
+        settle = _paywall_on(monkeypatch)
+        store_patch, task_patch = _harness(_mock_store("job-first"))
+        with store_patch, task_patch, _client() as client:
+            first = client.post(
+                "/api/generate/start",
+                json=_BODY,
+                cookies=auth_cookies(),
+                headers={"Idempotency-Key": "spent"},
+            )
+        assert first.status_code == 202
+        assert settle.await_count == 1
+
+        store_patch2, task_patch2 = _harness(_mock_store("job-second"))
+        with store_patch2, task_patch2, _client() as client:
+            resp = client.post(
+                "/api/generate/start",
+                json=_BODY,
+                cookies=auth_cookies(),
+                headers={"Idempotency-Key": "spent"},
+            )
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["reason"] == "idempotency_key_already_used"
+        assert settle.await_count == 1  # the retry took no money
+        assert len(_credits()) == 1
+
+    def test_a_402_releases_the_claim_so_the_key_stays_usable(self, monkeypatch):
+        """An unpaid first attempt must not lock the caller's key forever."""
+        from fastapi import HTTPException
+
+        monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+        monkeypatch.delenv("GENERATION_PAYMENTS_DRY_RUN", raising=False)
+        monkeypatch.setattr(
+            generation_payment,
+            "enforce_generation_payment",
+            AsyncMock(side_effect=HTTPException(status_code=402, detail="pay up")),
+        )
+        store_patch, task_patch = _harness(_mock_store())
+        with store_patch, task_patch, _client() as client:
+            resp = client.post(
+                "/api/generate/start",
+                json=_BODY,
+                cookies=auth_cookies(),
+                headers={"Idempotency-Key": "unpaid"},
+            )
+        assert resp.status_code == 402
+        rows = _credits()
+        assert len(rows) == 1
+        assert rows[0].status == CREDIT_VOID
+
+
+# ── 3. Job outcomes ──────────────────────────────────────────────────────
+
+
+class TestCreditFollowsDelivery:
+    async def _release(self, job_id: str, status: str | None):
+        store = MagicMock()
+        store.get = AsyncMock(return_value=None if status is None else {"status": status})
+        await generate_routes._release_credit_if_undelivered(job_id, store)
+
+    def _consumed_credit(self, job_id: str) -> int:
+        with get_session() as session:
+            _, credit = claim_credit(session, user_id=USER, idempotency_key=None)
+            mark_credit_settled(
+                session,
+                credit.id,
+                payer_wallet=PAYER_A,
+                amount_base_units=2_000_000,
+                price_usd="$2.00",
+                network="net",
+                settlement_ref="ref",
+            )
+            consume_credit(session, credit.id, job_id=job_id)
+            session.commit()
+            return credit.id
+
+    @pytest.mark.parametrize("status", ["error", "failed", "cancelled", "stalled", None])
+    async def test_a_run_that_did_not_deliver_hands_the_credit_back(self, status):
+        self._consumed_credit("job-x")
+        await self._release("job-x", status)
+        assert _credits()[0].status == CREDIT_AVAILABLE
+
+    async def test_a_delivered_run_keeps_the_credit_spent(self):
+        self._consumed_credit("job-x")
+        await self._release("job-x", "done")
+        assert _credits()[0].status == CREDIT_CONSUMED
+
+
+# ── 4. Inert until the payment stack is flipped on ───────────────────────
+
+
+class TestLedgerIsInertWithoutRealValue:
+    def test_dry_run_writes_no_credit(self, monkeypatch):
+        monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+        monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+        monkeypatch.setenv("PAYMENTS_DRY_RUN", "true")
+        monkeypatch.delenv("GENERATION_PAYMENTS_DRY_RUN", raising=False)
+        monkeypatch.setattr(generation_payment, "enforce_generation_payment", AsyncMock(return_value=None))
+        store_patch, task_patch = _harness(_mock_store())
+        with store_patch, task_patch, _client() as client:
+            assert client.post("/api/generate/start", json=_BODY, cookies=auth_cookies()).status_code == 202
+        assert _credits() == []
+
+    def test_flag_off_writes_no_credit(self, monkeypatch):
+        monkeypatch.delenv("GENERATION_PAYMENT_REQUIRED", raising=False)
+        store_patch, task_patch = _harness(_mock_store())
+        with store_patch, task_patch, _client() as client:
+            assert client.post("/api/generate/start", json=_BODY, cookies=auth_cookies()).status_code == 202
+        assert _credits() == []
+
+
+# ── 5. The credit and the receipt describe one payment ───────────────────
+
+
+def test_credit_and_receipt_agree_on_the_price(monkeypatch):
+    """Two tables render the same settled amount; they must not disagree."""
+    from archimedes.models.payment_receipt import PaymentReceiptRecord
+
+    _paywall_on(monkeypatch)
+    store_patch, task_patch = _harness(_mock_store("job-price"))
+    with store_patch, task_patch, _client() as client:
+        assert client.post("/api/generate/start", json=_BODY, cookies=auth_cookies()).status_code == 202
+
+    with get_session() as session:
+        receipt = session.query(PaymentReceiptRecord).one()
+        credit = session.query(GenerationCreditRecord).one()
+        assert credit.price_usd == receipt.price_usd == "$2.00"
+        assert credit.amount_base_units == receipt.amount_base_units
+        assert credit.settlement_ref == receipt.settlement_ref

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,6 +140,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`adr/portfolio-constructor-decision-tree.md`](adr/portfolio-constructor-decision-tree.md) | accepted | Önder Akkaya | 2026-05-22 | Which constructor runs when. |
 | [`adr/k1-generation-external-rigor-gate.md`](adr/k1-generation-external-rigor-gate.md) | accepted | Dan Browne | 2026-05-23 | K=1 generation with an externalised rigor gate. |
 | [`adr/aws-account-migration.md`](adr/aws-account-migration.md) | accepted | Dan Browne | 2026-06-24 | Production moved to account 037613907429 / us-east-1. |
+| [`adr/generation-payment-credit-not-refund.md`](adr/generation-payment-credit-not-refund.md) | accepted | Önder Akkaya | 2026-08-29 | An undelivered generation is repaid as a durable credit, never a refund; the claim is taken before the money moves. |
 | [`adr/glm-to-bedrock-llm-migration.md`](adr/glm-to-bedrock-llm-migration.md) | accepted | Dan Browne | 2026-06-24 | GLM → Bedrock. |
 | [`adr/non-custodial-vault-owner-agent.md`](adr/non-custodial-vault-owner-agent.md) | accepted | Dan Browne | 2026-06-26 | Owner ≠ agent; non-custodial vaults. |
 | [`adr/portfolio-constructor-consolidation.md`](adr/portfolio-constructor-consolidation.md) | accepted | Önder Akkaya | 2026-06-26 | Legacy constructor paths retired; dual-signal sizer activated. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,6 +47,7 @@ this table mirrors them.
 | [`portfolio-constructor-decision-tree.md`](portfolio-constructor-decision-tree.md) | Accepted | 2026-05-22 | Önder Akkaya | Which portfolio constructor runs when |
 | [`k1-generation-external-rigor-gate.md`](k1-generation-external-rigor-gate.md) | Accepted | 2026-05-23 | Dan Browne | Why generation emits **K=1** winner + considered-rejects, with the rigor gate run **externally** |
 | [`aws-account-migration.md`](aws-account-migration.md) | Accepted | 2026-06-24 | Dan Browne | Why prod moved to Dan's own AWS account (`037613907429`/`us-east-1`) post-Agora |
+| [`generation-payment-credit-not-refund.md`](generation-payment-credit-not-refund.md) | Accepted | 2026-08-29 | Önder Akkaya | Why an undelivered generation is repaid as a **durable credit, never a refund**, and why the idempotency claim is taken before the money moves (#1441) |
 | [`glm-to-bedrock-llm-migration.md`](glm-to-bedrock-llm-migration.md) | Accepted | 2026-06-24 | Dan Browne | Why the live LLM moved from **GLM to AWS Bedrock** (Nova Micro default, Converse backend) (#717) |
 | [`non-custodial-vault-owner-agent.md`](non-custodial-vault-owner-agent.md) | Accepted | 2026-06-26 | Dan Browne | Why vaults separate **owner (withdrawal)** from **agent (rebalance-only)** so a compromised agent key can't drain (#731) |
 | [`portfolio-constructor-consolidation.md`](portfolio-constructor-consolidation.md) | Accepted | 2026-06-26 | Önder Akkaya | Why legacy constructors were retired and a **dual-signal** (regime × consensus) sizer activated (#131, #662) |

--- a/docs/adr/generation-payment-credit-not-refund.md
+++ b/docs/adr/generation-payment-credit-not-refund.md
@@ -1,0 +1,125 @@
+# ADR: An undelivered generation is repaid as a credit, never refunded
+
+> **Audience:** Archimedes team
+> **Status:** **Accepted** (implementation shipped; payment-stack owner's sequencing unchanged)
+> **Date:** 2026-08-29
+> **Owner:** Önder Akkaya (payment-stack reviewer of record: Dan Browne)
+> **Supersedes:** —
+> **Superseded-by:** —
+> **Question being decided:** The x402 generation paywall settles a charge before the job is enqueued. When the job never delivers, does the payer get their money back, or something else?
+> **Related:** [#1441](https://github.com/a-apin/archimedes/issues/1441), [`backend/archimedes/models/generation_credit.py`](../../backend/archimedes/models/generation_credit.py), [`backend/archimedes/services/generation_credits.py`](../../backend/archimedes/services/generation_credits.py), [`backend/archimedes/api/generate_routes.py`](../../backend/archimedes/api/generate_routes.py) (`_paywall_with_credit`), [#975](https://github.com/a-apin/archimedes/issues/975) (custody migration), [`architectural-principles.md`](../architectural-principles.md) § fail-soft.
+
+## TL;DR
+
+**A settled generation payment buys a durable *credit*, and a generation spends the credit.
+A run that does not deliver hands the credit back, and the payer's next attempt spends it
+instead of paying again.** Refunds were considered and rejected: we cannot execute one
+today, and a refund promise we cannot keep is exactly the kind of claim this repo's first
+rule forbids.
+
+## Context
+
+`POST /api/generate/start` settled the charge and enqueued the job afterwards, with the
+premium-model entitlement gate sitting between the two. Every failure in that window — the
+gate raising 402, the enqueue erroring — and every failure after it — worker crash, LLM
+failure, a container roll mid-run, the payer cancelling — kept the money with nothing
+delivered. Nothing released the charge, and nothing recorded that the payer was owed
+anything.
+
+Separately, the payment step took no idempotency key. x402 is not crash-retry-idempotent:
+a client retrying after an ambiguous failure signs a **fresh** EIP-3009 authorization,
+which settles as a second real payment.
+
+`PAYMENTS_DRY_RUN` has held throughout, so no real value has ever moved on this path. That
+is what makes this a design decision rather than an incident — and why it had to be settled
+before the payment stack is flipped on, not after.
+
+## Options considered
+
+**1. Refund the charge.** The obvious answer, and the one the issue listed first.
+
+Rejected on feasibility, not on principle. Settlement runs one way through Circle's
+facilitator: we hand it a signed authorization and it moves the payer's USDC to the
+recipient DCW. There is no reverse call. A refund is a **new outbound transfer** out of that
+DCW, which needs the Circle signer on the money path — the surface #975's custody migration
+is still open on, and the one thing this repo treats as highest-risk. Shipping a refund path
+we could not actually execute would put a promise in the product that the code does not
+keep.
+
+**2. Credit the payer.** A settled payment creates a durable credit; a generation spends
+one. Undelivered runs return it.
+
+Chosen. It is local, needs no value to move, needs no signer, and is fully testable without
+touching Circle. It also composes with a refund later: if #975 lands and outbound transfers
+become safe, "redeem a credit as a refund" is a new operation on an existing ledger, not a
+redesign.
+
+**3. Reserve, then capture.** Authorize at request time and capture only on delivery — the
+card-network model.
+
+Rejected: x402/EIP-3009 has no authorize-and-capture split. The authorization *is* the
+transfer. Building a reservation would mean holding signed authorizations server-side and
+settling them later, which is strictly more custody risk than we have today, in the
+direction #975 is trying to move away from.
+
+## Decision
+
+Credits, with the claim taken **before** the money moves.
+
+The ledger is `generation_credits`, one row per logical charge:
+
+```
+pending ──settle ok──> available ──enqueue ok──> consumed
+   │                        ▲                        │
+   │                        └────job did not finish──┘
+   └──settle failed/refused──> void
+```
+
+`pending` is claimed ahead of the settle, mirroring
+[`marketplace/service.py`](../../backend/archimedes/marketplace/service.py)'s
+`_claim_settlement_intent`. Claiming afterwards would leave the window — settle returns,
+process dies before the write — wide open, and that window is precisely where a client
+retry lands. The caller's `Idempotency-Key` is the logical key;
+`uq_generation_credits_user_key` is what makes the claim atomic.
+
+Three consequences worth stating explicitly, because they are choices rather than
+mechanics:
+
+- **A cancelled run returns its credit.** A cancelled generation produced no strategy.
+  Charging for it would make the paywall a fee on trying rather than a price for delivery.
+- **A job whose record has expired counts as undelivered.** The safe direction to be wrong
+  in. The alternative silently keeps money for a run nobody can prove finished.
+- **Credits do not expire.** One is owed until it is spent. An expiring credit would be a
+  way of keeping money for undelivered work on a slower clock.
+
+## Consequences
+
+**Good.** Money taken is always money accounted for, provably and in one table. A payer
+whose generation dies is never asked to pay twice. A retry cannot double-settle. None of it
+needs a signer, so none of it is blocked on #975.
+
+**The cost.** A payer holding an unspent credit has money with us they cannot get back in
+cash — this is store credit, and it should be described that way rather than as a refund
+wherever we describe it publicly.
+
+**Fail-soft, applied asymmetrically and deliberately.** Before the settle, a ledger failure
+is loud and stops the request: proceeding would take money with no protection behind it.
+After the settle, a ledger failure is swallowed and logged at `error`: the payer's funds are
+already gone, and raising would hand them a 500 *and* keep their money — strictly worse than
+the inconsistency it would be reporting. Fail-soft is wrong for anything a claim depends on,
+and right when the alternative harms the person the claim was meant to protect.
+
+**Inert until the flip.** The whole mechanism hangs off `settles_real_value()`
+(`payment_required() and not _payments_dry_run()`). Under flag-off or dry-run — production
+today — no row is ever written.
+
+## Ratification
+
+The payment stack is Dan's lane and its flip sequencing (#1427→#1414→#1426→#1428) is
+unchanged by this. What this ADR settles is the semantics that sequence turns on, so that
+"what happens to the money when a job dies" has an answer written down before real value
+moves rather than after.
+
+**Open, and deliberately not decided here:** the public wording. There is no Terms page on
+`main` — it arrives with [#1432](https://github.com/a-apin/archimedes/pull/1432) — so
+whoever lands it must describe this as credit toward a future generation, not as a refund.


### PR DESCRIPTION
Closes #1441.

The paywall settled the charge and enqueued the job **afterwards**, with the premium-model entitlement gate sitting between the two. Everything that could fail in that window — the gate raising 402, the enqueue erroring — and everything that could fail after it — worker crash, LLM failure, container roll, the payer cancelling — kept the money with nothing delivered. Nothing released the charge and nothing recorded that the payer was owed anything.

Separately, the payment step took no idempotency key. x402 is not crash-retry-idempotent: a client retrying after an ambiguous failure signs a **fresh** EIP-3009 authorization, which settles as a second real payment. The tick-charging rail already knew this — `marketplace/service.py`'s `_claim_settlement_intent` exists for exactly that reason — but the generation rail never got the same treatment.

## The decision, written down

The issue asked me to pick refund or credit and write it down. **Credit.** Full reasoning in [`docs/adr/generation-payment-credit-not-refund.md`](docs/adr/generation-payment-credit-not-refund.md); the short version:

A refund isn't something we can execute. Settlement runs one way through Circle's facilitator — we hand it a signed authorization and it moves USDC to the recipient DCW. There's no reverse call. A refund is a **new outbound transfer** out of that DCW, which needs the Circle signer on the money path, which is the surface #975 is still open on. Shipping a refund path we can't actually perform would put a promise in the product the code doesn't keep, and that's the one thing this repo says not to do.

A credit needs no value to move, no signer, and nothing from #975. It also composes: if #975 lands and outbound transfers become safe, "redeem a credit as a refund" is a new operation on an existing ledger rather than a redesign.

I also considered authorize-then-capture, the card-network model. EIP-3009 has no such split — the authorization *is* the transfer — so building one would mean holding signed authorizations server-side and settling later. That's strictly more custody risk than we have now, in the direction #975 is trying to move away from.

## What changed

One row per logical charge in `generation_credits`:

```
pending ──settle ok──> available ──enqueue ok──> consumed
   │                        ▲                        │
   │                        └────job did not finish──┘
   └──settle failed/refused──> void
```

`pending` is claimed **before** the settle. Claiming afterwards leaves the window — settle returns, process dies before the write — wide open, and that window is precisely where a client retry lands. `uq_generation_credits_user_key` is what makes the claim atomic.

The route now runs `_paywall_with_credit`, which checks for an unspent credit *before* the paywall, so a payer whose last generation died is never asked for money twice. The credit is consumed only after `store.enqueue` returns — that single ordering change is what makes every failure before that point cost the payer nothing.

Three choices worth flagging rather than burying, because they're judgement calls and not mechanics:

- **A cancelled run returns its credit.** It produced no strategy. Charging for it would make the paywall a fee on trying rather than a price for delivery.
- **A job whose Redis record has expired counts as undelivered.** That's the safe direction to be wrong in; the alternative silently keeps money for a run nobody can prove finished.
- **Credits don't expire.** An expiring credit is just keeping money for undelivered work on a slower clock.

## It is inert in production today

The whole mechanism hangs off `settles_real_value()` — `payment_required() and not _payments_dry_run()`. Under flag-off or dry-run, **no row is ever written**. Two tests pin that. `PAYMENTS_DRY_RUN` has held for the paywall's whole life, which is also why the migration needs no backfill: no generation payment has ever settled real value, so there is no historical charge owed a credit.

## Shown to reject

Five mutations against the 28 new tests:

| mutation | result |
|---|---|
| remove the credit mechanism entirely (settle-then-enqueue, as before) | **8 failed** |
| consume the credit *before* the enqueue | **4 failed** |
| drop the credit-restore hook | **5 failed** |
| restore any credit for a job, not only a `consumed` one | **1 failed** |
| `void` a claim regardless of its state | **1 failed** — *after I added the test* |

The first one's headline failure is the defect itself, stated in one line:

```
test_the_next_attempt_spends_the_credit_and_is_not_charged_again
  AssertionError: assert 2 == 1        # settle.await_count — the payer charged twice
```

**The fifth mutation is the one worth reading.** It initially passed all 27 tests. `void_credit` guards on `status == CREDIT_PENDING`, and removing that guard lets it erase an `available` credit — money taken, and the only record that the payer is owed anything destroyed. No current caller can reach it in that state, so the guard was correct but unproven, which is the "guard that guards nothing" shape CLAUDE.md warns about. I added `test_voiding_cannot_destroy_a_credit_the_payer_already_bought` and re-ran: it now fails with *"void() destroyed a available credit"*. That test only exists because the mutation pass found the hole.

## Verification

- 28 new tests pass; hermetic gate (`env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend`) also 28.
- Existing paywall suites (`test_generate_payment_gate`, `test_payment_receipts`, `test_generation_quota`, `test_generate_model_gating`, `test_generation_concurrency`): 48 passed, unchanged.
- Full unit suite: **3747 passed, 2 skipped** — the 3719 on `main` plus exactly these 28.
- Migration applied for real against a scratch SQLite: chains onto `1752121b8d7c`, creates the table with all 13 columns, the unique constraint and the index; `downgrade -1` drops it cleanly. `migration_chain_guard.py` → *OK, extends origin/main's head cleanly*.
- The constraint was shown doing its job, not assumed: a duplicate `(user_id, idempotency_key)` raises `UNIQUE constraint failed`, and two NULL-key rows for one user are accepted — the behaviour the keyless path depends on.
- `ruff format --check` clean; blocking `--select E9,F63,F7,F40,F82` clean; full `ruff check` still 26, the same pre-existing count as `main`.
- `make docs-check`: 0 broken links of 1193, index 144/144. ADR added to both indexes and CLAUDE.md's ADR count corrected 18 → 19.

## Two things for the reviewer

**The fail-soft split is deliberate and asymmetric**, and it's the part I'd most want a second opinion on. Before the settle, a ledger failure is loud and stops the request — proceeding would take money with no protection behind it. After the settle, a ledger failure is swallowed and logged at `error` — the payer's funds are already gone, and raising would hand them a 500 *and* keep their money, which is strictly worse than the inconsistency it would be reporting. Fail-soft is wrong for anything a claim depends on, and right when the alternative harms the person the claim was meant to protect.

**The Terms coupling in the acceptance list can't be satisfied here.** There is no Terms page on `main` — it arrives with #1432. So there's no wording to keep true yet. The ADR states the semantics instead, and flags that whoever lands #1432 must describe this as credit toward a future generation, **not** as a refund. Worth a look from @dbrowneup since that's the payment-stack lane and the flip sequencing (#1427→#1414→#1426→#1428) is yours — this doesn't change that sequence, it settles what happens to the money when a job dies before real value starts moving through it.
