### PR TITLE
[data] Measure the window change_24h_pct covers instead of calling it 24h

### DIFF
--- a/backend/archimedes/api/explore_schemas.py
+++ b/backend/archimedes/api/explore_schemas.py
@@ -25,6 +25,20 @@ class AssetExploreItem(BaseModel):
     realized_vol_30d: float | None = Field(
         default=None, description="Annualized standard deviation of daily returns over last 30 trading days"
     )
+    change_window_hours: float | None = Field(
+        default=None,
+        description="Hours actually spanned by change_24h_pct — the elapsed time between the "
+        "last two bars. Null when it cannot be determined (fewer than two bars, or an "
+        "unparseable index).",
+    )
+    change_window_label: str | None = Field(
+        default=None,
+        description="Short honest label for that window: '24h' when the last two bars are a "
+        "day apart, otherwise '3d' / '4d' etc. change_24h_pct is a one-bar change, and one bar "
+        "is 24 hours only on a 24/7 feed — a Friday-to-Monday equity pair spans 72 (#1378). "
+        "Null means the window is unknown; render it as an unspecific 'prev close' rather than "
+        "falling back to '24h'.",
+    )
     oracle_address: str | None = None
     last_updated: str | None = Field(default=None, description="ISO8601 timestamp of last price update")
     price_source: Literal["oracle", "yfinance", "none"] = Field(

--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -37,7 +37,7 @@ import asyncio
 import logging
 import math
 import time
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any, Literal
 
 from archimedes.api.explore_schemas import (
@@ -280,6 +280,77 @@ def _pct_change(prices: list[float], n: int) -> float | None:
     ``_pct_change_with_reason`` for the full contract. Thin wrapper kept for
     callers (and the existing unit-test surface) that only need the value."""
     return _pct_change_with_reason(prices, n)[0]
+
+
+def _bar_timestamp(value: Any) -> datetime | None:
+    """Best-effort parse of one history index entry into a ``datetime``.
+
+    The index arrives in three shapes depending on the source: a pandas
+    ``Timestamp`` (the live ``_fetch_price_histories`` path), a ``date`` /
+    ``datetime`` object, or an ISO string (the ``{"close": [...],
+    "dates": [...]}`` dict shape). Anything unparseable returns ``None``,
+    which callers turn into an honest "window unknown" rather than a guess.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day)
+    if hasattr(value, "to_pydatetime"):  # pandas Timestamp, if not already a datetime
+        try:
+            return value.to_pydatetime()
+        except Exception:
+            return None
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _change_window(dates: list[Any]) -> tuple[float | None, str | None]:
+    """Elapsed hours between the last two bars, and an honest short label.
+
+    ``change_24h_pct`` is a *one-bar* change, not a 24-hour change (#1378).
+    For a 24/7 crypto feed the two coincide. For an equity they do not: the
+    Friday-to-Monday bar pair spans 72 hours, a mid-week holiday spans 48,
+    and a longer feed gap spans more. The old UI labelled all of them "24h".
+
+    Relabelling the field "1-bar change" would be true and useless — a reader
+    cannot tell what window that covers. So measure the window the value
+    actually covers and name it.
+
+    Returns ``(hours, label)``. Both are ``None`` when the window cannot be
+    determined (fewer than two bars, or an index we cannot parse). The UI
+    renders that as a non-specific "prev close" rather than falling back to
+    the "24h" claim this exists to remove — an unknown window must not
+    resolve to the most flattering guess.
+    """
+    if len(dates) < 2:
+        return None, None
+    last = _bar_timestamp(dates[-1])
+    prev = _bar_timestamp(dates[-2])
+    if last is None or prev is None:
+        return None, None
+    # Mixing an aware and a naive datetime raises TypeError on subtraction,
+    # and the two shapes genuinely co-occur here (pandas Timestamps carry a
+    # tz, bare ISO dates do not). Drop to naive for the delta only; we want an
+    # elapsed duration, not a wall-clock instant.
+    if (last.tzinfo is None) != (prev.tzinfo is None):
+        last = last.replace(tzinfo=None)
+        prev = prev.replace(tzinfo=None)
+    hours = (last - prev).total_seconds() / 3600.0
+    if hours <= 0:
+        # Unsorted or duplicated index. Say nothing rather than something wrong.
+        return None, None
+    # Daily bars sit on whole-day multiples, give or take a DST hour, so
+    # rounding to days is exact in practice: 24h -> 1, 48h -> 2, 72h -> 3.
+    # A borderline gap rounds *up* and away from the "24h" claim, which is the
+    # direction that discloses rather than flatters.
+    days = round(hours / 24)
+    return hours, ("24h" if days <= 1 else f"{days}d")
 
 
 def _realized_vol_annual_with_reason(
@@ -723,15 +794,39 @@ class AssetMarketService:
             # _fetch_price_histories returns {symbol: pd.Series} (close prices)
             # Convert Series to a plain list for downstream math.
             raw_hist = histories.get(synth)
+            # Bar timestamps, kept alongside the closes so the change window
+            # can be measured (#1378). Empty means "window unknown", which is
+            # served as such rather than defaulting to a 24h claim.
+            hist_dates: list[Any] = []
             if raw_hist is not None and hasattr(raw_hist, "tolist"):
                 # An object-dtype series (a feed gap, a mixed column) can hold
                 # None or other non-numbers. math.isnan() raises TypeError on a
                 # non-float, which previously aborted the entire /explore/assets
                 # response over one bad element — guard the type and drop those
                 # instead of dropping the whole universe (#928).
-                hist_prices = [float(v) for v in raw_hist.tolist() if isinstance(v, (int, float)) and not math.isnan(v)]
+                _values = raw_hist.tolist()
+                _index = list(raw_hist.index) if hasattr(raw_hist, "index") else []
+                if len(_index) == len(_values):
+                    # Filter dates and closes *together*. Dropping a NaN bar
+                    # from the closes while keeping the whole index would
+                    # misalign them, and the window would then be measured
+                    # between two bars the change was not computed from.
+                    _pairs = [
+                        (d, float(v))
+                        for d, v in zip(_index, _values, strict=True)
+                        if isinstance(v, (int, float)) and not math.isnan(v)
+                    ]
+                    hist_dates = [d for d, _ in _pairs]
+                    hist_prices = [p for _, p in _pairs]
+                else:
+                    hist_prices = [float(v) for v in _values if isinstance(v, (int, float)) and not math.isnan(v)]
             elif isinstance(raw_hist, dict):
                 hist_prices = raw_hist.get("close") or []
+                _dates = raw_hist.get("dates") or []
+                # Only trust the dates when they line up one-for-one with the
+                # closes; a mismatched pair of lists cannot be realigned here,
+                # and a wrong window is worse than no window.
+                hist_dates = list(_dates) if len(_dates) == len(hist_prices) else []
             else:
                 hist_prices = []
 
@@ -830,6 +925,10 @@ class AssetMarketService:
             if rej_vol:
                 rejected_fields.append("realized_vol_30d")
 
+            # The window change_24h_pct actually covers. One bar is 24h only
+            # when the feed has a bar every calendar day (#1378).
+            change_window_hours, change_window_label = _change_window(hist_dates)
+
             stat_dict: dict[str, Any] = {
                 "current_price": current_price,
                 "change_24h_pct": change_24h_pct,
@@ -862,6 +961,8 @@ class AssetMarketService:
                     price_source=price_source,
                     explanations=_explanations_for(stat_dict, is_247=is_247),
                     rejected_fields=rejected_fields,
+                    change_window_hours=change_window_hours,
+                    change_window_label=change_window_label,
                     **stat_dict,
                 )
             )

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -28,6 +28,8 @@ from archimedes.services.asset_market_service import (
     _CRYPTO_TRADING_DAYS_PER_YEAR,
     _EQUITY_TRADING_DAYS_PER_YEAR,
     AssetMarketService,
+    _bar_timestamp,
+    _change_window,
     _explanations_for,
     _explore_universe,
     _is_24_7_asset_class,
@@ -1041,3 +1043,202 @@ class TestBudgetedHistoryFetch:
             histories = await service._fetch_histories_budgeted(["sAAA", "sBBB"])
 
         assert set(histories) == {"sBBB"}
+
+
+# ── #1378: "24h" was a misnomer across weekends and feed gaps ────────────────
+#
+# `change_24h_pct` is `_pct_change(prices, 1)` — a ONE-BAR change. On a 24/7
+# crypto feed one bar is 24 hours. On an equity feed the Friday-to-Monday pair
+# spans 72 hours and a mid-week holiday spans 48, and every one of those was
+# labelled "24h" in the UI. These tests pin the measured window, not the label
+# text, so they fail if the window stops being derived from the data.
+#
+# Mutation each test must fail against is named in its own docstring.
+
+
+class TestChangeWindowMeasurement:
+    def test_consecutive_daily_bars_are_a_24h_window(self):
+        """Control. Fails if _change_window stops returning "24h" for the
+        ordinary case, which would make the weekend assertions vacuous."""
+        hours, label = _change_window(["2026-08-27", "2026-08-28"])
+        assert hours == 24.0
+        assert label == "24h"
+
+    def test_a_weekend_gap_is_reported_as_three_days_not_24h(self):
+        """The defect itself. Fails against any implementation that returns a
+        constant "24h", including the pre-fix behaviour of having no window at
+        all and letting the UI hardcode the string."""
+        hours, label = _change_window(["2026-08-28", "2026-08-31"])  # Fri -> Mon
+        assert hours == 72.0
+        assert label == "3d"
+
+    def test_a_midweek_holiday_gap_is_two_days(self):
+        """Fails if the label is derived from a weekday calculation rather than
+        elapsed time — a Tue->Thu gap has no weekend in it."""
+        hours, label = _change_window(["2026-08-25", "2026-08-27"])
+        assert hours == 48.0
+        assert label == "2d"
+
+    def test_a_long_weekend_is_four_days(self):
+        hours, label = _change_window(["2026-08-28", "2026-09-01"])  # Fri -> Tue
+        assert hours == 96.0
+        assert label == "4d"
+
+    def test_pandas_timestamps_are_handled_not_just_iso_strings(self):
+        """The live path is a pd.Series with a DatetimeIndex; only the dict
+        fallback carries ISO strings. Fails if _bar_timestamp only parses str,
+        which would make every other test here pass while production got None."""
+        pd = pytest.importorskip("pandas")
+        idx = list(pd.to_datetime(["2026-08-28", "2026-08-31"]))
+        hours, label = _change_window(idx)
+        assert hours == 72.0
+        assert label == "3d"
+
+    def test_an_unknown_window_is_none_and_never_defaults_to_24h(self):
+        """The load-bearing one. A guess of "24h" here would reintroduce the
+        exact false claim, so absence must stay absent. Fails if any branch
+        returns a default label."""
+        assert _change_window([]) == (None, None)
+        assert _change_window(["2026-08-30"]) == (None, None)
+        assert _change_window(["not-a-date", "also-not"]) == (None, None)
+
+    def test_an_out_of_order_index_reports_nothing_rather_than_a_negative_window(self):
+        """Fails if the delta is taken as an absolute value, which would invent
+        a plausible-looking window from an index we cannot actually trust."""
+        assert _change_window(["2026-08-31", "2026-08-28"]) == (None, None)
+
+    def test_mixed_tz_aware_and_naive_bars_do_not_raise(self):
+        """Subtracting an aware from a naive datetime raises TypeError, and the
+        two shapes co-occur here (pandas Timestamps carry a tz, bare ISO dates
+        do not). Fails if the normalisation is dropped."""
+        from datetime import UTC, datetime
+
+        aware = datetime(2026, 8, 31, tzinfo=UTC)
+        naive = datetime(2026, 8, 28)
+        hours, label = _change_window([naive, aware])
+        assert hours == 72.0
+        assert label == "3d"
+
+    def test_bar_timestamp_parses_each_shape_the_feed_emits(self):
+        from datetime import date as _date
+        from datetime import datetime as _dt
+
+        assert _bar_timestamp("2026-08-28") == _dt(2026, 8, 28)
+        assert _bar_timestamp(_date(2026, 8, 28)) == _dt(2026, 8, 28)
+        assert _bar_timestamp(_dt(2026, 8, 28, 13, 30)) == _dt(2026, 8, 28, 13, 30)
+        assert _bar_timestamp(None) is None
+        assert _bar_timestamp(object()) is None
+
+
+class TestServedItemCarriesItsChangeWindow:
+    @pytest.mark.asyncio
+    async def test_an_equity_over_a_weekend_is_served_as_3d_not_24h(self):
+        """End-to-end on the served item. Fails if the service computes the
+        window but does not put it on AssetExploreItem, which is the shape the
+        UI actually reads."""
+        service = AssetMarketService()
+        mock_histories = {
+            "sSPY": {
+                "close": [540.0, 548.0],
+                "dates": ["2026-08-28", "2026-08-31"],  # Fri -> Mon
+            }
+        }
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch("archimedes.services.strategy_signal_evaluator._fetch_price_histories", return_value=mock_histories),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sSPY"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sSPY": ("SPY", "SPY", "us_equity_etf", "NYSE")},
+            ),
+        ):
+            resp = await service.list_assets()
+
+        spy = next(a for a in resp.assets if a.symbol == "sSPY")
+        # The value is unchanged — it was always a correct one-bar change.
+        assert spy.change_24h_pct is not None
+        # What changes is that the item now says what window that covers.
+        assert spy.change_window_hours == 72.0
+        assert spy.change_window_label == "3d"
+
+    @pytest.mark.asyncio
+    async def test_a_crypto_feed_still_says_24h(self):
+        """Control against over-correction: 24/7 feeds genuinely do have a 24h
+        window, and relabelling those would be a new false claim in the other
+        direction."""
+        service = AssetMarketService()
+        mock_histories = {
+            "sBTC": {
+                "close": [60000.0, 61000.0],
+                "dates": ["2026-08-29", "2026-08-30"],
+            }
+        }
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch("archimedes.services.strategy_signal_evaluator._fetch_price_histories", return_value=mock_histories),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sBTC"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sBTC": ("BTC-USD", "BTC", "crypto", "Coinbase")},
+            ),
+        ):
+            resp = await service.list_assets()
+
+        btc = next(a for a in resp.assets if a.symbol == "sBTC")
+        assert btc.change_window_hours == 24.0
+        assert btc.change_window_label == "24h"
+
+    @pytest.mark.asyncio
+    async def test_a_nan_bar_does_not_misalign_the_window_from_the_price(self):
+        """The subtle one. The close list is filtered for NaN before the change
+        is computed; if the date list is not filtered in step, the window gets
+        measured between two bars the change was NOT computed from.
+
+        Here the last close is NaN, so the change is taken across 08-24/08-28
+        — a 4-day window. An unfiltered index would measure 08-28 to 08-31 and
+        report 3d. Fails against zipping the raw index with the filtered closes."""
+        pd = pytest.importorskip("pandas")
+        series = pd.Series(
+            [100.0, 105.0, float("nan")],
+            index=pd.to_datetime(["2026-08-24", "2026-08-28", "2026-08-31"]),
+        )
+        service = AssetMarketService()
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch(
+                "archimedes.services.strategy_signal_evaluator._fetch_price_histories",
+                return_value={"sSPY": series},
+            ),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sSPY"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sSPY": ("SPY", "SPY", "us_equity_etf", "NYSE")},
+            ),
+        ):
+            resp = await service.list_assets()
+
+        spy = next(a for a in resp.assets if a.symbol == "sSPY")
+        assert spy.change_window_hours == 96.0, "window must follow the bars the change used"
+        assert spy.change_window_label == "4d"
+
+    @pytest.mark.asyncio
+    async def test_a_history_with_no_dates_serves_a_null_window_not_24h(self):
+        """The dict fallback shape carries no dates. The item must say it does
+        not know, so the UI renders "prev close" rather than the old "24h"."""
+        service = AssetMarketService()
+        mock_histories = {"sSPY": {"close": [540.0, 548.0]}}
+        with (
+            patch.object(service, "_read_oracle_prices", return_value={}),
+            patch("archimedes.services.strategy_signal_evaluator._fetch_price_histories", return_value=mock_histories),
+            patch("archimedes.services.asset_market_service._explore_universe", return_value=["sSPY"]),
+            patch(
+                "archimedes.services.strategy_signal_evaluator.GLOBAL_ASSETS",
+                {"sSPY": ("SPY", "SPY", "us_equity_etf", "NYSE")},
+            ),
+        ):
+            resp = await service.list_assets()
+
+        spy = next(a for a in resp.assets if a.symbol == "sSPY")
+        assert spy.change_24h_pct is not None
+        assert spy.change_window_hours is None
+        assert spy.change_window_label is None

