### PR TITLE
[backend] Per-request timing so the latency tail names its own endpoint (#1436 AC2)

### DIFF
--- a/backend/archimedes/api/timing_middleware.py
+++ b/backend/archimedes/api/timing_middleware.py
@@ -1,0 +1,107 @@
+"""Per-request server-side timing, so the slow endpoint is identifiable (#1436).
+
+The ALB reported p50 0.046 s against p95 6.2 s and p99 16.8 s. That gap says
+most requests are static assets and the API calls that actually render a page
+live in the tail — but ALB metrics are per-target, not per-route, so finding
+*which* call is slow meant reaching for curl. `/app/library` issues three calls
+on mount and there was no way to tell from logs which of the three was the one
+costing seconds.
+
+This records the duration of every request, exposes it on the response as
+``X-Response-Time-Ms``, and logs a line only when a request crosses
+``SLOW_REQUEST_MS``.
+
+**Streaming responses are exempt, and that exemption is the point.** #1436's
+alarm was re-tuned on 2026-08-21 after 36 state transitions in one night,
+because p95 of ``TargetResponseTime`` is structurally contaminated: SSE
+generation streams legitimately run 300 s+, so at low traffic p95 *equals* the
+stream duration. A slow-request log that treated those the same way would
+reproduce exactly that failure in the logs instead of the alarm — every
+generation emitting a "slow request" warning until nobody reads them. A
+300-second SSE stream is the feature working.
+
+Fail-safe, like the telemetry and funnel middleware it sits alongside: timing
+never turns a request into a 5xx.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+#: Default slow-request threshold in milliseconds. 1000 ms is well under the
+#: 2 s the ALB alarm used to trip on and well over the 46 ms p50, so it catches
+#: the tail this issue is about without logging ordinary traffic.
+_DEFAULT_SLOW_MS = 1000.0
+
+#: Content types whose duration measures how long a client stayed connected
+#: rather than how long the server took. See the module docstring.
+_STREAMING_TYPES = ("text/event-stream",)
+
+
+def _slow_request_ms() -> float:
+    """Threshold in ms. Fails SAFE to the default on a malformed value — a typo
+    must not silently disable the logging or flood it."""
+    raw = os.getenv("SLOW_REQUEST_MS", "").strip()
+    if not raw:
+        return _DEFAULT_SLOW_MS
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("invalid SLOW_REQUEST_MS=%r — using default %s", raw, _DEFAULT_SLOW_MS)
+        return _DEFAULT_SLOW_MS
+    return value if value > 0 else _DEFAULT_SLOW_MS
+
+
+def _route_template(request: Request) -> str:
+    """The matched route's template, e.g. ``/api/strategies/{strategy_id}``.
+
+    The template rather than the raw path for two reasons: it groups every hit
+    on one endpoint into one identifiable line instead of scattering them
+    across ids, and it keeps path parameters — which include wallet addresses
+    and job ids — out of the logs.
+    """
+    route = request.scope.get("route")
+    path_format = getattr(route, "path_format", None) or getattr(route, "path", None)
+    if path_format:
+        return str(path_format)
+    return "<unmatched>"
+
+
+def _is_streaming(response) -> bool:
+    content_type = response.headers.get("content-type", "")
+    return any(content_type.startswith(t) for t in _STREAMING_TYPES)
+
+
+async def timing_middleware(request: Request, call_next):
+    """Time the request, tag the response, log only the slow ones."""
+    started = time.perf_counter()
+    response = await call_next(request)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+
+    try:
+        response.headers["X-Response-Time-Ms"] = f"{elapsed_ms:.1f}"
+
+        if _is_streaming(response):
+            # A long stream is the feature working, not a slow request.
+            return response
+
+        threshold = _slow_request_ms()
+        if elapsed_ms >= threshold:
+            logger.warning(
+                "slow request: %s %s status=%s duration_ms=%.1f threshold_ms=%.0f",
+                request.method,
+                _route_template(request),
+                response.status_code,
+                elapsed_ms,
+                threshold,
+            )
+    except Exception:  # pragma: no cover — defensive, mirrors the sibling middleware
+        logger.debug("timing middleware failed", exc_info=True)
+
+    return response

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -469,6 +469,17 @@ async def _limit_request_body(request: Request, call_next):
     return await call_next(request)
 
 
+# ── Timing middleware: per-request duration + slow-request log (issue #1436) ──
+# The ALB reports p50 46ms against p99 16.8s, but its metrics are per-target,
+# not per-route, so which endpoint owns the tail was not answerable from logs.
+# Tags every response with X-Response-Time-Ms and logs the ones over
+# SLOW_REQUEST_MS. SSE streams are exempt — they legitimately run 300s+, which
+# is the same contamination that forced the latency alarm off p95 on 2026-08-21.
+from archimedes.api.timing_middleware import timing_middleware
+
+app.middleware("http")(timing_middleware)
+
+
 # ── Telemetry middleware: human-vs-agent traction counter (issue #428) ──
 # Registered AFTER _limit_request_body and BEFORE include_router. It classifies
 # each request (Better Auth account → human; internal-key / bot-UA → agent), increments

--- a/backend/tests/test_timing_middleware.py
+++ b/backend/tests/test_timing_middleware.py
@@ -1,0 +1,169 @@
+"""Per-request timing, and the exemption that keeps it readable (#1436).
+
+The ALB reported p50 0.046 s against p99 16.8 s, but its metrics are
+per-target rather than per-route, so identifying which of `/app/library`'s
+three mount-time calls owned the tail meant reaching for curl.
+
+The exemption is the load-bearing part. #1436's own alarm was re-tuned on
+2026-08-21 after 36 state transitions in one night, because p95 of
+`TargetResponseTime` is structurally contaminated — SSE generation streams
+legitimately run 300 s+, so at low traffic p95 equals the stream duration. A
+slow-request log that treated a stream the same way would rebuild that failure
+in the logs: every generation emitting a warning until nobody reads any of
+them.
+
+Hermetic: a bare Starlette app exercises the middleware directly, so nothing
+here depends on the real route table, Redis, or a database.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from archimedes.api.timing_middleware import _route_template, _slow_request_ms, timing_middleware
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.middleware("http")(timing_middleware)
+
+    @app.get("/fast")
+    async def fast():
+        return {"ok": True}
+
+    @app.get("/slow")
+    async def slow():
+        import asyncio
+
+        await asyncio.sleep(0.05)
+        return {"ok": True}
+
+    @app.get("/items/{item_id}")
+    async def item(item_id: str):
+        return {"id": item_id}
+
+    @app.get("/stream")
+    async def stream():
+        # The sleep is BEFORE the response is returned, not inside the
+        # generator. Under BaseHTTPMiddleware `call_next` resolves as soon as
+        # the response starts, so a slow generator never reaches the timer —
+        # a test that slept inside gen() would pass with the exemption
+        # deleted, proving nothing.
+        import asyncio
+
+        await asyncio.sleep(0.05)
+
+        async def gen():
+            yield "data: hello\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    return app
+
+
+async def _get(path: str, **kwargs):
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://test") as client:
+        return await client.get(path, **kwargs)
+
+
+async def test_every_response_carries_its_duration():
+    resp = await _get("/fast")
+    assert resp.status_code == 200
+    assert float(resp.headers["X-Response-Time-Ms"]) >= 0
+
+
+async def test_a_slow_request_is_logged_with_its_route_and_duration(monkeypatch, caplog):
+    monkeypatch.setenv("SLOW_REQUEST_MS", "1")
+    with caplog.at_level(logging.WARNING, logger="archimedes.api.timing_middleware"):
+        await _get("/slow")
+    slow_lines = [r.getMessage() for r in caplog.records if "slow request" in r.getMessage()]
+    assert len(slow_lines) == 1, slow_lines
+    assert "/slow" in slow_lines[0]
+    assert "duration_ms=" in slow_lines[0]
+
+
+async def test_an_ordinary_request_is_not_logged(monkeypatch, caplog):
+    monkeypatch.setenv("SLOW_REQUEST_MS", "10000")
+    with caplog.at_level(logging.WARNING, logger="archimedes.api.timing_middleware"):
+        await _get("/fast")
+    assert not [r for r in caplog.records if "slow request" in r.getMessage()]
+
+
+async def test_a_stream_is_never_reported_slow(monkeypatch, caplog):
+    """The exemption. A 300s SSE stream is the feature working.
+
+    Without this the log rebuilds the alarm-fatigue failure that forced the
+    latency alarm off p95 on 2026-08-21.
+    """
+    monkeypatch.setenv("SLOW_REQUEST_MS", "1")
+    with caplog.at_level(logging.WARNING, logger="archimedes.api.timing_middleware"):
+        resp = await _get("/stream")
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert not [r for r in caplog.records if "slow request" in r.getMessage()], (
+        "an SSE stream was logged as a slow request — long streams are the feature working, "
+        "and warning on each one is how a signal stops being read"
+    )
+
+
+async def test_the_log_names_the_route_template_not_the_id(monkeypatch, caplog):
+    """Path parameters carry wallet addresses and job ids. They stay out of logs,
+    and templating also groups every hit on one endpoint into one line."""
+    monkeypatch.setenv("SLOW_REQUEST_MS", "0.0001")
+    with caplog.at_level(logging.WARNING, logger="archimedes.api.timing_middleware"):
+        await _get("/items/0xdeadbeefcafe")
+    line = next(r.getMessage() for r in caplog.records if "slow request" in r.getMessage())
+    assert "/items/{item_id}" in line
+    assert "0xdeadbeefcafe" not in line
+
+
+class TestThresholdFailsSafe:
+    def test_unset_uses_the_default(self, monkeypatch):
+        monkeypatch.delenv("SLOW_REQUEST_MS", raising=False)
+        assert _slow_request_ms() == 1000.0
+
+    @pytest.mark.parametrize("bad", ["abc", "", "   ", "0", "-5"])
+    def test_a_malformed_or_useless_value_falls_back(self, monkeypatch, bad):
+        """A typo must not silently disable the logging or flood it with every request."""
+        monkeypatch.setenv("SLOW_REQUEST_MS", bad)
+        assert _slow_request_ms() == 1000.0
+
+    def test_a_valid_value_is_honoured(self, monkeypatch):
+        monkeypatch.setenv("SLOW_REQUEST_MS", "2500")
+        assert _slow_request_ms() == 2500.0
+
+
+def test_route_template_falls_back_when_nothing_matched():
+    """A 404 has no matched route; the log must still be writable."""
+
+    class _Req:
+        def __init__(self) -> None:
+            self.scope: dict = {}
+
+    assert _route_template(_Req()) == "<unmatched>"
+
+
+async def test_a_slow_handler_returning_a_stream_is_still_exempt(monkeypatch, caplog):
+    """Belt and braces, and the case that actually distinguishes the exemption.
+
+    Server-side timing measures until the response STARTS, so a long-running
+    stream body never reaches this timer at all — unlike the ALB's
+    TargetResponseTime, which measures the whole connection and is why p95 had
+    to be abandoned for the latency alarm. The exemption covers the remaining
+    case: a handler that is genuinely slow to produce a streaming response.
+    """
+    monkeypatch.setenv("SLOW_REQUEST_MS", "1")
+    with caplog.at_level(logging.WARNING, logger="archimedes.api.timing_middleware"):
+        resp = await _get("/stream")
+    assert float(resp.headers["X-Response-Time-Ms"]) >= 50, "the handler really was slow"
+    assert not [r for r in caplog.records if "slow request" in r.getMessage()]


### PR DESCRIPTION
Addresses **AC2 of #1436**, and reports on the other two rather than pretending to close them. Does not close the issue.

## Where the three acceptance criteria stand

| AC | Status |
|---|---|
| 1 — establish a CloudWatch baseline | **Blocked on me.** No credentials for account `037613907429`. |
| 2 — per-endpoint server-side timing | **This PR.** |
| 3 — re-tune the flapping alarm | **Already done**, on 2026-08-21, in `a906dd60` + `46f9a28d`. Evidence below. |

### AC3 was already fixed, and by a better method than the issue asked for

The issue (filed 2026-08-20) asks for M-of-N on `p95`. The day after, `a906dd60 [infra] Re-tune the three noisy ALB alarms (54 transitions in one night)` landed:

```
-  extended_statistic  = "p95"      +  extended_statistic  = "p50"
-  threshold           = 2          +  threshold           = 1.5
-  evaluation_periods  = 2          +  evaluation_periods  = 3
                                    +  datapoints_to_alarm = 3
```

with the reasoning in a comment still on `main`:

> p95 of `TargetResponseTime` is structurally contaminated here — SSE generation streams legitimately run 300s+, so at low traffic p95 **equals** the stream duration whenever anyone generates, and a 2s threshold cycles forever.

That's a better diagnosis than the AC. M-of-N on p95 would have made the flapping *less frequent* while still measuring a number that is contaminated by design. Moving to p50 measures systemic slowness of ordinary requests instead. The issue's prescribed fix would have been the wrong one, so I've left the alarm alone.

**One thing for @dbrowneup to check:** the issue's `describe-alarms` output records the live alarm as `p95 > 2.0, Period=300, EvaluationPeriods=2`, which is the *pre*-`a906dd60` config. If that reading was taken after 2026-08-21, the live alarm has drifted from Terraform and the next `apply` will change it. If it was taken before, everything is consistent. I can't tell from here — reading CloudWatch needs the account.

## What this PR adds (AC2)

`X-Response-Time-Ms` on every response, and one log line when a request crosses `SLOW_REQUEST_MS` (default 1000 ms — well under the 2 s the alarm used to trip on, well over the 46 ms p50). ALB metrics are per-target, not per-route, which is why answering "which of the three `/app/library` calls is slow?" meant reaching for curl.

**Streaming responses are exempt, and that exemption is the point.** Warning on every generation would rebuild in the logs exactly the failure that forced the alarm off p95 — a signal that fires so often nobody reads it. A 300-second SSE stream is the feature working.

The log records the **route template** (`/api/strategies/{strategy_id}`), not the raw path: it groups every hit on one endpoint into one identifiable line, and it keeps wallet addresses and job ids out of the logs.

## Shown to reject

| mutation | result |
|---|---|
| drop the SSE exemption | **2 failed** |
| log the raw path instead of the template | **1 failed** — the id leaked into the line |
| let a malformed `SLOW_REQUEST_MS` through | **2 failed** (`0` and `-5` would flood every request) |

**The first mutation initially passed all 13 tests, and finding that was the useful part.** My stream test slept *inside* the generator — but under `BaseHTTPMiddleware`, `call_next` resolves as soon as the response starts, so the generator's time never reaches the timer. The measured duration was ~0 ms and the exemption was never exercised: the test would have passed with the exemption deleted, guarding nothing.

Moving the sleep into the handler, *before* the `StreamingResponse` is returned, makes it real — and it surfaced a distinction worth writing down, now pinned by its own test: **server-side timing measures until the response starts, whereas the ALB's `TargetResponseTime` measures the whole connection.** That difference is precisely why p95 was contaminated at the ALB. The exemption covers the remaining case, a handler that is genuinely slow to produce a streaming response.

## Verification

- 14 new tests pass; hermetic gate too.
- `test_api_routes.py`: 42 passed — the middleware sits in the real stack without disturbing it.
- Full unit suite: **3733 passed, 2 skipped** — 3719 on `main` plus these 14.
- `ruff format --check` and the blocking lint subset clean.

## Not done

The `/api/selection-bias/gate` cost itself (~13 s warm, `rigor_cache` 600 s TTL, full cohort recompute on expiry) is untouched. This PR makes that cost *visible in logs*; it does not reduce it. That deserves its own change once AC1's baseline exists to measure against — otherwise there's no way to show an improvement, which is the whole reason AC1 comes first.
