### PR TITLE
[rigor] Report a zero-variance passport series as degenerate, not pending

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1816,6 +1816,20 @@ def _generation_cost_for(strategy_id: str, session) -> dict | None:
 _RETURNS_NOT_PREFETCHED = object()
 
 
+def _rollback_quietly(session) -> None:
+    """Roll back after a swallowed read so the transaction is usable again.
+
+    Postgres aborts the whole transaction on a failed statement; every later
+    statement then raises InFailedSqlTransaction. sqlite does not, so a suite
+    that runs on sqlite cannot observe the difference — which is why this is
+    written down rather than left to the reader.
+    """
+    try:
+        session.rollback()
+    except Exception:  # pragma: no cover — nothing useful to do if rollback fails
+        pass
+
+
 def _passport_rigor_status(record, daily_returns: list[float]) -> tuple[str, bool]:
     """Tri-state + degenerate status for a generated/fusion passport row.
 
@@ -1901,6 +1915,9 @@ def _passport_to_strategy_response(record, session=None, daily_returns=_RETURNS_
                     record.id,
                     type(exc).__name__,
                 )
+                # See _passport_responses: without this, everything later in the
+                # request fails on Postgres and succeeds on sqlite.
+                _rollback_quietly(session)
     else:
         _returns = list(daily_returns or [])
 
@@ -2024,15 +2041,22 @@ def _passport_responses(records, session) -> list[StrategyResponse]:
 
     #1184 made ``_passport_to_strategy_response`` consult each row's persisted
     daily-return series so a zero-variance one reports ``degenerate`` instead of
-    ``pending``. Doing that per row would add a backtest read per strategy to
-    every list endpoint — the N+1 that #1436's latency tail is about. This
-    resolves the whole cohort through ``get_all_daily_returns``, the same DB
+    ``pending``. This routes that through ``get_all_daily_returns`` — the same DB
     boundary ``live_rigor_gate`` and the selection-bias route already read
-    through (and the one the suite mocks), then hands each row its own slice.
+    through, and the one the suite mocks — then hands each row its own slice.
+
+    **Cost, stated honestly:** ``get_all_daily_returns`` is a Python loop over
+    ``get_daily_returns``, so this is N indexed single-row reads, not one batched
+    query. It is the same query count reading per row would cost; the helper buys
+    a single mocking boundary and one failure decision, not a batching win. Each
+    read deserializes that strategy's whole ``artifact_json`` blob, so the real
+    cost scales with the generated corpus, and ``list_passports`` has no LIMIT.
+    Making the degenerate answer cheap needs it persisted at write time rather
+    than re-derived on read — tracked separately; do not paper over it here by
+    skipping rows, because which rows you skip is exactly the claim at stake.
     """
     if not records:
         return []
-    returns_by_id: dict[str, list[float]] = {}
     try:
         from archimedes.services.backtest_repository import get_all_daily_returns
 
@@ -2041,9 +2065,18 @@ def _passport_responses(records, session) -> list[StrategyResponse]:
         import logging as _logging
 
         _logging.getLogger(__name__).warning(
-            "cohort persisted-returns read failed (%s) — rigor status falls back to the stored aggregate",
+            "cohort persisted-returns read failed (%s) — falling back to a per-row read",
             type(exc).__name__,
         )
+        # A failed statement aborts the surrounding Postgres transaction, so
+        # every later read in this request would raise InFailedSqlTransaction.
+        # sqlite tolerates it, which is why no test can see this.
+        _rollback_quietly(session)
+        # NOT ``{}``: an empty map would hand every row [] — "the read found no
+        # series" — when the truth is "we do not know". That collapse is what
+        # sends a flat series back to "pending", the exact false claim #1184 is
+        # about. The sentinel makes each row decide for itself instead.
+        return [_passport_to_strategy_response(r, session) for r in records]
     return [_passport_to_strategy_response(r, session, returns_by_id.get(r.id, [])) for r in records]
 
 

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1810,7 +1810,48 @@ def _generation_cost_for(strategy_id: str, session) -> dict | None:
         return None
 
 
