### PR TITLE
[payments] Validate briefs before settlement — gibberish is never charged

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -172,14 +172,56 @@ def _invalid_brief_message(reason: object) -> str:
 # fine — the LLM validator still catches it, post-payment, exactly as
 # before. A false POSITIVE (flagging a genuine brief) is not — it would
 # block a paying user before they're even offered the chance to pay. So this
-# only rejects the unambiguous cases: empty, too short, or built entirely
-# from tokens that match neither everyday English nor investing vocabulary
-# and aren't plausible tickers. Semantic judgment calls (off-topic-but-
-# grammatical text like "add flour and bake at 350F", jailbreak attempts)
-# are deliberately left to the expensive LLM step — that outcome legitimately
-# consumes work, so it stays a credit spend, not a pre-payment refusal.
+# only rejects the unambiguous cases: empty, too short, letter-free, or
+# containing a token that is *physically* keyboard-mash-shaped (see
+# ``_looks_like_mash``). Note what that deliberately does NOT include:
+# unfamiliar vocabulary. "SPY covered calls", "muni ladder" and
+# "estrategia de baja volatilidad" all match nothing in the word lists
+# below and must all pass — an unknown word is the normal case, not a
+# junk signal. Semantic judgment calls (off-topic-but-grammatical text like
+# "add flour and bake at 350F", jailbreak attempts) are likewise left to the
+# expensive LLM step — that outcome legitimately consumes work, so it stays a
+# credit spend, not a pre-payment refusal.
 _MIN_INTENT_CHARS = 3
-_MIN_GIBBERISH_TOKENS = 2  # ≥2 unrecognized tokens before calling it junk
+_MIN_GIBBERISH_TOKENS = 2  # ≥2 tokens before any mash token counts as junk
+
+_VOWELS = frozenset("aeiouy")
+
+# Straight runs across a keyboard row, forwards and backwards, are a
+# fingerprint of mashing rather than typing ("asdf", "lkjh", "qwer", "poiu").
+# No English word contains one; checked as 4-char windows.
+_KEYBOARD_ROWS = ("qwertyuiop", "asdfghjkl", "zxcvbnm")
+_KEYBOARD_RUNS = frozenset(
+    row[i : i + 4] for base in _KEYBOARD_ROWS for row in (base, base[::-1]) for i in range(len(row) - 3)
+)
+
+
+def _looks_like_mash(token: str) -> bool:
+    """Is this lowercased token *shaped* like keyboard mash?
+
+    Structural only — this asks whether the letters could plausibly have been
+    typed as a word, never whether the word is one we happen to know. A brief
+    is full of words no list here contains ("muni", "ladder", "covered"), so
+    unfamiliarity carries no signal at all.
+
+    Non-ASCII tokens always return False. A Cyrillic, Greek or CJK brief has
+    no vowel/consonant structure this test can read, and mis-reading one as
+    mash would refuse a legitimate non-English user before they can even pay;
+    those defer to the LLM validator, exactly like off-topic English does.
+    """
+    if not token.isascii():
+        return False
+    if not any(ch in _VOWELS for ch in token):
+        return True  # "zxcvbnm", "qwrtp" — no vowel, not pronounceable
+    run = 0
+    for ch in token:
+        run = 0 if ch in _VOWELS else run + 1
+        if run >= 5:
+            return True  # "lkjhgfdsa" — 5+ consonants with no break
+    if any(a == b == c for a, b, c in zip(token, token[1:], token[2:], strict=False)):
+        return True  # "aaargh", "jjjj"
+    return any(token[i : i + 4] in _KEYBOARD_RUNS for i in range(len(token) - 3))
+
 
 # Ordinary English function/content words. Their presence means the text is
 # at least grammatical, even if off-topic — off-topic is the LLM's job, not
@@ -217,8 +259,12 @@ def cheap_brief_reject(brief: GenerateBrief) -> dict[str, str] | None:
     content, jailbreak attempts, semantic coherence). Returns a
     ``{"reason", "hint"}`` dict, shaped exactly like the LLM validator's
     invalid-brief output, when the brief is unambiguously invalid: empty,
-    too short, or built entirely from tokens that match neither everyday
-    English nor investing vocabulary and are not plausible tickers.
+    too short, containing no letters at all, or containing a token that is
+    keyboard-mash-shaped (``_looks_like_mash``).
+
+    Vocabulary the word lists below do not know is NOT a rejection reason —
+    most real briefs contain some — so "SPY covered calls", "muni ladder"
+    and non-English text all pass through to the real validator.
 
     See the module note above this function for why it is deliberately
     conservative.
