### PR TITLE
[payments] Double-charge fix: attempt-scoped idempotency + straight into the stream on success

### DIFF
--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import GenerationStream from "./GenerationStream";
 import GenerationStatus from "./GenerationStatus";
 import ModelCostPanel from "./ModelCostPanel";
@@ -307,21 +307,46 @@ export default function Generate({ onNavigate, onStageChange }) {
 		...(selectedModel ? { model: selectedModel } : {}),
 	});
 
+	// One idempotency key per payment ATTEMPT, reused across every /start call
+	// inside that attempt (the bare 402 probe, the signed retry, and any user
+	// re-click after an ambiguous failure) and regenerated only after a job is
+	// actually accepted. The backend's generation-credit ledger (#1498) dedups
+	// duplicate charges ONLY when this header is present — the 2026-08-30
+	// external review paid twice precisely because the frontend never sent it:
+	// each re-click signed a fresh EIP-3009 nonce, which settles as a brand-new
+	// payment (generation_credit.py's own docstring calls this out).
+	const paymentAttemptKeyRef = useRef(null);
+	const paymentAttemptKey = () => {
+		if (!paymentAttemptKeyRef.current) {
+			paymentAttemptKeyRef.current = crypto.randomUUID();
+		}
+		return paymentAttemptKeyRef.current;
+	};
+
 	// POST /start, optionally with a Payment-Signature header, and surface
 	// whatever the response carries (job id + PAYMENT-RESPONSE if present).
 	// Returns the receipt too (not just via the `receipt` state setter) so a
 	// caller mid-async-flow (handlePay) can branch on it immediately rather
 	// than reading stale state before the next render.
 	const submitStart = async (extraHeaders) => {
-		const { data, headers } = await apiPostWithMeta(
-			"/api/generate/start",
-			buildBrief(),
-			extraHeaders,
-		);
+		const { data, headers } = await apiPostWithMeta("/api/generate/start", buildBrief(), {
+			"Idempotency-Key": paymentAttemptKey(),
+			...extraHeaders,
+		});
 		setLastJobId(data.job_id);
 		const settledReceipt = extractReceipt(headers);
 		setReceipt(settledReceipt);
 		return { data, receipt: settledReceipt };
+	};
+
+	// A job was ACCEPTED (202): consume the attempt key so the next generation
+	// is a genuinely new attempt, and take the user straight into the running
+	// job's stream. Before this, a successful payment quietly re-armed the
+	// "Approve & Generate" button beside a small receipt line — which reads
+	// exactly like a failed payment, and is how the double-pay happened.
+	const enterStartedJob = (data) => {
+		paymentAttemptKeyRef.current = null;
+		if (data?.job_id) setDrillInJobId(data.job_id);
 	};
 
 	// Reset every payment-step-local piece of state — shared by a fresh
