### PR TITLE
[generation] User-facing stream copy: strip internal jargon from pipeline_selected

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -88,7 +88,13 @@ def _pick_pipeline(
     """
     if mode_override and mode_override != "debate":
         logger.info("generation: ignoring legacy mode override %r (debate-only cutover)", mode_override)
-    return "debate", "debate society is the generation pipeline (T1.1 Phase-3 cutover)"
+    # This reason string is USER-FACING: it rides the SSE stream verbatim
+    # (run_generation's `pipeline_selected` emit) and GenerationStream.jsx
+    # renders it into every viewer's event log. Internal shorthand ("T1.1
+    # Phase-3 cutover") leaked to production screens this way (#1525-era
+    # review, 2026-08-30) — keep it plain product copy, and keep the
+    # no-internal-jargon regression test in test_generation_pipeline.py green.
+    return "debate", "the debate society — proposer and critic agents argue each candidate before the rigor gate"
 
 
 # ── Brief validation (real LLM step on the live path) ─────────────────────

--- a/backend/tests/services/test_generation_pipeline.py
+++ b/backend/tests/services/test_generation_pipeline.py
@@ -321,7 +321,25 @@ def test_pick_pipeline_always_debate_after_cutover(monkeypatch):
     for override in (None, "fusion", "architect", "agent", "debate"):
         name, reason = gp._pick_pipeline(mode_override=override)
         assert name == "debate", f"override {override!r} routed off the society (got {name!r})"
-        assert "debate" in reason.lower() or "Phase-3" in reason
+        assert "debate" in reason.lower()
+
+
+def test_pick_pipeline_reason_is_user_copy_not_internal_jargon():
+    """The reason string is USER-FACING: run_generation emits it verbatim on the
+    SSE stream (`pipeline_selected`) and GenerationStream.jsx renders it into
+    every viewer's event log. Internal planning shorthand ("T1.1 Phase-3
+    cutover") shipped to production screens through exactly this pipe
+    (found in owner review, 2026-08-30). Guard: no issue-tracker numbering,
+    no cutover/phase/sprint/roadmap vocabulary, ever."""
+    import re
+
+    from archimedes.agents import generation_pipeline as gp
+
+    jargon = re.compile(r"T\d\.\d|cutover|Phase-|phase-\d|sprint|roadmap|TODO", re.IGNORECASE)
+    for override in (None, "fusion", "architect", "agent", "debate"):
+        _, reason = gp._pick_pipeline(mode_override=override)
+        hit = jargon.search(reason)
+        assert hit is None, f"internal jargon {hit.group(0)!r} in user-facing reason: {reason!r}"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -466,7 +466,11 @@ def test_pick_pipeline_is_debate_unconditionally(monkeypatch):
     for override in (None, "fusion", "architect", "agent", "debate"):
         name, reason = _pick_pipeline(mode_override=override)
         assert name == "debate", f"override {override!r} must not route off the society"
-        assert "Phase-3" in reason
+        # The reason string is user-facing SSE copy — it must describe the
+        # debate society in product language, never internal planning
+        # shorthand ("T1.1 Phase-3 cutover" shipped to prod screens; see
+        # test_generation_pipeline.py's no-internal-jargon guard).
+        assert "debate" in reason.lower()
 
 
 # ── Test 9 — cited-paper union non-empty; transcript fixed role order ─────────


### PR DESCRIPTION
The generation stream showed every user `debate — debate society is the generation pipeline (T1.1 Phase-3 cutover)` — a hardcoded internal changelog string piped verbatim from `_pick_pipeline()` through the SSE `pipeline_selected` event into the visible event log. One-line copy fix + a guard test banning issue-tracker numbering (`T\d.\d`) and planning vocabulary (cutover/Phase-/sprint/roadmap/TODO) from the reason string, with the adversarial demonstration in the commit body (the guard names 'T1.1' when run against the old string). Also tightened the existing test which explicitly ACCEPTED 'Phase-3' as valid reason copy.

Part of tonight's approved v8 Lane 1; diagnosis receipts in the session's stream-leak investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7