### PR TITLE
[frontend] Show the whole curated library — passing examples were hidden by default pagination

### DIFF
--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -701,7 +701,11 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
       // Published is a hidden roadmap surface (#1266/#1324) — its fetch must
       // not fire with the flag off, not just its tab stay unclickable.
       const [seedRes, genRes, gateRes, publishedRes] = await Promise.allSettled([
-        apiGet('/api/strategies/'),
+        // limit=100 (the backend's max): the endpoint defaults to 20 of the
+        // 34-strategy curated library, alphabetically — which structurally hid
+        // every currently-passing strategy (all sort past row 20). Found in
+        // the 2026-08-30 external product review ("0 of 20 examples pass").
+        apiGet('/api/strategies/?limit=100'),
         apiGet('/api/strategies/generated'),
         apiGet('/api/selection-bias/gate'),
         ROADMAP_SURFACES_ENABLED ? apiGet('/api/marketplace/my-published') : Promise.resolve([]),

--- a/ui/test/fail-soft.test.js
+++ b/ui/test/fail-soft.test.js
@@ -212,3 +212,12 @@ test("Leaderboard.jsx's degraded banner offers a Retry, matching the PR body's r
 	const degradedBannerRetry = /Board data is degraded\.<\/strong>\{' '\}\s*\{data\.degraded_reason[^}]*\}\{' '\}\s*<button type="button"[^>]*onClick=\{load\}/;
 	assert.match(leaderboard, degradedBannerRetry);
 });
+
+test("Strategies.jsx requests the whole curated library, not the default page", () => {
+	// The endpoint defaults to limit=20 of a 34-strategy library, sorted
+	// alphabetically — which structurally hid every currently-passing example
+	// (all sort past row 20; 2026-08-30 external review: "0 of 20 pass").
+	// The library fetch must always carry an explicit limit at the backend's
+	// max so the passing strategies are actually visible.
+	assert.match(strategies, /apiGet\(['"]\/api\/strategies\/\?limit=100['"]\)/);
+});


### PR DESCRIPTION
Verified live tonight: `/api/strategies/` returns 20 of 34 by default (alphabetical), and every strategy currently passing the rigor gate sorts past row 20 — so the public example library showed only non-passing results. One-line fetch fix + a source guard with its adversarial demonstration in the commit body. Backend default left untouched (other callers may rely on it); the frontend now asks for what it actually renders.

v8 Lane 1.5 (approved tonight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7