### PR TITLE
[infra] Publish SPF and DMARC for archimedes-arc.com (#1462)

### DIFF
--- a/infra/dns_email.tf
+++ b/infra/dns_email.tf
@@ -1,0 +1,71 @@
+# ── Email authentication for ${var.domain_name} (#1462) ──────────────────────
+#
+# The zone publishes three SES DKIM CNAMEs and the app sends real transactional
+# mail (Better Auth verification + password reset), but had no SPF and no DMARC.
+# Verified against live DNS on 2026-08-29:
+#
+#   dig +short TXT archimedes-arc.com @8.8.8.8
+#     "google-site-verification=nHeZsrl8SxRsJeKWIQx0kaSQkHOlzPDdfRZU_ZCUqk8"
+#   dig +short TXT _dmarc.archimedes-arc.com @8.8.8.8
+#     (empty)
+#
+# DKIM alone does not close this. DKIM proves a message we signed is authentic;
+# it says nothing about an unsigned forgery, and with no published policy a
+# receiver has nothing to check a forged envelope sender against. This matters
+# more now that /privacy and /terms publish privacy@archimedes-arc.com as the
+# contact for data-protection requests — a spoofable domain on the address
+# users are told to trust is a ready-made phishing pretext.
+
+# ── SPF ──────────────────────────────────────────────────────────────────────
+#
+# CAREFUL: Route 53 holds ONE record set per (name, type), so the apex TXT
+# cannot be split across two `aws_route53_record` resources. The Google Search
+# Console verification string already lives there and is NOT currently managed
+# by Terraform, so this resource has to ADOPT that record set rather than add
+# alongside it — which is why `allow_overwrite` is true and why the Google
+# string is carried explicitly below.
+#
+# Dropping that string from this list would un-verify Search Console on the
+# next apply. It is a published DNS value, not a secret.
+resource "aws_route53_record" "apex_txt" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "TXT"
+  ttl     = 300
+
+  records = [
+    var.google_site_verification,
+    # -all (hard fail) rather than ~all: SES is the only sender, so there is no
+    # legitimate mail from anywhere else to soft-fail. If another sender is
+    # added later, extend this include list in the SAME apply that enables it.
+    "v=spf1 include:amazonses.com -all",
+  ]
+
+  # Adopts the existing unmanaged record set. Without this the first apply
+  # fails with "record already exists"; with it, the record is replaced by the
+  # full list above — which is why both strings must be present.
+  allow_overwrite = true
+}
+
+# ── DMARC ────────────────────────────────────────────────────────────────────
+#
+# p=none deliberately. It publishes a policy and asks for aggregate reports
+# WITHOUT changing how any receiver treats our mail, so it cannot silently drop
+# our own sign-in and password-reset mail. Moving to p=quarantine and then
+# p=reject is a separate, evidence-led change: do it once the rua reports show
+# every legitimate sending path is aligned, not before.
+#
+# p=none is not decorative even before reports arrive — Gmail's and Yahoo's
+# bulk-sender rules require a DMARC record to exist at all.
+resource "aws_route53_record" "dmarc" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_dmarc.${var.domain_name}"
+  type    = "TXT"
+  ttl     = 300
+
+  # fo=1 asks for a failure report when EITHER SPF or DKIM fails, rather than
+  # only when both do — the useful setting while observing.
+  records = [
+    "v=DMARC1; p=none; rua=mailto:${var.dmarc_rua_address}; fo=1",
+  ]
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -165,3 +165,32 @@ variable "kb_runner_schedule_expression" {
   type        = string
   default     = "rate(1 day)"
 }
+
+# ── Email authentication (#1462) ─────────────────────────────────────────────
+
+variable "google_site_verification" {
+  description = <<-EOT
+    The Google Search Console verification token already published in the apex
+    TXT record. It is carried here because Route 53 keeps one record set per
+    (name, type): the SPF string has to share the apex TXT with it, so both
+    values must be written in the same resource. Dropping this un-verifies
+    Search Console. A published DNS value, not a secret.
+  EOT
+  type        = string
+  default     = "google-site-verification=nHeZsrl8SxRsJeKWIQx0kaSQkHOlzPDdfRZU_ZCUqk8"
+}
+
+variable "dmarc_rua_address" {
+  description = <<-EOT
+    Mailbox for DMARC aggregate reports (the rua= tag).
+
+    Reports only ARRIVE once inbound mail for this address is actually handled
+    — the zone's MX already points at SES inbound, but the receipt rule that
+    delivers it is #1460's scope. Until then the DMARC record still publishes
+    the policy signal Gmail/Yahoo bulk-sender rules look for; the reports are
+    simply not collected yet, and a reporter that cannot deliver drops them
+    silently rather than bouncing at us.
+  EOT
+  type        = string
+  default     = "dmarc-reports@archimedes-arc.com"
+}