-def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
+# Sentinel distinguishing "no returns were prefetched for this call" from "the
+# prefetch ran and this strategy genuinely has no persisted series". The two
+# must not collapse: the first means we do not know, the second is a fact.
+_RETURNS_NOT_PREFETCHED = object()
+
+
+def _passport_rigor_status(record, daily_returns: list[float]) -> tuple[str, bool]:
+    """Tri-state + degenerate status for a generated/fusion passport row.
+
+    Returns ``(status, is_placeholder)``.
+
+    #1184: the stored aggregate alone cannot tell a zero-variance persisted
+    series apart from an ungraded one. Both leave ``record.sharpe_ratio`` NULL,
+    so reading the aggregate by itself reported a flat, broken, or zero-trade
+    backtest as ``"pending"`` — "we have not graded this yet", which is a claim,
+    and a false one. The curated path already answers this correctly via
+    ``_verdict_from_result``; this is the same predicate applied to the persisted
+    series the passport path had never loaded.
+
+    ``daily_returns`` empty means no persisted series was found, which is the
+    genuine "not graded yet" case — the aggregate three-way is then correct.
+    """
+    if daily_returns:
+        from archimedes.services.rigor_evaluator import (
+            is_oos_zero_variance_series,
+            is_zero_variance_series,
+        )
+
+        # OR'd exactly as run_rigor_gate ORs them into is_degenerate, so this
+        # read path and the gate agree by construction on both kinds of
+        # flatness (whole-series, and flat only inside the OOS slice).
+        if is_zero_variance_series(daily_returns) or is_oos_zero_variance_series(daily_returns):
+            # A persisted series exists, so this is not an ungraded placeholder;
+            # it is a graded row whose series carries no variance to grade.
+            return "degenerate", False
+
+    if record.sharpe_ratio is None:
+        return "pending", True
+    return ("pass" if bool(record.passes_rigor_gate) else "fail"), False
+
+
+def _passport_to_strategy_response(record, session=None, daily_returns=_RETURNS_NOT_PREFETCHED) -> StrategyResponse:
     """Reshape a StrategyPassportRecord (fusion/architect output) into the
     StrategyResponse schema that StrategyPassport.jsx expects. Curated
     strategies still flow through LocalStrategyProvider above; this is the
@@ -1821,6 +1862,14 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
     (fusion generation stores only arxiv_ids), the corpus join backfills them so
     the UI can display a human-readable title instead of a bare arxiv id.
     Falls back to the arxiv_id string when the corpus has no matching row.
+
+    ``daily_returns`` — this strategy's persisted daily-return series, when the
+    caller has already bulk-loaded it for a whole page of rows. List callers
+    pass it so the degenerate check below costs one cohort read per request
+    instead of one per row; the single-row detail path leaves it unset and this
+    function loads its own. Left unset with no ``session`` either, the
+    degenerate check is skipped and the status falls back to the stored
+    aggregate — see ``_passport_rigor_status``.
     """
     from archimedes.api.schemas import PaperRefResponse
     from archimedes.services.return_source_classifier import (
@@ -1833,6 +1882,29 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
     # is also the answer for every strategy generated before the meter existed.
     # Either way the UI renders "not measured"; nothing is zeroed or invented.
     generation_cost = _generation_cost_for(record.id, session)
+
+    # #1184: resolve this row's persisted return series so the rigor status
+    # below can tell a zero-variance (degenerate) series apart from an ungraded
+    # one. Prefetched by list callers; self-loaded on the single-row path.
+    if daily_returns is _RETURNS_NOT_PREFETCHED:
+        _returns: list[float] = []
+        if session is not None:
+            try:
+                from archimedes.services.backtest_repository import get_daily_returns
+
+                _returns = get_daily_returns(session, record.id) or []
+            except Exception as exc:  # pragma: no cover — defensive; DB-level failure
+                import logging as _logging
+
+                _logging.getLogger(__name__).warning(
+                    "persisted-returns read failed for %s (%s) — rigor status falls back to the stored aggregate",
+                    record.id,
+                    type(exc).__name__,
+                )
+    else:
+        _returns = list(daily_returns or [])
+
+    _rigor_status, _is_placeholder = _passport_rigor_status(record, _returns)
 
     refs = list(record.paper_refs or [])
     first = refs[0] if refs else None
@@ -1919,21 +1991,15 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
         # *live* verdict, not a fixture boolean — so it is a legitimate badge source
         # per #821 ("read a persisted live-gate verdict"). Map it to the tri-state:
         # a passport with no real backtest (sharpe_ratio is None) is "pending".
-        passes_rigor_gate=bool(record.passes_rigor_gate),
-        # #1184 KNOWN GAP: this three-state map is NOT threaded through the
-        # DEGENERATE category live_rigor_gate/_verdict_from_result added — it
-        # reads only the stored aggregate (record.sharpe_ratio /
-        # passes_rigor_gate), not the persisted daily-return series, so a
-        # generated/fusion strategy with a zero-variance series still reports
-        # "fail" here rather than "degenerate". Fixing this needs the same
-        # is_zero_variance_series/is_oos_zero_variance_series check run against
-        # this passport's own persisted returns (get_daily_returns), which this
-        # read path does not currently load. Tracked as an open follow-up on
-        # #1184, not closed by this PR.
-        rigor_gate_status=(
-            "pending" if record.sharpe_ratio is None else ("pass" if bool(record.passes_rigor_gate) else "fail")
-        ),
-        is_backtest_placeholder=record.sharpe_ratio is None,
+        # A degenerate row is never a pass, whatever the stored boolean says.
+        passes_rigor_gate=bool(record.passes_rigor_gate) and _rigor_status != "degenerate",
+        # #1184: four-state, derived from this passport's OWN persisted series
+        # (see _passport_rigor_status). The stored aggregate alone cannot
+        # separate a zero-variance series from an ungraded one — both leave
+        # sharpe_ratio NULL — so reading it by itself reported broken data as
+        # "pending", which is a claim ("not graded yet"), and a false one.
+        rigor_gate_status=_rigor_status,
+        is_backtest_placeholder=_is_placeholder,
         sharpe_ci_lower=None,
         sharpe_ci_upper=None,
         backtest_start=record.backtest_start,
@@ -1951,6 +2017,34 @@ def _passport_to_strategy_response(record, session=None) -> StrategyResponse:
 # Curated strategies are UNCHANGED: callers keep sourcing those from
 # strategy_provider() and concatenate the GENERATED half these return on top —
 # nothing here alters the curated path.
+
+
+def _passport_responses(records, session) -> list[StrategyResponse]:
+    """Map passport rows to responses, bulk-loading their persisted returns once.
+
+    #1184 made ``_passport_to_strategy_response`` consult each row's persisted
+    daily-return series so a zero-variance one reports ``degenerate`` instead of
+    ``pending``. Doing that per row would add a backtest read per strategy to
+    every list endpoint — the N+1 that #1436's latency tail is about. This
+    resolves the whole cohort through ``get_all_daily_returns``, the same DB
+    boundary ``live_rigor_gate`` and the selection-bias route already read
+    through (and the one the suite mocks), then hands each row its own slice.
+    """
+    if not records:
+        return []
+    returns_by_id: dict[str, list[float]] = {}
+    try:
+        from archimedes.services.backtest_repository import get_all_daily_returns
+
+        returns_by_id = get_all_daily_returns(session, [r.id for r in records]) or {}
+    except Exception as exc:  # pragma: no cover — defensive; DB-level failure
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "cohort persisted-returns read failed (%s) — rigor status falls back to the stored aggregate",
+            type(exc).__name__,
+        )
+    return [_passport_to_strategy_response(r, session, returns_by_id.get(r.id, [])) for r in records]
 
 
 def _generated_strategy_responses(
@@ -1972,7 +2066,7 @@ def _generated_strategy_responses(
     if not records:
         return []
     visible = _visible_passports(session, records, caller, caller_user_id)
-    return [_passport_to_strategy_response(r, session) for r in visible]
+    return _passport_responses(visible, session)
 
 
 def _public_generated_strategy_responses(session) -> list[StrategyResponse]:
@@ -2006,7 +2100,7 @@ def _public_generated_strategy_responses(session) -> list[StrategyResponse]:
         )
     }
     visible = [r for r in records if r.id in published_ids]
