### PR TITLE
[frontend] Ship the Topic Clusters tab hidden until its data exists (#1406)

### DIFF
--- a/ui/.env.example
+++ b/ui/.env.example
@@ -40,6 +40,15 @@ VITE_MARKETPLACE_MIN_VAULT_FUNDS_RAW=1000000
 # in the tree either way.
 VITE_ROADMAP_SURFACES=false
 
+# Topic Clusters (knowledge-graph) tab inside /app/corpus (#1406). Off
+# (default) removes the tab from the Corpus Explorer entirely. Its backing
+# tables are 0 rows until #1090 (KB pipeline artifact) and #1092 (Postgres
+# backfill) land, so the tab would only offer an empty capability to click.
+# Set true to preview it — the zero-state branches on /health's corpus_kg_built
+# and stays honest either way. Separate from VITE_ROADMAP_SURFACES on purpose:
+# this is a missing-data gate, not an out-of-MVP-scope gate.
+VITE_KNOWLEDGE_GRAPH_TAB=false
+
 # Upfront cost-quote + x402 paywall step on the Generate page (RATIFIED —
 # docs/specs/generation-quote-contract.md, #1296). Off by default: Generate
 # submits directly, no quote step. Set true to try the quote card + 402/409

--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -4,8 +4,15 @@ import CorpusGraph from './CorpusGraph'
 import CorpusKG from './CorpusKG'
 import { cleanLatex } from '../utils/latex'
 import { apiGet } from '../api'
+import { KNOWLEDGE_GRAPH_TAB_ENABLED } from '../featureFlags'
 
-const TABS = ['catalog', 'overview', 'graph', 'knowledge-graph']
+// The Topic Clusters tab is filtered out at build time unless the flag is on
+// (#1406). Its backing tables (kg_entities/kg_relations) are 0 rows until
+// #1090 produces the KB pipeline artifact and #1092 backfills Postgres, so
+// shipping the tab means a visitor has to click an empty capability to find
+// that out. #1392 made the zero-state itself honest; this stops the round
+// trip. The tab returns by flipping the flag, not by editing this array.
+const TABS = ['catalog', 'overview', 'graph', ...(KNOWLEDGE_GRAPH_TAB_ENABLED ? ['knowledge-graph'] : [])]
 
 const TAB_LABELS = {
   catalog: 'Catalog',

--- a/ui/src/featureFlags.js
+++ b/ui/src/featureFlags.js
@@ -28,6 +28,28 @@ export const GENERATION_QUOTE_ENABLED =
 export const ROADMAP_SURFACES_ENABLED =
 	import.meta.env?.VITE_ROADMAP_SURFACES === "true";
 
+// Gates the Topic Clusters (knowledge-graph) tab inside /app/corpus (#1406).
+//
+// Deliberately NOT a ROADMAP_PAGES entry, and not routed through
+// featureEnabled(): those gate *pages* — ids that resolve through the router
+// as /app/<page> — and this is one entry in CorpusExplorer.jsx's local TABS
+// array inside the single /app/corpus page. featureEnabled('knowledge-graph')
+// would silently no-op, hiding nothing.
+//
+// It is also a different KIND of gate. ROADMAP_SURFACES_ENABLED means "out of
+// scope for the MVP"; this tab is in scope and simply has no data yet —
+// kg_entities/kg_relations are 0 rows until #1090 produces a KB pipeline
+// artifact and #1092 backfills Postgres from it. Folding it into the roadmap
+// umbrella would mean previewing vaults also reveals an empty Topic Clusters
+// tab, and that when the data lands the fix is deleting a ROADMAP_PAGES entry
+// rather than flipping a flag.
+//
+// Off by default (the ROADMAP_SURFACES_ENABLED convention). Set
+// VITE_KNOWLEDGE_GRAPH_TAB=true to preview it; CorpusKG.jsx's /health-branched
+// zero-state (#1392) stays the honest fallback for anyone who does.
+export const KNOWLEDGE_GRAPH_TAB_ENABLED =
+	import.meta.env?.VITE_KNOWLEDGE_GRAPH_TAB === "true";
+
 // Page ids the flag hides. Consumed by routes.js featureEnabled() — the
 // single gate for nav visibility, flat routes, and deep links alike — plus
 // the two spots routing can't reach: the Breadcrumbs mid-crumb and in-page

--- a/ui/test/corpus-kg-tab-gate.test.js
+++ b/ui/test/corpus-kg-tab-gate.test.js
@@ -1,0 +1,89 @@
+// The Topic Clusters tab ships hidden until its data exists (#1406).
+//
+// CorpusExplorer.jsx always rendered a `knowledge-graph` tab over
+// kg_entities/kg_relations, which are 0 rows until #1090 produces a KB
+// pipeline artifact and #1092 backfills Postgres. #1392 made the tab's own
+// zero-state honest, but a visitor still had to click an empty capability to
+// find that out.
+//
+// Two things are pinned here, and they fail for different reasons:
+//
+//   1. the flag is OFF unless the env var is exactly "true" — a typo or a
+//      truthy-looking "1" must not ship the tab;
+//   2. TABS is BUILT from the flag rather than listing the id literally, which
+//      is the shape that lets Vite fold the array at build time.
+//
+// Same idiom as oracle-copy.test.js: a raw source-text scan with anti-vacuity
+// coverage — every pattern must reject its own canonical pre-fix example, so a
+// pattern that stops matching anything fails loudly instead of guarding nothing.
+
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+function repoFile(rel) {
+	return new URL(`../${rel}`, import.meta.url);
+}
+
+const explorer = readFileSync(repoFile("src/components/CorpusExplorer.jsx"), "utf8");
+const flags = readFileSync(repoFile("src/featureFlags.js"), "utf8");
+const envExample = readFileSync(repoFile(".env.example"), "utf8");
+
+// The exact line this change removed. If the guard below ever stops matching
+// it, the guard is broken rather than satisfied.
+const PRE_FIX_TABS = "const TABS = ['catalog', 'overview', 'graph', 'knowledge-graph']";
+
+const UNGATED_TABS = /const TABS = \[[^\]]*['"]knowledge-graph['"][^\]]*\]\s*$/m;
+
+test("the flag is off unless the env var is exactly \"true\"", async () => {
+	// import.meta.env is undefined under node --test, which is the unset case.
+	const { KNOWLEDGE_GRAPH_TAB_ENABLED } = await import("../src/featureFlags.js");
+	assert.equal(
+		KNOWLEDGE_GRAPH_TAB_ENABLED,
+		false,
+		"the tab must default to hidden — its backing tables are empty until #1090/#1092",
+	);
+	assert.match(
+		flags,
+		/VITE_KNOWLEDGE_GRAPH_TAB === "true"/,
+		'strict === "true" only: a truthy-looking "1" or "yes" must not ship an empty capability',
+	);
+});
+
+test("TABS is derived from the flag, not a bare literal", () => {
+	assert.ok(
+		!UNGATED_TABS.test(explorer),
+		"CorpusExplorer.jsx lists 'knowledge-graph' in TABS unconditionally — the tab ships regardless of the flag",
+	);
+	assert.match(
+		explorer,
+		/KNOWLEDGE_GRAPH_TAB_ENABLED \? \['knowledge-graph'\] : \[\]/,
+		"TABS must spread the id in from the flag so Vite can fold the array away at build time",
+	);
+});
+
+test("the guard rejects the exact line this change removed", () => {
+	// Anti-vacuity: prove UNGATED_TABS still matches the real pre-fix source.
+	assert.ok(
+		UNGATED_TABS.test(PRE_FIX_TABS),
+		"the ungated-TABS pattern no longer matches the code it exists to catch — it is guarding nothing",
+	);
+});
+
+test("the flag is documented and separate from the roadmap umbrella", () => {
+	assert.match(envExample, /VITE_KNOWLEDGE_GRAPH_TAB=false/);
+	// ROADMAP_SURFACES means "out of scope for the MVP". This tab is in scope
+	// and merely has no data, so folding it in there would mean previewing
+	// vaults also reveals an empty Topic Clusters tab.
+	assert.ok(
+		!/ROADMAP_PAGES = new Set\(\[[^\]]*knowledge-graph/s.test(flags),
+		"'knowledge-graph' must not be a ROADMAP_PAGES entry: featureEnabled() gates routed pages and would no-op on a tab id",
+	);
+});
+
+test("the honest zero-state stays for anyone who previews the tab", () => {
+	// #1392's /health-branched copy is explicitly out of scope for #1406 — it
+	// remains the fallback when the flag is on.
+	const kg = readFileSync(repoFile("src/components/CorpusKG.jsx"), "utf8");
+	assert.match(kg, /corpus_kg_built/, "CorpusKG.jsx must still branch on the live /health signal (#1392)");
+});


### PR DESCRIPTION
Closes #1406. The follow-up #1392's item 4 promised.

`CorpusExplorer.jsx` always rendered a `knowledge-graph` tab over `kg_entities`/`kg_relations`, which are 0 rows until #1090 produces a KB pipeline artifact and #1092 backfills Postgres. #1392 made the tab's own zero-state honest about that; a visitor still had to click an empty capability to find out.

## Design: a dedicated flag, not a `ROADMAP_PAGES` entry

The issue offered both and asked for the reasoning either way. I went dedicated, for two reasons.

**Mechanically, the umbrella wouldn't work.** `featureEnabled()`/`ROADMAP_PAGES` gate *pages* — ids that resolve through the router as `/app/<page>`. This is one entry in a local `TABS` array inside the single `/app/corpus` page, so `featureEnabled('knowledge-graph')` would silently no-op and hide nothing. The issue's design note already spotted this; I've pinned it with a test so the shortcut can't be taken later.

**Semantically, it's a different kind of gate.** `ROADMAP_SURFACES_ENABLED` means *"out of scope for the MVP"*. This tab is in scope and merely has no data yet. Folding it in would mean:

- flipping `VITE_ROADMAP_SURFACES=true` to preview vaults also reveals an empty Topic Clusters tab — the exact thing this issue is removing;
- when #1090/#1092 land, the fix is *deleting* a `ROADMAP_PAGES` entry rather than flipping a flag.

So: `VITE_KNOWLEDGE_GRAPH_TAB`, off by default, matching the `ROADMAP_SURFACES_ENABLED` convention.

## The acceptance criterion, verified in the built bundle

The issue asks that a default build produce no reachable tab. `TABS` spreads the id in from the flag, which lets Vite fold the array at build time. Both builds, read out of `dist/`:

```
default build:   mg=[`catalog`,`overview`,`graph`],hg={…,"knowledge-graph":`Topic Clusters`}
flag-on build:   mg=[`catalog`,`overview`,`graph`,`knowledge-graph`],hg={…}
```

The tab array folds to three entries. No button renders, and `tab` can never be set to `'knowledge-graph'`.

**Being precise about what I did not achieve:** the *strings* `knowledge-graph` and `Topic Clusters` still appear in the default bundle. The `TAB_LABELS` map keeps its entry and `CorpusKG` is still imported, so a naive `grep dist/` for either string finds hits. They are unreachable, not absent. I checked rather than assuming, and I'd rather say so than let a reader run that grep and think the change didn't work.

## Shown to reject

| mutation | result |
|---|---|
| revert `TABS` to the bare literal | **fails** — *"lists 'knowledge-graph' in TABS unconditionally"* |
| make the flag on-by-default (`!== "false"`) | **fails** — *"must default to hidden"* |
| fold it into `ROADMAP_PAGES` instead | **fails** — *"featureEnabled() gates routed pages and would no-op on a tab id"* |

There's also an anti-vacuity test asserting the ungated-`TABS` pattern still matches the exact line this change removed, so a regex that stops matching anything fails loudly instead of guarding nothing — the `oracle-copy.test.js` idiom.

The strict-`=== "true"` check is deliberate and separately asserted: a truthy-looking `"1"` or `"yes"` must not ship an empty capability.

## Anti-goals respected

- `backend/tests/test_corpus_claim_integrity.py` is **unmodified** — no backend file changed at all — and its 26 tests still pass. The `kg_tab_labeled_knowledge_graph` and `kg_zero_state_no_entities_found` literal guards keep guarding the always-shipped source, which is exactly what the issue asked for.
- `CorpusKG.jsx`'s `/health`-branched zero-state (#1392) is untouched and stays the honest fallback for anyone previewing with the flag on. A test pins that it still branches on `corpus_kg_built`.
- `CorpusGraph.jsx` (the separate "Graph" tab) not touched.

## Verification

- 5 new tests; full `ui` suite **409 passed, 0 failed**.
- `npm run lint` clean, `npm run build` succeeds both with and without the flag.
- Full python suite: **3719 passed, 2 skipped** — unchanged from `main`, as expected for a frontend-only change.
- Flag documented in `ui/.env.example` with the reason it's separate from `VITE_ROADMAP_SURFACES`.