--- a/ui/src/components/AssetGroupModal.jsx
+++ b/ui/src/components/AssetGroupModal.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import PriceHistoryChart from './PriceHistoryChart'
 import AssetGroupIcon from './AssetGroupIcon'
 import { groupMeta } from '../assetGroups'
-import { median } from '../statUtils'
+import { median, groupChangeWindowLabel } from '../statUtils'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 const RANGES = ['1D', '1W', '1M', '1Y', '5Y', '10Y', 'MAX']
@@ -165,6 +165,9 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
     const vals = members.map(a => a.change_24h_pct).filter(v => v != null && !Number.isNaN(v))
     return median(vals)
   }, [members])
+  // Null when the contributing members' windows disagree, which a group
+  // spanning a holiday legitimately can (#1378).
+  const medianWindow = useMemo(() => groupChangeWindowLabel(members), [members])
 
   if (!assetClass) return null
 
@@ -222,7 +225,7 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
         <div style={{ display: 'flex', gap: 24, alignItems: 'baseline', marginTop: 16, flexWrap: 'wrap' }}>
           <div>
             <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
-              Median 24h change ({members.length} assets)
+              {medianWindow ? `Median ${medianWindow} change` : 'Median change'} ({members.length} assets)
             </div>
             <div className={`mono ${changeClass(medianChange24h)}`} style={{ fontSize: '1.3rem', fontWeight: 600 }}>
               {fmtPct(medianChange24h)}

