### PR TITLE
[chain] Bound a JSON-RPC call to the timeout we document for it

### DIFF
--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -12,13 +12,14 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
-from aiohttp import ClientTimeout
+from aiohttp import ClientError, ClientTimeout
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from pydantic_settings import BaseSettings
 from web3 import AsyncWeb3
 from web3.middleware import ExtraDataToPOAMiddleware
 from web3.providers import AsyncHTTPProvider
+from web3.providers.rpc.utils import ExceptionRetryConfiguration
 
 logger = logging.getLogger(__name__)
 
@@ -115,15 +116,31 @@ class ChainSettings(BaseSettings):
     # RPC
     arc_rpc_url: str = "https://rpc.testnet.arc.network"
     chain_id: int = 5042002  # Arc testnet chain ID (0x4cef52)
-    # Connect+read timeout for the AsyncHTTPProvider (N2 — dead-egress detection).
-    # A blackholed NAT (e.g. a NAT instance down, see infra/cloudwatch.tf's
-    # per-NAT StatusCheckFailed alarm) otherwise hangs the RPC call with no
-    # timeout at all, which can exceed /health's own health-check budget (the
+    # TOTAL wall-clock budget for one JSON-RPC call, retries and backoff included
+    # (N2 — dead-egress detection). A blackholed NAT (e.g. a NAT instance down,
+    # see infra/cloudwatch.tf's per-NAT StatusCheckFailed alarm) otherwise hangs
+    # the call with no timeout at all, which can exceed /health's own budget (the
     # ECS task healthCheck timeout is 5s — infra/ecs.tf) and gets a perfectly
     # healthy app process killed for an RPC-layer problem. 3s leaves headroom
     # inside that 5s budget for /health's other work (DB, corpus, LLM probes).
     # ARC_RPC_TIMEOUT_SECONDS overrides.
+    #
+    # "TOTAL" is load-bearing and is why rpc_retries exists below. Passing this
+    # as the aiohttp timeout alone bounds ONE ATTEMPT, not the call: web3 7.x
+    # retries allowlisted methods (eth_call, eth_chainId, eth_getBalance, ... —
+    # 43 of them) five times by default, so the real ceiling was
+    # 5 x 3s + backoff = 16.9s, measured, against a documented 3s. That gap is
+    # what turns a brief RPC blip into a 90s nginx 504 on /api/config/contracts
+    # instead of a 3s degraded read, and it defeats the very cascade this
+    # timeout was added to prevent. rpc_retry_policy() below re-derives the
+    # per-attempt timeout from this total so the number here is the truth.
     rpc_timeout_seconds: float = 3.0
+    # Attempts per call (1 = no retry). web3 counts this as the TOTAL attempt
+    # count, not extra tries beyond the first — see AsyncHTTPProvider._make_request,
+    # `for i in range(retries)`. Two keeps one cheap retry for a genuine transient
+    # blip while leaving each attempt ~1.4s, roughly 9x the live Arc round trip.
+    # ARC_RPC_RETRIES overrides.
+    rpc_retries: int = 2
 
     # Agent account (the address that calls rebalance, publishes traces, etc.)
     agent_private_key: str = ""
@@ -192,6 +209,52 @@ class ChainSettings(BaseSettings):
         return _resolve_ssot_addresses(_ORACLE_DEFAULTS, "ORACLE_ADDRESS")
 
 
