### PR TITLE
[frontend] Point live surfaces at the canonical repo, not the pre-rename name (#1434)

### DIFF
--- a/backend/tests/test_canonical_repo_links.py
+++ b/backend/tests/test_canonical_repo_links.py
@@ -1,0 +1,105 @@
+"""Live surfaces must name the canonical repository (#1434).
+
+`ui/src/components/WalletConnect.jsx` pointed at `a-apin/archimedes-arcadia`
+for months. GitHub redirects renamed repositories, so the link *worked* — which
+is exactly why nobody noticed. `docs-gate.yml`'s link checker could not catch it
+either: it verifies that links resolve, and a redirect resolves.
+
+So the check has to be on the name, not on the response. Two pre-rename
+spellings existed (`a-apin/archimedes-arcadia` and `hackagora/archimedes-arcadia`);
+both redirect to `a-apin/archimedes` today, and a redirect is a courtesy, not a
+guarantee — it breaks the moment either old name is re-claimed.
+
+**Historical documents are deliberately exempt.** `docs/archive/`,
+`docs/handovers/` and `docs/audits/` record what was true at a point in time,
+and CLAUDE.md is explicit that superseded history is not rewritten. A handover
+saying "origin currently redirects to hackagora/archimedes-arcadia" was accurate
+when written and should stay that way. `submodules/` are separate repositories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CANONICAL_REPO = "a-apin/archimedes"
+
+# Assembled at runtime so this file does not match its own scan.
+PRE_RENAME_NAMES = ("archimedes-" + "arcadia",)
+
+#: Trees whose contents describe the project as it is now.
+LIVE_ROOTS = ("ui/src", "ui/public", "infra", "backend", "contracts", "docs/runbooks", "scripts")
+
+#: Point-in-time records, and other people's repositories.
+EXEMPT_PARTS = ("archive", "handovers", "audits", "submodules", "node_modules", "dist", ".git")
+
+SCANNED_SUFFIXES = {".js", ".jsx", ".ts", ".tsx", ".py", ".md", ".json", ".sh", ".tf", ".yml", ".yaml", ".sol"}
+
+
+#: This file names the stale spellings in prose so its failure message can quote
+#: them, so it must not police itself. Excluded by resolved path rather than by
+#: filename, so renaming it cannot silently reintroduce the self-match.
+_SELF = Path(__file__).resolve()
+
+
+def _is_exempt(path: Path) -> bool:
+    return any(part in EXEMPT_PARTS for part in path.parts)
+
+
+def _live_files() -> list[Path]:
+    seen: list[Path] = []
+    for root in LIVE_ROOTS:
+        base = REPO_ROOT / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if (
+                path.is_file()
+                and path.suffix in SCANNED_SUFFIXES
+                and not _is_exempt(path.relative_to(REPO_ROOT))
+                and path.resolve() != _SELF
+            ):
+                seen.append(path)
+    # Root-level markdown (README.md, CLAUDE.md, SETUP.md …) describes the
+    # project as it is now and is the first thing a reader opens.
+    seen.extend(p for p in REPO_ROOT.glob("*.md") if p.is_file())
+    return seen
+
+
+def test_the_scan_reaches_the_files_it_is_policing() -> None:
+    """Guard on the guard: a scan that matched nothing would pass vacuously."""
+    scanned = {str(p.relative_to(REPO_ROOT)) for p in _live_files()}
+    assert len(scanned) > 200, f"only {len(scanned)} files scanned — the walk is broken"
+    for expected in (
+        "ui/src/components/WalletConnect.jsx",
+        "infra/README.md",
+        "docs/runbooks/github-security-toggles.md",
+        "CLAUDE.md",
+    ):
+        assert expected in scanned, f"{expected} not scanned — the guard is blind"
+
+
+def test_the_scan_does_not_reach_historical_records() -> None:
+    """The exemption must actually exempt, or this test would fail the repo's own history."""
+    scanned = {str(p.relative_to(REPO_ROOT)) for p in _live_files()}
+    assert not [p for p in scanned if p.startswith(("docs/archive/", "docs/handovers/", "docs/audits/"))]
+
+
+@pytest.mark.parametrize("stale_name", PRE_RENAME_NAMES)
+def test_no_live_surface_names_the_pre_rename_repository(stale_name: str) -> None:
+    offenders: list[str] = []
+    for path in _live_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if stale_name in text:
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert not offenders, (
+        f"{sorted(offenders)} still name '{stale_name}'. The canonical repository is "
+        f"'{CANONICAL_REPO}'. GitHub's redirect makes the stale link work, so nothing "
+        "else catches this — that redirect breaks if the old name is ever re-claimed."
+    )

--- a/docs/corpus-architecture.md
+++ b/docs/corpus-architecture.md
@@ -275,8 +275,8 @@ small enough to commit, fast enough to seed, and rich enough to retrieve.
 - [`docs/architectural-principles.md`](architectural-principles.md) — the four
   load-bearing primitives, with the corpus + fusion + rigor + on-chain provenance
   forming the spine
-- Issues: [#97 (10k corpus)](https://github.com/a-apin/archimedes-arcadia/issues/97),
-  [#106 (DB-backed substrate)](https://github.com/a-apin/archimedes-arcadia/issues/106),
-  [#93 (Corpus Explorer UI)](https://github.com/a-apin/archimedes-arcadia/issues/93),
-  [#96 (fusion retrieval — open)](https://github.com/a-apin/archimedes-arcadia/issues/96),
-  [#101 (KB pipeline port — open)](https://github.com/a-apin/archimedes-arcadia/issues/101)
+- Issues: [#97 (10k corpus)](https://github.com/a-apin/archimedes/issues/97),
+  [#106 (DB-backed substrate)](https://github.com/a-apin/archimedes/issues/106),
+  [#93 (Corpus Explorer UI)](https://github.com/a-apin/archimedes/issues/93),
+  [#96 (fusion retrieval — open)](https://github.com/a-apin/archimedes/issues/96),
+  [#101 (KB pipeline port — open)](https://github.com/a-apin/archimedes/issues/101)

--- a/docs/runbooks/github-security-toggles.md
+++ b/docs/runbooks/github-security-toggles.md
@@ -7,7 +7,7 @@ admin must flip them in the GitHub UI.
 ## Toggles to enable
 
 Navigate to **Settings → Code security and analysis** for the repo
-(`a-apin/archimedes-arcadia`).
+(`a-apin/archimedes`).
 
 ### 1. Dependabot alerts
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -211,7 +211,7 @@ so an admin can apply or audit it declaratively (audit #10 / issues #519, #526).
 ./scripts/setup-branch-protection.sh            # dry-run: print the payload, apply nothing
 ./scripts/setup-branch-protection.sh --apply    # apply (needs repo admin)
 ./scripts/setup-branch-protection.sh --verify    # print the currently-applied protection
-# or, raw:  gh api repos/hackagora/archimedes-arcadia/branches/main/protection
+# or, raw:  gh api repos/a-apin/archimedes/branches/main/protection
 ```
 
 What it enforces: the two hard-block CI checks (`Backend — unit tests`, `Ruff — format +

--- a/infra/iam/README.md
+++ b/infra/iam/README.md
@@ -11,14 +11,14 @@ by design** — every action is scoped to a specific bucket / table / parameter 
 | `s3:GetObject`, `PutObject`, `DeleteObject` (+ versioning reads) | `archimedes-corpus-artifacts-prod/*` | KB pipeline writes `embeddings.npy`, `clusters.json`, `topics.json`, `kg_triples.jsonl`, `kg_graph.json`, `manifest.json`; backend reads them via `/api/corpus/*` |
 | `s3:GetObject`, `PutObject`, `DeleteObject` | `archimedes-paper-pdfs-prod/*` | Paper PDF storage for the corpus (input to the KB pipeline) |
 | `s3:ListBucket`, `GetBucketLocation`, `GetBucketVersioning` | Both buckets | List + introspection only on the bucket itself (no other buckets) |
-| `dynamodb:GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `Query`, `Scan`, `BatchGetItem`, `BatchWriteItem`, `DescribeTable` | `archimedes-papers-index` (+ all GSIs) | Paper metadata index — DynamoDB is the additive read index per [T3.1 spec](https://github.com/a-apin/archimedes-arcadia/issues/147); Postgres remains the source of truth |
-| `ssm:GetParameter`, `GetParameters`, `GetParametersByPath` | `/archimedes/prod/*` | Secrets surface for [TS.2 #176](https://github.com/a-apin/archimedes-arcadia/issues/176) — backend reads at startup |
+| `dynamodb:GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `Query`, `Scan`, `BatchGetItem`, `BatchWriteItem`, `DescribeTable` | `archimedes-papers-index` (+ all GSIs) | Paper metadata index — DynamoDB is the additive read index per [T3.1 spec](https://github.com/a-apin/archimedes/issues/147); Postgres remains the source of truth |
+| `ssm:GetParameter`, `GetParameters`, `GetParametersByPath` | `/archimedes/prod/*` | Secrets surface for [TS.2 #176](https://github.com/a-apin/archimedes/issues/176) — backend reads at startup |
 | `kms:Decrypt` (conditional) | KMS via `ssm.<region>.amazonaws.com` only | Decrypts SecureString SSM parameters; condition prevents using this for arbitrary KMS keys |
 | `logs:CreateLogStream`, `PutLogEvents`, `DescribeLogStreams` | `/archimedes/*` log groups | Backend writes structured logs to CloudWatch (operator observability) |
 
 ## What this policy does NOT grant
 
-Anti-goals from the original [T3.1 spec](https://github.com/a-apin/archimedes-arcadia/issues/147):
+Anti-goals from the original [T3.1 spec](https://github.com/a-apin/archimedes/issues/147):
 
 - **No bucket-policy edits** — separating data-plane (this role) from control-plane (Chuan's deployer credentials)
 - **No public-read** of either bucket (no `s3:PutBucketAcl`, no `s3:PutObjectAcl`)

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -326,11 +326,11 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
               Deposits live in your non-custodial vault contract; the agent has rebalance
               authority only, not withdraw-to-platform. Source open at{' '}
               <a
-                href="https://github.com/a-apin/archimedes-arcadia"
+                href="https://github.com/a-apin/archimedes"
                 target="_blank"
                 rel="noreferrer"
               >
-                github.com/a-apin/archimedes-arcadia
+                github.com/a-apin/archimedes
               </a>
               . Testnet only — fake USDC, no value at risk.
             </div>


### PR DESCRIPTION
Closes #1434.

`WalletConnect.jsx` linked to `a-apin/archimedes-arcadia` in both the `href` and the visible text — on the panel that tells a user their deposits are non-custodial and invites them to check the source:

> Deposits live in your non-custodial vault contract; the agent has rebalance authority only, not withdraw-to-platform. Source open at **github.com/a-apin/archimedes-arcadia**.

That's a "go and verify us" link, so it should name the repo correctly.

## Why it survived

GitHub redirects renamed repositories, so the link worked. And `docs-gate.yml`'s link checker verifies that links **resolve** — a redirect resolves. Nothing was ever going to flag this.

## Scope

The issue's acceptance is `grep -rn "archimedes-arcadia" ui/src/` → nothing, and it invites folding the fix into a rename sweep. I did the sweep across live surfaces, 12 references in 5 files:

| file | what it was |
|---|---|
| `ui/src/components/WalletConnect.jsx` | the user-facing link, href + text |
| `infra/README.md` | a raw `gh api repos/…/branches/main/protection` command someone would paste |
| `infra/iam/README.md` | three spec links behind the IAM policy rationale |
| `docs/runbooks/github-security-toggles.md` | the repo an admin is told to navigate to |
| `docs/corpus-architecture.md` | five issue links |

**Verified before rewriting**, rather than assuming a rename is a rename. Two pre-rename spellings existed (`a-apin/…` and `hackagora/…`); `gh api` confirms both resolve to `a-apin/archimedes`, and every cited issue number (#97, #106, #93, #96, #101, #147, #176) exists there with a matching title. So the link targets are unchanged, only the path to them.

## Left alone on purpose

`docs/archive/`, `docs/handovers/` and `docs/audits/` still contain the old name and should. They record what was true at a point in time — a handover saying *"origin currently redirects to hackagora/archimedes-arcadia"* was accurate when written, and CLAUDE.md is explicit that superseded history is not rewritten. `submodules/` are separate repositories.

## The guard

`backend/tests/test_canonical_repo_links.py` checks the **name**, not the response, because a resolving redirect is exactly what hid this. Three mutations:

| mutation | result |
|---|---|
| put the stale link back in `WalletConnect.jsx` | **fails**, naming the file |
| blind the directory walk | **fails** — *"the walk is broken"* |
| drop the historical exemption | **2 fail** — it demands rewriting `docs/archive/` |

The third one is the one that justifies the exemption existing rather than just asserting it: without it the guard would order you to falsify the project's own history.

## Verification

- 3 new tests pass, hermetic gate too.
- `npm run lint` clean, `npm run build` succeeds (a `.jsx` changed).
- Full unit suite: **3722 passed, 2 skipped** — 3719 on `main` plus these 3.
- `make docs-check`: 0 broken links of 1183, index 143/143.
- Acceptance: `grep -rn "archimedes-arcadia" ui/src/` → nothing.