--- a/ui/src/components/AssetModal.jsx
+++ b/ui/src/components/AssetModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import PriceHistoryChart, { fmtPrice } from './PriceHistoryChart'
+import { changeWindowLabel } from '../statUtils'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 const RANGES = ['1D', '1W', '1M', '1Y', '5Y', '10Y', 'MAX']
@@ -151,7 +152,9 @@ export default function AssetModal({ asset, onClose }) {
             </div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>24h change</div>
+            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
+              {changeWindowLabel(asset)} change
+            </div>
             <div
               className={`mono ${changeClass(asset.change_24h_pct)}`}
               style={{ fontSize: '1.1rem', fontWeight: 600 }}

--- a/ui/src/components/Explore.jsx
+++ b/ui/src/components/Explore.jsx
@@ -3,7 +3,7 @@ import AssetModal from './AssetModal'
 import AssetGroupModal from './AssetGroupModal'
 import AssetGroupIcon from './AssetGroupIcon'
 import { groupMeta } from '../assetGroups'
-import { median } from '../statUtils'
+import { median, changeWindowLabel, groupChangeWindowLabel } from '../statUtils'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -229,6 +229,9 @@ export default function Explore() {
               const vals = g.members.map(a => a.change_24h_pct).filter(v => v != null && !Number.isNaN(v))
               return median(vals)
             })()