+# web3's retry backoff sleeps ``backoff_factor * 2**i`` between attempts, for
+# i = 0 .. retries-2 (AsyncHTTPProvider._make_request). Keeping the default here
+# means the only thing rpc_retry_policy has to solve for is the per-attempt timeout.
+RPC_BACKOFF_FACTOR = 0.125
+
+# Mirrors web3's own default set (AsyncHTTPProvider.exception_retry_configuration)
+# so this override changes ONLY the attempt count, never which failures retry.
+# Python 3.11+ aliases asyncio.TimeoutError to the builtin, so the builtin covers
+# the aiohttp ClientTimeout expiry too.
+RPC_RETRY_ERRORS = (ClientError, TimeoutError)
+
+
+def rpc_retry_policy(
+    total_seconds: float, retries: int, backoff_factor: float = RPC_BACKOFF_FACTOR
+) -> tuple[float, int]:
+    """Split a TOTAL wall-clock budget into web3's ``(per-attempt timeout, attempts)``.
+
+    web3 bounds one attempt; callers care about the whole call. Worst case is
+    ``attempts * per_attempt + backoff_factor * (2**(attempts-1) - 1)``, so this
+    subtracts the backoff web3 will sleep and divides what is left. Feed the
+    first element to ``ClientTimeout(total=...)`` and the second to
+    ``ExceptionRetryConfiguration(retries=...)`` — passing the requested
+    ``retries`` instead of the returned one reintroduces the bug.
+
+    Both halves are returned because a budget too small to split cannot be fixed
+    by shortening attempts alone: at 0.2s over 5 attempts the mandatory backoff
+    is 1.875s on its own, and a per-attempt timeout that fits would be negative.
+    That case drops to a single attempt spending the whole budget and logs it.
+    Fewer attempts is a degraded retry policy; a non-positive timeout is a broken
+    client, and holding ``retries`` while shortening the timeout is neither — it
+    just multiplies the budget by the attempt count again.
+    """
+    attempts = max(1, retries)
+    backoff_total = backoff_factor * (2 ** (attempts - 1) - 1)
+    per_attempt = (total_seconds - backoff_total) / attempts
+    if per_attempt <= 0:
+        logger.warning(
+            "rpc budget %.3fs cannot cover %d attempts (backoff alone is %.3fs) — falling back to a single attempt",
+            total_seconds,
+            attempts,
+            backoff_total,
+        )
+        return total_seconds, 1
+    return per_attempt, attempts
+
+
 class ChainClient:
     """Singleton Web3 client for all on-chain interactions."""
 
@@ -202,10 +265,19 @@ class ChainClient:
         # request itself, but web3's HTTPSessionManager.async_cache_and_return_session
         # separately accesses `request_timeout.total` on its own session-eviction
         # path, which requires an actual ClientTimeout instance (see N2).
+        per_attempt, attempts = rpc_retry_policy(self.settings.rpc_timeout_seconds, self.settings.rpc_retries)
         self.w3 = AsyncWeb3(
             AsyncHTTPProvider(
                 self.settings.arc_rpc_url,
-                request_kwargs={"timeout": ClientTimeout(total=self.settings.rpc_timeout_seconds)},
+                request_kwargs={"timeout": ClientTimeout(total=per_attempt)},
+                # Passed explicitly, never left to default: web3's default is five
+                # attempts, which multiplies rpc_timeout_seconds by five and breaks
+                # the total-budget promise the setting documents.
+                exception_retry_configuration=ExceptionRetryConfiguration(
+                    errors=RPC_RETRY_ERRORS,
+                    retries=attempts,
+                    backoff_factor=RPC_BACKOFF_FACTOR,
+                ),
             )
         )
 

--- a/backend/archimedes/marketplace/settlement.py
+++ b/backend/archimedes/marketplace/settlement.py
@@ -35,6 +35,15 @@ GATEWAY_CHAIN = os.getenv("GATEWAY_CHAIN", DEFAULT_GATEWAY_CHAIN)
 
 _THRESHOLD_RAW = int(Decimal(SWEEP_WITHDRAW_THRESHOLD_USDC) * 10**6)
 
+# TOTAL wall-clock budget for one balance read, retries and backoff included, and
+# the attempt count it is split across. Deliberately looser than the async client's
+# 3s: nothing here sits behind an ALB health check, and a sweep that reads a stale
+# balance is worse than a sweep that waits. What matters is that it is BOUNDED —
+# this call previously had no timeout of any kind. RPC_BALANCE_TIMEOUT_SECONDS /
+# RPC_BALANCE_ATTEMPTS override.
+_RPC_TOTAL_BUDGET_SECONDS = float(os.getenv("RPC_BALANCE_TIMEOUT_SECONDS", "10.0"))
+_RPC_ATTEMPTS = int(os.getenv("RPC_BALANCE_ATTEMPTS", "3"))
+
 
 class SettlementSweeper:
     """Two-cadence settlement sweeper for one publisher's agent wallet.
@@ -271,10 +280,35 @@ class SettlementSweeper:
 
         Uses web3 (already a dependency) rather than pulling in another SDK.
         """
