### PR TITLE
[oracle] Calendar-aware freshness, Circle COMPLETE parse, wedged-tx abandonment (#1525)

### DIFF
--- a/backend/archimedes/chain/oracle_runner.py
+++ b/backend/archimedes/chain/oracle_runner.py
@@ -62,7 +62,23 @@ async def run() -> None:
                     if tx:
                         logger.info(f"Price push complete — first tx: {tx}")
                     else:
-                        logger.info("Prices fetched (no on-chain push — owner key not configured)")
+                        # NOT "owner key not configured" (#1525 adjudication):
+                        # this runner pushes exclusively via the Circle
+                        # Developer-Controlled-Wallets API — there is no raw
+                        # owner private key on this path at all, so that
+                        # phrasing is a holdover from a pre-Circle design and
+                        # is almost never the actual cause. `tx` is falsy
+                        # whenever zero submissions reached a terminal-success
+                        # state this cycle, and every one of those causes
+                        # (missing Circle creds, a failed/timed-out tx, a
+                        # rejected price) already logs its own WARNING/ERROR
+                        # with the real reason inside push_prices_on_chain —
+                        # this line only duplicated that detail, with the
+                        # wrong cause attached. Downgraded to DEBUG and
+                        # reworded rather than removed outright, so a quiet
+                        # cycle (nothing to push, nothing wrong) still leaves
+                        # a trace at debug verbosity.
+                        logger.debug("Prices fetched — no tx reached a terminal-success state this cycle")
                 else:
                     logger.error(
                         "[lease:%s] lease NOT held — SKIPPING on-chain price push this cycle "

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -58,9 +58,33 @@ CIRCLE_BLOCKCHAIN = "ARC-TESTNET"
 # NOT "landed on-chain" — the tx can still FAIL/revert later. Every push is
 # polled to a terminal state before the price is treated as pushed; mirrors
 # circle_signer._poll_transaction's states/cadence.
-_TX_TERMINAL_STATES = {"COMPLETE", "FAILED", "DENIED", "CANCELLED"}
+#
+# Split into success/failure subsets (#1525) so a submission response can be
+# graded correctly: "COMPLETE"/"CONFIRMED" are terminal successes (Circle can
+# return either depending on how far the tx got before the API call returned
+# — e.g. a fast testnet tx that already landed by the time the create-call's
+# response is built), "FAILED"/"DENIED"/"CANCELLED" are terminal failures.
+# Before #1525, the create-response handler only trusted HTTP 201 and logged
+# EVERY OTHER response — including a 200 carrying a terminal-success state —
+# as "Circle API error", which buried genuine failures under bogus ones.
+_TX_SUCCESS_STATES = {"COMPLETE", "CONFIRMED"}
+_TX_FAILURE_STATES = {"FAILED", "DENIED", "CANCELLED"}
+_TX_TERMINAL_STATES = _TX_SUCCESS_STATES | _TX_FAILURE_STATES
 _TX_POLL_INTERVAL_S = 2.0
 _TX_MAX_POLLS = 60  # 2 minutes max per tx
+
+# ─── Wedged-tx abandonment (#1525) ───
+# _TX_MAX_POLLS/_TX_POLL_INTERVAL_S bound how long ONE push cycle will poll a
+# tx before giving up (2 minutes). They do NOT protect against a tx that is
+# wedged on Circle's side across MANY CYCLES: the per-symbol idempotency key
+# is deterministic on (wallet, contract, price), so an unchanged price (e.g.
+# an equity synth over a weekend) reproduces the SAME key every cycle, Circle
+# dedups to the SAME never-resolving tx id, and this runner re-polls that one
+# id forever with no path back to a fresh submission. After this many
+# consecutive cycles seeing the identical unresolved id for a symbol, abandon
+# it (WARN) and force a new Circle tx next cycle. Override via
+# ORACLE_TX_MAX_REPOLLS.
+DEFAULT_TX_MAX_REPOLLS = 10
 
 # ─── Sanity bounds for on-chain pushes (audit #13 / issue #508) ───
 # Max allowed move vs the last known good price, in basis points.
@@ -155,6 +179,17 @@ class OracleUpdater:
         self._crosscheck_max_staleness_s: int = _int_env(
             "PRICE_CROSSCHECK_MAX_STALENESS_SECONDS", DEFAULT_CROSSCHECK_MAX_STALENESS_SECONDS
         )
+
+        # Wedged-tx abandonment (#1525).
+        self._tx_max_repolls: int = _int_env("ORACLE_TX_MAX_REPOLLS", DEFAULT_TX_MAX_REPOLLS)
+        # symbol -> (tx id, consecutive cycles seen unresolved). Cleared as soon
+        # as that symbol's tx reaches any terminal state, or a different tx id
+        # shows up (a legitimate new submission, not a wedge).
+        self._wedge_tracking: dict[str, tuple[str, int]] = {}
+        # symbol -> salt bumped on abandonment so the next idempotency key is
+        # guaranteed to differ from the wedged one even if the price hasn't
+        # moved (the whole reason the old key kept deduping to the dead tx).
+        self._tx_retry_salt: dict[str, int] = {}
 
     # ─── Public API ──────────────────────────────────────────────
 
@@ -300,6 +335,24 @@ class OracleUpdater:
                     logger.warning(f"Refusing to push {price.symbol} price {price.price_usd}: {rejection}")
                     continue
 
+                # Wedged-tx abandonment (#1525): if the LAST cycle's tx for this
+                # symbol has now been seen unresolved for `_tx_max_repolls`
+                # consecutive cycles, it is never going to resolve on its own —
+                # bump the retry salt so the idempotency key below is
+                # guaranteed fresh (Circle would otherwise dedup right back to
+                # the same dead tx) and drop the old tracking entry.
+                wedged_id, wedged_count = self._wedge_tracking.get(price.symbol, (None, 0))
+                if wedged_count >= self._tx_max_repolls:
+                    logger.warning(
+                        "Circle tx %s for %s re-polled %d consecutive cycles with no "
+                        "terminal state — abandoning it and submitting fresh",
+                        wedged_id,
+                        price.symbol,
+                        wedged_count,
+                    )
+                    self._tx_retry_salt[price.symbol] = self._tx_retry_salt.get(price.symbol, 0) + 1
+                    self._wedge_tracking.pop(price.symbol, None)
+
                 try:
                     ciphertext = _encrypt_entity_secret(self._entity_secret, public_key)
 
@@ -312,13 +365,16 @@ class OracleUpdater:
                     # genuinely different push (different oracle or price)
                     # still produces a different key. uuid5 is used so the
                     # result is a validly-formatted UUID per Circle's
-                    # IdempotencyKey schema.
+                    # IdempotencyKey schema. `retrySalt` defaults to 0 (no
+                    # behavior change) and only moves once wedge-abandonment
+                    # above has fired for this symbol (#1525).
                     idempotency_source = json.dumps(
                         {
                             "walletId": self._wallet_id,
                             "contractAddress": oracle_addr,
                             "abiFunctionSignature": "setPrice(uint256)",
                             "abiParameters": [str(price_int)],
+                            "retrySalt": self._tx_retry_salt.get(price.symbol, 0),
                         },
                         sort_keys=True,
                     )
@@ -344,25 +400,49 @@ class OracleUpdater:
                         },
                     ) as resp:
                         body = await resp.json()
