### PR TITLE
[frontend][docs] Retire the stale #588 claims and tie the two manifests together (#1448)

### DIFF
--- a/backend/tests/test_agent_manifest_static_consistency.py
+++ b/backend/tests/test_agent_manifest_static_consistency.py
@@ -1,0 +1,101 @@
+"""The static discovery document and the served manifest must agree (#1448).
+
+Two surfaces describe the same API to an agent:
+
+- ``ui/public/.well-known/agent.json`` — the static discovery document, fetched
+  straight off the CDN at a well-known path;
+- ``GET /api/agent/manifest`` — the served manifest, built in
+  ``api/agent_manifest_routes.py``.
+
+They drifted. PR #1447 corrected the served manifest's ``deploy`` /
+``marketplace`` / ``monitor`` groups from "landing with the T3.2 redeploy
+(#588)" to ``live``, because the redeploy landed 2026-07-09 and #588 closed
+2026-07-14. The static file kept asserting the stale state in seven places, so
+an agent that discovered us the well-known way was told three live capabilities
+were unavailable — for over a month.
+
+Nothing connected the two files, so nothing noticed. This test is that
+connection: the drift is the defect, not either value on its own.
+
+Statuses only. Route KEYS deliberately differ between the surfaces — the static
+document is camelCase (``createVault``) and the served one is snake_case
+(``create_vault``) — and forcing those to match would be a different, larger
+change than keeping the two honest about what works.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STATIC_MANIFEST = REPO_ROOT / "ui" / "public" / ".well-known" / "agent.json"
+
+
+def _static_statuses() -> dict[str, str]:
+    doc = json.loads(STATIC_MANIFEST.read_text(encoding="utf-8"))
+    return {
+        name: group["status"]
+        for name, group in doc["endpoints"].items()
+        if isinstance(group, dict) and "status" in group
+    }
+
+
+async def _served_statuses() -> dict[str, str]:
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+    assert resp.status_code == 200, resp.text
+    return {
+        name: group["status"]
+        for name, group in resp.json()["endpoints"].items()
+        if isinstance(group, dict) and "status" in group
+    }
+
+
+async def test_both_surfaces_describe_the_same_capability_groups():
+    """A group on one surface and not the other is drift too, not just a status gap."""
+    static, served = _static_statuses(), await _served_statuses()
+    assert set(static) == set(served), (
+        f"only in the static document: {sorted(set(static) - set(served))}; "
+        f"only in the served manifest: {sorted(set(served) - set(static))}"
+    )
+
+
+async def test_the_two_manifests_agree_on_every_group_status():
+    static, served = _static_statuses(), await _served_statuses()
+    disagreements = {
+        name: (static[name], served[name]) for name in set(static) & set(served) if static[name] != served[name]
+    }
+    assert not disagreements, (
+        "the static discovery document and the served manifest disagree about what works:\n"
+        + "\n".join(
+            f"  {name}: .well-known/agent.json says {s!r}, /api/agent/manifest says {v!r}"
+            for name, (s, v) in sorted(disagreements.items())
+        )
+        + "\nAn agent's answer would depend on which surface it happened to read."
+    )
+
+
+async def test_the_comparison_actually_covers_the_groups_that_drifted():
+    """Guard on the guard: an empty or tiny comparison would pass vacuously."""
+    static = _static_statuses()
+    assert len(static) >= 8, f"only {len(static)} static groups parsed — the reader is broken"
+    for group in ("deploy", "marketplace", "monitor", "paper"):
+        assert group in static, f"{group} not compared — it is one of the groups that drifted"
+
+
+@pytest.mark.parametrize("group", ["deploy", "marketplace", "monitor"])
+def test_the_groups_that_were_stale_are_not_still_advertised_as_pending(group: str):
+    """The specific false claim, pinned by value.
+
+    Distinct from the agreement test above on purpose: that one would also pass
+    if BOTH surfaces regressed to the stale string together.
+    """
+    status = _static_statuses()[group]
+    assert "588" not in status, f"{group} still cites #588, which closed 2026-07-14"
+    assert status == "live", f"{group} advertises {status!r}"

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -358,12 +358,15 @@ request sent — unless the winning candidate's LIVE GATE read above is
 `deployable: true`. **Never weaken or skip that check to force a deploy.**
 
 `--deploy` defaults to a **DRY RUN**: the harness prints the exact payload
-and sends nothing. Pass `--deploy` to actually call the endpoint. Default OFF
-because, as of this writing, the contract suite was just redeployed (T3.2,
-2026-07-09) and issue [#588](https://github.com/a-apin/archimedes/issues/588)
-(whether the repo's cached ABI matches the live deployed bytecode) is still
-open — no vault, agent or human, had been created against the new deployment
-at the time this shipped.
+and sends nothing. Pass `--deploy` to actually call the endpoint. The default
+stays OFF, but the original reason no longer holds: the T3.2 redeploy landed
+2026-07-09 and issue
+[#588](https://github.com/a-apin/archimedes/issues/588) (whether the repo's
+cached ABI matches the live deployed bytecode) closed 2026-07-14. The
+`deploy` group has been `live` in the served manifest since
+[#1447](https://github.com/a-apin/archimedes/pull/1447). It stays OFF now for
+the ordinary reason: this call spends gas and creates a real on-chain vault,
+so it should be an explicit act, not a default.
 
 ### MONITOR — read vault health back
 

--- a/ui/public/.well-known/agent.json
+++ b/ui/public/.well-known/agent.json
@@ -101,25 +101,27 @@
         "read": "GET /api/paper/deployments/{deployment_id}",
         "stop": "POST /api/paper/deployments/{deployment_id}/stop"
       },
-      "note": "Simulated: no chain, no funds. The only deployment path that is live today."
+      "note": "Simulated: no chain, no funds. deploy is also live and puts real capital on-chain \u2014 choosing between them trades simulation for capital at risk, not working for not working."
     },
     "deploy": {
-      "status": "landing with the T3.2 redeploy (#588)",
+      "status": "live",
       "authRequired": true,
       "routes": {
         "createVault": "POST /api/vaults/create"
-      }
+      },
+      "note": "Creates a real, non-custodial vault on Arc: the caller's linked wallet owns it and the agent holds rebalance authority only, never withdraw-to-platform."
     },
     "marketplace": {
-      "status": "landing with the T3.2 redeploy (#588)",
+      "status": "live",
       "authRequired": true,
       "routes": {
         "publish": "POST /api/marketplace/publish",
         "subscribe": "POST /api/marketplace/subscribe"
-      }
+      },
+      "note": "live describes the routes: publish/subscribe are wired to the redeployed contracts. It does not assert that a subscription's recurring USDC charge settles for real \u2014 that is gated separately by PAYMENTS_DRY_RUN, and this manifest advertises no payment scheme."
     },
     "monitor": {
-      "status": "landing with the T3.2 redeploy (#588)",
+      "status": "live",
       "authRequired": false,
       "routes": {
         "vaultHealth": "GET /api/vaults/{address}/health"
@@ -143,25 +145,25 @@
       "id": "deploy-vault",
       "name": "Deploy vault",
       "description": "Execute a generated, rigor-passing strategy into a non-custodial USDC vault on Arc.",
-      "status": "landing with the T3.2 redeploy (#588)"
+      "status": "live"
     },
     {
       "id": "monitor",
       "name": "Monitor",
       "description": "Read a deployed vault's live health, allocations, and performance.",
-      "status": "landing with the T3.2 redeploy (#588)"
+      "status": "live"
     },
     {
       "id": "publish",
       "name": "Publish",
       "description": "Publish a strategy to the nanopayment marketplace for other agents or users to subscribe to.",
-      "status": "landing with the T3.2 redeploy (#588)"
+      "status": "live"
     },
     {
       "id": "subscribe",
       "name": "Subscribe",
       "description": "Subscribe to a published strategy via sub-cent USDC nanopayments (x402 / Circle Gateway).",
-      "status": "landing with the T3.2 redeploy (#588)"
+      "status": "live"
     }
   ]
 }


### PR DESCRIPTION
Closes #1448. Follow-up to #1447, which fixed this class of claim in the served manifest and left the two sibling surfaces behind.

## What was false

`ui/public/.well-known/agent.json` asserted `"status": "landing with the T3.2 redeploy (#588)"` in **seven** places — the `deploy`, `marketplace` and `monitor` endpoint groups, and four skills. The redeploy landed 2026-07-09; #588 closed 2026-07-14 (`gh issue view 588` → `CLOSED 2026-07-14T15:26:31Z`). #1447 corrected the served manifest on 2026-08-20 and the static file kept the old claim.

That's the worse of the two to get wrong. An agent discovering us the well-known way was told three working capabilities were unavailable, and would have routed around them.

Two more stale claims fell out of reading the file properly:

- **`paper`'s note said it was *"The only deployment path that is live today."*** That stopped being true the moment `deploy` went live. Now framed the way the served manifest frames it: choosing between them trades simulation for capital at risk, not working for not working.
- **`docs/agent-api.md` gave "#588 is still open" as the reason** the reference client's `--deploy` defaults to a dry run. The default stays off — but for the ordinary reason, which is that the call spends gas and creates a real on-chain vault, so it should be an explicit act. The remaining `#588` reference in that file now says it *closed*, which is the true statement.

I also carried across two honesty notes the served manifest states in-line and the static file never had:

- `deploy` — creates a real non-custodial vault; the caller's linked wallet owns it and the agent holds rebalance authority only.
- `marketplace` — `live` describes **the routes**. It does not assert that a subscription's recurring USDC charge settles for real; that's gated separately by `PAYMENTS_DRY_RUN`. Without this, "marketplace: live" on a discovery document reads as "billing works", which it doesn't yet.

## The test

The issue asked for a consistency test, and that's the part that actually matters — nothing connected the two surfaces, so nothing noticed a month of drift. `test_agent_manifest_static_consistency.py` compares the static document against `GET /api/agent/manifest`.

Statuses only, deliberately. The route keys differ by design (`createVault` vs `create_vault`), and forcing those to match is a different and larger change than keeping the two honest about what works.

## Shown to reject

| mutation | result |
|---|---|
| put the stale claim back on the **static** side | **2 failed** |
| change the **served** side instead (`monitor` → `degraded`) | **1 failed** |
| drop a group from the static document | **3 failed** |
| blind the static reader | **4 failed** — *"the reader is broken"* |

Mutations 1 and 2 are the pair worth having: the guard catches drift from either direction, not just a stale static file. The message names both sides:

```
deploy: .well-known/agent.json says 'landing with the T3.2 redeploy (#588)',
        /api/agent/manifest says 'live'
```

There's also a separate test pinning `deploy`/`marketplace`/`monitor` to `live` by value. The agreement test alone would still pass if **both** surfaces regressed to the stale string together, which is exactly how this class of claim comes back.

## Verification

- 6 new tests pass; hermetic gate too.
- Existing `test_agent_manifest.py` + `test_agent_discovery.py`: 30 passed, unchanged.
- Full unit suite: **3725 passed, 2 skipped** — 3719 on `main` plus these 6.
- `agent.json` still parses; edited as text rather than round-tripped through `json.dumps`, so the diff is 12 insertions / 10 deletions instead of reformatting every inline array in the file.
- `make docs-check`: 0 broken links of 1184, index 143/143.
- Acceptance: `grep -n 588 ui/public/.well-known/agent.json` → nothing; the one remaining hit in `agent-api.md` states the closure rather than claiming it is open.