+        from requests.exceptions import ConnectionError as _ReqConnectionError
+        from requests.exceptions import HTTPError as _ReqHTTPError
+        from requests.exceptions import Timeout as _ReqTimeout
         from web3 import Web3
+        from web3.providers.rpc.utils import ExceptionRetryConfiguration
 
+        from archimedes.chain.client import RPC_BACKOFF_FACTOR, rpc_retry_policy
+
+        # This runs inside asyncio.to_thread, so an unbounded call does not just
+        # stall one sweep — it parks a worker from the default executor pool for
+        # as long as the RPC stays dark, and enough of them stall every other
+        # to_thread caller in the process. Bound it the same way the async client
+        # is bounded: a TOTAL budget, split across a small attempt count, because
+        # web3 retries eth_call five times by default and would otherwise turn
+        # this into 5x whatever timeout we set. requests takes a bare number
+        # (aiohttp needs a ClientTimeout — see chain/client.py).
         rpc_url = os.getenv("RPC_URL", "http://localhost:8545")
-        w3 = Web3(Web3.HTTPProvider(rpc_url))
+        per_attempt, attempts = rpc_retry_policy(_RPC_TOTAL_BUDGET_SECONDS, _RPC_ATTEMPTS)
+        w3 = Web3(
+            Web3.HTTPProvider(
+                rpc_url,
+                request_kwargs={"timeout": per_attempt},
+                exception_retry_configuration=ExceptionRetryConfiguration(
+                    errors=(_ReqConnectionError, _ReqHTTPError, _ReqTimeout),
+                    retries=attempts,
+                    backoff_factor=RPC_BACKOFF_FACTOR,
+                ),
+            )
+        )
         usdc_addr = Web3.to_checksum_address(self._settings.usdc_address)
         addr = Web3.to_checksum_address(address)
 