### PR DESCRIPTION
Addresses #1462. **Not applied — this needs @dbrowneup's AWS account.** I can write and validate the config; I cannot `plan` or `apply` it, and the issue's acceptance criteria are all `dig` against live DNS, so they can only be met after apply. See "What I could not verify" below.

## Re-verified the premise before writing anything

```
$ dig +short TXT archimedes-arc.com @8.8.8.8
"google-site-verification=nHeZsrl8SxRsJeKWIQx0kaSQkHOlzPDdfRZU_ZCUqk8"

$ dig +short TXT _dmarc.archimedes-arc.com @8.8.8.8
(empty)

$ dig +short MX archimedes-arc.com @8.8.8.8
10 inbound-smtp.us-east-1.amazonaws.com.
```

Still true on 2026-08-29. One TXT, no SPF, no DMARC.

## The apex TXT is the part to read carefully

Route 53 keeps **one record set per (name, type)**, so SPF cannot be added as a second `aws_route53_record` alongside the Google Search Console string. And that string is **not currently managed by Terraform** — nothing in `infra/*.tf` declares a TXT record at all.

So the new resource has to *adopt* the existing record set: `allow_overwrite = true`, carrying **both** strings. Getting this wrong is not subtle — a resource with only the SPF string plus `allow_overwrite` would replace the set and un-verify Search Console on the next apply, which is exactly the failure the issue warns about. The Google token is lifted into a variable so it is visible rather than buried in a list, with a comment saying why it lives there.

## `-all`, not `~all`

The issue specifies `-all` and I checked before agreeing. `auth/mailer.js` sends through `SESv2Client`; its only other mode is a console stub for local dev that logs instead of sending. Nothing else in the tree sends mail — no SendGrid, Mailgun, Postmark, nodemailer or SMTP config anywhere.

So there is no legitimate mail from another source to soft-fail. **If that changes, the include list must be extended in the same apply that enables the new sender**, or its mail hard-fails.

## DMARC stays at `p=none`

Deliberately. It publishes a policy and requests reports without changing how any receiver treats our mail, so it cannot silently drop our own sign-in and password-reset mail. `p=quarantine` → `p=reject` is evidence-led and belongs in a later change once the aggregate reports show every sending path is aligned. I've filed that as a follow-up rather than leaving it as a comment.

`p=none` isn't decorative in the meantime: Gmail's and Yahoo's bulk-sender rules require a DMARC record to *exist*, which is one of the three consequences the issue lists.

**One honest caveat on `rua`.** It defaults to `dmarc-reports@archimedes-arc.com`. The zone's MX already points at SES inbound, but the receipt rule that actually delivers to that address is **#1460's scope** — so until #1460 lands, the reports are requested and not collected. A reporter that cannot deliver drops them silently rather than bouncing at us, so this is a gap in observability, not a breakage. I'd rather say that plainly than let the record imply reports are being read.

## What I could not verify

- **No `plan`, no `apply`.** No credentials for account `037613907429`.
- **All three acceptance criteria are post-apply** (`dig` for SPF, `dig` for DMARC, and a test send showing `spf=pass`). None can be checked from here.
- What I did run: `tofu validate` → *Success! The configuration is valid.*, and `tofu fmt -check -recursive infra/` → clean, with the diff limited to one new file plus two variables.

Worth noting this is exactly the gap #1483 is about — nothing in CI parses a `.tf` file, so `validate` ran only because I ran it by hand.

## Out of scope, with reasoning

Item 4 (custom MAIL FROM domain in SES, so the envelope sender aligns for SPF as well as DKIM) is marked "consider" in the issue and I left it out. It needs an SES domain-identity resource that doesn't exist in Terraform yet, plus its own MX and SPF records on a subdomain — a bigger change that shouldn't ride along with the record that closes the immediate spoofing hole. Happy to do it next if you want it before mainnet.

## For the applier

```bash
cd infra && tofu plan -target=aws_route53_record.apex_txt -target=aws_route53_record.dmarc
```

The apex TXT plan should show a **replace carrying two strings** — if it shows one string, stop, because that apply would drop the Search Console verification.

After apply, the issue's own commands:

```bash
dig +short TXT archimedes-arc.com @8.8.8.8
dig +short TXT _dmarc.archimedes-arc.com @8.8.8.8
```
