### PR TITLE
[infra] Send Cache-Control: no-store on every liveness endpoint

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -14,7 +14,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
@@ -556,14 +556,46 @@ app.include_router(metrics_private_router)
 app.include_router(leaderboard_router)
 
 
+# ── Liveness responses must never be cached (issue #1520) ──────────────
+# /health matched no CloudFront ordered_cache_behavior, so it fell through to
+# the default one (infra/cloudfront.tf) whose `html` policy has default_ttl=60.
+# With no Cache-Control from here, CloudFront cached it: measured `x-cache: Hit`
+# with `age: 17` on the live site, and — worse — cached 504s coming back in
+# 0.07s, far too fast to have reached the origin. A cached health check is not a
+# health check: it keeps reporting "ok" for up to a minute after the origin
+# starts failing, which is the plausible-substitute failure this codebase treats
+# as the primary defect class. The CloudFront behaviour is the other half of the
+# fix and needs a terraform apply; this half travels with the app, so it holds
+# wherever the app is deployed and whoever sits in front of it.
+_NO_STORE = "no-store, no-cache, must-revalidate, max-age=0"
+
+
+def _no_store(response: Response) -> None:
+    """Mark a liveness response uncacheable by any intermediary."""
+    response.headers["Cache-Control"] = _NO_STORE
+    response.headers["Pragma"] = "no-cache"
+
+
+def _no_store_headers() -> dict[str, str]:
+    """Same headers, for handlers that build their own Response object.
+
+    A handler that returns a JSONResponse directly never touches the injected
+    ``response``, so it needs these passed in explicitly — the AMM probe returns
+    503s that way, and an uncacheable 200 with a cacheable 503 is the worse half
+    to get wrong.
+    """
+    return {"Cache-Control": _NO_STORE, "Pragma": "no-cache"}
+
+
 @app.get("/health")
 @app.get("/api/health")
 @limiter.exempt
-async def health():
+async def health(response: Response):
     """Health check — used by Docker healthcheck and CI/CD.
 
     Reports corpus state so silent degradation is visible.
     """
+    _no_store(response)
 
     from archimedes.agents.strategy_fusion import fusion_enabled, load_corpus
     from archimedes.chain.client import chain_client
@@ -855,8 +887,9 @@ async def health():
 
 @app.get("/health/paper-rag")
 @limiter.exempt
-async def health_paper_rag():
+async def health_paper_rag(response: Response):
     """Dedicated paper-rag health endpoint."""
+    _no_store(response)
     from archimedes.services.paper_rag import paper_rag_health
 
     # probe=True: this endpoint exists to PROVE the model loads, so it is the
@@ -872,7 +905,7 @@ async def health_paper_rag():
 @app.get("/health/amm")
 @app.get("/api/health/amm")
 @limiter.exempt