--- a/backend/tests/chain/test_rpc_call_bounds.py
+++ b/backend/tests/chain/test_rpc_call_bounds.py
@@ -1,0 +1,228 @@
+"""One JSON-RPC call must not outlast the timeout we document for it.
+
+``ChainSettings.rpc_timeout_seconds`` is written up as the budget that keeps a
+dead RPC from blowing through /health's ECS healthCheck window. It did not do
+that. web3 7.x retries allowlisted methods (``eth_call``, ``eth_chainId``,
+``eth_getBalance`` — 43 of them) five times by default, and the aiohttp timeout
+we passed bounds ONE ATTEMPT, so the real ceiling was five times the documented
+one: 16.9s measured against a stated 3s. That is what turns a brief RPC blip
+into a 90s nginx 504 on /api/config/contracts instead of a 3s degraded read.
+
+These tests pin the budget rather than the symptom. Most are arithmetic and
+configuration checks so they cost nothing; one measures real wall-clock against
+a local socket that accepts and never answers, because an arithmetic test alone
+cannot prove the numbers reach web3.
+
+Hermetic: the wall-clock test binds 127.0.0.1 on an ephemeral port. No outbound
+network, no RPC, no services.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+
+import pytest
+from aiohttp import ClientTimeout
+from archimedes.chain.client import (
+    RPC_BACKOFF_FACTOR,
+    ChainClient,
+    ChainSettings,
+    rpc_retry_policy,
+)
+from web3.providers import AsyncHTTPProvider
+
+# web3 sleeps backoff_factor * 2**i between attempts, for i = 0 .. retries-2.
+_backoff_total = lambda retries: RPC_BACKOFF_FACTOR * (2 ** (retries - 1) - 1)  # noqa: E731
+
+
+@pytest.fixture
+def silent_rpc():
+    """A listening socket that never answers — connect() succeeds, read hangs.
+
+    The read-timeout path is the one that matters: a blackholed NAT and an
+    overloaded RPC both look like this to the client, and both are what the
+    retry multiplier turns into a minute-long request.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(8)  # backlog only; nothing ever accept()s
+    yield f"http://127.0.0.1:{sock.getsockname()[1]}"
+    sock.close()
+
+
+class TestBudgetArithmetic:
+    @pytest.mark.parametrize("total", [0.05, 0.5, 1.0, 3.0, 8.0, 30.0])
+    @pytest.mark.parametrize("retries", [1, 2, 3, 5])
+    def test_the_returned_policy_always_fits_inside_the_total(self, total, retries):
+        """No hole in the matrix. The tight budgets matter most: they are the ones
+        where honouring the requested attempt count would blow the budget, and
+        shortening the timeout while keeping the attempts multiplies it right back."""
+        per_attempt, attempts = rpc_retry_policy(total, retries)
+        assert per_attempt > 0, "a non-positive per-attempt timeout fails every call instantly"
+        worst_case = attempts * per_attempt + _backoff_total(attempts)
+        assert worst_case <= total + 1e-9, (
+            f"{attempts} attempts of {per_attempt:.4f}s worst-case {worst_case:.4f}s > budget {total}s"
+        )
+
+    def test_a_budget_too_small_to_split_drops_to_one_attempt_and_says_so(self, caplog):
+        """0.2s over 5 attempts leaves 1.875s of mandatory backoff on its own, so
+        a per-attempt timeout that fit would have to be negative."""
+        with caplog.at_level("WARNING"):
+            per_attempt, attempts = rpc_retry_policy(0.2, 5)
+        assert (per_attempt, attempts) == (0.2, 1), "keeping 5 attempts here spends 1.0s against a 0.2s budget"
+        assert "cannot cover" in caplog.text, "a silently degraded retry policy is the failure mode, not the fix"
+
+    def test_a_feasible_budget_keeps_every_attempt_it_was_asked_for(self):
+        """Guards the guard above: a fallback that also fired on healthy budgets
+        would satisfy every bound in this file while quietly deleting all retries."""
+        assert rpc_retry_policy(3.0, 2)[1] == 2
+        assert rpc_retry_policy(10.0, 3)[1] == 3
+
+    def test_retries_below_one_still_yields_one_attempt(self):
+        assert rpc_retry_policy(3.0, 0) == rpc_retry_policy(3.0, 1)
+
+
+class TestProviderConfiguration:
+    def test_the_attempt_count_reaches_the_provider(self):
+        settings = ChainSettings(arc_rpc_url="http://127.0.0.1:1", rpc_retries=2)
+        provider = ChainClient(settings).w3.provider
+        assert provider.exception_retry_configuration.retries == 2
+
+    def test_the_provider_timeout_is_the_derived_one_not_the_raw_total(self):
+        settings = ChainSettings(arc_rpc_url="http://127.0.0.1:1", rpc_timeout_seconds=3.0, rpc_retries=2)
+        timeout = ChainClient(settings).w3.provider._request_kwargs["timeout"]
+        assert isinstance(timeout, ClientTimeout), "aiohttp session eviction reads .total off a ClientTimeout"
+        assert timeout.total == rpc_retry_policy(3.0, 2)[0]
+        assert timeout.total < 3.0, "passing the whole budget as the per-attempt timeout is the bug this fixes"
+
+    def test_which_failures_retry_is_unchanged_from_web3s_default(self):
+        """Only the attempt COUNT is ours. Narrowing the error set would silently
+        stop retrying transient connection resets."""
+        ours = ChainClient(ChainSettings(arc_rpc_url="http://127.0.0.1:1")).w3.provider
+        assert set(ours.exception_retry_configuration.errors) == set(
+            AsyncHTTPProvider("http://127.0.0.1:1").exception_retry_configuration.errors
+        )
+        assert set(ours.exception_retry_configuration.method_allowlist) == set(
+            AsyncHTTPProvider("http://127.0.0.1:1").exception_retry_configuration.method_allowlist
+        )
+
+    def test_web3s_own_default_is_still_the_five_this_fix_defends_against(self):
+        """Anti-vacuity. If upstream ever drops to 1 attempt the tests above keep
+        passing while proving nothing, so pin the number they are defending against."""
+        assert AsyncHTTPProvider("http://127.0.0.1:1").exception_retry_configuration.retries == 5
+
+
+class TestMeasuredWallClock:
+    async def test_a_retried_method_finishes_inside_the_budget(self, silent_rpc):
+        """eth_chainId is on web3's retry allowlist — the multiplied path.
+
+        Budget 1.0s over 2 attempts. Unpatched (whole budget per attempt, 5 of
+        them) this is 5 x 1.0 + 1.875 = 6.9s; dropping only the retry config is
+        5 x 0.4375 + 1.875 = 4.1s. The 2.0s assertion sits well clear of both.
+        """
+        client = ChainClient(ChainSettings(arc_rpc_url=silent_rpc, rpc_timeout_seconds=1.0, rpc_retries=2))
+        started = time.perf_counter()
+        with pytest.raises((TimeoutError, OSError)):
+            await client.w3.eth.chain_id
+        elapsed = time.perf_counter() - started
+        assert elapsed < 2.0, f"eth_chainId took {elapsed:.2f}s against a 1.0s budget — the retry multiplier is back"
+
+    async def test_the_liveness_probe_reports_down_instead_of_hanging(self, silent_rpc):
+        client = ChainClient(ChainSettings(arc_rpc_url=silent_rpc, rpc_timeout_seconds=1.0, rpc_retries=2))
+        started = time.perf_counter()
+        connected = await client.is_connected()
+        elapsed = time.perf_counter() - started
+        assert connected is False
+        assert elapsed < 2.0, f"is_connected() took {elapsed:.2f}s against a 1.0s budget"
+
+    async def test_concurrent_calls_do_not_serialise_into_a_longer_stall(self, silent_rpc):
+        """/health and /api/config/contracts fire several reads per request; the
+        budget has to hold per-call under concurrency, not just in isolation."""
+        client = ChainClient(ChainSettings(arc_rpc_url=silent_rpc, rpc_timeout_seconds=1.0, rpc_retries=2))
+        started = time.perf_counter()
+        await asyncio.gather(*(client.is_connected() for _ in range(4)))
+        elapsed = time.perf_counter() - started
+        assert elapsed < 2.0, f"4 concurrent probes took {elapsed:.2f}s — they are serialising"
+
+
+def _run_with_deadline(fn, deadline: float):
+    """Run ``fn`` in a daemon thread and give up after ``deadline`` seconds.
+
+    The unbounded provider this class guards does not fail slowly, it fails
+    never — restoring it made the suite hang until the job timeout instead of
+    reporting anything. A dead thread is left to the interpreter; the point is
+    that the assertion fails with a readable message.
+    """
+    box: dict[str, object] = {}
+
+    def target():
+        started = time.perf_counter()
+        try:
+            box["value"] = fn()
+        except BaseException as exc:
+            box["error"] = exc
+        box["elapsed"] = time.perf_counter() - started
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout=deadline)
+    return (not thread.is_alive()), box
+
+
+class TestSettlementBalanceRead:
+    """``SettlementSweeper._usdc_balance_of`` is the sync twin of the above.
+
+    It had no timeout of any kind, and it runs inside ``asyncio.to_thread`` — so
+    a dark RPC did not merely stall one sweep, it parked a worker from the
+    default executor pool indefinitely, and enough of those stall every other
+    ``to_thread`` caller in the process. Measured unpatched: still blocked after
+    40s and climbing.
+    """
+
+    @pytest.fixture
+    def sweeper(self, monkeypatch, silent_rpc):
+        from unittest.mock import MagicMock
+
+        from archimedes.marketplace import settlement
+
+        monkeypatch.setenv("RPC_URL", silent_rpc)
+        # The module constants are read at import; shrink them so the assertions
+        # below cost about a second rather than the 10s production budget.
+        monkeypatch.setattr(settlement, "_RPC_TOTAL_BUDGET_SECONDS", 1.0)
+        monkeypatch.setattr(settlement, "_RPC_ATTEMPTS", 2)
+
+        sweeper = settlement.SettlementSweeper.__new__(settlement.SettlementSweeper)
+        sweeper._settings = MagicMock(usdc_address="0x" + "11" * 20)
+        return sweeper
+
+    def test_the_balance_read_gives_up_inside_its_budget(self, sweeper):
+        finished, box = _run_with_deadline(lambda: sweeper._usdc_balance_of("0x" + "22" * 20), deadline=2.0)
+        assert finished, "balance read still running after 2.0s against a 1.0s budget — it is unbounded again"
+        assert isinstance(box.get("error"), Exception), f"expected a timeout, got {box.get('value')!r}"
+        assert "timed out" in str(box["error"]).lower(), f"finished for the wrong reason: {box['error']!r}"
+        assert box["elapsed"] < 2.0
+
+    def test_the_provider_carries_both_halves_of_the_policy(self, sweeper, monkeypatch):
+        """The wall-clock test above would still pass if only the timeout landed
+        and the attempt count silently stayed at web3's five, because 2 x 0.44s
+        and 5 x 0.44s both finish well inside a 2s deadline."""
+        from web3 import Web3
+
+        captured: dict = {}
+        original = Web3.HTTPProvider
+
+        def spy(endpoint_uri=None, **kwargs):
+            captured.update(kwargs)
+            return original(endpoint_uri, **kwargs)
+
+        monkeypatch.setattr(Web3, "HTTPProvider", spy)
+        finished, _ = _run_with_deadline(lambda: sweeper._usdc_balance_of("0x" + "22" * 20), deadline=3.0)
+        assert finished
+
+        assert captured["request_kwargs"]["timeout"] > 0, "requests with no timeout waits forever"
+        assert captured["exception_retry_configuration"].retries == 2, "web3's default of 5 multiplies the budget"
+        worst_case = 2 * captured["request_kwargs"]["timeout"] + _backoff_total(2)
+        assert worst_case <= 1.0 + 1e-9