-    return [_passport_to_strategy_response(r, session) for r in visible]
+    return _passport_responses(visible, session)
 
 
 def _owned_generated_strategy_responses(
@@ -2048,7 +2142,7 @@ def _owned_generated_strategy_responses(
         }
         if is_strategy_visible(row_view, caller_wallet, caller_user_id=caller_user_id):
             owned.append(r)
-    return [_passport_to_strategy_response(r, session) for r in owned]
+    return _passport_responses(owned, session)
 
 
 @strategies_router.get("/{strategy_id}/returns", response_model=StrategyReturnsResponse)

--- a/backend/tests/test_multipaper_passport.py
+++ b/backend/tests/test_multipaper_passport.py
@@ -279,3 +279,199 @@ class TestPassportToStrategyResponse:
         # Legacy scalar fields still populated
         assert resp.paper_title == "Quantitative Trading with ML"
         assert resp.paper_arxiv_id == "0706.2631"
+
+
+# ---------------------------------------------------------------------------
+# #1184 — a zero-variance persisted series must not report as "pending"
+# ---------------------------------------------------------------------------
+
+
+def _add_backtest_row(
+    session: Session,
+    strategy_id: str,
+    daily_returns: list[float],
+) -> None:
+    """Persist a backtest row carrying ``daily_returns`` in ``artifact_json``.
+
+    The nesting mirrors what ``get_daily_returns`` actually parses
+    (``backtest_repository.py`` — ``artifact["results"][i]["metrics"]["daily_returns"]``),
+    not a shape invented for the test.
+    """
+    import json as _json
+
+    from archimedes.models.backtest_store import BacktestResultRecord
+    from archimedes.services.backtest_repository import SOURCE_PIPELINE_DSL_FUSION
+
+    session.add(
+        BacktestResultRecord(
+            strategy_id=strategy_id,
+            content_hash="deadbeef",
+            # Required by the model, no default — these rows stand in for the
+            # fusion pipeline's own writes, which is the path #1184 is about.
+            source_pipeline=SOURCE_PIPELINE_DSL_FUSION,
+            artifact_json=_json.dumps({"results": [{"metrics": {"daily_returns": daily_returns}}]}),
+        )
+    )
+    session.flush()
+
+
+def _passport_with_aggregate(
+    session: Session,
+    strategy_id: str,
+    *,
+    sharpe_ratio: float | None,
+    passes: bool,
+) -> StrategyPassportRecord:
+    record = _make_passport_record(session, strategy_id, [{"arxiv_id": "2301.00009", "title": "T"}])
+    record.sharpe_ratio = sharpe_ratio
+    record.passes_rigor_gate = passes
+    session.flush()
+    return record
+
+
+class TestZeroVarianceSeriesReportsDegenerate:
+    """#1184: the generated/fusion passport read path graded the stored aggregate
+    alone, so a flat persisted series — broken data, or a zero-trade backtest —
+    surfaced as ``"pending"``. "Pending" is a claim ("not graded yet"), and for
+    these rows it was false. These tests pin the four-state answer.
+
+    Anti-vacuity: every assertion below is written against a specific mutation,
+    named in its docstring. Reverting ``rigor_gate_status`` to the old
+    ``"pending" if record.sharpe_ratio is None else ("pass" if ... else "fail")``
+    expression fails each one.
+    """
+
+    def test_flat_series_with_no_stored_sharpe_is_degenerate_not_pending(self, session: Session):
+        """MUTATION: the old three-way returns "pending" here — the exact defect."""
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "flat-none", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "flat-none", [0.0] * 400)
+
+        resp = _passport_to_strategy_response(record, session)
+
+        assert resp.rigor_gate_status == "degenerate"
+        assert resp.is_backtest_placeholder is False, "a persisted series exists, so this is graded, not ungraded"
+
+    def test_flat_series_with_a_stored_sharpe_is_degenerate_not_fail(self, session: Session):
+        """MUTATION: the old three-way returns "fail" here.
+
+        Kept alongside the case above deliberately: a fix that only handled the
+        NULL-sharpe shape would pass that test and fail this one.
+        """
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "flat-zero", sharpe_ratio=0.0, passes=False)
+        _add_backtest_row(session, "flat-zero", [0.0] * 400)
+
+        assert _passport_to_strategy_response(record, session).rigor_gate_status == "degenerate"
+
+    def test_a_flat_series_can_never_report_as_passing(self, session: Session):
+        """MUTATION: drop the ``and _rigor_status != "degenerate"`` conjunct.
+
+        A stored ``passes_rigor_gate=True`` on a row with no variance to grade is
+        contradictory data. The badge must not repeat the contradiction — this is
+        the claims-integrity half of the fix, not the labelling half.
+        """
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "flat-claims-pass", sharpe_ratio=1.9, passes=True)
+        _add_backtest_row(session, "flat-claims-pass", [0.0] * 400)
+
+        resp = _passport_to_strategy_response(record, session)
+
+        assert resp.rigor_gate_status == "degenerate"
+        assert resp.passes_rigor_gate is False
+
+    def test_series_flat_only_inside_the_oos_window_is_degenerate(self, session: Session):
+        """MUTATION: drop the ``is_oos_zero_variance_series`` half of the OR.
+
+        A strategy that stops trading partway through — one of the two causes
+        #1184 names — leaves the full series non-constant, so the full-series
+        predicate alone misses it while ``compute_oos_sharpe`` still returns None.
+        """
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        varied = [0.001 * ((i % 7) - 3) for i in range(280)]
+        record = _passport_with_aggregate(session, "flat-oos", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "flat-oos", varied + [0.0] * 120)
+
+        assert _passport_to_strategy_response(record, session).rigor_gate_status == "degenerate"
+
+    def test_a_real_series_with_no_stored_sharpe_still_reports_pending(self, session: Session):
+        """CONTROL. MUTATION: relabel unconditionally, ignoring the series.
+
+        Without this, a fix that returned "degenerate" for everything would pass
+        every test above. "Pending" has to survive where it is still true.
+        """
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "varied-none", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "varied-none", [0.001 * ((i % 11) - 5) for i in range(400)])
+
+        resp = _passport_to_strategy_response(record, session)
+
+        assert resp.rigor_gate_status == "pending"
+        assert resp.is_backtest_placeholder is True
+
+    def test_no_persisted_series_at_all_still_reports_pending(self, session: Session):
+        """CONTROL: genuinely ungraded. An absent series is not a flat series."""
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "no-series", sharpe_ratio=None, passes=False)
+
+        assert _passport_to_strategy_response(record, session).rigor_gate_status == "pending"
+
+    def test_a_real_series_that_passed_still_reports_pass(self, session: Session):
+        """CONTROL: the fix must not disturb the verdict it was not about."""
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "varied-pass", sharpe_ratio=1.4, passes=True)
+        _add_backtest_row(session, "varied-pass", [0.001 * ((i % 11) - 5) for i in range(400)])
+
+        resp = _passport_to_strategy_response(record, session)
+
+        assert resp.rigor_gate_status == "pass"
+        assert resp.passes_rigor_gate is True
+
+
+class TestTheListPathAgreesWithTheDetailPath:
+    """The list endpoints bulk-prefetch returns rather than loading per row.
+
+    That is a second code path to the same claim, so it gets its own guard: a
+    prefetch that silently handed every row an empty series would restore the
+    bug on exactly the surface (Library, the leaderboard) where it is most
+    visible, while every single-row test above kept passing.
+    """
+
+    def test_bulk_prefetch_reaches_the_same_verdict_as_the_single_row_load(self, session: Session):
+        """MUTATION: make ``_passport_responses`` pass ``[]`` for every row."""
+        from archimedes.api.strategies_routes import _passport_responses, _passport_to_strategy_response
+
+        flat = _passport_with_aggregate(session, "bulk-flat", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "bulk-flat", [0.0] * 400)
+        varied = _passport_with_aggregate(session, "bulk-varied", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "bulk-varied", [0.001 * ((i % 11) - 5) for i in range(400)])
+
+        bulk = {r.id: r.rigor_gate_status for r in _passport_responses([flat, varied], session)}
+
+        assert bulk == {"bulk-flat": "degenerate", "bulk-varied": "pending"}
+        # And it agrees with the per-row path, which is the point of the guard.
+        assert bulk["bulk-flat"] == _passport_to_strategy_response(flat, session).rigor_gate_status
+        assert bulk["bulk-varied"] == _passport_to_strategy_response(varied, session).rigor_gate_status
+
+    def test_an_explicitly_empty_prefetch_slice_is_not_treated_as_unknown(self, session: Session):
+        """A row the cohort read found nothing for is ungraded, not degenerate.
+
+        Guards the ``_RETURNS_NOT_PREFETCHED`` sentinel: collapsing "no prefetch
+        happened" into "the prefetch found nothing" would make the list path
+        re-query per row, quietly reintroducing the N+1 the bulk helper exists to
+        avoid.
+        """
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "empty-slice", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "empty-slice", [0.0] * 400)
+
+        # Explicit empty slice: do NOT go back to the DB, even though a row exists.
+        assert _passport_to_strategy_response(record, session, []).rigor_gate_status == "pending"

