### PR TITLE
[chain] Name the payments and execution chains separately (#1240)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,27 @@ ANTHROPIC_API_KEY=
 # secret — do NOT commit. Leave blank to skip on-chain features locally.
 RPC=
 
+# ── Two-chain split: payments vs execution (#1240) ─────────────────────────
+# LEAVE ALL FOUR BLANK unless you are deliberately running a split. Blank means
+# both roles use the single-chain settings (ARC_CHAIN_ID / ARC_ARC_RPC_URL, or
+# their defaults), which is exactly how the system behaves today.
+#
+# At the Arc mainnet cutover the payment rail (USDC / x402 / Gateway /
+# PaymentSplitter) moves to mainnet while vault, synth, AMM and oracle
+# execution stays on testnet. These four are how that is expressed.
+#
+# SET BOTH HALVES OF A PAIR OR NEITHER. A chain id without its endpoint (or an
+# endpoint without its id) makes the process REFUSE TO START, naming the
+# missing variable. That is deliberate: filling the missing half from the
+# single-chain settings would settle real USDC against an endpoint nobody chose
+# while reporting a chain nobody chose.
+#
+# Every contract address in this file belongs to the EXECUTION chain.
+ARC_PAYMENTS_CHAIN_ID=
+ARC_PAYMENTS_RPC_URL=
+ARC_EXECUTION_CHAIN_ID=
+ARC_EXECUTION_RPC_URL=
+
 # ── Wallet (dev only — never put a wallet with real funds here) ────────────
 # Generate a fresh dev wallet for hackathon testing. Cast example:
 #   cast wallet new

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -597,6 +597,17 @@ class ChatPostResponse(BaseModel):
 # ═══════════════════════════════════════════════════════════════
 
 
+class ChainEndpointResponse(BaseModel):
+    """One chain a client may need to talk to."""
+
+    chain_id: int
+    rpc_url: str
+    # False means this chain was inherited from the single-chain configuration
+    # rather than chosen for this role. A client that must not guess — anything
+    # about to move real money — can tell a decision from a default.
+    explicit: bool
+
+
 class ContractAddressesResponse(BaseModel):
     """All deployed contract addresses. Frontend needs these for direct on-chain calls."""
 
@@ -620,9 +631,23 @@ class ContractAddressesResponse(BaseModel):
     # Vault addresses. Same None-vs-{} distinction as `pools`.
     vaults: dict[str, str] | None  # symbol → address, e.g. {"vMOMENTUM": "0x..."}
 
-    # Chain info
+    # Chain info.
+    #
+    # These two keep their original meaning: the chain the contract addresses
+    # above are deployed on, i.e. the EXECUTION chain. Existing clients read
+    # them and stay correct. New clients should prefer the explicit blocks
+    # below, which say which chain they mean instead of leaving it implied.
     chain_id: int
     rpc_url: str
+
+    # Two-chain split (#1240). Payments and execution are the same chain today
+    # and diverge at the Arc mainnet cutover. Serving both unconditionally —
+    # rather than only once they differ — means a client never has to infer a
+    # missing block, and `split` says outright whether a wallet flow needs
+    # chain switching.
+    payments_chain: ChainEndpointResponse
+    execution_chain: ChainEndpointResponse
+    split_chain: bool
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
 from aiohttp import ClientError, ClientTimeout
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
 from web3 import AsyncWeb3
 from web3.middleware import ExtraDataToPOAMiddleware
@@ -88,6 +90,22 @@ def _resolve_ssot_addresses(defaults: dict[str, str], suffix: str) -> dict[str, 
     return resolved
 
 
+@dataclass(frozen=True)
+class ChainEndpoint:
+    """One resolved chain: which id, which RPC, and whether it was chosen.
+
+    ``explicit`` records whether this endpoint came from its own
+    ``ARC_PAYMENTS_*`` / ``ARC_EXECUTION_*`` variables or fell back to the
+    single-chain ``chain_id`` / ``arc_rpc_url``. Callers that need to know a
+    chain was *decided* rather than *inherited* — a mainnet payment path, a
+    startup assertion — read this instead of comparing ids and guessing.
+    """
+
+    chain_id: int
+    rpc_url: str
+    explicit: bool
+
+
 class ChainSettings(BaseSettings):
     """On-chain connection settings — loaded from .env or environment variables.
 
@@ -142,6 +160,27 @@ class ChainSettings(BaseSettings):
     # ARC_RPC_RETRIES overrides.
     rpc_retries: int = 2
 
+    # ── Two-chain split (#1240) ────────────────────────────────────────────
+    # Payments (USDC / x402 / Gateway / PaymentSplitter) and execution (vault,
+    # synth, AMM, oracle) run on one chain today and become two at the Arc
+    # mainnet cutover, where the payment rail goes to mainnet and execution
+    # stays on testnet.
+    #
+    # All four default to the single-chain values above, so an environment that
+    # sets none of them behaves exactly as it does now. That is the point: this
+    # is a seam, not a cutover. Setting them is what moves a chain.
+    #
+    # A HALF-CONFIGURED SPLIT IS REJECTED at construction rather than filled in
+    # from the other chain — see _reject_half_configured_split below. Silently
+    # borrowing the execution RPC for a payments chain id would mean settling
+    # real USDC against an endpoint nobody chose, which is the fail-soft
+    # pattern docs/architectural-principles.md forbids for anything a claim
+    # depends on. Money is the strongest such claim we make.
+    payments_chain_id: int | None = None  # ARC_PAYMENTS_CHAIN_ID
+    payments_rpc_url: str = ""  # ARC_PAYMENTS_RPC_URL
+    execution_chain_id: int | None = None  # ARC_EXECUTION_CHAIN_ID
+    execution_rpc_url: str = ""  # ARC_EXECUTION_RPC_URL
+
     # Agent account (the address that calls rebalance, publishes traces, etc.)
     agent_private_key: str = ""
     agent_address: str = ""  # Will be derived from private key if empty
@@ -177,6 +216,78 @@ class ChainSettings(BaseSettings):
     abi_dir: str = str(Path(__file__).resolve().parents[3] / "contracts" / "abis")
 
     model_config = {"env_prefix": "ARC_", "env_file": ".env", "extra": "ignore"}
+
+    @field_validator("payments_chain_id", "execution_chain_id", mode="before")
+    @classmethod
+    def _blank_chain_id_is_unset(cls, v: object) -> object:
+        """Treat an empty string as unset, because .env.example ships these blank.
+
+        ``cp .env.example .env`` — the documented first step in SETUP.md — puts
+        ``ARC_PAYMENTS_CHAIN_ID=`` in the environment as an empty string, and
+        pydantic will not parse that as an int. Without this the whole backend
+        refuses to start for anyone who follows the setup instructions, while
+        working fine for anyone whose .env predates these lines. Blank means
+        "no split configured", which is the same thing as absent.
+        """
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
+
+    @model_validator(mode="after")
+    def _reject_half_configured_split(self) -> ChainSettings:
+        """Refuse to boot on a chain id without its RPC, or an RPC without its id.
+
+        The tempting default is to fill the missing half from the single-chain
+        settings. That produces a process that reports one chain and talks to
+        another, and on the payments side it would do so while moving real USDC.
+        A missing half is an incomplete decision, so it stops here with the
+        variable name that would complete it.
+        """
+        for label, chain_id, rpc_url in (
+            ("PAYMENTS", self.payments_chain_id, self.payments_rpc_url),
+            ("EXECUTION", self.execution_chain_id, self.execution_rpc_url),
+        ):
+            if chain_id is not None and not rpc_url:
+                raise ValueError(
+                    f"ARC_{label}_CHAIN_ID is set to {chain_id} but ARC_{label}_RPC_URL is empty. "
+                    f"Set both or neither — a chain id without its own endpoint would silently "
+                    f"reuse the ARC_ARC_RPC_URL endpoint while reporting a different chain."
+                )
+            if rpc_url and chain_id is None:
+                raise ValueError(
+                    f"ARC_{label}_RPC_URL is set but ARC_{label}_CHAIN_ID is empty. "
+                    f"Set both or neither — an endpoint with no declared chain id cannot be "
+                    f"checked against what the RPC actually reports."
+                )
+        return self
+
+    @property
+    def payments_chain(self) -> ChainEndpoint:
+        """The chain USDC settles on. Falls back to the single-chain settings."""
+        if self.payments_chain_id is None:
+            return ChainEndpoint(chain_id=self.chain_id, rpc_url=self.arc_rpc_url, explicit=False)
+        return ChainEndpoint(chain_id=self.payments_chain_id, rpc_url=self.payments_rpc_url, explicit=True)
+
+    @property
+    def execution_chain(self) -> ChainEndpoint:
+        """The chain vaults, synths, AMM and oracles live on.
+
+        Every contract address on this settings object belongs to THIS chain,
+        which is why ``chain_id`` / ``arc_rpc_url`` keep their present meaning
+        and every existing signing call site stays correct without change.
+        """
+        if self.execution_chain_id is None:
+            return ChainEndpoint(chain_id=self.chain_id, rpc_url=self.arc_rpc_url, explicit=False)
+        return ChainEndpoint(chain_id=self.execution_chain_id, rpc_url=self.execution_rpc_url, explicit=True)
+
+    @property
+    def is_split_chain(self) -> bool:
+        """True when payments and execution resolve to different chain ids.
+
+        The browser wallet UX turns on this: one chain needs no switching, two
+        do. Reading it beats comparing ids at each call site and drifting.
+        """
+        return self.payments_chain.chain_id != self.execution_chain.chain_id
 
     @property
     def agent_account(self) -> LocalAccount | None:

--- a/backend/archimedes/services/config_service.py
+++ b/backend/archimedes/services/config_service.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 import logging
 
-from archimedes.api.schemas import ContractAddressesResponse
-from archimedes.chain.client import chain_client
+from archimedes.api.schemas import ChainEndpointResponse, ContractAddressesResponse
+from archimedes.chain.client import ChainEndpoint, chain_client
 
 logger = logging.getLogger(__name__)
+
+
+def _endpoint(resolved: ChainEndpoint) -> ChainEndpointResponse:
+    """Wire shape for one resolved chain endpoint."""
+    return ChainEndpointResponse(
+        chain_id=resolved.chain_id,
+        rpc_url=resolved.rpc_url,
+        explicit=resolved.explicit,
+    )
 
 
 class ConfigService:
@@ -60,4 +69,11 @@ class ConfigService:
             vaults=vaults,
             chain_id=settings.chain_id,
             rpc_url=settings.arc_rpc_url,
+            # Both blocks are built from the resolved endpoints, never from the
+            # raw ARC_PAYMENTS_* / ARC_EXECUTION_* fields — the fallback to the
+            # single-chain settings lives in one place on ChainSettings, and
+            # re-deriving it here is how the two drift apart (#1240).
+            payments_chain=_endpoint(settings.payments_chain),
+            execution_chain=_endpoint(settings.execution_chain),
+            split_chain=settings.is_split_chain,
         )

--- a/backend/tests/chain/test_two_chain_config.py
+++ b/backend/tests/chain/test_two_chain_config.py
@@ -1,0 +1,220 @@
+"""Two-chain configuration seam: payments vs execution (#1240).
+
+The Arc mainnet cutover puts the payment rail (USDC / x402 / Gateway /
+PaymentSplitter) on mainnet while vault, synth, AMM and oracle execution stays
+on testnet. Until then both roles resolve to the single ``chain_id`` /
+``arc_rpc_url`` pair, and this module's first job is to prove that an
+unconfigured environment is bit-for-bit unchanged.
+
+Its second job is the guard: a chain id set without its RPC (or the reverse) is
+rejected at construction rather than quietly completed from the other chain. On
+the payments side that fallback would settle real USDC against an endpoint
+nobody selected while reporting a chain nobody selected either.
+
+Hermetic: every ``ChainSettings`` is built with ``_env_file=None`` and every
+variable touched here is set through ``monkeypatch``, so no ambient ``.env`` or
+developer shell reaches in. No network, no RPC.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.chain.client import ChainSettings
+from pydantic import ValidationError
+
+_SINGLE_CHAIN_ID = 5042002
+_SINGLE_RPC = "https://rpc.testnet.arc.network"
+
+# The four variables the split is configured through. env_prefix is "ARC_", so
+# a field named ``payments_chain_id`` is ARC_PAYMENTS_CHAIN_ID on the wire.
+_SPLIT_VARS = [
+    "ARC_PAYMENTS_CHAIN_ID",
+    "ARC_PAYMENTS_RPC_URL",
+    "ARC_EXECUTION_CHAIN_ID",
+    "ARC_EXECUTION_RPC_URL",
+]
+
+
+@pytest.fixture(autouse=True)
+def _strip_split_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ambient split configuration leaks into any test here."""
+    for var in [*_SPLIT_VARS, "ARC_CHAIN_ID", "ARC_ARC_RPC_URL"]:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _settings(**kwargs) -> ChainSettings:
+    return ChainSettings(_env_file=None, **kwargs)
+
+
+class TestUnconfiguredIsUnchanged:
+    """An environment that sets nothing must behave exactly as it does today."""
+
+    def test_both_roles_resolve_to_the_single_chain(self) -> None:
+        s = _settings()
+        assert s.payments_chain.chain_id == _SINGLE_CHAIN_ID
+        assert s.execution_chain.chain_id == _SINGLE_CHAIN_ID
+        assert s.payments_chain.rpc_url == _SINGLE_RPC
+        assert s.execution_chain.rpc_url == _SINGLE_RPC
+
+    def test_an_inherited_chain_is_not_marked_explicit(self) -> None:
+        """`explicit` is the whole point of the flag: inherited must read False.
+
+        Fails against returning a hard-coded ``explicit=True``, which would tell
+        a caller a chain had been chosen for this role when nothing had.
+        """
+        s = _settings()
+        assert s.payments_chain.explicit is False
+        assert s.execution_chain.explicit is False
+
+    def test_one_chain_is_not_a_split(self) -> None:
+        assert _settings().is_split_chain is False
+
+    def test_the_legacy_fields_keep_the_execution_chain(self) -> None:
+        """`chain_id` / `arc_rpc_url` still mean the chain the contracts are on.
+
+        Every signing call site (executor, trace_publisher, strategy_publisher)
+        reads ``settings.chain_id``. Repointing it at the payments chain would
+        sign execution transactions for the wrong network, so this pins it.
+        """
+        s = _settings(payments_chain_id=999, payments_rpc_url="https://payments.example")
+        assert s.chain_id == s.execution_chain.chain_id
+        assert s.arc_rpc_url == s.execution_chain.rpc_url
+
+
+class TestSplitResolution:
+    def test_payments_moves_while_execution_stays(self) -> None:
+        """The exact mainnet-cutover shape: payments elsewhere, execution here."""
+        s = _settings(payments_chain_id=999, payments_rpc_url="https://payments.example")
+        assert s.payments_chain.chain_id == 999
+        assert s.payments_chain.rpc_url == "https://payments.example"
+        assert s.payments_chain.explicit is True
+        # Execution untouched, and still marked inherited.
+        assert s.execution_chain.chain_id == _SINGLE_CHAIN_ID
+        assert s.execution_chain.explicit is False
+        assert s.is_split_chain is True
+
+    def test_execution_can_move_independently(self) -> None:
+        s = _settings(execution_chain_id=31337, execution_rpc_url="https://exec.example")
+        assert s.execution_chain.chain_id == 31337
+        assert s.execution_chain.explicit is True
+        assert s.payments_chain.chain_id == _SINGLE_CHAIN_ID
+        assert s.is_split_chain is True
+
+    def test_both_set_to_the_same_id_is_explicit_but_not_a_split(self) -> None:
+        """Deliberately pinning both to one chain is a decision, not a split.
+
+        Fails against deriving `explicit` from `is_split_chain` — the two answer
+        different questions, and conflating them would report a pinned
+        single-chain deployment as having inherited its configuration.
+        """
+        s = _settings(
+            payments_chain_id=5042002,
+            payments_rpc_url="https://a.example",
+            execution_chain_id=5042002,
+            execution_rpc_url="https://b.example",
+        )
+        assert s.payments_chain.explicit is True
+        assert s.execution_chain.explicit is True
+        assert s.is_split_chain is False
+
+
+class TestHalfConfiguredSplitIsRejected:
+    """The guard. Each case must raise, naming the variable that completes it."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_var"),
+        [
+            ({"payments_chain_id": 999}, "ARC_PAYMENTS_RPC_URL"),
+            ({"payments_rpc_url": "https://payments.example"}, "ARC_PAYMENTS_CHAIN_ID"),
+            ({"execution_chain_id": 31337}, "ARC_EXECUTION_RPC_URL"),
+            ({"execution_rpc_url": "https://exec.example"}, "ARC_EXECUTION_CHAIN_ID"),
+        ],
+    )
+    def test_each_half_is_refused(self, kwargs: dict, expected_var: str) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _settings(**kwargs)
+        assert expected_var in str(exc.value), (
+            f"the error must name {expected_var}, the variable that completes the pair"
+        )
+
+    def test_a_complete_pair_is_accepted(self) -> None:
+        """Anti-vacuity for the guard above: the same fields, both halves set, pass.
+
+        Without this a validator that rejected everything would satisfy every
+        rejection case and look like a working guard.
+        """
+        s = _settings(payments_chain_id=999, payments_rpc_url="https://payments.example")
+        assert s.payments_chain.chain_id == 999
+
+
+class TestTheEnvironmentVariableNamesAreReal:
+    """Constructing with kwargs proves nothing about the wire names.
+
+    ``env_prefix = "ARC_"`` means the variable for ``payments_chain_id`` is
+    ARC_PAYMENTS_CHAIN_ID. These tests go through the environment so a renamed
+    field or a changed prefix fails here rather than in a deploy, where the
+    symptom is a silently ignored variable and a chain that never moved.
+    """
+
+    def test_payments_vars_are_read_from_the_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARC_PAYMENTS_CHAIN_ID", "999")
+        monkeypatch.setenv("ARC_PAYMENTS_RPC_URL", "https://payments.example")
+        s = _settings()
+        assert s.payments_chain.chain_id == 999
+        assert s.payments_chain.rpc_url == "https://payments.example"
+        assert s.payments_chain.explicit is True
+
+    def test_execution_vars_are_read_from_the_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARC_EXECUTION_CHAIN_ID", "31337")
+        monkeypatch.setenv("ARC_EXECUTION_RPC_URL", "https://exec.example")
+        s = _settings()
+        assert s.execution_chain.chain_id == 31337
+        assert s.execution_chain.explicit is True
+
+    def test_a_half_set_environment_refuses_to_construct(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The guard has to fire on the env path too, not only on kwargs.
+
+        This is the path a real deployment takes: someone adds
+        ARC_PAYMENTS_CHAIN_ID to ecs.tf and forgets the endpoint.
+        """
+        monkeypatch.setenv("ARC_PAYMENTS_CHAIN_ID", "999")
+        with pytest.raises(ValidationError, match="ARC_PAYMENTS_RPC_URL"):
+            _settings()
+
+
+class TestBlankValuesFromTheEnvTemplate:
+    """`.env.example` ships all four blank, so blank must mean unset.
+
+    ``cp .env.example .env`` is the documented first step in SETUP.md. It puts
+    ``ARC_PAYMENTS_CHAIN_ID=`` into the environment as an empty string, which
+    pydantic will not parse as an int. Without the coercion these tests pin, the
+    backend refuses to start for anyone who follows the setup instructions while
+    continuing to work for anyone whose .env predates the template change — the
+    worst shape of environment bug, because the people who can reproduce it are
+    exactly the new contributors least able to diagnose it.
+    """
+
+    def test_blank_chain_ids_are_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fails against dropping the mode="before" coercion (int_parsing error)."""
+        for var in _SPLIT_VARS:
+            monkeypatch.setenv(var, "")
+        s = _settings()
+        assert s.payments_chain.chain_id == _SINGLE_CHAIN_ID
+        assert s.execution_chain.chain_id == _SINGLE_CHAIN_ID
+        assert s.is_split_chain is False
+
+    def test_whitespace_only_is_also_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A stray space after `=` is the same mistake with a harder-to-see cause."""
+        monkeypatch.setenv("ARC_PAYMENTS_CHAIN_ID", "   ")
+        assert _settings().payments_chain.chain_id == _SINGLE_CHAIN_ID
+
+    def test_a_blank_id_beside_a_real_rpc_is_still_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The coercion must not swallow a genuinely half-configured split.
+
+        Blank id + real endpoint is the half-configured case, not the unset one.
+        Fails against a coercion that returns None and lets the guard pass.
+        """
+        monkeypatch.setenv("ARC_PAYMENTS_CHAIN_ID", "")
+        monkeypatch.setenv("ARC_PAYMENTS_RPC_URL", "https://payments.example")
+        with pytest.raises(ValidationError, match="ARC_PAYMENTS_CHAIN_ID"):
+            _settings()

--- a/backend/tests/services/test_config_service.py
+++ b/backend/tests/services/test_config_service.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from archimedes.chain.client import ChainEndpoint
 from archimedes.services.config_service import ConfigService
 
 
@@ -28,6 +29,14 @@ def _fake_settings() -> SimpleNamespace:
         synth_addresses={"sTSLA": "0xT", "sBTC": "0xB", "sNULL": ""},
         chain_id=5042002,
         arc_rpc_url="https://rpc.example",
+        # Two-chain endpoints (#1240), DERIVED from the single-chain values
+        # above rather than restated, so this fake cannot describe a split its
+        # own chain_id / arc_rpc_url do not support. Resolution and fallback
+        # rules are covered against real ChainSettings in
+        # backend/tests/chain/test_two_chain_config.py.
+        payments_chain=ChainEndpoint(chain_id=5042002, rpc_url="https://rpc.example", explicit=False),
+        execution_chain=ChainEndpoint(chain_id=5042002, rpc_url="https://rpc.example", explicit=False),
+        is_split_chain=False,
     )
 
 

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from archimedes.chain.client import ChainEndpoint
 from archimedes.db import get_session
 from archimedes.models.backtest_fixtures_store import FIXTURE_FIELDS, StrategyBacktestFixture
 from archimedes.services.backtest_mapper import (
@@ -140,6 +141,25 @@ _SETTINGS_NAMESPACE = SimpleNamespace(
         "sTSLA": "0xe1c9f2b11be97097223a66a188fca541e07873a6",
         "sSPY": "0xd8161a8eeab7c7100e2863abe3d5f346b5ff9e52",
     },
+)
+
+# Two-chain endpoints (#1240), DERIVED from the single-chain fields above rather
+# than restated, so this namespace can never describe a split its own chain_id /
+# arc_rpc_url do not support. The resolution and fallback rules themselves are
+# covered in backend/tests/chain/test_two_chain_config.py against real
+# ChainSettings; here they only have to be self-consistent.
+_SETTINGS_NAMESPACE.payments_chain = ChainEndpoint(
+    chain_id=_SETTINGS_NAMESPACE.chain_id,
+    rpc_url=_SETTINGS_NAMESPACE.arc_rpc_url,
+    explicit=False,
+)
+_SETTINGS_NAMESPACE.execution_chain = ChainEndpoint(
+    chain_id=_SETTINGS_NAMESPACE.chain_id,
+    rpc_url=_SETTINGS_NAMESPACE.arc_rpc_url,
+    explicit=False,
+)
+_SETTINGS_NAMESPACE.is_split_chain = (
+    _SETTINGS_NAMESPACE.payments_chain.chain_id != _SETTINGS_NAMESPACE.execution_chain.chain_id
 )
 
 
@@ -545,6 +565,81 @@ class TestConfigRoutes:
         # Pool/vault enumeration returns empty under the mocked loader.
         assert data["pools"] == {}
         assert data["vaults"] == {}
+
+    def test_contracts_serves_both_chain_blocks(self, chain_settings_client):
+        """/api/config/contracts names the payments and execution chains (#1240).
+
+        Both blocks are served unconditionally, not only once the two chains
+        differ, so a client never has to infer a missing block or fall back to
+        the legacy `chain_id` and guess which role it meant.
+
+        Fails against dropping either block from the response, against serving
+        `explicit: true` for an inherited chain, and against computing
+        `split_chain` as anything other than a comparison of the two ids.
+        """
+        mock_loader = MagicMock()
+        mock_loader.amm_router.functions.getAllPools.return_value.call = AsyncMock(return_value=[])
+        mock_loader.vault_factory.functions.getVaults.return_value.call = AsyncMock(return_value=[])
+        with patch("archimedes.chain.contracts.get_contract_loader", return_value=mock_loader):
+            resp = chain_settings_client.get("/api/config/contracts")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        for role in ("payments_chain", "execution_chain"):
+            assert role in data, f"{role} must be served unconditionally"
+            assert data[role]["chain_id"] == 5042002
+            assert data[role]["rpc_url"] == "https://rpc.testnet.arc.network"
+            # Nothing has been split yet, so neither role was chosen.
+            assert data[role]["explicit"] is False, f"{role} was inherited, not chosen"
+
+        assert data["split_chain"] is False
+        # The legacy field keeps meaning the execution chain, which is where
+        # every contract address in this response lives.
+        assert data["chain_id"] == data["execution_chain"]["chain_id"]
+
+    def test_contracts_does_not_swap_the_two_chain_blocks(self, chain_settings_client, monkeypatch):
+        """Each block must carry ITS OWN chain, proven on a genuinely split config.
+
+        The sibling test above cannot show this: today both roles resolve to the
+        same id and RPC, so `payments_chain` and `execution_chain` are identical
+        and serving one in the other's slot is invisible. Passing the same
+        literal to both sides of the boundary the bug lives on is exactly the
+        shape that makes a test pass against broken code, so this one installs
+        the post-cutover shape — payments on mainnet, execution on testnet —
+        where a swap changes the bytes.
+
+        Fails against `payments_chain=_endpoint(settings.execution_chain)` and
+        the reverse, neither of which the sibling test detects.
+        """
+        from archimedes.chain.client import chain_client as patched_client
+
+        monkeypatch.setattr(
+            patched_client.settings,
+            "payments_chain",
+            ChainEndpoint(chain_id=99999, rpc_url="https://payments.example", explicit=True),
+            raising=False,
+        )
+        monkeypatch.setattr(patched_client.settings, "is_split_chain", True, raising=False)
+
+        mock_loader = MagicMock()
+        mock_loader.amm_router.functions.getAllPools.return_value.call = AsyncMock(return_value=[])
+        mock_loader.vault_factory.functions.getVaults.return_value.call = AsyncMock(return_value=[])
+        with patch("archimedes.chain.contracts.get_contract_loader", return_value=mock_loader):
+            resp = chain_settings_client.get("/api/config/contracts")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["payments_chain"] == {
+            "chain_id": 99999,
+            "rpc_url": "https://payments.example",
+            "explicit": True,
+        }
+        assert data["execution_chain"]["chain_id"] == 5042002
+        assert data["split_chain"] is True
+        # The legacy field follows execution, so an existing client that reads
+        # it keeps talking to the chain the contract addresses are deployed on
+        # rather than silently following the payment rail to mainnet.
+        assert data["chain_id"] == 5042002
 
 
 class TestAssetRoutes:


### PR DESCRIPTION
Part of #1240. **Not** `Closes` — this is the seam, not the cutover, and the checklist item also covers the UI and the manifests.

## Why

Mainnet is payment-rail only: USDC / x402 / Gateway / PaymentSplitter go to Arc mainnet, vault and synth and AMM execution stay on testnet. The codebase has one chain everywhere, so today there is no way to say which of the two you mean. #1240 calls this the most under-estimated item on the list and I think that is right.

## What this adds

Four variables, all defaulting to the existing single-chain values:

```
ARC_PAYMENTS_CHAIN_ID    ARC_PAYMENTS_RPC_URL
ARC_EXECUTION_CHAIN_ID   ARC_EXECUTION_RPC_URL
```

`ChainSettings` resolves them into two `ChainEndpoint` records, and `/api/config/contracts` serves both blocks plus `split_chain`. Both blocks are served unconditionally rather than only once the chains differ, so a client never has to notice a missing block and fall back to guessing which role `chain_id` meant.

`ChainEndpoint.explicit` says whether a chain was chosen for its role or inherited from the single-chain settings. Comparing ids cannot answer that: deliberately pinning both roles to one chain and setting nothing at all produce identical ids.

## What does not change

An environment that sets none of the four behaves exactly as it does now, and the tests lead with that rather than treating it as a footnote.

`chain_id` and `rpc_url` keep meaning the execution chain, which is where every contract address in that response is deployed. That is what leaves the five signing call sites in `executor.py`, `trace_publisher.py` and `strategy_publisher.py` correct without touching them, and it is pinned by a test so a later change cannot quietly repoint them at the payment rail.

## Guard demonstrations

Repo rule: a guard must be shown to reject something. Seven mutations, each reverted after:

| # | Mutation | Result |
|---|---|---|
| M1 | Validator iterates nothing (guard removed) | **5 failed** |
| M2 | `explicit` hard-coded `True` | **1 failed** |
| M3 | `is_split_chain` returns `False` | **2 failed** |
| M4 | Payments falls back to `arc_rpc_url` when a payments RPC is set | **2 failed** |
| M5 | Serve `execution_chain` in the `payments_chain` slot | **1 failed** |
| M6 | Rename the field so `ARC_PAYMENTS_CHAIN_ID` stops mapping | **7 failed** |
| M7 | Remove the blank-string coercion | **3 failed** |

Two of those are worth calling out because they went wrong first.

**M1 initially passed.** My mutation was `for x in () if False else (...)`, which parses as the original tuple, so it applied textually and changed nothing. A mutation you did not actually apply is indistinguishable from a guard that works. Redone by making the loop iterate an empty tuple, after which it fails 5.

**M5 initially passed, and that one was a real gap in the test.** Both roles resolve to the same id and RPC today, so `payments_chain` and `execution_chain` were byte-identical in the fixture and swapping them was invisible. Passing the same literal to both sides of the boundary the bug lives on is the exact shape our conventions warn about. Fixed by adding `test_contracts_does_not_swap_the_two_chain_blocks`, which installs the post-cutover shape where a swap changes the bytes; M5 fails against it now.

**A third thing the targeted runs missed.** `backend/tests/chain/` and `test_api_routes.py` both passed, so I nearly pushed on that. The full `pytest -m "not integration"` from the repo root then failed 5 in `backend/tests/services/test_config_service.py`, which keeps a *second* hand-rolled settings namespace I did not know existed. Two fakes of the same object, in two files, and updating one told me nothing about the other. Both now derive the endpoints from their own `chain_id` / `arc_rpc_url` instead of restating them, so neither can claim a split its own fields do not support.

## The half-configured guard

Setting a chain id without its endpoint, or the reverse, refuses to construct and names the missing variable. The tempting alternative is to fill the missing half from the single-chain settings, which on the payments side would settle real USDC against an endpoint nobody selected while reporting a chain nobody selected. `architectural-principles.md` § fail-soft rules that out for anything a claim depends on, and money is the strongest claim we make.

## One bug found by testing the documented path

`.env.example` ships the four blank, so `cp .env.example .env` puts `ARC_PAYMENTS_CHAIN_ID=` into the environment as an empty string, and pydantic will not parse that as an `int | None`. Without the `mode="before"` coercion the backend refuses to start for anyone who follows SETUP.md, while working fine for anyone whose `.env` predates these lines. Found by actually running the copied template instead of assuming it was equivalent to unset.

## Please look at

**`.env.example` is on the ask-before-acting list.** Four blank lines and a comment block, no value changes. Flagging rather than assuming the PR counts as the ask.

## Not in scope

No routing change: nothing reads the new endpoints to decide where to send a transaction yet. No `ecs.tf` values. No UI.

The frontend half is bigger than #1240 states, and the reason is worth recording. #1240 names `ui/src/siwe.js:15` twice as the fix site, and `docs/sprint/README.md:68` corrects that to "the file has never existed" based on a working-tree grep. Git disagrees: the file existed, `7415b245` (2026-06-13) gave it `VITE_ARC_CHAIN_ID ?? '5042002'`, and `95c9faf7` (2026-07-28) deleted all 89 lines. A working-tree grep cannot tell a deleted file from a fictional one. So the seam was lost rather than never built, and today `config.js:10`, `circle-wallet.js:36`, `linked-wallets.js:13`, `api.js:16` and `AuthenticatedApp.jsx:71` all hardcode the id with no override. I will fix the doc and the UI in the follow-up.

## Verification

- `pytest -m "not integration"` from the repo root: **3896 passed, 2 skipped, 0 failed** (223s)
- `pytest backend/tests/chain/test_two_chain_config.py`: 18 passed
- `ruff format --check` and `ruff check` on every touched file: clean