### PR DESCRIPTION
## What was wrong

`ChainSettings.rpc_timeout_seconds` is documented as the budget that keeps a dead RPC
from blowing through /health's ECS healthCheck window. It did not do that.

web3 7.x retries allowlisted methods five times by default (`eth_call`, `eth_chainId`,
`eth_getBalance`, 43 of them), and the aiohttp timeout we passed bounds **one attempt**,
not the call. So the real ceiling was `5 x 3.0s + 1.875s backoff`. Measured, before this
branch:

```
is_connected()    3.00s   (not on the retry allowlist, so it was honest)
eth.chain_id     16.89s   against a documented 3s budget
```

The comment at `client.py:118` asserted a property the code did not have, which is the
defect class CLAUDE.md calls out directly.

`SettlementSweeper._usdc_balance_of` was worse: `Web3.HTTPProvider(rpc_url)` with no
timeout argument at all. It runs inside `asyncio.to_thread`, so a dark RPC does not stall
one sweep, it parks a worker from the default executor pool and enough of them stall every
other `to_thread` caller in the process. Measured against a blackholed address: still
blocked after 40s and climbing.

## Why I went looking

`/api/config/contracts` returned nothing for 90s this morning while the static site served
in 0.43s and `/api/agent/manifest` in 0.44s, then recovered to 0.73s within the hour. That
endpoint issues two `eth_call`s per request, so a bounded RPC layer should have made it a
few seconds of degraded read either way. Chasing why it could not be pointed at the
multiplier.