@@ -235,7 +281,10 @@ def cheap_brief_reject(brief: GenerateBrief) -> dict[str, str] | None:
             "hint": "Mention an asset class, a goal, or a risk appetite.",
         }
 
-    tokens = re.findall(r"[A-Za-z]{2,}", intent)
+    # Unicode-aware: letters in ANY script, no digits/underscores. A Cyrillic
+    # or CJK brief must tokenize as words, not vanish into the letter-free
+    # branch below and be refused for "containing no words".
+    tokens = re.findall(r"[^\W\d_]{2,}", intent)
     if not tokens:
         # No word-like content at all — pure digits/punctuation/symbols.
         return {
@@ -250,12 +299,13 @@ def cheap_brief_reject(brief: GenerateBrief) -> dict[str, str] | None:
     if all(t.isupper() and len(t) <= 5 for t in tokens):
         return None  # plausible ticker list, e.g. "BTC ETH SOL"
 
-    if len(tokens) >= _MIN_GIBBERISH_TOKENS:
+    # Junk needs positive evidence of mashing, never just unfamiliar words.
+    if len(tokens) >= _MIN_GIBBERISH_TOKENS and any(_looks_like_mash(t) for t in lowered):
         return {
             "reason": "it does not look like an investment goal",
             "hint": "Mention an asset class, a goal, or a risk appetite.",
         }
-    return None  # single unrecognized token — could be real; defer to the LLM
+    return None  # nothing mash-shaped to point at; defer to the LLM
 
 
 async def _validate_brief(brief: GenerateBrief) -> dict[str, Any]:

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -40,6 +40,7 @@ import json
 import logging
 import math
 import os
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -154,14 +155,125 @@ def _invalid_brief_message(reason: object) -> str:
     )
 
 