@@ -353,11 +378,14 @@ export default function Generate({ onNavigate, onStageChange }) {
 		resetPaymentStepState();
 		setReceipt(null);
 		try {
-			await submitStart();
+			const { data } = await submitStart();
 			// Re-quote for the next generation — flat pricing has nothing to
 			// consume, but the flag/dry_run/recipient could change underneath.
 			if (GENERATION_QUOTE_ENABLED) fetchQuote();
-			// Stay on the page — the job table will show the new row.
+			// Straight into the running job's stream — "stay on the page and
+			// find the new table row" read as a failed start (2026-08-30
+			// external review), and the stream IS the product moment.
+			enterStartedJob(data);
 		} catch (e) {
 			const dryRun = e?.detail?.quote?.dry_run ?? quote?.dry_run;
 			const state = derivePaymentState(e, dryRun);
@@ -444,10 +472,11 @@ export default function Generate({ onNavigate, onStageChange }) {
 
 	const finishStart = async (header) => {
 		setPayStep("starting");
-		const { receipt: settledReceipt } = await submitStart({ "Payment-Signature": header });
+		const { data, receipt: settledReceipt } = await submitStart({ "Payment-Signature": header });
 		resetPaymentStepState();
 		setNoSettlementNotice(!settledReceipt);
 		if (GENERATION_QUOTE_ENABLED) fetchQuote();
+		enterStartedJob(data);
 	};
 
 	// ── One tap when funded: the signing ceremony runs FIRST, inside the
@@ -495,7 +524,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 					payerAddress: session.address,
 				});
 				setPayStep("starting");
-				const { receipt: settledReceipt } = await submitStart({
+				const { data, receipt: settledReceipt } = await submitStart({
 					"Payment-Signature": header,
 					// The paywall binds authorization.from to a LINKED wallet
 					// resolved from this header — it must name the payment
@@ -505,6 +534,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 				resetPaymentStepState();
 				setNoSettlementNotice(!settledReceipt);
 				if (GENERATION_QUOTE_ENABLED) fetchQuote();
+				enterStartedJob(data);
 				return;
 			}
 

--- a/ui/test/payment-idempotency.test.js
+++ b/ui/test/payment-idempotency.test.js
@@ -1,0 +1,50 @@
+// Guards for the double-charge fix (2026-08-30 external review: a successful
+// $2 payment showed a receipt, quietly re-armed "Approve & Generate", and the
+// reviewer — reading that as failure — paid again; the second click signed a
+// fresh EIP-3009 nonce, which settles as a brand-new payment).
+//
+// Two independent halves, both source-asserted here:
+//   1. Every /api/generate/start call carries an Idempotency-Key scoped to the
+//      payment ATTEMPT — that header is what engages the backend credit
+//      ledger's dedup (#1498); without it the ledger issues a fresh credit per
+//      click by design (NULLs don't collide under the UNIQUE constraint).
+//   2. An accepted job (202) takes the user INTO the running job's stream
+//      (setDrillInJobId) instead of leaving the armed submit button beside a
+//      one-line receipt.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const generate = readFileSync(
+	new URL("../src/components/Generate.jsx", import.meta.url),
+	"utf8",
+);
+
+test("every /start call carries the attempt-scoped Idempotency-Key", () => {
+	// The header is merged inside submitStart itself, so no caller (bare
+	// probe, signed retry, passkey branch) can forget it.
+	assert.match(
+		generate,
+		/apiPostWithMeta\("\/api\/generate\/start", buildBrief\(\), \{\s*"Idempotency-Key": paymentAttemptKey\(\),\s*\.\.\.extraHeaders,\s*\}\)/,
+	);
+});
+
+test("the attempt key is reused until a job is accepted, then regenerated", () => {
+	// Created lazily once per attempt…
+	assert.match(generate, /paymentAttemptKeyRef\.current = crypto\.randomUUID\(\)/);
+	// …and consumed only on acceptance, inside the shared success helper.
+	assert.match(
+		generate,
+		/const enterStartedJob = \(data\) => \{\s*paymentAttemptKeyRef\.current = null;\s*if \(data\?\.job_id\) setDrillInJobId\(data\.job_id\);/,
+	);
+});
+
+test("every success path enters the started job's stream", () => {
+	// finishStart (EOA path), the passkey branch, and the free/dry-run
+	// startJob path must all end in enterStartedJob — count the call sites.
+	const calls = generate.match(/enterStartedJob\(data\)/g) ?? [];
+	assert.ok(
+		calls.length >= 3,
+		`expected >=3 enterStartedJob(data) call sites (EOA, passkey, free path), found ${calls.length}`,
+	);
+});


### PR DESCRIPTION
Both verified halves of the external reviewer's double-pay: the frontend never sent the `Idempotency-Key` the #1498 ledger dedups on (zero matches in ui/src — every re-click was a genuinely new EIP-3009 payment), and the post-success UI re-armed the pay button beside a small receipt, reading exactly like failure. Now: one attempt key per payment attempt merged inside `submitStart` itself (no caller can forget it), consumed on 202; every success path drops the user into the running job's stream. Three source guards with the adversarial demonstration in the commit body.

v8 Lane 1.2 (approved tonight). Diagnosis receipts: the session's double-charge verification (file:line chain from `resetPaymentStepState` through `claim_credit`'s NULL-key branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7