To be clear about what that is not: I first wrote that the same window explained a 90.6s
504 on `/health`, and that is wrong. `/health`'s only chain work is `is_connected()`, which
is not on web3's retry allowlist and so was bounded at 3s even before this branch, plus the
oracle probe with its own 1.5s deadline. The multiplier cannot produce a slow `/health`. I
have retracted that on #1436; the `/health` tail is a separate open question there.

## Possible bearing on #1436

Stated as a lead, not a conclusion, because I have no prod-internal measurement.

#1436 records `p99 16.789 s`, with 30-minute bin maxima of 17.3s and 30.0s. The
pre-fix client-side ceiling for one retried RPC method is `16.875s` by construction and
`16.89s` measured. A p99 sitting 0.09s under a hard client-side ceiling is what you would
expect if the tail is dominated by calls that exhaust the retry budget, and 30.0s is close
to two of them, which is what `/api/config/contracts` issues per request.

That is a numeric coincidence plus a mechanism, not a measurement. It does not displace the
cold-cache and `/api/selection-bias/gate` leads already in #1436. It is worth checking
against the ALB numbers after this deploys, which is a cheap test: if the tail is this, p99
should drop toward 3s without anything else changing.

## What changed

`rpc_retry_policy(total, retries)` returns `(per_attempt_timeout, attempts)`. Both halves,
because a budget too small to split cannot be fixed by shortening attempts alone: at 0.2s
over 5 attempts the mandatory backoff is 1.875s on its own. That case drops to a single
attempt spending the whole budget and logs it. Shortening the timeout while keeping the
attempt count just multiplies the budget again, which is the bug in miniature.