-                        if resp.status == 201:
-                            tx_id = body["data"]["id"]
+                        # Circle's create-transaction call can validly return
+                        # either 201 or 200 with a transaction id — including a
+                        # terminal-success state already (a fast testnet tx, or
+                        # an idempotency-key dedup hitting an already-resolved
+                        # tx). Grading solely on `resp.status == 201` treated
+                        # every one of those legitimate 200s as an error (#1525:
+                        # "Circle API error for sBTC (200): {'state': 'COMPLETE'}"
+                        # logged every cycle for a push that had already
+                        # succeeded). Grade on the payload instead: a usable tx
+                        # id whose state isn't a genuine failure is a success;
+                        # only a terminal failure state or a response with no
+                        # usable id at all is a real error, named explicitly.
+                        data = body.get("data") if isinstance(body, dict) else None
+                        tx_id = data.get("id") if isinstance(data, dict) else None
+                        state = data.get("state") if isinstance(data, dict) else None
+                        if tx_id and state not in _TX_FAILURE_STATES:
                             submitted.append((price.symbol, price.price_usd, price_int, tx_id))
-                            logger.info(f"Submitted {price.symbol} price {price.price_usd:.2f} → Circle tx {tx_id}")
+                            logger.info(
+                                f"Submitted {price.symbol} price {price.price_usd:.2f} → Circle tx {tx_id}"
+                                + (f" ({state})" if state else "")
+                            )
                         else:
-                            logger.error(f"Circle API error for {price.symbol} ({resp.status}): {body}")
+                            logger.error(
+                                "Circle API error for %s (%s): %s",
+                                price.symbol,
+                                resp.status,
+                                f"tx {tx_id} state={state}" if tx_id else body,
+                            )
                 except Exception:
                     logger.exception(f"Failed to push price for {price.symbol}")
 
             # ── Confirmation phase (#905): poll each submission to a terminal
-            # state. Only a COMPLETE tx counts as pushed; anything else leaves
-            # the cached deviation reference untouched and is logged loudly so
-            # a stuck oracle is visible to operators, never masked.
+            # state. Only a terminal-success tx (COMPLETE/CONFIRMED, #1525)
+            # counts as pushed; anything else leaves the cached deviation
+            # reference untouched and is logged loudly so a stuck oracle is
+            # visible to operators, never masked.
             for symbol, price_usd, price_int, tx_id in submitted:
                 state = await self._poll_circle_tx(session, tx_id)
-                if state == "COMPLETE":
+                if state in _TX_SUCCESS_STATES:
                     self._last_pushed_price_int[symbol] = price_int
                     confirmed_tx_ids.append(tx_id)
-                    logger.info(f"Pushed {symbol} price {price_usd:.2f} on-chain (Circle tx {tx_id} COMPLETE)")
+                    self._wedge_tracking.pop(symbol, None)
+                    logger.info(f"Pushed {symbol} price {price_usd:.2f} on-chain (Circle tx {tx_id} {state})")
                 else:
                     logger.error(
                         "Oracle push for %s (price %.2f, Circle tx %s) ended %s — "
@@ -372,6 +452,21 @@ class OracleUpdater:
                         tx_id,
                         state,
                     )
