### PR TITLE
[backend] Traces display routes report anchored_only, not a verification (#1407)

### DIFF
--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -340,6 +340,20 @@ class TraceResponse(BaseModel):
     arc_tx_hash: str | None = None
     is_verified: bool = False  # Has on-chain hash been confirmed?
 
+    # How that confirmation was reached — same vocabulary as
+    # TraceVerifyResponse.verification_mode (#1359), so the display routes and
+    # the verify route cannot invent two different words for the same state.
+    #
+    # None is the honest default: this response makes NO verification claim.
+    # The off-chain path replays whatever `is_verified` was stored with the
+    # trace and compares nothing itself, so it has no mode to report — call
+    # /api/traces/{id}/verify for one.
+    #
+    # "anchored_only" is what the on-chain-only path reports (#1407): an anchor
+    # exists in the registry and ZERO hashes were compared against it. It must
+    # not render with the same affordance as a hash match.
+    verification_mode: Literal["hash_matched", "anchored_only", "failed"] | None = None
+
     # Context
     regime_at_decision: str | None = None
     trades_executed: list[TradeExecutedResponse] = []

--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -23,6 +23,52 @@ logger = logging.getLogger(__name__)
 traces_router = APIRouter(prefix="/api/traces", tags=["traces"])
 
 
+#: The trace as the on-chain registry ALONE can describe it. Same word as
+#: ``TraceVerifyResponse.verification_mode`` uses for this state (#1359).
+ANCHORED_ONLY = "anchored_only"
+
+
+def _anchored_only_trace(trace_id: str, detail: dict) -> TraceResponse:
+    """Project a registry entry with no off-chain body behind it (#1407).
+
+    Both display routes fall back to this when the off-chain store has no
+    record — or is unreachable, which this path deliberately does not
+    distinguish, because from here the two are the same fact: **nothing was
+    compared.**
+
+    What is genuinely known is that an anchor exists at this id; we just read
+    it out of the registry. That is why ``is_verified`` stays true, and why
+    flipping it false would be a different fabrication rather than a fix:
+    ``Portfolio.jsx`` renders the false branch as "anchor pending — registry
+    write didn't complete yet", which would be an invented denial of the one
+    thing this path is certain about.
+
+    What was never true is the implication that a hash was *compared*. Nothing
+    on this path re-derives or matches anything, so ``verification_mode`` says
+    ``anchored_only`` and ``arc_tx_hash`` stays ``None`` — the registry read
+    does not surface the anchoring transaction, and an absent reference must
+    render as absent rather than be invented.
+    """
+    from datetime import datetime
+
+    return TraceResponse(
+        id=trace_id,
+        vault_address=detail["vault"],
+        # "unknown", not "rebalance" (#1356): the on-chain anchor does not
+        # record which decision type produced it, so asserting "rebalance" for
+        # every trace on this path is an invented fact. "unknown" is the same
+        # default the off-chain path already uses when its data lacks the field.
+        decision_type="unknown",
+        trigger="on-chain",
+        timestamp=datetime.fromtimestamp(detail["timestamp"], tz=UTC).isoformat(),
+        reasoning="On-chain trace (off-chain metadata not available)",
+        confidence=0.0,
+        trace_hash=detail["trace_hash"],
+        is_verified=True,
+        verification_mode=ANCHORED_ONLY,
+    )
+
+
 @traces_router.get("/", response_model=TraceListResponse)
 async def list_traces(
     vault_address: str | None = None,
@@ -102,27 +148,7 @@ async def list_traces(
                 if vault_address and detail["vault"].lower() != vault_address.lower():
                     continue
 
-                from datetime import datetime
-
-                traces.append(
-                    TraceResponse(
-                        id=str(trace_id),
-                        vault_address=detail["vault"],
-                        # "unknown", not "rebalance" (#1356): the on-chain
-                        # anchor does not record which decision type
-                        # produced it, so asserting "rebalance" for every
-                        # trace on this path is an invented fact. "unknown"
-                        # is the same default the off-chain path already
-                        # uses when its own data lacks the field.
-                        decision_type="unknown",
-                        trigger="on-chain",
-                        timestamp=datetime.fromtimestamp(detail["timestamp"], tz=UTC).isoformat(),
-                        reasoning="On-chain trace (off-chain metadata not available)",
-                        confidence=0.0,
-                        trace_hash=detail["trace_hash"],
-                        is_verified=True,
-                    )
-                )
+                traces.append(_anchored_only_trace(str(trace_id), detail))
         except Exception:
             logger.debug("on-chain trace listing failed", exc_info=True)
 
@@ -134,8 +160,6 @@ async def list_traces(
 @traces_router.get("/{trace_id}", response_model=TraceResponse)
 async def get_trace(trace_id: str):
     """Get a single reasoning trace by ID (on-chain or off-chain hash)."""
-    from datetime import datetime
-
     from fastapi import HTTPException
 
     from archimedes.chain.trace_publisher import trace_publisher
@@ -182,20 +206,7 @@ async def get_trace(trace_id: str):
         if detail is None:
             raise HTTPException(status_code=404, detail="Trace not found")
 
-        return TraceResponse(
-            id=trace_id,
-            vault_address=detail["vault"],
-            # "unknown", not "rebalance" — see the identical note on the list
-            # route above (#1356). The on-chain anchor doesn't record which
-            # decision type produced it.
-            decision_type="unknown",
-            trigger="on-chain",
-            timestamp=datetime.fromtimestamp(detail["timestamp"], tz=UTC).isoformat(),
-            reasoning="On-chain trace (off-chain metadata not available)",
-            confidence=0.0,
-            trace_hash=detail["trace_hash"],
-            is_verified=True,
-        )
+        return _anchored_only_trace(trace_id, detail)
     finally:
         await state.close()
 

--- a/backend/tests/test_traces_display_anchored_only.py
+++ b/backend/tests/test_traces_display_anchored_only.py
@@ -1,0 +1,172 @@
+"""The display routes stop claiming a verification they never performed (#1407).
+
+`GET /api/traces/` and `GET /api/traces/{id}` both fall back to an on-chain-only
+projection when the off-chain store has no record for a trace — or is
+unreachable, which that path does not distinguish. Both hard-coded
+`is_verified=True` with `arc_tx_hash` left `None` and **nothing compared
+anywhere**: no hash re-derivation, no receipt check beyond "an object exists at
+this id". `Reasoning.jsx` rendered that boolean as a green check reading
+*"verified"*, so the flagship provenance page asserted a verification on traces
+where zero hashes had been looked at.
+
+#1356 fixed `decision_type` and `total` on this exact path; its Evidence E.2
+listed `is_verified` as a third fabrication on the same path, and PR #1394
+scoped it out.
+
+**What was fixed is the claim, not the boolean.** `is_verified` stays true here,
+because the anchor genuinely is confirmed — we read it out of the registry.
+Flipping it false would be a different fabrication: `Portfolio.jsx` renders the
+false branch as *"anchor pending — registry write didn't complete yet"*, an
+invented denial of the one thing this path is certain about. What was never true
+is the implication that a hash was *compared*, and `verification_mode` now
+carries that, reusing #1359's vocabulary so the display routes and the verify
+route cannot invent two different words for one state.
+
+Hermetic: `AgentStateStore` and the chain `trace_publisher` are mocked at the
+boundary, same as `test_traces_verify_modes.py`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_ON_CHAIN = {"vault": "0xVault", "trace_hash": "0xaabbccdd", "timestamp": 1_700_000_000, "agent": "0xAgent"}
+
+#: The two ways the off-chain store fails to answer. The route treats them
+#: identically on purpose — from here they are the same fact, "nothing was
+#: compared" — and both must produce the same honest label.
+STORE_SILENT = {
+    "empty": AsyncMock(return_value=([], 0)),
+    "unreachable": AsyncMock(side_effect=ConnectionError("redis down")),
+}
+STORE_SILENT_DETAIL = {
+    "empty": AsyncMock(return_value=None),
+    "unreachable": AsyncMock(side_effect=ConnectionError("redis down")),
+}
+
+
+async def _list_with(list_traces_mock):
+    from archimedes.main import app
+    from archimedes.services.redis_state import AgentStateStore
+
+    with (
+        patch.object(AgentStateStore, "list_traces", list_traces_mock),
+        patch.object(AgentStateStore, "close", AsyncMock()),
+        patch("archimedes.chain.trace_publisher.trace_publisher") as pub,
+    ):
+        pub.get_total_trace_count = AsyncMock(return_value=1)
+        pub.get_trace_by_id = AsyncMock(return_value=dict(_ON_CHAIN))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            return await client.get("/api/traces/?limit=10")
+
+
+async def _detail_with(get_trace_mock):
+    from archimedes.main import app
+    from archimedes.services.redis_state import AgentStateStore
+
+    with (
+        patch.object(AgentStateStore, "get_trace", get_trace_mock),
+        patch.object(AgentStateStore, "close", AsyncMock()),
+        patch("archimedes.chain.trace_publisher.trace_publisher") as pub,
+        patch("archimedes.api.traces_routes.trace_publisher", create=True),
+    ):
+        pub.get_trace_by_id = AsyncMock(return_value=dict(_ON_CHAIN))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            return await client.get("/api/traces/1")
+
+
+@pytest.mark.parametrize("store_state", ["empty", "unreachable"])
+async def test_list_fallback_reports_anchored_only_not_a_verification(store_state):
+    resp = await _list_with(STORE_SILENT[store_state])
+    assert resp.status_code == 200
+    trace = resp.json()["traces"][0]
+
+    # The claim under test: not a bare verified-with-nothing-compared.
+    assert trace["verification_mode"] == "anchored_only"
+    # And the absent reference stays absent rather than being invented.
+    assert trace["arc_tx_hash"] is None
+
+
+@pytest.mark.parametrize("store_state", ["empty", "unreachable"])
+async def test_detail_fallback_reports_anchored_only_not_a_verification(store_state):
+    resp = await _detail_with(STORE_SILENT_DETAIL[store_state])
+    assert resp.status_code == 200
+    trace = resp.json()
+
+    assert trace["verification_mode"] == "anchored_only"
+    assert trace["arc_tx_hash"] is None
+
+
+async def test_a_trace_is_never_verified_with_nothing_compared_and_no_tx_hash():
+    """The issue's own wording, asserted directly.
+
+    Kept separate from the mode assertions because it is the invariant that
+    matters even if the vocabulary is renamed later: a response must not
+    simultaneously claim a plain verification and carry no evidence of one.
+    """
+    for resp in (await _list_with(STORE_SILENT["unreachable"]), await _detail_with(STORE_SILENT_DETAIL["unreachable"])):
+        body = resp.json()
+        trace = body["traces"][0] if "traces" in body else body
+        unqualified_claim = trace["is_verified"] and trace.get("verification_mode") is None
+        assert not (unqualified_claim and trace["arc_tx_hash"] is None), (
+            "trace claims is_verified with no verification_mode and no arc_tx_hash — "
+            "nothing on this path compares anything, so that is a fabricated verification"
+        )
+
+
+async def test_the_off_chain_path_makes_no_verification_claim_at_all():
+    """When the store DOES answer, the route replays what was stored and
+    compares nothing itself — so it reports no mode rather than borrowing one."""
+    from archimedes.main import app
+    from archimedes.services.redis_state import AgentStateStore
+
+    stored = {
+        "id": "trace-1",
+        "vault_address": "0xVault",
+        "trace_hash": "0xaabbccdd",
+        "arc_tx_hash": "0xTxHash",
+        "is_verified": True,
+    }
+    with (
+        patch.object(AgentStateStore, "list_traces", AsyncMock(return_value=([stored], 1))),
+        patch.object(AgentStateStore, "close", AsyncMock()),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/traces/?limit=10")
+
+    trace = resp.json()["traces"][0]
+    assert trace["verification_mode"] is None
+    assert trace["is_verified"] is True  # replayed from the store, not invented here
+
+
+def test_display_and_verify_routes_share_one_vocabulary():
+    """The two surfaces must not grow separate words for the same state (#1359).
+
+    The issue asked for exactly this alignment. Comparing the annotations keeps
+    a later edit to one schema from silently forking the vocabulary.
+    """
+    import typing
+
+    from archimedes.api.schemas import TraceResponse, TraceVerifyResponse
+
+    display = TraceResponse.model_fields["verification_mode"].annotation
+    verify = TraceVerifyResponse.model_fields["verification_mode"].annotation
+
+    display_values = set(typing.get_args(typing.get_args(display)[0]))
+    verify_values = set(typing.get_args(verify))
+    assert display_values == verify_values, (
+        f"display route says {sorted(display_values)}, verify route says {sorted(verify_values)} — "
+        "two vocabularies for one concept is how the surfaces drift apart"
+    )
+    assert "anchored_only" in display_values

--- a/ui/src/components/Reasoning.jsx
+++ b/ui/src/components/Reasoning.jsx
@@ -202,7 +202,21 @@ function OnChainTraces({ onNavigate, highlightTraceId }) {
                     <span className={`tag ${t.decision_type === 'rebalance' ? 'tag-positive' : t.decision_type === 'construction' ? 'tag-accent' : t.decision_type === 'skip' ? 'tag-warning' : 'tag-muted'}`}>
                       {t.decision_type}
                     </span>
-                    {t.is_verified && <span className="flex items-center gap-1 text-xs text-[var(--positive)]"><span className="i-lucide-check w-3 h-3" /> verified</span>}
+                    {/* "verified" is reserved for a real hash comparison. The
+                        on-chain-only path (verification_mode === 'anchored_only')
+                        confirmed an anchor exists and compared nothing, so it
+                        must not borrow the same word or the same green check
+                        (#1407). Same vocabulary as /verify's response. */}
+                    {t.verification_mode === 'anchored_only' ? (
+                      <span
+                        className="flex items-center gap-1 text-xs text-[var(--text-3)]"
+                        title="A hash is anchored on-chain for this trace. No off-chain body was available, so no hashes were compared — this is not a verification."
+                      >
+                        <span className="i-lucide-anchor w-3 h-3" /> anchored only
+                      </span>
+                    ) : t.is_verified ? (
+                      <span className="flex items-center gap-1 text-xs text-[var(--positive)]"><span className="i-lucide-check w-3 h-3" /> verified</span>
+                    ) : null}
                     {t.arc_tx_hash && <span className="flex items-center gap-1 text-xs"><span className="i-lucide-anchor w-3 h-3" /> on-chain</span>}
                   </div>
                   <div className="caption">{timeAgo(t.timestamp)}</div>

--- a/ui/src/components/VaultDetail.jsx
+++ b/ui/src/components/VaultDetail.jsx
@@ -559,7 +559,15 @@ export default function VaultDetail({ address, onBack }) {
                   <code className="vault-trace-hash">{t.trace_hash?.slice(0, 16)}…</code>
                 )}
                 <span className="vault-trace-time">{timeAgo(t.timestamp)}</span>
-                {t.is_verified && <span className="vault-trace-verified i-lucide-check" style={{width:12,height:12}} />}
+                {t.is_verified && (
+                  <span
+                    className={t.verification_mode === 'anchored_only' ? 'vault-trace-hash i-lucide-anchor' : 'vault-trace-verified i-lucide-check'}
+                    style={{width:12,height:12}}
+                    title={t.verification_mode === 'anchored_only'
+                      ? 'Anchored on-chain; no off-chain body to compare, so no hashes were checked.'
+                      : 'On-chain hash confirmed.'}
+                  />
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
Closes #1407. Follow-up to #1356 Evidence E.2, which PR #1394 scoped out.

Both display routes fell back to an on-chain-only projection hard-coding `is_verified=True`, with `arc_tx_hash` left `None` and **nothing compared anywhere** — no hash re-derivation, no receipt check beyond "an object exists at this id".

The part that isn't in the issue: `Reasoning.jsx:205` renders that boolean as a green check reading **"verified"**, straight off `/api/traces/`. So this wasn't a latent schema wart — the provenance page was asserting a verification on traces where zero hashes had been looked at.

## I took option (b), and (a) would have made it worse

The issue offered either `is_verified=False`, or a tri-state aligned with whatever `verification_mode` #1359 landed. #1359 merged first and landed exactly that shape, so the vocabulary existed to reuse.

Option (a) alone would have swapped one fabrication for another. `Portfolio.jsx` renders the **false** branch as:

> ⏱ anchor pending — *"registry write didn't complete yet (usually transient)"*

On this path the anchor demonstrably exists; we just read it out of the registry. Reporting "anchor pending" would be an invented denial of the one thing the path is certain about.

So `is_verified` stays true — matching `verify_trace`'s own `anchored_only`, which also sets it true — and `verification_mode` carries what was never true: that a hash was *compared*.

| path | `is_verified` | `verification_mode` |
|---|---|---|
| on-chain only | `True` (the anchor is confirmed) | `"anchored_only"` |
| off-chain record present | replayed from the store | `None` — this route compares nothing, so it claims nothing |

`None` as the default is the honest one: the off-chain branch replays a stored boolean and performs no comparison itself, so it has no mode to report. Call `/verify` for one.

## On the acceptance grep

The issue's grep criterion (`is_verified=True` no longer matching inside either fallback block) was written assuming option (a). Taking (b), the literal still has to exist somewhere.

Both fallbacks now call a single `_anchored_only_trace()` constructor, so **neither block contains the literal** — the projection is described once, in a named function whose docstring explains exactly what is and isn't known on that path, instead of being duplicated across two routes. That satisfies the criterion without gaming it. The two remaining hits in the file are that constructor and `verify_trace`'s own `anchored_only`, which is #1359's and explicitly an anti-goal here.

## Frontend

Kept minimal, but not skipped — leaving it would pass every grep while the false claim stayed on screen.

- `Reasoning.jsx` reserves "verified" for a real hash match; `anchored_only` renders as **"anchored only"** in muted text with an anchor icon and a tooltip saying no hashes were compared.
- `VaultDetail.jsx`'s bare check icon gains the same distinction plus a title.

## Shown to reject

| mutation | result |
|---|---|
| restore the defect (`is_verified=True`, no mode) | **5 failed** |
| fork the vocabulary (`anchored_only` → `anchor_only` on one side) | **6 failed** |
| let the off-chain path borrow `hash_matched` | **1 failed** |

There's a test asserting the issue's own wording as an invariant — a response must never claim `is_verified` with no mode *and* no `arc_tx_hash` — kept separate from the mode assertions so it survives a later rename of the vocabulary. And `test_display_and_verify_routes_share_one_vocabulary` compares the two `Literal` annotations directly, which is what mutation 2 trips: the issue asked for alignment, so the alignment itself is pinned rather than assumed.

Both store-silent cases are parametrised (`empty`, `unreachable`). The route treats them identically on purpose — from this path they are the same fact, *nothing was compared* — unlike `verify_trace`, where #1359 correctly 503s on an outage because a user asking "is this verified?" must not get an outage reported as a result.

## Verification

- 7 new tests pass; hermetic gate too.
- All trace-related tests: **118 passed** (111 before).
- Full unit suite: **3726 passed, 2 skipped** — 3719 on `main` plus these 7.
- `npm run lint` clean, `npm run build` succeeds.
- `ruff format --check` and the blocking lint subset clean.