- `chain/client.py` splits `rpc_timeout_seconds` (now genuinely a TOTAL) across
  `rpc_retries` (new, default 2, `ARC_RPC_RETRIES`). Worst case is 3.0000s exactly.
- `marketplace/settlement.py` uses the same helper for the balance read, with its own
  looser 10s budget over 3 attempts. Nothing there sits behind a health check, and a sweep
  that reads a stale balance is worse than one that waits. What matters is that it is
  bounded.
- The error set and method allowlist are passed through from web3's defaults unchanged.
  Only the attempt count is ours. Narrowing the error set would silently stop retrying
  transient connection resets.

Measured after:

```
eth.chain_id                      3.01s  (budget 3.0s)
is_connected()                    1.44s
_usdc_balance_of                 10.09s  (budget 10.0s, was unbounded)
```

`is_connected()` now fails at 1.44s rather than 3.00s, since it gets one attempt at the
derived per-attempt timeout. Live Arc RPC answers in 0.16s, so that is about 9x headroom,
and /health already logs `HEALTH_CHAIN_DISCONNECTED` loudly when it trips.

## Guards shown to reject

36 tests in `backend/tests/chain/test_rpc_call_bounds.py`. Hermetic: the wall-clock ones
bind a socket on 127.0.0.1 that accepts and never answers, so there is no outbound network
and no RPC dependency.

Six mutations, each reverted after:

| mutation | result |
| --- | --- |
| M1 drop `exception_retry_configuration` in `client.py` | 2 failed |
| M2 pass the raw total as the per-attempt timeout | 2 failed |
| M3 settlement back to `Web3.HTTPProvider(rpc_url)` | 2 failed |
| M4 degenerate fallback keeps the requested attempt count | 6 failed |
| M5 fallback fires unconditionally, deleting all retries | 4 failed |
| M6 settlement keeps the timeout, drops the retry config | 2 failed |

Two of those tests exist only because of what the mutations showed:

- M3 originally made the suite **hang** rather than fail, since the thing it restores never
  returns. The settlement test now runs the call on a thread with a join deadline, so an
  unbounded provider fails with a readable message instead of sitting until the job timeout.
- M6 (timeout lands, attempt count silently stays at 5) passes any wall-clock assertion,
  because 2 x 0.44s and 5 x 0.44s both finish inside a 2s deadline against a fast-failing
  socket. `test_the_provider_carries_both_halves_of_the_policy` spies on the provider
  kwargs to catch it.

Two anti-vacuity guards:

- `test_web3s_own_default_is_still_the_five_this_fix_defends_against` pins the upstream
  number. If web3 ever drops it, the rest of the file keeps passing while proving nothing.
- `test_a_feasible_budget_keeps_every_attempt_it_was_asked_for` guards M5. A fallback that
  also fired on healthy budgets would satisfy every bound in the file while quietly
  deleting all retries.

## Verification

```
python -m pytest backend/tests/chain/test_rpc_call_bounds.py -q      -> 36 passed
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
    backend/tests/chain/test_rpc_call_bounds.py -q                  -> 36 passed
python -m pytest backend/tests/chain backend/tests/marketplace -q -m "not integration"
                                                                    -> 383 passed, 2 skipped
ruff format --check . ; ruff check --select E9,F63,F7,F40,F82 .      -> clean
```

## Not in scope

`api/_erc6492.py` passes a bare number as the aiohttp timeout, which is the pattern
`client.py`'s own comment warns against. It is harmless today only because the call sits
inside `asyncio.wait_for(..., timeout=10)`, which bounds it regardless. Left alone rather
than folded in here.

Closes nothing on its own. Relates to #1436.