+                    # Wedged-tx tracking (#1525): only a TIMEOUT — this exact
+                    # tx never reaching ANY terminal state within the poll
+                    # budget — is evidence of a wedge. A genuine terminal
+                    # failure (FAILED/DENIED/CANCELLED) is a resolved outcome,
+                    # not a wedge: clear any prior tracking so a legitimately
+                    # failed-then-freshly-retried tx doesn't inherit a stale
+                    # count.
+                    if state == "TIMEOUT":
+                        wedged_id, wedged_count = self._wedge_tracking.get(symbol, (None, 0))
+                        self._wedge_tracking[symbol] = (
+                            tx_id,
+                            wedged_count + 1 if wedged_id == tx_id else 1,
+                        )
+                    else:
+                        self._wedge_tracking.pop(symbol, None)
 
         return confirmed_tx_ids[0] if confirmed_tx_ids else None
 

--- a/backend/archimedes/services/oracle_health.py
+++ b/backend/archimedes/services/oracle_health.py
@@ -46,6 +46,8 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
+from datetime import date, datetime, time as dtime, timedelta
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +62,120 @@ logger = logging.getLogger(__name__)
 # asset_market_service._ORACLE_TOTAL_BUDGET_SECONDS already guards, tightened
 # for the health path's smaller budget.
 _PROBE_BUDGET_SECONDS = 1.5
+
+# ── Weekend-blind freshness fix (#1525) ──────────────────────────────────
+#
+# ``PriceOracle.isFresh()`` enforces one flat ``MAX_STALENESS`` (24h) window
+# on-chain, identically for every symbol — it has no notion of a trading
+# calendar. That is correct for a 24/7 market (crypto) and wrong for an
+# equity synth: the US equity market is closed ~64/168 hours a week (more
+# with holidays), so an equity synth's on-chain price cannot update while
+# closed, and the flat threshold flips `isFresh()` false every single
+# weekend "by design" (the symptom this issue reports). A signal that fires
+# every weekend trains operators to ignore it, which is exactly how a real
+# weekday staleness incident goes unnoticed.
+#
+# Fix: for equity synths only, when the on-chain `isFresh()` says NOT fresh,
+# apply a dep-free trading-calendar override — `zoneinfo` is stdlib, no new
+# dependency — using the SAME `lastUpdated()` timestamp already read from
+# chain (never a liveness/heartbeat signal; see the module docstring's trap
+# note). A last update at/after the most recently completed US market
+# session is still that session's valid closing price until the market
+# reopens; only once the market has reopened without a fresh push does this
+# fall through to the chain's own (already-computed) not-fresh verdict.
+# Crypto synths are never touched by this override — they keep exactly the
+# existing flat-threshold behavior via the raw on-chain `isFresh()` read.
+_NY_TZ = ZoneInfo("America/New_York")
+_MARKET_OPEN = dtime(9, 30)
+_MARKET_CLOSE = dtime(16, 0)
+
+# Static 2026 NYSE full-closure holiday list — dep-free approximation (no
+# holidays/pandas_market_calendars dependency). Source: NYSE's published 2026
+# holiday calendar. Only full-market closures are listed; NYSE has no
+# early-close observance that matters here (this override only cares about
+# whether the market is open AT ALL, not intraday half-day hours).
+_NYSE_HOLIDAYS_2026: frozenset[date] = frozenset(
+    {
+        date(2026, 1, 1),  # New Year's Day
+        date(2026, 1, 19),  # Martin Luther King, Jr. Day
+        date(2026, 2, 16),  # Washington's Birthday
+        date(2026, 4, 3),  # Good Friday
+        date(2026, 5, 25),  # Memorial Day
+        date(2026, 6, 19),  # Juneteenth National Independence Day
+        date(2026, 7, 3),  # Independence Day (observed — July 4 falls on a Saturday)
+        date(2026, 9, 7),  # Labor Day
+        date(2026, 11, 26),  # Thanksgiving Day
+        date(2026, 12, 25),  # Christmas Day
+    }
+)
+
+
+def _is_trading_day(d: date) -> bool:
+    return d.weekday() < 5 and d not in _NYSE_HOLIDAYS_2026
+
+
+def _previous_trading_day(d: date) -> date:
+    d -= timedelta(days=1)
+    while not _is_trading_day(d):
+        d -= timedelta(days=1)
+    return d
+
+
+def _next_trading_day(d: date) -> date:
+    d += timedelta(days=1)
+    while not _is_trading_day(d):
+        d += timedelta(days=1)
+    return d
+
+
+def _most_recent_close_before(now_ny: datetime) -> datetime:
+    """The most recent scheduled 16:00 ET close at/before ``now_ny``.
+
+    On a trading day after close, that is today's close. On a trading day
+    before close (market open or pre-open), or on a weekend/holiday, that is
+    the previous trading day's close.
+    """
+    d = now_ny.date()
+    if _is_trading_day(d) and now_ny.time() >= _MARKET_CLOSE:
+        close_day = d
+    else:
+        close_day = _previous_trading_day(d)
+    return datetime.combine(close_day, _MARKET_CLOSE, tzinfo=_NY_TZ)
+
+
+def _next_open_after(close_dt: datetime) -> datetime:
+    """The next scheduled 09:30 ET open strictly after ``close_dt``'s day."""
+    open_day = _next_trading_day(close_dt.date())
+    return datetime.combine(open_day, _MARKET_OPEN, tzinfo=_NY_TZ)
+
+
+def _equity_weekend_override_fresh(last_updated_ts: int, now_ts: float) -> bool:
+    """True iff an equity synth's on-chain-stale verdict should be overridden.
+
+    Only ever called to relax an on-chain ``isFresh() == False`` read for an
+    equity synth — never to make a genuinely-stale weekday miss look fresh.
+    Returns ``False`` (no override; defer to the chain's own verdict) unless
+    ``now`` is currently within a closed-market gap (weekend, holiday, or
+    overnight) that opened at/after ``last_updated``'s trading session — i.e.
+    the market has not reopened since the last known price was pushed, so
+    that price is still the operative truth.
+
+    Compares by NY-local calendar DATE, not exact clock time, against the
+    most recently completed session: a push landing at 15:59 ET (one push
+    cycle before the nominal 16:00 close, or any other time that trading
+    day — including the market-open push) is still that session's price, not
+    a stale earlier one.
+    """
+    now_ny = datetime.fromtimestamp(now_ts, tz=_NY_TZ)
+    last_ny = datetime.fromtimestamp(last_updated_ts, tz=_NY_TZ)
+    close_before_now = _most_recent_close_before(now_ny)
+    next_open = _next_open_after(close_before_now)
+    if now_ny >= next_open:
+        # The market has reopened at least once since that close — a fresh
+        # push should have landed by now; a still-stale on-chain read is a
+        # genuine miss, not a weekend/holiday artifact.
+        return False
+    return last_ny.date() >= close_before_now.date()
 
 
 @dataclass(frozen=True)