+            // Null when the members' windows disagree — a group spanning a
+            // holiday genuinely has no single true window (#1378).
+            const medianWindow = groupChangeWindowLabel(g.members)
             return (
               <button
                 key={g.assetClass}
@@ -296,7 +299,7 @@ export default function Explore() {
                     {fmtPct(medianChange)}
                   </span>
                   <span className="caption" style={{ color: 'var(--text-4)', fontSize: '0.65rem' }}>
-                    median 24h
+                    {medianWindow ? `median ${medianWindow}` : 'median change'}
                   </span>
                 </div>
               </button>
@@ -390,8 +393,16 @@ export default function Explore() {
                 >
                   {fmtPct(a.change_24h_pct)}
                 </span>
-                <span className="caption" style={{ color: 'var(--text-4)', fontSize: '0.65rem' }}>
-                  24h
+                <span
+                  className="caption"
+                  style={{ color: 'var(--text-4)', fontSize: '0.65rem' }}
+                  title={
+                    a.change_window_hours != null
+                      ? `Change over the ${a.change_window_hours.toFixed(0)}h between the last two bars`
+                      : 'Change since the previous close; the elapsed window could not be determined'
+                  }
+                >
+                  {changeWindowLabel(a)}
                 </span>
               </div>
             </button>

--- a/ui/src/statUtils.js
+++ b/ui/src/statUtils.js
@@ -16,3 +16,32 @@ export function median(nums) {
   const mid = Math.floor(sorted.length / 2)
   return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
 }
+
+// ── Change-window labelling (#1378) ──────────────────────────────────────────
+//
+// `change_24h_pct` is a one-bar change, not a 24-hour change. One bar is 24
+// hours only on a 24/7 feed; a Friday-to-Monday equity pair spans 72, and a
+// holiday spans more. The backend now measures the real window and sends
+// `change_window_label` ("24h", "3d", ...). These helpers keep the fallback
+// consistent in the four places that used to hardcode "24h".
+
+/** Label for one asset's change window. Falls back to an unspecific, still
+ * true phrase when the backend could not determine the window — never back to
+ * "24h", because an unknown window must not resolve to the flattering guess. */
+export function changeWindowLabel(asset) {
+  return asset?.change_window_label || 'prev close'
+}
+
+/** Label shared by a group of assets, or null when they disagree.
+ *
+ * Only members that actually contributed to the aggregate are considered, so
+ * this matches whatever the caller filtered before taking a median. A group
+ * spanning a holiday can legitimately hold both "24h" and "2d" members; there
+ * is no single true label for that, so the caller renders a generic one. */
+export function groupChangeWindowLabel(members) {
+  const labels = (members || [])
+    .filter(a => a && a.change_24h_pct != null && !Number.isNaN(a.change_24h_pct))
+    .map(a => a.change_window_label || null)
+  if (labels.length === 0) return null
+  return labels.every(l => l && l === labels[0]) ? labels[0] : null
+}

--- a/ui/test/stat-utils.test.js
+++ b/ui/test/stat-utils.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { median } from "../src/statUtils.js";
+import { changeWindowLabel, groupChangeWindowLabel, median } from "../src/statUtils.js";
 
 // ── #1322: group "24h change" headline must be robust to a single outlier ──
 // A prior arithmetic-mean implementation let one bad tick (or one genuinely
@@ -60,14 +60,19 @@ test("median is robust to one outlier of any magnitude (the actual #1322 bug)", 
 const explorePage = readFileSync(new URL("../src/components/Explore.jsx", import.meta.url), "utf8");
 const groupModal = readFileSync(new URL("../src/components/AssetGroupModal.jsx", import.meta.url), "utf8");
 
+// The import pins allow sibling named imports — #1378 added
+// changeWindowLabel / groupChangeWindowLabel alongside median. The property
+// under test is that `median` comes from the shared module rather than being
+// re-implemented locally, which a `[^}]*\bmedian\b[^}]*` pin still enforces;
+// pinning the exact one-name import list guarded spelling, not sourcing.
 test("Explore.jsx group headline imports and calls the shared median, not a local mean", () => {
-	assert.match(explorePage, /import \{ median \} from '\.\.\/statUtils'/);
+	assert.match(explorePage, /import \{[^}]*\bmedian\b[^}]*\} from '\.\.\/statUtils'/);
 	assert.match(explorePage, /median\(vals\)/);
 	assert.doesNotMatch(explorePage, /reduce\(\(a, b\) => a \+ b, 0\) \/ vals\.length/);
 });
 
 test("AssetGroupModal.jsx aggregate stat imports and calls the shared median, not a local mean", () => {
-	assert.match(groupModal, /import \{ median \} from '\.\.\/statUtils'/);
+	assert.match(groupModal, /import \{[^}]*\bmedian\b[^}]*\} from '\.\.\/statUtils'/);
 	assert.match(groupModal, /median\(vals\)/);
 	assert.doesNotMatch(groupModal, /reduce\(\(a, b\) => a \+ b, 0\) \/ vals\.length/);
 });
