### PR TITLE
[frontend] Restore the chain-id seam the frontend lost (#1240)

### DIFF
--- a/backend/tests/test_agent_manifest_static_consistency.py
+++ b/backend/tests/test_agent_manifest_static_consistency.py
@@ -99,3 +99,89 @@ def test_the_groups_that_were_stale_are_not_still_advertised_as_pending(group: s
     status = _static_statuses()[group]
     assert "588" not in status, f"{group} still cites #588, which closed 2026-07-14"
     assert status == "live", f"{group} advertises {status!r}"
+
+
+def _static_chain_ids() -> list[int]:
+    """Every chain id the static document advertises, wherever it appears."""
+    doc = json.loads(STATIC_MANIFEST.read_text(encoding="utf-8"))
+    found: list[int] = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in ("chain_id", "chainId", "walletLinkChainId") and isinstance(value, int):
+                    found.append(value)
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(doc)
+    return found
+
+
+def test_the_static_document_advertises_the_chain_the_backend_enforces():
+    """The static file cannot read env, so it must not be free to disagree (#1240).
+
+    ``agent_manifest_routes._CHAIN_ID`` reads ``ARC_CHAIN_ID`` — as do
+    ``wallet_routes`` and ``auth_siwe`` — while ``.well-known/agent.json`` is
+    served straight off the CDN and can only ever hold a literal. The
+    achievable property is therefore not "the static file is configurable" but
+    "it cannot silently drift from the value the backend enforces", which is
+    what this pins.
+
+    A real cutover has to edit this file. That is the point: the edit becomes a
+    required, visible step instead of a discrepancy nobody notices, which is
+    exactly how the #1448 status drift survived a month.
+
+    Fails against changing ARC_CHAIN_ID's default without updating the static
+    document, and against adding a new chain-carrying field that disagrees.
+    """
+    from archimedes.api import agent_manifest_routes
+
+    advertised = _static_chain_ids()
+    assert advertised, "no chain id found in the static document — the reader is broken"
+    disagreeing = sorted({c for c in advertised if c != agent_manifest_routes._CHAIN_ID})
+    assert not disagreeing, (
+        f".well-known/agent.json advertises chain(s) {disagreeing} but the backend enforces "
+        f"{agent_manifest_routes._CHAIN_ID}. An agent reading the well-known path would link a "
+        f"wallet on the wrong chain."
+    )
+
+
+def test_the_chain_id_reader_sees_every_structured_field():
+    """Guard on the guard: a reader that found nothing would pass vacuously.
+
+    The document names a chain in two structured shapes — `walletLinkChainId`
+    at the top level and a nested `chain_id` — so a reader that only checked
+    the top level would let the nested one drift.
+    """
+    advertised = _static_chain_ids()
+    assert len(advertised) >= 2, (
+        f"only {len(advertised)} chain id(s) parsed; the document names more. "
+        "A partial reader would let a nested one drift."
+    )
+
+
+def test_the_prose_description_does_not_name_a_different_chain():
+    """The description says the chain in words, and words drift too (#1240).
+
+    `description` currently reads "... on the Arc testnet (chain ID 5042002)".
+    That is a claim an agent reads, and it is not covered by the structured
+    check above, so at a cutover it could keep naming testnet while every field
+    around it moved. Checked separately rather than folded in, because a test
+    that passed once the structured fields were fixed would leave the sentence
+    saying something false.
+    """
+    import re
+
+    from archimedes.api import agent_manifest_routes
+
+    doc = json.loads(STATIC_MANIFEST.read_text(encoding="utf-8"))
+    described = [int(m) for m in re.findall(r"chain ID (\d+)", doc.get("description", ""))]
+    assert described, "the description no longer names a chain — update or remove this guard"
+    wrong = sorted({c for c in described if c != agent_manifest_routes._CHAIN_ID})
+    assert not wrong, (
+        f"the description names chain(s) {wrong} while the backend enforces {agent_manifest_routes._CHAIN_ID}"
+    )

--- a/docs/sprint/README.md
+++ b/docs/sprint/README.md
@@ -63,12 +63,18 @@ PRs as still open. **Both were accurate when written** — the card was authored
    is now a quorum over *runnable* legs — `passes = legs_evaluated == len(_RUNNABLE_LEGS) and
    all(...)` — so a leg that could not run makes the verdict `false` rather than invisible.
    Kept here rather than deleted because cluster-8's row still points at it.
-3. **Do not trust this directory's anchors.** Follow session rule 1 without exception. Two are
-   not stale but fictional: cluster-0 records `ui/src/siwe.js:15` as a *verified* day-0 finding
-   and **that file has never existed** — `grep -rn VITE_ARC_CHAIN_ID .` matches only the card.
-   The chain id is hardcoded with no override seam in `ui/src/circle-wallet.js:36`,
-   `linked-wallets.js:13`, `api.js:16`, `AuthenticatedApp.jsx:71`, which is worse than the card
-   says. Four acceptance commands name files that do not exist (see Corrections).
+3. **Do not trust this directory's anchors.** Follow session rule 1 without exception, and
+   note that this rule's own first draft got a correction backwards. It said `ui/src/siwe.js`
+   **"has never existed"**, on the evidence that `grep -rn VITE_ARC_CHAIN_ID .` matched only
+   the card. That grep searches the working tree, where a deleted file and a fictional one look
+   identical. The file was real: `7415b245` (2026-06-13) gave it
+   `VITE_ARC_CHAIN_ID ?? '5042002'`, and `95c9faf7` (2026-07-28) deleted all 89 lines, taking
+   the seam with it. So cluster-0's anchor was accurate when written and the seam was **lost,
+   not never built** — a regression, which is a different thing to plan around than an
+   imaginary file. Verify a "never existed" claim with `git log --all --oneline -- <path>`
+   before recording it. The hardcoded ids it left behind (`config.js:10`, `circle-wallet.js:36`,
+   `linked-wallets.js:13`, `api.js:16`, `AuthenticatedApp.jsx:71`) are removed by #1240's UI
+   half. Four acceptance commands still name files that do not exist (see Corrections).
 4. **Two big items shipped by a different design than their card specifies.** #1194's quota
    rebuild closed cluster-5's headline bug without building the meter; #1266's
    `VITE_ROADMAP_SURFACES` flag closed cluster-7's nav work while *reversing* two of its
@@ -106,7 +112,8 @@ a row.
    window. Never `Read` a file whole to get oriented. **This rule overrides every line number in
    this directory.** The Aug-16 note claiming the anchors were "re-verified 6/6 fresh — trust
    them" was retired 2026-08-21: every rule-2 count had drifted and two anchors named a file
-   that has never existed.
+   no longer in the tree. (Those two named `ui/src/siwe.js`, which was deleted rather than
+   fictional — see item 3 below. The anchors were stale, which is what this rule is for.)
 2. **Never read whole** — counts at `f3d4103` (2026-08-21): `strategies_routes.py` (2621) ·
    `Architecture.jsx` (1329) · `rigor_evaluator.py` (1246) · `_rigor_helpers.py` (1176, under
    `services/`, not `api/`) · `main.py` (928) · `fusion_evaluator.py` (884).
@@ -142,7 +149,7 @@ Substantive errors only. Line drift is pervasive and rule 1 handles it.
 
 | Card | Claim | Correction |
 |---|---|---|
-| cluster-0 | `ui/src/siwe.js:15` hardcodes `5042002` / is `VITE_ARC_CHAIN_ID ?? '5042002'`, recorded as an executed result | **The file has never existed** and no override seam exists anywhere. Check 2's conclusion stands; its evidence does not |
+| cluster-0 | `ui/src/siwe.js:15` hardcodes `5042002` / is `VITE_ARC_CHAIN_ID ?? '5042002'`, recorded as an executed result | The card was right; **this table's first answer was wrong**. The file existed with that exact seam (`7415b245`) until `95c9faf7` deleted it on 2026-07-28. The working-tree grep behind "never existed" cannot see a deleted file. Seam lost, not absent — restored in `ui/src/chain-config.js` (#1240) |
 | cluster-0 | "Zero code. Bash and `gh` only." | Contradicted by the card's own two-bug-fix section, which shipped +14/−1 in PR #1239 |
 | cluster-1 | `cd analytics-engine && uv run pytest tests/test_cost_parity.py` | Never created; the analytics half went into `tests/test_costs.py:287-378`. The command cannot pass |
 | cluster-2 | `pytest backend/tests/test_fusion_evaluator.py` | Path is `backend/tests/services/test_fusion_evaluator.py` |

--- a/docs/sprint/cluster-0-unblock.md
+++ b/docs/sprint/cluster-0-unblock.md
@@ -100,6 +100,14 @@ Two follow-on facts:
 **Check 2 — no.** `contracts/foundry.toml` still has only `arc-testnet`;
 `ui/src/siwe.js:15` is `VITE_ARC_CHAIN_ID ?? '5042002'`.
 
+> **Both halves have moved since (2026-08-30).** `siwe.js` was deleted whole by `95c9faf7`
+> (2026-07-28) and its env seam went with it, leaving the chain id written as a literal in
+> five files. `README.md`'s correction table briefly recorded this file as one that "has
+> never existed"; that was a working-tree grep reading a deletion as an absence, and the
+> anchor above was accurate when written. The seam is restored in `ui/src/chain-config.js`
+> (#1240 UI half), which is now the only place the id is written. `foundry.toml` still has
+> only `arc-testnet` and remains Dan's item on #1240.
+
 **Check 4 — meter ceiling.** Funnel on 2026-08-16: landed 301, wallet_connected 35,
 generation_started 22, vault_deployed 0. Versus 2026-08-10 (282/35/22/0): **+19 landings, zero
 new wallet connections, zero new generations in six days.** `/api/marketplace/published` still

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -56,3 +56,27 @@ VITE_KNOWLEDGE_GRAPH_TAB=false
 # while the backend's own GENERATION_PAYMENT_REQUIRED is still off (the
 # quote just reports payment_required: false).
 VITE_GENERATION_QUOTE_ENABLED=true
+
+# ── Chain identity (#1240) ────────────────────────────────────────────────
+# LEAVE BLANK unless you are pointing the frontend at a different chain.
+# Blank means Arc testnet (5042002 / rpc.testnet.arc.network), which is what
+# every build does today.
+#
+# These are the frontend half of the two-chain split. The backend half is
+# ARC_PAYMENTS_* / ARC_EXECUTION_* in the repo-root .env.example. Vite inlines
+# these at BUILD time, so changing one means rebuilding, not restarting.
+#
+# VITE_ARC_CHAIN_ID is decimal digits only. The switch-chain hex is derived
+# from it, so there is nothing to keep in sync. A malformed value logs to the
+# console and falls back to testnet rather than producing NaN.
+#
+# Note: ui/public/.well-known/agent.json is served statically and cannot read
+# any of these. A real chain change has to edit that file too, and a test
+# (backend/tests/test_agent_manifest_static_consistency.py) fails if it drifts
+# from what the backend enforces.
+VITE_ARC_CHAIN_ID=
+VITE_ARC_RPC_URL=
+
+# The chain USDC settles on. Blank means "same as VITE_ARC_CHAIN_ID", which is
+# true until the Arc mainnet cutover splits the payment rail from execution.
+VITE_ARC_PAYMENTS_CHAIN_ID=

--- a/ui/src/AuthenticatedApp.jsx
+++ b/ui/src/AuthenticatedApp.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { disconnectWallet, reconnectWallet } from "./config";
+import { EXECUTION_CHAIN_ID } from "./chain-config";
 import { checkLegacyWallet, listLinkedWallets } from "./linked-wallets";
 import AccountSettings from "./components/AccountSettings";
 import CorpusExplorer from "./components/CorpusExplorer";
@@ -68,7 +69,7 @@ export default function AuthenticatedApp({
 					wallets.some(
 						(wallet) =>
 							wallet.address === result.address.toLowerCase() &&
-							wallet.chain_id === 5042002,
+							wallet.chain_id === EXECUTION_CHAIN_ID,
 					)
 				) {
 					setWalletAddr(result.address);

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -8,12 +8,13 @@
  */
 
 import { getAddress } from './config'
+import { EXECUTION_CHAIN_ID } from './chain-config'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
 function walletHeaders() {
   const address = getAddress()
-  return address ? { 'X-Wallet-Address': address, 'X-Wallet-Chain-Id': '5042002' } : {}
+  return address ? { 'X-Wallet-Address': address, 'X-Wallet-Chain-Id': String(EXECUTION_CHAIN_ID) } : {}
 }
 
 /**

--- a/ui/src/chain-config.js
+++ b/ui/src/chain-config.js
@@ -1,0 +1,102 @@
+/**
+ * Chain identity for the frontend — one place, env-overridable (#1240).
+ *
+ * The Arc mainnet cutover puts the payment rail (USDC / x402 / Gateway /
+ * PaymentSplitter) on mainnet while vault, synth, AMM and oracle execution
+ * stays on testnet. Before this module the chain id was written as the literal
+ * 5042002 in seven places plus a separately-written hex copy, so there was no
+ * single thing to change and no way to say which of the two chains a call site
+ * meant.
+ *
+ * History worth keeping, because a doc in this repo says otherwise:
+ * `ui/src/siwe.js` DID hold `VITE_ARC_CHAIN_ID ?? '5042002'` (added 7415b245,
+ * 2026-06-13). The file was deleted whole in 95c9faf7 (2026-07-28) and the seam
+ * went with it, leaving the literals behind. `docs/sprint/README.md` records
+ * this as a file that "has never existed", which is what a working-tree grep
+ * shows — it cannot distinguish a deleted file from a fictional one.
+ *
+ * Vite inlines `import.meta.env.*` at BUILD time, so these are build constants
+ * rather than runtime configuration. A wrong value is a wrong build.
+ */
+
+// Arc testnet. The safe default in every direction: it moves no real money, so
+// falling back to it can only fail closed.
+export const DEFAULT_CHAIN_ID = 5042002
+export const DEFAULT_RPC_URL = 'https://rpc.testnet.arc.network'
+
+/**
+ * Parse a chain id from an environment string.
+ *
+ * Returns `fallback` for unset, blank, or malformed input, and reports the
+ * malformed case on the console rather than swallowing it. Falling back is the
+ * right call ONLY because the fallback is testnet: a build that meant to reach
+ * mainnet and instead reaches testnet fails to move money, while the reverse
+ * would move it somewhere nobody chose. If the default here ever becomes a
+ * mainnet id, this function must throw instead of falling back.
+ */
+export function resolveChainId(raw, fallback = DEFAULT_CHAIN_ID) {
+  if (raw === undefined || raw === null) return fallback
+  const text = String(raw).trim()
+  if (text === '') return fallback
+  // Number() would accept '0x4cef52', ' 12 ', '1e3' and '' — all of which are
+  // either the wrong notation for this variable or silently not what was
+  // written. Require plain decimal digits.
+  if (!/^\d+$/.test(text)) {
+    console.error(
+      `[chain-config] ignoring malformed chain id ${JSON.stringify(raw)}; ` +
+        `expected decimal digits. Falling back to ${fallback}.`,
+    )
+    return fallback
+  }
+  const parsed = Number(text)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    console.error(`[chain-config] chain id ${text} is out of range. Falling back to ${fallback}.`)
+    return fallback
+  }
+  return parsed
+}
+
+/**
+ * EIP-155 hex form, as `wallet_switchEthereumChain` wants it.
+ *
+ * Derived rather than written down. The previous code carried '0x4cef52' as its
+ * own literal next to the decimal one, so changing the id would have left the
+ * switch-chain call pointing at the old network with nothing to catch it.
+ */
+export function chainIdToHex(id) {
+  return `0x${Number(id).toString(16)}`
+}
+
+function envValue(key) {
+  // `import.meta.env` is undefined outside a Vite build (node --test), which is
+  // the same thing as unset.
+  return import.meta.env?.[key]
+}
+
+/** The chain vaults, synths, AMM and oracles live on — and every contract address. */
+export const EXECUTION_CHAIN_ID = resolveChainId(envValue('VITE_ARC_CHAIN_ID'))
+export const EXECUTION_CHAIN_HEX = chainIdToHex(EXECUTION_CHAIN_ID)
+export const EXECUTION_RPC_URL = envValue('VITE_ARC_RPC_URL') || DEFAULT_RPC_URL
+
+/**
+ * The chain USDC settles on. Defaults to the execution chain, so a build that
+ * sets nothing behaves exactly as it does now.
+ */
+export const PAYMENTS_CHAIN_ID = resolveChainId(envValue('VITE_ARC_PAYMENTS_CHAIN_ID'), EXECUTION_CHAIN_ID)
+
+/**
+ * True when payments and execution are different chains.
+ *
+ * The browser wallet flow turns on this: one chain needs no switching, two do.
+ * Nothing consumes it yet — the wallet UX for a split is deliberately out of
+ * scope here and #1240 argues for launching API-first precisely to avoid it.
+ */
+export const IS_SPLIT_CHAIN = PAYMENTS_CHAIN_ID !== EXECUTION_CHAIN_ID
+
+/** viem chain object for the execution chain. Shared so the EOA and passkey paths cannot drift. */
+export const arcExecutionChain = {
+  id: EXECUTION_CHAIN_ID,
+  name: 'Arc Testnet',
+  nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 18 },
+  rpcUrls: { default: { http: [EXECUTION_RPC_URL] } },
+}

--- a/ui/src/circle-wallet.js
+++ b/ui/src/circle-wallet.js
@@ -17,6 +17,7 @@
 // Setup: ui/.env.example documents VITE_CIRCLE_CLIENT_KEY + VITE_CIRCLE_CLIENT_URL.
 
 import { createPublicClient } from 'viem'
+import { EXECUTION_CHAIN_ID } from './chain-config'
 import { toWebAuthnAccount } from 'viem/account-abstraction'
 import {
   toWebAuthnCredential,
@@ -33,7 +34,7 @@ const CLIENT_URL = import.meta.env.VITE_CIRCLE_CLIENT_URL
 // Arc Testnet chain definition; matches the EOA-path chain in config.js so
 // any downstream code that introspects .chain sees the same object shape.
 const arcTestnet = {
-  id: 5042002,
+  id: EXECUTION_CHAIN_ID,
   name: 'Arc Testnet',
   nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 18 },
   rpcUrls: { default: { http: ['https://rpc.testnet.arc.network'] } },

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,4 +1,5 @@
 import { createPublicClient, createWalletClient, custom, http } from 'viem'
+import { arcExecutionChain, EXECUTION_CHAIN_HEX } from './chain-config'
 import {
   connectCirclePasskey,
   clearCircleSession,
@@ -6,12 +7,9 @@ import {
   rehydrateSmartAccount,
 } from './circle-wallet'
 
-const arcTestnet = {
-  id: 5042002,
-  name: 'Arc Testnet',
-  nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 18 },
-  rpcUrls: { default: { http: ['https://rpc.testnet.arc.network'] } },
-}
+// Chain identity lives in chain-config.js so the EOA path, the passkey path
+// and the switch-chain hex cannot drift apart (#1240).
+const arcTestnet = arcExecutionChain
 
 export const publicClient = createPublicClient({
   chain: arcTestnet,
@@ -377,7 +375,8 @@ export async function reconnectWallet() {
   }
 }
 
-const ARC_CHAIN_HEX = '0x4cef52'  // 5042002
+// Derived from the chain id, never written twice — see chain-config.js.
+const ARC_CHAIN_HEX = EXECUTION_CHAIN_HEX
 
 // MetaMask returns -32002 when a wallet_requestPermissions / eth_requestAccounts
 // is already pending — usually because the user dismissed the popup without

--- a/ui/src/linked-wallets.js
+++ b/ui/src/linked-wallets.js
@@ -1,5 +1,6 @@
 import { apiDelete, apiGet, apiPost } from './api'
 import { CIRCLE_PROVIDER_ID, signSiweMessage } from './config'
+import { EXECUTION_CHAIN_ID } from './chain-config'
 
 const providerName = (provider) => {
   if (provider === CIRCLE_PROVIDER_ID) return 'circle'
@@ -10,7 +11,7 @@ const providerName = (provider) => {
 export async function linkConnectedWallet({ address, provider }) {
   const challenge = await apiPost('/api/wallets/challenge', {
     address,
-    chain_id: 5042002,
+    chain_id: EXECUTION_CHAIN_ID,
     provider: providerName(provider),
   })
   const signature = await signSiweMessage(challenge.message)

--- a/ui/src/payment-session.js
+++ b/ui/src/payment-session.js
@@ -40,6 +40,7 @@
 
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { apiPost } from "./api";
+import { EXECUTION_CHAIN_ID } from "./chain-config";
 import { listLinkedWallets } from "./linked-wallets";
 
 const STORAGE_PREFIX = "archimedes_payment_key:";
@@ -92,7 +93,7 @@ export async function ensureSessionLinked(account) {
 	}
 	const challenge = await apiPost("/api/wallets/challenge", {
 		address: account.address,
-		chain_id: 5042002,
+		chain_id: EXECUTION_CHAIN_ID,
 		provider: "headless",
 	});
 	const signature = await account.signMessage({ message: challenge.message });

--- a/ui/test/chain-config.test.js
+++ b/ui/test/chain-config.test.js
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+	DEFAULT_CHAIN_ID,
+	chainIdToHex,
+	resolveChainId,
+} from "../src/chain-config.js";
+
+// #1240 — the frontend must stop writing the chain id as a literal, so the Arc
+// mainnet cutover is a build-time variable rather than a seven-file edit.
+//
+// This seam existed once: ui/src/siwe.js held `VITE_ARC_CHAIN_ID ?? '5042002'`
+// from 7415b245 (2026-06-13) until 95c9faf7 (2026-07-28) deleted the file and
+// the seam with it. The literals it left behind are what this module removes,
+// and the scan at the bottom is what stops them coming back.
+
+const SRC = new URL("../src/", import.meta.url).pathname;
+
+function sourceFiles(dir) {
+	const out = [];
+	for (const entry of readdirSync(dir)) {
+		const full = path.join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			out.push(...sourceFiles(full));
+		} else if (/\.(js|jsx)$/.test(entry)) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+/** Strip comments so a documentary mention of the id is not read as a hardcode. */
+function stripComments(source) {
+	return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+test("an unset environment resolves to the Arc testnet default", () => {
+	assert.equal(resolveChainId(undefined), DEFAULT_CHAIN_ID);
+	assert.equal(resolveChainId(null), DEFAULT_CHAIN_ID);
+	assert.equal(DEFAULT_CHAIN_ID, 5042002);
+});
+
+test("a blank or whitespace value is the same as unset", () => {
+	// `.env` files ship variables blank, so this is the copied-template case,
+	// not a hypothetical. Fails against a bare Number() coercion, which turns
+	// "" into 0 and would hand every caller chain 0.
+	assert.equal(resolveChainId(""), DEFAULT_CHAIN_ID);
+	assert.equal(resolveChainId("   "), DEFAULT_CHAIN_ID);
+});
+
+test("an unset or blank value resolves silently, without console noise", () => {
+	// `.env` ships these variables blank, so blank is the NORMAL case, not an
+	// error one. Reaching the malformed-value branch would log to console.error
+	// on every page load of an ordinary build. Fails against removing the
+	// `text === ""` early return, which is otherwise behaviourally invisible
+	// because the regex below also rejects "".
+	const original = console.error;
+	const calls = [];
+	console.error = (...args) => calls.push(args);
+	try {
+		resolveChainId("");
+		resolveChainId("   ");
+		resolveChainId(undefined);
+	} finally {
+		console.error = original;
+	}
+	assert.deepEqual(calls, [], "a blank value is unset, not malformed");
+});
+
+test("a malformed value is reported, not swallowed", () => {
+	// The other half: a value someone actually typed wrong must be visible.
+	const original = console.error;
+	const calls = [];
+	console.error = (...args) => calls.push(args);
+	try {
+		resolveChainId("mainnet");
+	} finally {
+		console.error = original;
+	}
+	assert.equal(calls.length, 1, "a malformed chain id must reach the console");
+	assert.match(String(calls[0][0]), /malformed chain id/);
+});
+
+test("a real value is read, as a number", () => {
+	assert.equal(resolveChainId("31337"), 31337);
+	assert.equal(resolveChainId(" 42 "), 42);
+	assert.equal(resolveChainId(1), 1);
+});
+
+test("a malformed value falls back rather than producing NaN", () => {
+	// Fails against `Number(raw)`, which yields NaN here and would silently
+	// give every downstream call a chain id that equals nothing, including
+	// itself. Falling back is safe ONLY because the default is testnet.
+	assert.equal(resolveChainId("mainnet"), DEFAULT_CHAIN_ID);
+	assert.equal(resolveChainId("12abc"), DEFAULT_CHAIN_ID);
+	assert.equal(resolveChainId("-1"), DEFAULT_CHAIN_ID);
+	assert.equal(resolveChainId("1e3"), DEFAULT_CHAIN_ID);
+});
+
+test("hex notation is refused rather than half-accepted", () => {
+	// Number('0x4cef52') is 5042002, so a bare Number() would accept hex here
+	// and quietly work — until someone writes '0x1' meaning chain 1 and gets
+	// it, or writes a decimal elsewhere and the two notations diverge. One
+	// notation, enforced.
+	assert.equal(resolveChainId("0x4cef52"), DEFAULT_CHAIN_ID);
+});
+
+test("an explicit fallback is honoured, so payments can default to execution", () => {
+	// This is how PAYMENTS_CHAIN_ID defaults to EXECUTION_CHAIN_ID.
+	assert.equal(resolveChainId(undefined, 31337), 31337);
+	assert.equal(resolveChainId("", 31337), 31337);
+	assert.equal(resolveChainId("999", 31337), 999);
+});
+
+test("the switch-chain hex is derived from the id", () => {
+	// The old code carried '0x4cef52' as its own literal beside the decimal
+	// one. Fails against reintroducing a written hex constant, because this
+	// asserts the derivation for ids that are not Arc's.
+	assert.equal(chainIdToHex(5042002), "0x4cef52");
+	assert.equal(chainIdToHex(1), "0x1");
+	assert.equal(chainIdToHex(31337), "0x7a69");
+});
+
+test("no source file outside chain-config.js writes the chain id as a literal", () => {
+	// The regression guard. Every one of these was a literal before #1240:
+	// config.js (twice, decimal and hex), circle-wallet.js, linked-wallets.js,
+	// payment-session.js, api.js, AuthenticatedApp.jsx.
+	const offenders = [];
+	for (const file of sourceFiles(SRC)) {
+		if (file.endsWith("chain-config.js")) continue;
+		const code = stripComments(readFileSync(file, "utf8"));
+		if (/\b5042002\b/.test(code) || /0x4cef52/i.test(code)) {
+			offenders.push(path.relative(SRC, file));
+		}
+	}
+	assert.deepEqual(
+		offenders,
+		[],
+		`these files hardcode the chain id instead of importing it from chain-config.js: ${offenders.join(", ")}`,
+	);
+});
+
+test("chain-config.js holds exactly one decimal default", () => {
+	// Anti-vacuity for the scan above: if the SSOT itself stopped carrying the
+	// value, the scan would pass while nothing defined the chain at all.
+	const source = stripComments(readFileSync(path.join(SRC, "chain-config.js"), "utf8"));
+	const matches = source.match(/\b5042002\b/g) ?? [];
+	assert.equal(matches.length, 1, "the default belongs in exactly one place");
+});


### PR DESCRIPTION
Part of #1240, the UI half. Independent of #1530 (the backend half) — branched off `main`, consumes nothing from it, mergeable in either order.

## Why

The chain id was written as the literal `5042002` in six places, plus a separately-written `'0x4cef52'` for the wallet switch-chain call. Nothing to change for the cutover, and two notations of one fact that could drift apart silently.

## This is a restoration, and that matters for how you read #1240

`ui/src/siwe.js` held `VITE_ARC_CHAIN_ID ?? '5042002'` from `7415b245` (2026-06-13) until `95c9faf7` (2026-07-28) deleted the file whole. The seam went with it; its callers kept their literals.

`docs/sprint/README.md:68` records that file as one that **"has never existed"**, on the evidence of `grep -rn VITE_ARC_CHAIN_ID .`. That grep reads the working tree, where a deleted file and a fictional one look identical. `git log --all --oneline -- ui/src/siwe.js` settles it in one command. The card's anchor was accurate when written, and a lost seam is a different thing to plan around than an imaginary one. Corrected in three places in `README.md` plus the cluster-0 card.

## What changed

`ui/src/chain-config.js` is the only place the id is written now. The hex is **derived** from it. The viem chain object is shared, so `config.js` (EOA) and `circle-wallet.js` (passkey) cannot describe different chains.

Repointed: `config.js` (×2), `circle-wallet.js`, `linked-wallets.js`, `payment-session.js`, `api.js`, `AuthenticatedApp.jsx`.

`resolveChainId` takes decimal digits only. `Number()` would have accepted `'0x4cef52'` (wrong notation for this variable), `'1e3'` (not the number anyone wrote) and `''` (what a blank `.env` line produces, silently becoming chain 0). Malformed input logs and falls back — acceptable **only** because the fallback is testnet. A build that meant mainnet and lands on testnet fails to move money; the reverse moves it somewhere nobody chose. If that default ever becomes a mainnet id the function has to throw instead, and the comment says so.

## Proof the seam actually works

Source review does not show that Vite wired it up, so I checked the artifact:

```
$ VITE_ARC_CHAIN_ID=31337 npm run build
$ grep -o '.\{70\}31337.\{50\}' dist/assets/ErrorBoundary-*.js
...VITE_ARC_CHAIN_ID:`31337`}[e]}var vp=hp(_p(`VITE_ARC_CHAIN_ID`)),yp=gp(vp)
```

`5042002` survives in the bundle only as the fallback default (`var mp=5042002`), which is correct.

## The manifest, stated honestly

`ui/public/.well-known/agent.json` is served straight off the CDN and **cannot read an env var**, so it keeps its literal. Pretending otherwise would be the fake-seam version of this change.

What it should not do is disagree in silence. The existing static-vs-served consistency guard now also compares every chain id the document advertises against what the backend enforces — including the one written in **prose** in its `description`, which no structured check would catch. A cutover has to edit that file, and now it fails loudly if someone forgets. That is the same failure mode that let the #1448 status drift survive a month.

## Guard demonstrations

Ten mutations, each reverted after:

| # | Mutation | Result |
|---|---|---|
| U1 | Put a `'5042002'` literal back in `api.js` | **fails** the source scan |
| U2 | Drop the decimal-digits check | **fails** malformed-value |
| U3 | Write the hex as a literal again | **fails** hex-is-derived |
| U4 | Change `DEFAULT_CHAIN_ID` | **fails** 2 (default + SSOT-count) |
| U5 | Remove the blank early-return | **fails** console-noise |
| U6 | Drop the malformed `console.error` | **fails** malformed-is-reported |
| U7 | Drift the manifest's nested `chain_id` | **fails** manifest agreement |
| U8 | Drift `walletLinkChainId` | **fails** manifest agreement |
| U9 | Drift **only** the prose description | **fails** prose check |
| U10 | Neuter the manifest chain-id reader | **fails** 2 (anti-vacuity) |

**U5 first reported no failures, and that was the correct result.** Removing the blank early-return changes no behaviour my assertions covered, because blank also falls through the regex. But it does differ: `.env` ships these blank, so every ordinary build would log an error on each page load. Rather than record it as guarded, I added a test asserting a normal build logs nothing — after which it fails as it should.

## Please look at

**`ui/.env.example`** — three blank variables and a comment block, no value changes. Env contracts are on the ask-before-acting list, so I am flagging rather than assuming.

## Not in scope

No wallet UX for an actual split (`IS_SPLIT_CHAIN` is exported and unconsumed — #1240 argues for launching API-first precisely to avoid that flow). No consumption of #1530's `payments_chain` / `execution_chain` blocks. `flow-diagram.svg` still carries the id as a cosmetic label.

## Verification

- `npm test`: **420 passed, 0 failed** (11 new)
- `pytest -m "not integration"` from the repo root: **3879 passed, 2 skipped, 0 failed**
- `npm run lint`, `npm run build`, `ruff format --check backend/`: clean
- `make docs-check`: 0 broken links, 0 orphaned