@@ -110,6 +226,19 @@ def _push_set_symbols() -> list[str]:
     equity_synths = {s for s in YFINANCE_MAP if s.startswith("s")}
     crypto_synths = set(CRYPTO_MAP)
     return sorted(equity_synths | crypto_synths)
+
+
+def _is_equity_symbol(symbol: str) -> bool:
+    """True iff ``symbol`` is one of the equity synths in the push set (#1525).
+
+    Same source of truth and same filter as ``_push_set_symbols()`` —
+    ``YFINANCE_MAP`` keys with the leading-``"s"`` synth filter (excluding the
+    ``^GSPC``/``^VIX`` regime-signal tickers). Crypto symbols (``CRYPTO_MAP``)
+    are never equities and get no calendar override.
+    """
+    from archimedes.chain.oracle_updater import YFINANCE_MAP
+
+    return symbol in YFINANCE_MAP and symbol.startswith("s")
 
 
 def _universe_count() -> int:
@@ -191,7 +320,21 @@ async def oracle_health(budget_seconds: float | None = None) -> OracleHealth:
             oracle.functions.isFresh().call(),
             oracle.functions.lastUpdated().call(),
         )
-        return bool(is_fresh), int(last_updated)
+        is_fresh = bool(is_fresh)
+        last_updated = int(last_updated)
+        if not is_fresh and _is_equity_symbol(symbol):
+            # Weekend-blind freshness (#1525): the on-chain isFresh() enforces
+            # one flat MAX_STALENESS window with no trading-calendar
+            # awareness, so an equity synth reads stale every weekend by
+            # design. Override with the dep-free calendar check below, using
+            # the SAME lastUpdated() timestamp already read from chain — this
+            # can only turn a chain-verdict False into True (never the
+            # reverse), and only during a genuine closed-market gap; a real
+            # weekday miss still reports not-fresh. Crypto symbols never
+            # reach this branch — they keep exactly the existing flat
+            # threshold via the raw on-chain isFresh() read above.
+            is_fresh = _equity_weekend_override_fresh(last_updated, now)
+        return is_fresh, last_updated
 
     budget = _PROBE_BUDGET_SECONDS if budget_seconds is None else budget_seconds
     try:

--- a/backend/archimedes/services/oracle_health.py
+++ b/backend/archimedes/services/oracle_health.py
@@ -334,7 +334,13 @@ async def oracle_health(budget_seconds: float | None = None) -> OracleHealth:
             # reach this branch — they keep exactly the existing flat
             # threshold via the raw on-chain isFresh() read above.
             is_fresh = _equity_weekend_override_fresh(last_updated, now)
-        return is_fresh, last_updated
+            if is_fresh:
+                # Surface the override instead of silently massaging the
+                # verdict — the reason string names calendar-fresh symbols so
+                # an operator can always tell chain-fresh from calendar-fresh
+                # (fail-soft principle: transformations stay visible).
+                return is_fresh, last_updated, True
+        return is_fresh, last_updated, False
 
     budget = _PROBE_BUDGET_SECONDS if budget_seconds is None else budget_seconds
     try:
@@ -361,13 +367,16 @@ async def oracle_health(budget_seconds: float | None = None) -> OracleHealth:
             reason=f"oracle_health probe_timeout: exceeded {budget:.1f}s budget",
         )
 
+    calendar_fresh_symbols: list[str] = []
     for symbol, outcome in zip(symbols, outcomes, strict=True):
         if isinstance(outcome, BaseException):
             errors.append(f"{symbol}: {outcome}")
             continue
-        is_fresh, last_updated = outcome
+        is_fresh, last_updated, calendar_override = outcome
         ages.append(max(0, int(now - last_updated)))
         all_fresh_flags.append(is_fresh)
+        if calendar_override:
+            calendar_fresh_symbols.append(symbol)
 
     if not ages:
         # Every probed read failed — unobtainable, not confirmed-stale (mirrors