--- a/backend/tests/test_multipaper_passport.py
+++ b/backend/tests/test_multipaper_passport.py
@@ -312,7 +312,10 @@ def _add_backtest_row(
             artifact_json=_json.dumps({"results": [{"metrics": {"daily_returns": daily_returns}}]}),
         )
     )
-    session.flush()
+    # commit, not flush: the fallback path under test rolls the session back
+    # before retrying, and a rollback discards un-committed rows. Production
+    # rows are committed, so flushing here would test a state that cannot occur.
+    session.commit()
 
 
 def _passport_with_aggregate(
@@ -325,7 +328,7 @@ def _passport_with_aggregate(
     record = _make_passport_record(session, strategy_id, [{"arxiv_id": "2301.00009", "title": "T"}])
     record.sharpe_ratio = sharpe_ratio
     record.passes_rigor_gate = passes
-    session.flush()
+    session.commit()  # see _add_backtest_row
     return record
 
 
@@ -397,6 +400,36 @@ class TestZeroVarianceSeriesReportsDegenerate:
         _add_backtest_row(session, "flat-oos", varied + [0.0] * 120)
 
         assert _passport_to_strategy_response(record, session).rigor_gate_status == "degenerate"
+
+    def test_a_SHORT_flat_series_is_degenerate(self, session: Session):
+        """MUTATION: drop the ``is_zero_variance_series`` half of the OR.
+
+        The mirror of the OOS case above, and the one my first pass missed. Every
+        other flat fixture here is 400 bars, where BOTH predicates fire — so the
+        full-series half was never load-bearing and could have been deleted with
+        the suite still green. It is only load-bearing below ~60 bars, where the
+        OOS slice is too short for ``is_oos_zero_variance_series`` to return True:
+
+            n=25  is_zero_variance_series=True  is_oos_zero_variance_series=False
+
+        A zero-trade backtest is exactly this shape, and it is one of the two
+        causes #1184 names.
+        """
+        from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+        record = _passport_with_aggregate(session, "flat-short", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "flat-short", [0.0] * 25)
+
+        assert _passport_to_strategy_response(record, session).rigor_gate_status == "degenerate"
+
+    def test_a_short_flat_series_is_degenerate_through_the_bulk_path_too(self, session: Session):
+        """Same mutation, via the list path — the two must not diverge."""
+        from archimedes.api.strategies_routes import _passport_responses
+
+        record = _passport_with_aggregate(session, "bulk-flat-short", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "bulk-flat-short", [0.0] * 25)
+
+        assert _passport_responses([record], session)[0].rigor_gate_status == "degenerate"
 
     def test_a_real_series_with_no_stored_sharpe_still_reports_pending(self, session: Session):
         """CONTROL. MUTATION: relabel unconditionally, ignoring the series.
@@ -475,3 +508,27 @@ class TestTheListPathAgreesWithTheDetailPath:
 
         # Explicit empty slice: do NOT go back to the DB, even though a row exists.
         assert _passport_to_strategy_response(record, session, []).rigor_gate_status == "pending"
+
+
+class TestACohortReadFailureDoesNotSilentlyBecomePending:
+    """The failure branch of the bulk read is itself claim-bearing.
+
+    Handing every row ``[]`` when the cohort read raises would report a flat
+    series as "pending" again — the exact false claim this work removes — while
+    every other test in this file stayed green.
+    """
+
+    def test_a_failed_cohort_read_falls_back_to_per_row_not_to_pending(self, session: Session, monkeypatch):
+        """MUTATION: swallow the failure and hand every row ``[]``."""
+        import archimedes.services.backtest_repository as repo
+        from archimedes.api.strategies_routes import _passport_responses
+
+        record = _passport_with_aggregate(session, "cohort-boom", sharpe_ratio=None, passes=False)
+        _add_backtest_row(session, "cohort-boom", [0.0] * 400)
+
+        def _boom(*a, **k):
+            raise RuntimeError("cohort read exploded")
+
+        monkeypatch.setattr(repo, "get_all_daily_returns", _boom)
+
+        assert _passport_responses([record], session)[0].rigor_gate_status == "degenerate"


### PR DESCRIPTION
## What

The generated/fusion passport read path derived `rigor_gate_status` from the stored aggregate alone:

```python
# strategies_routes.py, before
rigor_gate_status=(
    "pending" if record.sharpe_ratio is None else ("pass" if bool(record.passes_rigor_gate) else "fail")
),
```

A flat persisted return series — broken data, or a zero-trade backtest — produces no Sharpe, so `record.sharpe_ratio` is NULL and the row came out as **`"pending"`**. "Pending" is a claim: it says the strategy has not been graded yet. For these rows that is false. They were graded; the series has no variance to grade.

The curated list/detail path already answers this correctly (#1374, via `_verdict_from_result`). This applies the same predicate to the series the passport path had never loaded.

## Why the aggregate can't answer it

`record.sharpe_ratio` is NULL for both "not graded yet" and "graded, series is flat". One value, two meanings, and the code picked the flattering one. Reading the series is the only way to separate them — there is no stored volatility column, and `total_trades` covers only one of the two causes #1184 names.

## What changed

- `_passport_rigor_status(record, daily_returns)` returns the four-state status. It ORs `is_zero_variance_series` with `is_oos_zero_variance_series` exactly as `run_rigor_gate` ORs them into `is_degenerate`, so this read path and the gate agree by construction on both whole-series flatness and flatness confined to the OOS slice.
- A degenerate row forces `passes_rigor_gate` False. A stored `True` on a series with no variance is contradictory data; the badge shouldn't repeat the contradiction.
- `is_backtest_placeholder` is False for degenerate — a persisted series exists, so the row is graded, not ungraded.
- List endpoints resolve the cohort once through `get_all_daily_returns` (the same DB boundary `live_rigor_gate` and the selection-bias route already read through, and the one the suite mocks) instead of reading per row. That keeps an N+1 off the endpoints #1436 is about. The single-row detail path loads its own.
- `_RETURNS_NOT_PREFETCHED` sentinel so "no prefetch happened" and "the prefetch found nothing" stay distinct — collapsing them would make the list path silently re-query per row.

Deleted the `#1184 KNOWN GAP` comment it fixes. That comment also understated the symptom as `"fail"`; the actual output was `"pending"` whenever `sharpe_ratio` was NULL, which is the dominant case for a flat backtest.

## Tests

19 pass in `test_multipaper_passport.py`, hermetic:

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_multipaper_passport.py -q
19 passed
```

Full unit suite as CI runs it: **3840 passed, 2 skipped, 0 failed**.

Every test is written against a named mutation. I ran all five and confirmed each fails:

| Mutation | Result |
|---|---|
| Revert `rigor_gate_status` to the old three-way | 5 failed |
| Drop the `and _rigor_status != "degenerate"` conjunct | 1 failed |
| Drop `is_oos_zero_variance_series` from the OR | 1 failed |
| Make the bulk prefetch hand every row `[]` | 1 failed |
| Relabel everything degenerate (over-broad) | 5 failed |

The last one is the anti-vacuity control — three tests exist purely so a fix that returned `"degenerate"` for everything can't pass.

## What this does not do

**#1184 should stay open.** Its acceptance criteria include naming the five affected strategies and establishing the root cause per strategy. Neither is answerable from this repo — the one strategy id confirmed in the issue thread appears nowhere in the tree, so it exists only in the live DB. This closes the reporting defect, not the data question.

## Note for #1390

`degenerate` now actually reaches the passport surfaces. The frontend currently collapses it into "does not pass rigor gate", and `DeployabilityChip` renders "not deployable" titled *"Does not pass the rigor gate even at the most permissive level"* — a positive claim about an evaluation that never validly happened. Flagged on that PR.

Refs #1184