+# ── Cheap, deterministic brief prelude (no LLM) — Lane 1.3c ────────────────
+#
+# "Never charge for a brief we can cheaply reject." Before this, a gibberish
+# brief only surfaced BRIEF_INVALID after the LLM validator ran INSIDE
+# run_generation — i.e. after the caller already paid (see
+# generate_routes.start_generation: payment happens before the job, and
+# `_validate_brief` above only runs once the job is running). This function
+# is the ONE deterministic check both the pre-payment route gate
+# (`generate_routes.start_generation`, via a direct call to this function)
+# and the real validator (`_validate_brief` below, as its own prelude) share
+# — extracted once so the two call sites can never drift apart on what
+# counts as "obviously invalid".
+#
+# It must be conservative: a false NEGATIVE here (missing real gibberish) is
+# fine — the LLM validator still catches it, post-payment, exactly as
+# before. A false POSITIVE (flagging a genuine brief) is not — it would
+# block a paying user before they're even offered the chance to pay. So this
+# only rejects the unambiguous cases: empty, too short, or built entirely
+# from tokens that match neither everyday English nor investing vocabulary
+# and aren't plausible tickers. Semantic judgment calls (off-topic-but-
+# grammatical text like "add flour and bake at 350F", jailbreak attempts)
+# are deliberately left to the expensive LLM step — that outcome legitimately
+# consumes work, so it stays a credit spend, not a pre-payment refusal.
+_MIN_INTENT_CHARS = 3
+_MIN_GIBBERISH_TOKENS = 2  # ≥2 unrecognized tokens before calling it junk
+
+# Ordinary English function/content words. Their presence means the text is
+# at least grammatical, even if off-topic — off-topic is the LLM's job, not
+# this heuristic's.
+_COMMON_WORDS = frozenset(
+    "a an the and or but for nor so if of to in on at by with from into is are "
+    "was were be been being this that these those i you he she it we they my "
+    "your his her its our their not no yes want need make build create "
+    "generate please can could would should like about money fund funds".split()
+)
+
+# Investing / finance-signal vocabulary. Presence means the text is on-topic
+# even when it fails the common-word check above (e.g. "crypto momentum").
+_FINANCE_WORDS = frozenset(
+    "stock stocks bond bonds equity equities crypto bitcoin ethereum token "
+    "tokens coin coins etf etfs treasury treasuries yield yields dividend "
+    "dividends momentum value growth trend trending hedge hedged leverage "
+    "leveraged volatility volatile vol risk risky conservative aggressive "
+    "moderate income rebalance rebalancing diversify diversified "
+    "diversification asset assets allocation market markets trading trade "
+    "trades rate rates inflation macro commodity commodities gold silver "
+    "oil futures options derivative derivatives arbitrage carry basis "
+    "spread stablecoin usdc usdt defi staking lending long short bull bear "
+    "index indices quant quantitative alpha beta sharpe drawdown portfolio "
+    "invest investment strategy strategies".split()
+)
+
+
+def cheap_brief_reject(brief: GenerateBrief) -> dict[str, str] | None:
+    """Deterministic, no-LLM prelude to brief validation.
+
+    Returns ``None`` when the brief passes this cheap check — which does
+    NOT mean it is a *good* brief, only that it is not obviously junk; the
+    real (LLM) validator remains the authority on everything else (off-topic
+    content, jailbreak attempts, semantic coherence). Returns a
+    ``{"reason", "hint"}`` dict, shaped exactly like the LLM validator's
+    invalid-brief output, when the brief is unambiguously invalid: empty,
+    too short, or built entirely from tokens that match neither everyday
+    English nor investing vocabulary and are not plausible tickers.
+
+    See the module note above this function for why it is deliberately
+    conservative.
+    """
+    intent = (brief.intent or "").strip()
+    if not intent:
+        return {
+            "reason": "it did not describe an investment goal",
+            "hint": "Mention an asset class, a goal, or a risk appetite.",
+        }
+    if len(intent) < _MIN_INTENT_CHARS:
+        return {
+            "reason": "too short to describe an investment goal",
+            "hint": "Mention an asset class, a goal, or a risk appetite.",
+        }
+
+    tokens = re.findall(r"[A-Za-z]{2,}", intent)
+    if not tokens:
+        # No word-like content at all — pure digits/punctuation/symbols.
+        return {
+            "reason": "it does not contain any words",
+            "hint": "Mention an asset class, a goal, or a risk appetite.",
+        }
+
+    lowered = [t.lower() for t in tokens]
+    if any(t in _COMMON_WORDS or t in _FINANCE_WORDS for t in lowered):
+        return None  # recognizable language — defer to the real validator
+
+    if all(t.isupper() and len(t) <= 5 for t in tokens):
+        return None  # plausible ticker list, e.g. "BTC ETH SOL"
+
+    if len(tokens) >= _MIN_GIBBERISH_TOKENS:
+        return {
+            "reason": "it does not look like an investment goal",
+            "hint": "Mention an asset class, a goal, or a risk appetite.",
+        }
+    return None  # single unrecognized token — could be real; defer to the LLM
+
+
 async def _validate_brief(brief: GenerateBrief) -> dict[str, Any]:
     """Call the LLM to validate the brief.
+
+    Runs ``cheap_brief_reject`` FIRST — see that function's docstring — so an
+    unambiguously-junk brief never reaches the LLM call at all, here or on
+    any other caller of this function.
 
     Returns the parsed validation JSON. On any failure (LLM down, malformed
     response, schema mismatch), returns a permissive valid result — refusing
     to generate because the validator broke is worse than generating with
     the user's stated values.
     """
+    cheap_reject = cheap_brief_reject(brief)
+    if cheap_reject is not None:
+        return {"is_valid": False, **cheap_reject}
+
     permissive = {
         "is_valid": True,
         "intent_summary": brief.intent[:140],

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -27,7 +27,11 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 
-from archimedes.agents.generation_pipeline import run_generation
+from archimedes.agents.generation_pipeline import (
+    _invalid_brief_message,
+    cheap_brief_reject,
+    run_generation,
+)
 from archimedes.api.account_auth import CurrentUser, require_current_user
 from archimedes.api.funnel_middleware import record_funnel
 from archimedes.api.generate_schemas import (
@@ -355,6 +359,28 @@ async def start_generation(
                     f"The generation queue is full ({_WAITING_GENERATIONS} jobs waiting). "
                     "No payment was taken. Retry in a few minutes."
                 ),
+            },
+        )
+
+    # Cheap, deterministic brief prelude (Lane 1.3c: "never charge for a
+    # brief we can cheaply reject"). Deliberately BEFORE the payment gate —
+    # a caller must never be charged for a brief that is obviously invalid
+    # (empty / gibberish). Shares its exact criteria with the real (LLM)
+    # validator's own prelude in generation_pipeline._validate_brief via
+    # `cheap_brief_reject` — see that function's docstring for why the two
+    # call sites can never drift apart. Anything this misses (off-topic but
+    # grammatical text, jailbreak attempts) still gets the expensive LLM
+    # check post-payment, exactly as before — that outcome legitimately
+    # consumes work, so it stays a credit spend, not a pre-payment refusal.
+    cheap_reject = cheap_brief_reject(req.brief)
+    if cheap_reject is not None:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "reason": "brief_invalid",
+                "code": "BRIEF_INVALID",
+                "message": _invalid_brief_message(cheap_reject.get("reason")),
+                "hint": cheap_reject.get("hint") or "Mention an asset class, a goal, or a risk appetite.",
             },
         )
 