@@ -397,6 +406,10 @@ async def oracle_health(budget_seconds: float | None = None) -> OracleHealth:
     if all_fresh:
         status = "fresh"
         reason = f"{fresh_count}/{probed_count} probed oracle(s) fresh (of {universe_count} in the universe)"
+        if calendar_fresh_symbols:
+            reason += (
+                f"; {', '.join(sorted(calendar_fresh_symbols))} calendar-fresh (market closed since last update, #1525)"
+            )
     else:
         status = "stale"
         reason = (

--- a/backend/tests/chain/test_oracle_runner.py
+++ b/backend/tests/chain/test_oracle_runner.py
@@ -64,12 +64,34 @@ class TestOracleRunnerLoop:
         updater.push_prices_on_chain.assert_awaited_once()
 
     async def test_prices_fetched_but_no_push_tx(self):
-        # push returns None (owner key not configured) — must not crash.
+        # push returns None (no tx reached a terminal-success state this
+        # cycle) — must not crash.
         updater = MagicMock()
         updater.fetch_prices = AsyncMock(return_value=[_price()])
         updater.push_prices_on_chain = AsyncMock(return_value=None)
         await _run_one_cycle(updater)
         updater.push_prices_on_chain.assert_awaited_once()
+
+    async def test_no_push_tx_logs_debug_not_the_stale_owner_key_claim(self, caplog):
+        # #1525 adjudication: the old INFO line asserted "owner key not
+        # configured" — a holdover from a pre-Circle raw-key design that is
+        # almost never the actual cause (this runner has pushed exclusively
+        # via Circle Wallets since #905) and duplicated detail already logged
+        # with the real reason, at the correct severity, inside
+        # push_prices_on_chain. It is downgraded to DEBUG with accurate
+        # wording rather than asserting a specific (usually wrong) cause.
+        updater = MagicMock()
+        updater.fetch_prices = AsyncMock(return_value=[_price()])
+        updater.push_prices_on_chain = AsyncMock(return_value=None)
+        with caplog.at_level("DEBUG", logger="archimedes.chain.oracle_runner"):
+            await _run_one_cycle(updater)
+        messages = [r.getMessage() for r in caplog.records]
+        assert not any("owner key not configured" in m for m in messages)
+        assert any(
+            r.getMessage() == "Prices fetched — no tx reached a terminal-success state this cycle"
+            and r.levelname == "DEBUG"
+            for r in caplog.records
+        )
 
     async def test_no_prices_this_cycle_skips_push(self):
         updater = MagicMock()

--- a/backend/tests/chain/test_oracle_updater.py
+++ b/backend/tests/chain/test_oracle_updater.py
@@ -374,3 +374,177 @@ class TestPushConfirmation:
         session.get = MagicMock(return_value=get_cm)
 
         assert await updater._poll_circle_tx(session, "tx-905") == "TIMEOUT"
+
+
+# ── Circle 200-with-terminal-state must not be logged as an error (#1525) ──
+
+
+@pytest.mark.usefixtures("circle_creds")
+class TestSubmissionResponseParsing:
+    """Circle's create-transaction call can validly return a 200 (not just
+    201) carrying an already-terminal state — e.g. a fast testnet tx, or an
+    idempotency-key dedup landing on an already-resolved tx. Before #1525,
+    grading solely on `resp.status == 201` sent every one of those into the
+    error branch: `Circle API error for sBTC (200): {'data': {'id': ...,
+    'state': 'COMPLETE'}}` — logged every cycle for a push that had already
+    succeeded, burying genuine failures under bogus ones."""
+
+    def _updater_with_response(self, status: int, body: dict):
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        resp = MagicMock(status=status)
+        resp.json = AsyncMock(return_value=body)
+        return updater, _mock_aiohttp_session(post_response=resp)
+
+    async def test_200_complete_is_treated_as_success_not_logged_as_error(self, caplog):
+        # The exact shape from the issue's live log line, at the exact status.
+        updater, (session_cm, session) = self._updater_with_response(
+            200, {"data": {"id": "tx-dup", "state": "COMPLETE"}}
+        )
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="COMPLETE")),
+            caplog.at_level(logging.ERROR, logger="archimedes.chain.oracle_updater"),
+        ):
+            result = await updater.push_prices_on_chain([good])
+
+        assert result == "tx-dup"
+        assert updater._last_pushed_price_int["sSPY"] == _int6(110.0)
+        error_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not any("Circle API error" in m for m in error_messages), error_messages
+
+    async def test_200_confirmed_is_also_treated_as_success(self, caplog):
+        updater, (session_cm, session) = self._updater_with_response(
+            200, {"data": {"id": "tx-conf", "state": "CONFIRMED"}}
+        )
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="CONFIRMED")),
+            caplog.at_level(logging.ERROR, logger="archimedes.chain.oracle_updater"),
+        ):
+            result = await updater.push_prices_on_chain([good])
+
+        assert result == "tx-conf"
+        error_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not any("Circle API error" in m for m in error_messages), error_messages
+
+    async def test_genuine_terminal_failure_state_still_logs_error_named(self, caplog):
+        # Adversarial/guard-rejects-something check: a REAL failure — Circle
+        # accepted the call but the tx itself is already DENIED — must still
+        # be caught, named, and NOT silently treated as submitted.
+        updater, (session_cm, session) = self._updater_with_response(200, {"data": {"id": "tx-bad", "state": "DENIED"}})
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            caplog.at_level(logging.ERROR, logger="archimedes.chain.oracle_updater"),
+        ):
+            result = await updater.push_prices_on_chain([good])
+
+        assert result is None
+        assert "sSPY" not in updater._last_pushed_price_int
+        error_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("DENIED" in m for m in error_messages), error_messages
+
+    async def test_malformed_response_with_no_data_still_logs_error(self, caplog):
+        # A genuinely broken/unrecognized response (no "data"/"id" at all)
+        # must still be caught — the guard must not be relaxed into silence.
+        updater, (session_cm, session) = self._updater_with_response(400, {"code": 123, "message": "bad request"})
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            caplog.at_level(logging.ERROR, logger="archimedes.chain.oracle_updater"),
+        ):
+            result = await updater.push_prices_on_chain([good])
+
+        assert result is None
+        error_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("Circle API error" in m for m in error_messages), error_messages
+
+
+# ── Wedged-tx abandonment (#1525) ──────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("circle_creds")
+class TestWedgedTxAbandonment:
+    """A tx id Circle keeps handing back unresolved (same id, TIMEOUT every
+    cycle) must be abandoned after a bounded number of cycles rather than
+    re-polled forever — the observed production symptom: sSPY re-polling the
+    same Circle tx id every cycle for days."""
+
+    def _updater_with_response(self, tx_id: str = "tx-wedged"):
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        resp = MagicMock(status=201)
+        resp.json = AsyncMock(return_value={"data": {"id": tx_id}})
+        return updater, _mock_aiohttp_session(post_response=resp)
+
+    async def _push_once(self, updater, session_cm, tx_id: str, poll_state: str):
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value=poll_state)),
+        ):
+            return await updater.push_prices_on_chain([good])
+
+    async def test_below_threshold_keeps_repolling_the_same_id_quietly(self, caplog):
+        # Guard-rejects-something's negative control: BELOW the cap, no
+        # abandonment fires — proves the test below is actually exercising
+        # the threshold, not something that always fires.
+        updater, (session_cm, _session) = self._updater_with_response("tx-wedged")
+        updater._tx_max_repolls = 10
+        for _ in range(9):
+            result = await self._push_once(updater, session_cm, "tx-wedged", "TIMEOUT")
+        assert result is None
+        assert updater._wedge_tracking["sSPY"] == ("tx-wedged", 9)
+        assert updater._tx_retry_salt.get("sSPY", 0) == 0
+
+    async def test_exceeding_threshold_abandons_with_warning_and_forces_fresh_key(self, caplog):
+        updater, (session_cm, _session) = self._updater_with_response("tx-wedged")
+        updater._tx_max_repolls = 10
+        with caplog.at_level(logging.WARNING, logger="archimedes.chain.oracle_updater"):
+            # 10 cycles land the tracked count at 10 (== cap); the 11th cycle
+            # sees count>=cap BEFORE submitting and abandons.
+            for _ in range(11):
+                await self._push_once(updater, session_cm, "tx-wedged", "TIMEOUT")
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("abandoning" in m and "tx-wedged" in m for m in warnings), warnings
+        # The abandonment cleared tracking and bumped the salt so the NEXT
+        # idempotency key for this symbol is guaranteed to differ.
+        assert updater._tx_retry_salt["sSPY"] == 1
+
+    async def test_a_terminal_success_clears_wedge_tracking(self):
+        # Anti-goal: a tx that eventually resolves must not leave stale
+        # tracking behind to falsely trigger abandonment later.
+        updater, (session_cm, _session) = self._updater_with_response("tx-wedged")
+        await self._push_once(updater, session_cm, "tx-wedged", "TIMEOUT")
+        assert "sSPY" in updater._wedge_tracking
+        await self._push_once(updater, session_cm, "tx-wedged", "COMPLETE")
+        assert "sSPY" not in updater._wedge_tracking
+
+    async def test_a_different_tx_id_resets_the_count_instead_of_accumulating(self):
+        # A genuinely new submission (different id — e.g. price moved) must
+        # not inherit a previous id's repoll count.
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        resp = MagicMock(status=201)
+        resp.json = AsyncMock(side_effect=[{"data": {"id": "tx-a"}}, {"data": {"id": "tx-b"}}])
+        session_cm, _session = _mock_aiohttp_session(post_response=resp)
+
+        await self._push_once(updater, session_cm, "tx-a", "TIMEOUT")
+        assert updater._wedge_tracking["sSPY"] == ("tx-a", 1)
+
+        await self._push_once(updater, session_cm, "tx-b", "TIMEOUT")
+        assert updater._wedge_tracking["sSPY"] == ("tx-b", 1)