-async def health_amm():
+async def health_amm(response: Response):
     """AMM pool liquidity health — per-pool status for operator/judge probes.
 
     Returns 200 with pool list when pools exist, or 503 with an explicit
@@ -882,12 +915,14 @@ async def health_amm():
 
     from archimedes.chain.client import chain_client
 
+    _no_store(response)
     try:
         connected = await chain_client.is_connected()
         if not connected:
             return JSONResponse(
                 status_code=503,
                 content={"status": "chain_disconnected", "reason": "Cannot reach Arc RPC"},
+                headers=_no_store_headers(),
             )
 
         from archimedes.chain.contracts import get_contract_loader
@@ -906,6 +941,7 @@ async def health_amm():
                     "reason": "No AMM pools exist yet. Run bootstrap_vaults to create pools.",
                     "pools": [],
                 },
+                headers=_no_store_headers(),
             )
 
         # For each pool, read basic state
@@ -951,6 +987,7 @@ async def health_amm():
                 "status": "amm_health_check_failed",
                 "reason": "AMM health check failed — see server logs.",
             },
+            headers=_no_store_headers(),
         )
 
 

--- a/backend/tests/test_health_is_uncacheable.py
+++ b/backend/tests/test_health_is_uncacheable.py
@@ -1,0 +1,157 @@
+"""Liveness endpoints must be uncacheable by any intermediary (issue #1520).
+
+`/health` matched no CloudFront `ordered_cache_behavior`, so it fell through to
+the default one, whose `html` cache policy has `default_ttl = 60`. Sending no
+`Cache-Control` from the app let CloudFront cache it — measured on the live site
+as `x-cache: Hit from cloudfront` with `age: 17`, and, on the error side, 504s
+returning in 0.07s: far too fast to have reached the origin.
+
+A cached health check is not a health check. It keeps answering "ok" for up to a
+minute after the origin starts failing, which is the plausible-substitute
+degradation this codebase treats as the primary defect class — the honest
+degraded state is a loud absence, not a stale success.
+
+The CloudFront behaviour is the other half and needs a terraform apply. This
+half travels with the app, so it holds under any CDN and any future front door.
+
+All tests are hermetic — no network, no .env, no DB.
+Run: env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
+       backend/tests/test_health_is_uncacheable.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Read-only endpoint checks go through ASGITransport, not TestClient: entering
+# TestClient's context manager runs the app's startup lifespan, which seeds the
+# corpus and warms loader caches for every test that runs afterwards in the same
+# process. Precedent: backend/tests/test_risk_routes.py.
+
+
+def _health_routes() -> list[str]:
+    """Every registered GET route whose path is a liveness path.
+
+    Enumerated from the app rather than hard-coded, so a health endpoint added
+    later is covered the day it is added instead of the day someone remembers
+    this file exists.
+    """
+    from archimedes.main import app
+
+    return sorted(
+        {
+            r.path
+            for r in app.routes
+            if getattr(r, "path", "").startswith(("/health", "/api/health")) and "GET" in getattr(r, "methods", set())
+        }
+    )
+
+
+def test_the_enumeration_actually_finds_routes():
+    """Guards the guard: an empty list would make every test below vacuous."""
+    routes = _health_routes()
+    assert len(routes) >= 4, routes
+    assert "/health" in routes
+
+
+class TestEveryLivenessRouteForbidsCaching:
+    @pytest.mark.parametrize("path", _health_routes())
+    async def test_route_sends_no_store(self, path: str):
+        """MUTATION: drop the `_no_store(response)` call in any health handler.
+
+        Asserts on the response regardless of status code — the AMM probe answers
+        503 through a JSONResponse it builds itself, and a cacheable 503 is the
+        worse half to get wrong: it pins a transient failure in front of every
+        viewer at that edge until the TTL expires.
+        """
+        from archimedes.main import app
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(path)
+
+        cache_control = response.headers.get("cache-control", "")
+        assert "no-store" in cache_control, (
+            f"{path} returned Cache-Control={cache_control!r} with status "
+            f"{response.status_code} — a cacheable liveness response can report "
+            f"a stale 'ok' after the origin has started failing"
+        )
+
+    @pytest.mark.parametrize("path", _health_routes())
+    async def test_route_sets_no_max_age_an_intermediary_could_honour(self, path: str):
+        """CONTROL: `no-store` alongside a positive `max-age` is contradictory.
+
+        Without this, `Cache-Control: no-store, max-age=3600` would satisfy the
+        test above while still handing a CDN a number to act on.
+        """
+        from archimedes.main import app
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(path)
+
+        cache_control = response.headers.get("cache-control", "")
+        for directive in cache_control.replace(" ", "").split(","):
+            if directive.startswith("max-age="):
+                assert directive == "max-age=0", f"{path} sent {directive!r} beside no-store"
+
+
+class TestTheHeaderIsNotAppliedIndiscriminately:
+    """The fix must be scoped to liveness paths, not bolted onto everything.
+
+    MUTATION: apply no-store in middleware for every request. That would pass
+    every test above while silently disabling HTML caching sitewide — the
+    `html` policy's 60s TTL is deliberate and unrelated to this bug.
+    """
+
+    async def test_the_root_route_is_left_cacheable(self):
+        from archimedes.main import app
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/")
+
+        assert "no-store" not in response.headers.get("cache-control", "")
+
+
+class TestTheHandlerBuiltResponsesCarryItToo:
+    """A handler returning its own JSONResponse never touches the injected
+    ``response``, so those branches need the headers passed explicitly.
+
+    Found by mutation: deleting ``headers=_no_store_headers()`` from the AMM
+    chain-disconnected 503 left the whole file green, because in a hermetic run
+    ``is_connected()`` raises and the route exits through the outer handler
+    instead. The branch was reachable in production and untested here — exactly
+    the shape where a cacheable 503 would pin a transient RPC blip in front of
+    every viewer at an edge. Mocked at the chain-client boundary, per the repo
+    convention of mocking boundaries rather than internals.
+    """
+
+    async def test_the_chain_disconnected_503_is_uncacheable(self, monkeypatch):
+        """MUTATION: drop `headers=_no_store_headers()` from that JSONResponse."""
+        from unittest.mock import AsyncMock
+
+        from archimedes.chain.client import chain_client
+        from archimedes.main import app
+
+        monkeypatch.setattr(chain_client, "is_connected", AsyncMock(return_value=False))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/health/amm")
+
+        assert response.status_code == 503
+        assert response.json()["status"] == "chain_disconnected"
+        assert "no-store" in response.headers.get("cache-control", "")
+
+    async def test_the_amm_failure_503_is_uncacheable(self, monkeypatch):
+        """MUTATION: drop the headers from the outer exception JSONResponse."""
+        from unittest.mock import AsyncMock
+
+        from archimedes.chain.client import chain_client
+        from archimedes.main import app
+
+        monkeypatch.setattr(chain_client, "is_connected", AsyncMock(side_effect=RuntimeError("boom")))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/health/amm")
+
+        assert response.status_code == 503
+        assert "no-store" in response.headers.get("cache-control", "")


### PR DESCRIPTION
## What

`/health` was being served from the CloudFront cache. It matches no `ordered_cache_behavior`, so it falls through to `default_cache_behavior`, whose `html` cache policy has `default_ttl = 60` (`infra/cloudfront.tf:138-143`). The app sent no `Cache-Control`, so CloudFront applied the default TTL and cached it.

Measured on the live site:

```
probe 1  200  x-cache: Miss from cloudfront          x-response-time-ms: 916.0  total=1.11s
probe 2  200  x-cache: Hit from cloudfront           x-response-time-ms: 916.0  total=0.13s
probe 3  200  x-cache: Hit from cloudfront   age: 1  x-response-time-ms: 916.0  total=0.06s
probe 4  200  x-cache: Hit from cloudfront   age: 1  x-response-time-ms: 916.0  total=0.10s
```

And the error side, earlier the same session:

```
health #1  504  total=90.40s   x-response-time-ms: 3203.0
health #2  504  total=0.12s
health #3  504  total=0.07s
```

Probe #1 there is worth reading twice: the server-side header says the application answered in 3.2 seconds while the client got a 504 at 90.4s. The two that follow came back in 0.07–0.12s, too fast to have reached the origin — cached 504s. There is no `custom_error_response` block in `infra/cloudfront.tf`, so CloudFront's default error caching applies.

## Why it's worth fixing in the app and not only in Terraform

A cached health check is not a health check. It keeps answering `{"status":"ok"}` for up to a minute after the origin starts failing — a plausible substitute for a live signal, which is the degradation shape `docs/architectural-principles.md` § fail-soft names as the primary defect class. `CLAUDE.md` tells every reader that current status comes from `/health`, and for up to 60s it was coming from an edge cache instead.

It also makes `/health` useless for the latency work in #1436: four consecutive probes reported a byte-identical `916.0` because they were one body replayed.

The CloudFront behaviour (#1520) is the other half and needs a `terraform apply`, so it lands with Dan. This half travels with the app, so it holds under any CDN and whoever sits in front of it next.

## What changed

`Cache-Control: no-store, no-cache, must-revalidate, max-age=0` plus `Pragma: no-cache` on all six registered liveness routes: `/health`, `/api/health`, `/health/paper-rag`, `/health/amm`, `/api/health/amm`.

`/health/amm` returns `JSONResponse` objects it builds itself in three branches, and a handler that does that never touches the injected `response`. Those get the headers passed explicitly. A cacheable 503 is the worse half to get wrong — it pins a transient RPC blip in front of every viewer at that edge until the TTL expires.

## Tests

`backend/tests/test_health_is_uncacheable.py`, 14 passing, hermetic:

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_health_is_uncacheable.py -q
14 passed
```

The route list is enumerated from `app.routes` rather than hard-coded, so a liveness endpoint added later is covered the day it is added. `test_the_enumeration_actually_finds_routes` guards that — an empty enumeration would make every parametrised test vacuous.

Mutations run, all fail:

| Mutation | Result |
|---|---|
| Drop `_no_store(response)` from `/health` | 2 failed |
| Drop `headers=` from the AMM chain-disconnected 503 | 1 failed |
| Drop `headers=` from the AMM outer-failure 503 | 3 failed |
| `no-store` alongside a live `max-age=3600` | 5 failed |
| Apply `no-store` to the root route too | 1 failed |

The last two matter. `no-store, max-age=3600` would satisfy a naive "contains no-store" assertion while still handing a CDN a number to act on. And the root-route case is there because the obvious implementation — one middleware for everything — would pass every other test while silently disabling the deliberate 60s HTML cache sitewide.

The AMM branch tests came out of a mutation that initially survived: dropping the headers from the chain-disconnected 503 left the file green, because in a hermetic run `is_connected()` raises and the route exits through the outer handler instead. That branch was reachable in production and untested here, so it now has a test mocked at the chain-client boundary.

Refs #1520