@@ -75,6 +80,72 @@ test("AssetGroupModal.jsx aggregate stat imports and calls the shared median, no
 test("the group headline labels no longer claim 'avg' when the value is a median", () => {
 	assert.doesNotMatch(explorePage, />\s*avg 24h\s*</);
 	assert.doesNotMatch(groupModal, /Avg 24h change/);
-	assert.match(explorePage, /median 24h/);
-	assert.match(groupModal, /Median 24h change/);
+	// #1378 made the window dynamic, so the pin follows the template literal
+	// rather than the old hardcoded "24h". "median" is still the word under
+	// test — that is what #1322 was about.
+	assert.match(explorePage, /`median \$\{medianWindow\}`/);
+	assert.match(groupModal, /`Median \$\{medianWindow\} change`/);
+});
+
+// ── #1378: the window label must never fall back to the "24h" claim ─────────
+//
+// `change_24h_pct` is a one-bar change. One bar is 24 hours only on a 24/7
+// feed; a Friday-to-Monday equity pair spans 72. The backend now measures the
+// real window; these guard the display-layer fallbacks, which are where the
+// old false claim actually lived.
+
+test("changeWindowLabel: uses the backend's measured window when present", () => {
+	assert.equal(changeWindowLabel({ change_window_label: "3d" }), "3d");
+	assert.equal(changeWindowLabel({ change_window_label: "24h" }), "24h");
+});
+
+test("changeWindowLabel: an unknown window never falls back to '24h'", () => {
+	// The load-bearing assertion. Defaulting to "24h" here would reinstate the
+	// exact claim #1378 exists to remove, on precisely the rows where we have
+	// least reason to make it.
+	assert.equal(changeWindowLabel({ change_window_label: null }), "prev close");
+	assert.equal(changeWindowLabel({}), "prev close");
+	assert.equal(changeWindowLabel(undefined), "prev close");
+});
+
+test("groupChangeWindowLabel: returns the shared window when members agree", () => {
+	const members = [
+		{ change_24h_pct: 1.0, change_window_label: "3d" },
+		{ change_24h_pct: -2.0, change_window_label: "3d" },
+	];
+	assert.equal(groupChangeWindowLabel(members), "3d");
+});
+
+test("groupChangeWindowLabel: returns null when members disagree", () => {
+	// A group spanning a holiday genuinely holds both windows. There is no
+	// single true label for that, so the caller must render a generic one
+	// rather than picking a member's window and implying it covers the group.
+	const members = [
+		{ change_24h_pct: 1.0, change_window_label: "24h" },
+		{ change_24h_pct: -2.0, change_window_label: "2d" },
+	];
+	assert.equal(groupChangeWindowLabel(members), null);
+});
+
+test("groupChangeWindowLabel: one unknown window poisons the group label", () => {
+	const members = [
+		{ change_24h_pct: 1.0, change_window_label: "24h" },
+		{ change_24h_pct: -2.0, change_window_label: null },
+	];
+	assert.equal(groupChangeWindowLabel(members), null);
+});
+
+test("groupChangeWindowLabel: ignores members that contributed no value", () => {
+	// Matches the median's own filter — a member with a null change is not in
+	// the aggregate, so its window must not constrain the aggregate's label.
+	const members = [
+		{ change_24h_pct: 1.0, change_window_label: "3d" },
+		{ change_24h_pct: null, change_window_label: "24h" },
+	];
+	assert.equal(groupChangeWindowLabel(members), "3d");
+});
+
+test("groupChangeWindowLabel: empty and absent inputs return null, not a guess", () => {
+	assert.equal(groupChangeWindowLabel([]), null);
+	assert.equal(groupChangeWindowLabel(undefined), null);
 });


### PR DESCRIPTION
Closes #1378.

`change_24h_pct` is `_pct_change(prices, 1)` — a **one-bar** change. One bar is 24 hours
only when the feed has a bar every calendar day. On an equity feed the Friday-to-Monday
pair spans 72 hours and a mid-week holiday spans 48. The UI labelled every one of them
"24h".

The value was never wrong; the label was. #1378's anti-goal rules out renaming the field
"1-bar change" — true, and useless to a reader who cannot tell what window that covers —
so this takes the issue's first suggested shape: measure the elapsed time between the last
two bars and say what it is.

## Backend

`_bar_timestamp` + `_change_window` derive the window from the history index, and
`AssetExploreItem` gains `change_window_hours` and `change_window_label`:

| bars | hours | label |
|---|---|---|
| Thu → Fri | 24 | `24h` |
| Tue → Thu (holiday) | 48 | `2d` |
| Fri → Mon | 72 | `3d` |
| Fri → Tue (long weekend) | 96 | `4d` |
| crypto, consecutive days | 24 | `24h` |
| unknown / unparseable / out of order | — | `null` |

Both fields are null when the window cannot be determined, and the UI renders that as
"prev close". **An unknown window must not resolve to the flattering guess** — defaulting
to "24h" there would reinstate the exact claim this removes, on precisely the rows with
least reason to make it. There is a test that fails against that default.

Two details that were easy to get wrong, both with a test naming the mutation:

- **The closes are filtered for NaN before the change is computed.** The dates have to be
  filtered *in step*: zipping the raw index against filtered closes measures the gap
  between two bars the change was not computed from. `test_a_nan_bar_does_not_misalign_the_window_from_the_price`
  builds that case and fails against the unzipped version.
- **pandas Timestamps carry a tz; bare ISO dates do not.** Subtracting one from the other
  raises `TypeError`, and both shapes genuinely reach this code — the live
  `_fetch_price_histories` path returns a `pd.Series`, the dict fallback carries ISO
  strings.

## Frontend

**Four** sites hardcoded the label, not the two the issue names. The extra pair were the
group aggregates:

- `Explore.jsx` — the per-card caption, and the group card's `median 24h`
- `AssetModal.jsx` — `24h change`
- `AssetGroupModal.jsx` — `Median 24h change (N assets)`

Shared helpers in `statUtils.js` keep the fallback consistent. A group's label is null
unless every *contributing* member agrees, matching the median's own filter: a group
spanning a holiday holds both `24h` and `2d` members and has no single true window, so it
renders "median change" instead of picking one member's window and implying it covers the
group.

## Shown to reject

Six backend mutations, each against the whole file:

| mutation | result |
|---|---|
| `_change_window` always returns `(24.0, "24h")` — the defect, made explicit | **10 failed** |
| zip the raw index with the NaN-filtered closes | **1 failed** |
| drop the tz normalisation | **1 failed** |
| unknown window defaults to `24h` instead of `None` | **2 failed** |
| `abs()` the delta, inventing a window from an untrustworthy index | **1 failed** |
| stop putting the window on the served item | **3 failed** |

Three frontend mutations:

| mutation | result |
|---|---|
| `changeWindowLabel` falls back to `'24h'` | **1 failed** |
| group label takes the first member's window, no unanimity check | **2 failed** |
| `Explore.jsx` group caption back to hardcoded `median 24h` | **1 failed** |

## Existing tests I had to change — worth a look

Three tests in `ui/test/stat-utils.test.js` pinned the literal strings and went red. Their
subject is #1322's "median, not mean" property, which this does not touch. I loosened the
import pin from `import { median }` to `import {[^}]*\bmedian\b[^}]*}` so sibling named
imports are allowed, and repointed the label pins at the new template literals.

Loosening a pin deserves a second pair of eyes, so stating it plainly: the mean-vs-median
assertion is unchanged and still fails against a local `reduce`. What the old import pin
additionally guarded was the exact spelling of the import list, which is not a property
worth protecting.

## Verification

- `pytest -m "not integration"` from the repo root, CI's command → **3873 passed, 2 skipped, 0 failed** (13 new)
- `cd ui && npm test` → **416 passed, 0 failed** (7 new)
- `ruff format --check backend/` → 497 files already formatted; `ruff check` on the touched files → clean
- `eslint src` → clean; `npm run build` → succeeds

Not exercised against the live page — this needs the backend serving real market data, and
the evidence above is unit-level plus source pins. The runtime risk that leaves is a
render error, which the production build and ESLint's no-undef cover.

`post-mainnet`, so no rush on it.