--- a/backend/tests/test_oracle_health_telemetry.py
+++ b/backend/tests/test_oracle_health_telemetry.py
@@ -250,6 +250,11 @@ class TestOracleHealthWeekendFreshness:
 
         assert diag.oracle_fresh is True
         assert diag.status == "fresh"
+        # The override must be VISIBLE, never a silent massage: the reason
+        # names the calendar-fresh symbol so an operator can always tell
+        # chain-fresh from calendar-fresh (fail-soft: transformations loud).
+        assert "sSPY calendar-fresh" in diag.reason
+        assert "#1525" in diag.reason
 
     @pytest.mark.asyncio
     async def test_equity_stale_flag_not_overridden_on_tuesday(self) -> None:

--- a/backend/tests/test_oracle_health_telemetry.py
+++ b/backend/tests/test_oracle_health_telemetry.py
@@ -35,16 +35,24 @@ import logging
 import time as time_mod
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import archimedes.services.oracle_health as oracle_health_mod
 import pytest
 from archimedes.services.oracle_health import (
     OracleHealth,
+    _equity_weekend_override_fresh,
     _push_set_symbols,
     _universe_count,
     oracle_health,
 )
 from httpx import ASGITransport, AsyncClient
+
+_NY_TZ = ZoneInfo("America/New_York")
+
+
+def _ny(year: int, month: int, day: int, hour: int, minute: int) -> float:
+    return datetime(year, month, day, hour, minute, tzinfo=_NY_TZ).timestamp()
 
 
 def _mock_loader(per_symbol: dict[str, tuple[bool | None, int | None, Exception | None]]) -> MagicMock:
@@ -180,6 +188,111 @@ class TestOracleHealthOneStale:
         assert diag.oracle_oldest_age_s == stale_age
         assert diag.oracle_probed_count == 2
         assert "1/2" in diag.reason
+
+
+class TestEquityWeekendOverrideFreshUnit:
+    """Direct unit coverage of the calendar-override function (#1525) —
+    dates chosen to match the issue's own worked example: last update Friday
+    2026-08-28 15:59 ET (one push cycle before the nominal 16:00 close),
+    evaluated from Sunday 2026-08-30 (fresh) vs. Tuesday 2026-09-01 (stale —
+    the market has since opened Monday 2026-08-31 09:30 ET and reopened
+    again Tuesday, so a still-Friday price is a genuine miss, not a weekend
+    artifact)."""
+
+    def test_friday_close_still_fresh_on_sunday(self) -> None:
+        last_updated = _ny(2026, 8, 28, 15, 59)
+        now = _ny(2026, 8, 30, 12, 0)  # Sunday noon ET
+        assert _equity_weekend_override_fresh(int(last_updated), now) is True
+
+    def test_same_friday_timestamp_is_stale_once_evaluated_on_tuesday(self) -> None:
+        last_updated = _ny(2026, 8, 28, 15, 59)
+        now = _ny(2026, 9, 1, 12, 0)  # Tuesday noon ET — market open, 2 sessions since
+        assert _equity_weekend_override_fresh(int(last_updated), now) is False
+
+    def test_does_not_override_during_open_market_hours(self) -> None:
+        # Guard-rejects-something check: a stale-looking Tuesday-morning
+        # timestamp must NOT be waved through just because SOME calendar
+        # logic ran — the override must return False once the market has
+        # reopened, even mid-session.
+        last_updated = _ny(2026, 8, 28, 15, 59)
+        now = _ny(2026, 9, 1, 11, 0)  # Tuesday 11am ET, market open since 9:30
+        assert _equity_weekend_override_fresh(int(last_updated), now) is False
+
+    def test_fresh_through_pre_open_gap_before_market_reopens(self) -> None:
+        last_updated = _ny(2026, 8, 28, 15, 59)
+        now = _ny(2026, 8, 31, 7, 0)  # Monday 7am ET — before the 9:30 open
+        assert _equity_weekend_override_fresh(int(last_updated), now) is True
+
+
+class TestOracleHealthWeekendFreshness:
+    """End-to-end through oracle_health(): the on-chain isFresh() enforces a
+    flat threshold with no calendar awareness, so it reports sSPY not-fresh
+    both on a weekend AND on a weekday when it's genuinely 44h+ stale — the
+    Python-side override must relax ONLY the equity-weekend case."""
+
+    @pytest.mark.asyncio
+    async def test_equity_stale_flag_overridden_fresh_on_sunday(self) -> None:
+        now = _ny(2026, 8, 30, 12, 0)  # Sunday noon ET
+        friday_close = int(_ny(2026, 8, 28, 15, 59))
+        loader = _mock_loader(
+            {
+                "sBTC": (True, int(now) - 60, None),
+                # On-chain isFresh() says False (flat 24h window, ~44h old) —
+                # the exact #1525 symptom shape.
+                "sSPY": (False, friday_close, None),
+            }
+        )
+        with (
+            patch("archimedes.chain.contracts.get_contract_loader", return_value=loader),
+            patch.object(oracle_health_mod.time, "time", return_value=now),
+        ):
+            diag = await oracle_health()
+
+        assert diag.oracle_fresh is True
+        assert diag.status == "fresh"
+
+    @pytest.mark.asyncio
+    async def test_equity_stale_flag_not_overridden_on_tuesday(self) -> None:
+        now = _ny(2026, 9, 1, 12, 0)  # Tuesday noon ET — market reopened since
+        friday_close = int(_ny(2026, 8, 28, 15, 59))
+        loader = _mock_loader(
+            {
+                "sBTC": (True, int(now) - 60, None),
+                "sSPY": (False, friday_close, None),
+            }
+        )
+        with (
+            patch("archimedes.chain.contracts.get_contract_loader", return_value=loader),
+            patch.object(oracle_health_mod.time, "time", return_value=now),
+        ):
+            diag = await oracle_health()
+
+        assert diag.oracle_fresh is False
+        assert diag.status == "stale"
+        assert "1/2" in diag.reason
+
+    @pytest.mark.asyncio
+    async def test_crypto_44h_old_stays_stale_regardless_of_weekend(self) -> None:
+        # Crypto keeps the existing flat threshold — no calendar override
+        # ever applies to it, even when `now` falls on a weekend.
+        now = _ny(2026, 8, 30, 12, 0)  # Sunday noon ET
+        stale_age_s = 44 * 60 * 60  # 44h — past the 24h flat MAX_STALENESS
+        loader = _mock_loader(
+            {
+                # On-chain isFresh() correctly reports False for 44h-old data.
+                "sBTC": (False, int(now) - stale_age_s, None),
+                "sSPY": (True, int(now) - 60, None),
+            }
+        )
+        with (
+            patch("archimedes.chain.contracts.get_contract_loader", return_value=loader),
+            patch.object(oracle_health_mod.time, "time", return_value=now),
+        ):
+            diag = await oracle_health()
+
+        assert diag.oracle_fresh is False
+        assert diag.status == "stale"
+        assert diag.oracle_oldest_age_s == stale_age_s
 
 
 class TestOracleHealthChainReadFailure:


### PR DESCRIPTION
Closes #1525.

Three defects, diagnosed live from the runner logs on 2026-08-30 and fixed with no new dependencies:

## 1. Weekend-blind freshness probe
`PriceOracle.isFresh()` enforces one flat 24h window on-chain with no trading-calendar awareness, so every equity synth reads stale every weekend by design — an alarm that fires weekly trains operators to ignore the one that matters. Fix: a dep-free (`zoneinfo`, stdlib + static 2026 NYSE closure list) calendar override in `oracle_health.py`, applied **only** when the chain verdict is already False and the symbol is an equity synth. It can only relax False→True inside a genuine closed-market gap; once the market reopens without a push, the chain's own not-fresh verdict stands. Crypto keeps the flat threshold untouched.

**The override is loud, not silent**: `/health`'s reason names the symbols — `"…fresh; sSPY calendar-fresh (market closed since last update, #1525)"` — so chain-fresh and calendar-fresh are always distinguishable (fail-soft principle).

## 2. Circle `COMPLETE` parsed as ERROR
`push_prices_on_chain` graded the create-transaction response solely on `status == 201`; a valid 200 carrying an already-terminal-success state (fast testnet tx, or an idempotency dedup returning a resolved tx) was logged as `Circle API error … {'state': 'COMPLETE'}` **every cycle**, burying real errors. Now graded on the payload: usable tx id + non-failure state = submitted; `CONFIRMED` joins `COMPLETE` as terminal success throughout; genuine `FAILED/DENIED/CANCELLED` (or no id) still logs ERROR naming the state.

## 3. Wedged-tx retry loop
The per-push idempotency key is deterministic on `(wallet, contract, price)` — an unchanged weekend price reproduces the same key, Circle dedups to the same never-resolving tx id (observed: sSPY `30a4c44b…` re-polled every minute for days), and there was no path back to a fresh submission. Now: per-symbol wedge tracking increments only when the *same* id TIMEOUTs across consecutive cycles (a genuine terminal failure clears it); past `ORACLE_TX_MAX_REPOLLS` (default 10), WARN + a retry-salt bump in the idempotency key forces a genuinely new Circle tx.

Also adjudicated: the once-a-minute `"no on-chain push — owner key not configured"` INFO line is a pre-Circle holdover — this runner pushes exclusively via Circle DCW and every real failure cause already logs its own WARN/ERROR. Downgraded to DEBUG with honest wording.

## Guard demonstrations (repo rule 4 — fix stashed, tests re-run against old code)
```
test_oracle_health_telemetry.py: ImportError: cannot import name '_equity_weekend_override_fresh'
TestSubmissionResponseParsing::test_200_complete…  AssertionError — and the bogus
  "Circle API error for sSPY (200): {'state': 'COMPLETE'}" reappears in caplog
TestWedgedTxAbandonment::test_exceeding_threshold… AssertionError: [] (no WARNING ever logged)
test_no_push_tx_logs_debug_not_the_stale_owner_key_claim  assert not True
```
Negative controls included: 44h-old **crypto** stays stale on a weekend (no calendar leak); below-threshold re-polls do **not** abandon; `DENIED` still logs ERROR. All hermetic (Circle/chain mocked at boundary). Touched suites: **61 passed**. Full `pytest -m "not integration"`: **3876 passed, 0 failed** (agent run pre-rebase; CI re-verifies on this exact head).

## The live experiment
sSPY's wedged tx has been re-polled since Friday's close. **Monday 09:30 ET market open discriminates**: if the price moves, the new idempotency key escapes the dedup naturally; if it somehow stays wedged, the abandonment path (defect 3) fires within 10 cycles and logs the WARN. Either way tomorrow's logs prove the fix in prod.

## Out of scope, worth a follow-up
`backend/archimedes/chain/README.md` and `.env.example` claim a raw-private-key fallback ("if Circle credentials are missing") that does not exist in `push_prices_on_chain` — docs/code drift to correct or implement.

Implementation by a sonnet workflow agent in an isolated worktree; personally reviewed line-by-line, rebased onto `2382c35f`, transparency patch + reason-string guard added, adversarial pass re-verified before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