--- a/backend/tests/test_generate_brief_prevalidate.py
+++ b/backend/tests/test_generate_brief_prevalidate.py
@@ -1,0 +1,186 @@
+"""Lane 1.3c: never charge for a brief we can cheaply reject.
+
+Before this, a gibberish brief only surfaced BRIEF_INVALID from the LLM
+validator running INSIDE run_generation — after the caller had already paid
+(payment happens in generate_routes.start_generation, before the job runs;
+see generation_pipeline._validate_brief). This file pins two things:
+
+  * ``cheap_brief_reject`` itself — the deterministic, no-LLM prelude, unit
+    tested directly (empty / too-short / keyboard-mash rejected; coherent-
+    but-vague, finance-signal, and ticker-list intents pass through to the
+    real validator, matching the LLM system prompt's own worked examples).
+  * the ROUTE WIRING — POST /api/generate/start returns 422 with the honest
+    BRIEF_INVALID shape for a gibberish brief, and — the load-bearing
+    assertion — the payment dependency is never invoked and nothing is
+    enqueued. Same harness as test_generate_payment_gate.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from archimedes.agents.generation_pipeline import GenerateBrief, _validate_brief, cheap_brief_reject
+from tests.auth_helpers import auth_cookies
+
+RECIPIENT = "0x00000000000000000000000000000000000000a1"
+
+# Deliberately unambiguous keyboard-mash: no everyday word, no finance-signal
+# word, not a plausible ticker list (lowercase, >5 chars each).
+_GIBBERISH_BODY = {"brief": {"intent": "zxcvbnm qwiopasd lkjhgfdsa", "risk_appetite": "moderate"}}
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _mock_store() -> MagicMock:
+    store = MagicMock()
+    store.enqueue = AsyncMock(return_value="job-should-not-exist")
+    return store
+
+
+def _close_background_coroutine(coro):
+    coro.close()
+    return MagicMock()
+
+
+def _harness(store):
+    return (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        patch("archimedes.api.generate_routes.asyncio.create_task", side_effect=_close_background_coroutine),
+    )
+
+
+# ── cheap_brief_reject — unit tests ─────────────────────────────────────────
+
+
+def test_empty_intent_is_rejected():
+    result = cheap_brief_reject(GenerateBrief(intent=""))
+    assert result is not None
+    assert "reason" in result and "hint" in result
+
+
+def test_whitespace_only_intent_is_rejected():
+    result = cheap_brief_reject(GenerateBrief(intent="   \t\n  "))
+    assert result is not None
+
+
+def test_too_short_intent_is_rejected():
+    result = cheap_brief_reject(GenerateBrief(intent="ab"))
+    assert result is not None
+
+
+def test_keyboard_mash_is_rejected():
+    result = cheap_brief_reject(GenerateBrief(intent="zxcvbnm qwiopasd lkjhgfdsa"))
+    assert result is not None
+    assert result["reason"]
+    assert result["hint"]
+
+
+def test_pure_symbols_is_rejected():
+    result = cheap_brief_reject(GenerateBrief(intent="!!! ### $$$ 1234"))
+    assert result is not None
+
+
+def test_finance_signal_word_defers_to_llm():
+    # "momentum" alone is enough — cheap check must not overreach into
+    # judging whether the FULL sentence is a coherent strategy ask.
+    assert cheap_brief_reject(GenerateBrief(intent="crypto with momentum")) is None
+
+
+def test_vague_but_coherent_bond_alternative_defers_to_llm():
+    # Straight from the validator's own system-prompt example of a VALID
+    # (if vague) brief — the cheap check must not reject it.
+    assert cheap_brief_reject(GenerateBrief(intent="low-vol bond alternative")) is None
+
+
+def test_ticker_list_defers_to_llm():
+    # All-caps short tokens with no vowels required (BTC has none) must not
+    # be flagged as gibberish — tickers commonly lack recognizable "words".
+    assert cheap_brief_reject(GenerateBrief(intent="BTC ETH SOL")) is None
+
+
+def test_single_unrecognized_token_defers_to_llm():
+    # A single odd token could be a real (unlisted) word or slang; only
+    # reject once there are enough unrecognized tokens to be confident.
+    assert cheap_brief_reject(GenerateBrief(intent="degen")) is None
+
+
+def test_off_topic_but_grammatical_text_defers_to_llm():
+    # "add flour and bake at 350F" — off-topic (a recipe), but grammatical.
+    # Judging topicality is the LLM's job, not this heuristic's: the cheap
+    # check must not weaken/duplicate-drift what the real validator decides.
+    assert cheap_brief_reject(GenerateBrief(intent="add flour and bake at 350F")) is None
+
+
+# ── _validate_brief — the shared prelude fires without ever touching the LLM ─
+
+
+async def test_validate_brief_rejects_gibberish_without_calling_the_llm_backend():
+    """The real validator's OWN prelude (shared with the route gate) must
+    catch this before it ever constructs an LLM backend — proves the two
+    call sites use the same function, not a duplicated/drifted copy."""
+    with patch(
+        "archimedes.services.llm_backend.make_llm_backend",
+        side_effect=AssertionError("the LLM backend must never be constructed for a cheaply-rejectable brief"),
+    ):
+        result = await _validate_brief(GenerateBrief(intent="zxcvbnm qwiopasd lkjhgfdsa"))
+    assert result["is_valid"] is False
+    assert result["reason"]
+    assert result["hint"]
+
+
+# ── Route wiring: POST /api/generate/start ──────────────────────────────────
+
+
+def test_gibberish_brief_is_422_before_payment_and_settlement(monkeypatch) -> None:
+    """The guard this issue is about: a gibberish brief must be refused with
+    422 BEFORE the payment gate runs — no settlement attempted, nothing
+    enqueued. Payment is ON (mirrors test_generate_payment_gate.py) so this
+    actually exercises the ordering, not a vacuously-skipped gate."""
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    paywall_spy = AsyncMock(side_effect=AssertionError("payment must never be invoked for a cheaply-rejected brief"))
+    with (
+        p1,
+        p2,
+        patch("archimedes.api.generate_routes.generation_payment.enforce_generation_payment", paywall_spy),
+    ):
+        resp = _client().post("/api/generate/start", json=_GIBBERISH_BODY, cookies=auth_cookies())
+
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["reason"] == "brief_invalid"
+    assert detail["code"] == "BRIEF_INVALID"
+    assert "message" in detail and detail["message"]
+    assert "hint" in detail and detail["hint"]
+
+    paywall_spy.assert_not_called()
+    store.enqueue.assert_not_called()
+
+
+def test_valid_brief_still_reaches_the_paywall(monkeypatch) -> None:
+    """Negative control: a normal brief must NOT be caught by the new gate —
+    it still reaches the payment step exactly as before (402, since no
+    Payment-Signature header is presented)."""
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    body = {"brief": {"intent": "low-vol treasury alternative", "risk_appetite": "moderate"}}
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=body, cookies=auth_cookies())
+
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["reason"] == "payment_required"
+    store.enqueue.assert_not_called()

--- a/backend/tests/test_generate_brief_prevalidate.py
+++ b/backend/tests/test_generate_brief_prevalidate.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from archimedes.agents.generation_pipeline import GenerateBrief, _validate_brief, cheap_brief_reject
@@ -81,6 +82,20 @@ def test_keyboard_mash_is_rejected():
     assert result["hint"]
 
 
+@pytest.mark.parametrize(
+    ("intent", "why"),
+    [
+        ("zxcvbnm qwrtplk", "no vowel at all"),
+        ("lkjhgfdsa mnbvcxz", "5+ consonants with no break"),
+        ("aaaargh bbbb", "same character 3+ times"),
+        ("asdf jkli qwer", "straight runs along a keyboard row"),
+    ],
+)
+def test_each_mash_signal_is_rejected(intent, why):
+    """One case per mash signal, so a regression names which rule broke."""
+    assert cheap_brief_reject(GenerateBrief(intent=intent)) is not None, why
+
+
 def test_pure_symbols_is_rejected():
     result = cheap_brief_reject(GenerateBrief(intent="!!! ### $$$ 1234"))
     assert result is not None
@@ -115,6 +130,48 @@ def test_off_topic_but_grammatical_text_defers_to_llm():
     # Judging topicality is the LLM's job, not this heuristic's: the cheap
     # check must not weaken/duplicate-drift what the real validator decides.
     assert cheap_brief_reject(GenerateBrief(intent="add flour and bake at 350F")) is None
+
+
+# ── False positives: the failure mode that actually costs us a customer ─────
+#
+# Every brief below is a REAL strategy ask built entirely out of words the
+# module's two hand-written vocab lists do not contain. An earlier revision
+# rejected exactly these, because it treated "no recognized vocabulary" as
+# proof of gibberish. It is not: unfamiliar vocabulary is the normal case,
+# and a false positive here refuses a paying user before the paywall — the
+# one outcome this check is not allowed to produce. Rejection now requires
+# positive evidence of mashing (no vowel / consonant pile-up / repeated char
+# / keyboard-row run), which none of these have.
+
+
+@pytest.mark.parametrize(
+    "intent",
+    [
+        "SPY covered calls",
+        "muni ladder",
+        "sector rotation",
+        "covered call overlay on dividend aristocrats",
+    ],
+)
+def test_real_briefs_made_of_unlisted_words_defer_to_llm(intent):
+    assert cheap_brief_reject(GenerateBrief(intent=intent)) is None
+
+
+@pytest.mark.parametrize(
+    "intent",
+    [
+        "estrategia de baja volatilidad para bonos",  # Spanish — ASCII, unlisted
+        "стратегия низкой волатильности",  # Cyrillic
+        "低波动率债券替代方案",  # CJK — one token, no spaces
+    ],
+)
+def test_non_english_briefs_defer_to_llm(intent):
+    """A non-English brief has no structure this heuristic can read, so it
+    must always fall through to the LLM. Two ways it could wrongly reject:
+    ASCII-but-unlisted words (Spanish), and non-ASCII scripts — which must
+    also survive TOKENIZATION, or a Cyrillic/CJK brief looks letter-free and
+    gets refused for 'not containing any words'."""
+    assert cheap_brief_reject(GenerateBrief(intent=intent)) is None
 
 
 # ── _validate_brief — the shared prelude fires without ever touching the LLM ─
@@ -182,5 +239,28 @@ def test_valid_brief_still_reaches_the_paywall(monkeypatch) -> None:
         resp = _client().post("/api/generate/start", json=body, cookies=auth_cookies())
 
     assert resp.status_code == 402
+    assert resp.json()["detail"]["reason"] == "payment_required"
+    store.enqueue.assert_not_called()
+
+
+def test_brief_of_only_unlisted_words_still_reaches_the_paywall(monkeypatch) -> None:
+    """The false-positive guard at the ROUTE, where the money is.
+
+    "SPY covered calls" contains no word in either vocab list, so an earlier
+    revision of the cheap check refused it with 422 — a real customer turned
+    away before ever being shown a price. It must reach the paywall (402)
+    like any other brief. Distinct from the test above, whose intent hits
+    the recognized-vocabulary fast path and so never exercises this."""
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+
+    store = _mock_store()
+    p1, p2 = _harness(store)
+    body = {"brief": {"intent": "SPY covered calls", "risk_appetite": "moderate"}}
+    with p1, p2:
+        resp = _client().post("/api/generate/start", json=body, cookies=auth_cookies())
+
+    assert resp.status_code == 402, f"a legitimate brief was refused pre-payment: {resp.json()}"
     assert resp.json()["detail"]["reason"] == "payment_required"
     store.enqueue.assert_not_called()


### PR DESCRIPTION
v8 Lane 1.3c. Cheap deterministic brief validation (`cheap_brief_reject`) now runs in `/api/generate/start` BEFORE the payment gate: structural-gibberish evidence (vowel-free tokens, consonant runs, repeats, keyboard-row runs) is required to reject — unknown vocabulary alone never blocks a paying user, and non-ASCII briefs defer to the LLM. The expensive LLM rejection stays post-payment (that outcome legitimately consumes work → credit).

**Pipeline provenance:** Sonnet builder → independent Opus review that *drove the real route* and caught the original allowlist predicate rejecting 'SPY covered calls' and Spanish briefs pre-payment → Opus fixer applied the reviewer's redesigned predicate → owner-side validation exercised the final predicate directly (5 legitimate briefs pass incl. Japanese; 3 gibberish reject). 25 tests in the new file; full CI suite 3,924 passed; adversarial demonstrations in both directions in the commit bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7