### PR TITLE
[generation] Bound hangs: GENERATION_TIMEOUT_SECONDS with honest status, event, and credit release

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -147,6 +147,11 @@ def _generation_timeout_seconds() -> float:
     Parsed as defensively as `_max_concurrent_generations` above (and
     `revenue_sweep._min_usdc`): a missing, non-numeric, or non-positive value
     must never crash startup — it falls back to the default instead.
+
+    `GENERATION_TIMEOUT_SECONDS=inf` is the one intended escape hatch: `float`
+    accepts it, it passes the `> 0` floor, and `asyncio.wait_for` with an
+    infinite timeout never fires — restoring the old unbounded behaviour on
+    purpose (e.g. a long-running local batch) rather than by accident.
     """
     try:
         value = float(os.getenv("GENERATION_TIMEOUT_SECONDS", str(_DEFAULT_GENERATION_TIMEOUT_SECONDS)))
@@ -613,23 +618,53 @@ async def _run_with_cleanup(
                     ),
                     timeout=timeout_seconds,
                 )
-            except TimeoutError:
+            # `asyncio.TimeoutError` IS the builtin `TimeoutError` on 3.11+ (a
+            # pure alias), so UP041 is right that this is redundant — but the
+            # alias is the intent: this catches the timeout `asyncio.wait_for`
+            # raises, NOT some `TimeoutError` bubbling up out of the pipeline's
+            # own socket/HTTP layer. Spelling it `asyncio.` keeps the next
+            # reader from having to rediscover which one is meant.
+            except asyncio.TimeoutError:  # noqa: UP041
                 # wait_for cancels the still-running run_generation coroutine
-                # on timeout; its own `except asyncio.CancelledError` branch
-                # already ran and wrote status "cancelled"/"cancelled by
-                # client" — dishonest here, since nobody clicked Cancel.
-                # update_status (not update_terminal_status, which treats
-                # "cancelled" as sticky on purpose for the real-cancel race)
-                # overwrites it with the true cause. Any non-"done" terminal
-                # status still reaches `_release_credit_if_undelivered` below,
-                # so the payer's credit restores either way.
+                # on timeout and waits for it to unwind, so its own
+                # `except asyncio.CancelledError` branch has ALREADY run by the
+                # time we get here. That branch left two dishonest traces —
+                # nobody clicked Cancel:
+                #   1. status "cancelled"/"cancelled by client", and
+                #   2. an `error`/`CANCELLED` "job cancelled" event.
+                # (1) is overwritten below by update_status — not
+                # update_terminal_status, which treats "cancelled" as sticky on
+                # purpose for the real-cancel race. Any non-"done" terminal
+                # status still reaches `_release_credit_if_undelivered` in the
+                # outer finally, so the payer's credit restores either way.
+                # (2) cannot be overwritten: the event log is append-only, so
+                # the honest TIMEOUT frame is APPENDED after it. Who actually
+                # reads it: `_TERMINAL_EVENTS` makes `stream_events` return on
+                # the FIRST `error` frame, so a client connected for the whole
+                # run still closes on "job cancelled" — but a client resuming
+                # with `Last-Event-ID` past that frame gets TIMEOUT, and the
+                # log itself is the durable record of why the job really died.
                 message = f"generation exceeded the {timeout_seconds:g}-second limit"
                 logger.warning(
                     "job %s exceeded GENERATION_TIMEOUT_SECONDS=%s — marking error",
                     sanitize_log_value(job_id),
                     timeout_seconds,
                 )
+                # Status first: it is the authoritative record, and it stays
+                # honest even if the event push below fails.
                 await store.update_status(job_id, "error", error=message)
+                await store.push_event(
+                    job_id,
+                    {
+                        "event": "error",
+                        "data": {
+                            "job_id": job_id,
+                            "message": message,
+                            "recoverable": False,
+                            "code": "TIMEOUT",
+                        },
+                    },
+                )
         finally:
             gate.release()
     except asyncio.CancelledError:

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -91,6 +91,15 @@ _JOB_HEARTBEAT_INTERVAL_SECONDS = 30.0
 # § Failure modes: "Lock-without-progress for > 5 min").
 _STALLED_AFTER_SECONDS = 300
 
+# Hard ceiling on one generation run (v8 Lane 1.3b — bound generation hangs).
+# `_STALLED_AFTER_SECONDS` only makes a dead run *observable*; nothing
+# previously stopped `run_generation` itself from hanging forever (an LLM
+# call with no client-side timeout, a stuck backtest thread) while quietly
+# holding the payer's consumed credit and a `_GENERATION_GATE` slot the whole
+# time. `_run_with_cleanup` wraps the awaited call in `asyncio.wait_for` at
+# this bound.
+_DEFAULT_GENERATION_TIMEOUT_SECONDS = 600
+
 # Live registry of in-flight asyncio tasks per job. Lets cancel_job actually
 # stop the work — without this, /cancel only flips Redis status while the
 # agent keeps burning LLM tokens to completion.
@@ -130,6 +139,20 @@ def _max_queued_generations() -> int:
         return max(0, int(os.getenv("GENERATION_MAX_QUEUE", "10")))
     except ValueError:
         return 10
+
+
+def _generation_timeout_seconds() -> float:
+    """Bound for one run, from `GENERATION_TIMEOUT_SECONDS` (v8 Lane 1.3b).
+
+    Parsed as defensively as `_max_concurrent_generations` above (and
+    `revenue_sweep._min_usdc`): a missing, non-numeric, or non-positive value
+    must never crash startup — it falls back to the default instead.
+    """
+    try:
+        value = float(os.getenv("GENERATION_TIMEOUT_SECONDS", str(_DEFAULT_GENERATION_TIMEOUT_SECONDS)))
+    except ValueError:
+        return float(_DEFAULT_GENERATION_TIMEOUT_SECONDS)
+    return value if value > 0 else float(_DEFAULT_GENERATION_TIMEOUT_SECONDS)
 
 
 def _generation_gate() -> asyncio.Semaphore:
@@ -575,16 +598,38 @@ async def _run_with_cleanup(
                 _WAITING_GENERATIONS -= 1
         else:
             await gate.acquire()
+        timeout_seconds = _generation_timeout_seconds()
         try:
-            await run_generation(
-                job_id=job_id,
-                brief=brief,
-                n_candidates=n_candidates,
-                mode=mode,
-                model=model,
-                owner_user_id=owner_user_id,
-                owner_wallet=owner_wallet,
-            )
+            try:
+                await asyncio.wait_for(
+                    run_generation(
+                        job_id=job_id,
+                        brief=brief,
+                        n_candidates=n_candidates,
+                        mode=mode,
+                        model=model,
+                        owner_user_id=owner_user_id,
+                        owner_wallet=owner_wallet,
+                    ),
+                    timeout=timeout_seconds,
+                )
+            except TimeoutError:
+                # wait_for cancels the still-running run_generation coroutine
+                # on timeout; its own `except asyncio.CancelledError` branch
+                # already ran and wrote status "cancelled"/"cancelled by
+                # client" — dishonest here, since nobody clicked Cancel.
+                # update_status (not update_terminal_status, which treats
+                # "cancelled" as sticky on purpose for the real-cancel race)
+                # overwrites it with the true cause. Any non-"done" terminal
+                # status still reaches `_release_credit_if_undelivered` below,
+                # so the payer's credit restores either way.
+                message = f"generation exceeded the {timeout_seconds:g}-second limit"
+                logger.warning(
+                    "job %s exceeded GENERATION_TIMEOUT_SECONDS=%s — marking error",
+                    sanitize_log_value(job_id),
+                    timeout_seconds,
+                )
+                await store.update_status(job_id, "error", error=message)
         finally:
             gate.release()
     except asyncio.CancelledError:

--- a/backend/tests/test_generation_timeout.py
+++ b/backend/tests/test_generation_timeout.py
@@ -1,0 +1,112 @@
+"""Bound generation hangs (v8 Lane 1.3b).
+
+``_run_with_cleanup`` wraps the awaited ``run_generation`` call in
+``asyncio.wait_for(..., timeout=GENERATION_TIMEOUT_SECONDS)``. Two guards:
+
+  * env parsing is defensive — a missing/non-numeric/non-positive
+    ``GENERATION_TIMEOUT_SECONDS`` falls back to the 600s default, never
+    crashes (mirrors ``_max_concurrent_generations`` / ``revenue_sweep._min_usdc``);
+  * a run that never returns is PROVEN to end the job ``error`` (with an
+    honest "exceeded the N-second limit" message, not the pipeline's own
+    "cancelled by client" wording) within the configured timeout, AND that
+    write is PROVEN to flow through the existing
+    ``_release_credit_if_undelivered`` path — ``generation_credits.restore_for_job``
+    is actually invoked, not just assumed reachable.
+
+Hermetic — no Redis/DB/network. Mirrors the mocked-store harness in
+test_generation_concurrency.py (``_run_with_cleanup`` driven directly, the
+same coroutine ``/start`` spawns).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from archimedes.api import generate_routes
+
+
+def _reset_gate(monkeypatch) -> None:
+    monkeypatch.setattr(generate_routes, "_GENERATION_GATE", None)
+    monkeypatch.setattr(generate_routes, "_GENERATION_GATE_LOOP", None)
+    monkeypatch.setattr(generate_routes, "_WAITING_GENERATIONS", 0)
+    monkeypatch.setenv("GENERATION_MAX_CONCURRENT", "1")
+    monkeypatch.setenv("GENERATION_MAX_QUEUE", "10")
+
+
+class _FakeStore:
+    """Minimal stateful stand-in for JobStore — real enough that a status
+    written by one call is visible to the next `get`, which is exactly the
+    wiring this test needs to prove (unlike a stateless MagicMock)."""
+
+    def __init__(self) -> None:
+        self.status: str | None = None
+        self.error: str = ""
+        self.history: list[tuple[str, str]] = []
+
+    async def get(self, job_id: str) -> dict:
+        return {"status": self.status, "error": self.error}
+
+    async def update_status(self, job_id: str, status: str, *, result=None, error: str = "") -> None:
+        self.status = status
+        self.error = error
+        self.history.append((status, error))
+
+    async def touch(self, job_id: str) -> bool:
+        return True
+
+    async def push_event(self, job_id: str, payload: dict) -> int:
+        return 1
+
+
+async def _hang_forever(*, job_id: str, **_kwargs) -> None:
+    """Stands in for a `run_generation` that never returns (stuck LLM call,
+    stuck backtest thread) — the exact failure mode this guard bounds."""
+    await asyncio.Event().wait()
+
+
+def test_generation_timeout_env_parsing_is_defensive(monkeypatch) -> None:
+    monkeypatch.setenv("GENERATION_TIMEOUT_SECONDS", "garbage")
+    assert generate_routes._generation_timeout_seconds() == 600.0
+    monkeypatch.setenv("GENERATION_TIMEOUT_SECONDS", "0")
+    assert generate_routes._generation_timeout_seconds() == 600.0  # floor: never a 0s (=instant-fail) timeout
+    monkeypatch.setenv("GENERATION_TIMEOUT_SECONDS", "-5")
+    assert generate_routes._generation_timeout_seconds() == 600.0
+    monkeypatch.delenv("GENERATION_TIMEOUT_SECONDS", raising=False)
+    assert generate_routes._generation_timeout_seconds() == 600.0
+    monkeypatch.setenv("GENERATION_TIMEOUT_SECONDS", "45")
+    assert generate_routes._generation_timeout_seconds() == 45.0
+
+
+async def test_hung_run_generation_ends_job_error_and_releases_credit(monkeypatch) -> None:
+    _reset_gate(monkeypatch)
+    monkeypatch.setenv("GENERATION_TIMEOUT_SECONDS", "0.05")  # tiny, monkeypatched bound
+
+    store = _FakeStore()
+    brief = MagicMock()
+
+    with (
+        patch.object(generate_routes, "run_generation", _hang_forever),
+        patch.object(generate_routes, "get_job_store", return_value=store),
+        patch.object(generate_routes.generation_credits, "restore_for_job", return_value=True) as restore_mock,
+    ):
+        # Outer safety bound (generous — 5s), NOT the guard under test: without
+        # it, a regression that removes the inner wait_for would hang this
+        # test (and the suite) forever instead of failing fast and readably.
+        await asyncio.wait_for(
+            generate_routes._run_with_cleanup("job-hung", brief, 1),
+            timeout=5,
+        )
+
+    # The job ended in the honest terminal state — not silently stuck
+    # "running", and not the pipeline's own (dishonest, for a timeout)
+    # "cancelled by client" write.
+    assert store.status == "error"
+    assert "exceeded" in store.error
+    assert "0.05-second limit" in store.error
+
+    # The EXISTING _release_credit_if_undelivered path actually ran: it reads
+    # the just-written status (not "done") and calls
+    # generation_credits.restore_for_job — proven here by mocking that exact
+    # call, not merely asserting reachability.
+    restore_mock.assert_called_once_with("job-hung")

--- a/backend/tests/test_generation_timeout.py
+++ b/backend/tests/test_generation_timeout.py
@@ -11,7 +11,11 @@
     "cancelled by client" wording) within the configured timeout, AND that
     write is PROVEN to flow through the existing
     ``_release_credit_if_undelivered`` path — ``generation_credits.restore_for_job``
-    is actually invoked, not just assumed reachable.
+    is actually invoked, not just assumed reachable;
+  * the honest ``error``/``TIMEOUT`` event is PROVEN to reach the job's event
+    log after the pipeline's ``error``/``CANCELLED`` frame, and the full
+    status history is pinned so the last-write-wins ordering the honest status
+    depends on cannot silently reverse.
 
 Hermetic — no Redis/DB/network. Mirrors the mocked-store harness in
 test_generation_concurrency.py (``_run_with_cleanup`` driven directly, the
@@ -43,6 +47,7 @@ class _FakeStore:
         self.status: str | None = None
         self.error: str = ""
         self.history: list[tuple[str, str]] = []
+        self.events: list[dict] = []
 
     async def get(self, job_id: str) -> dict:
         return {"status": self.status, "error": self.error}
@@ -56,13 +61,40 @@ class _FakeStore:
         return True
 
     async def push_event(self, job_id: str, payload: dict) -> int:
-        return 1
+        self.events.append(payload)
+        return len(self.events)
 
 
 async def _hang_forever(*, job_id: str, **_kwargs) -> None:
     """Stands in for a `run_generation` that never returns (stuck LLM call,
-    stuck backtest thread) — the exact failure mode this guard bounds."""
-    await asyncio.Event().wait()
+    stuck backtest thread) — the exact failure mode this guard bounds.
+
+    Carries the REAL pipeline's cancel handler (generation_pipeline.py's
+    ``except asyncio.CancelledError``: emit ``error``/``CANCELLED`` "job
+    cancelled", then write status ``cancelled``/"cancelled by client", then
+    re-raise). That is not decoration — ``wait_for`` cancels this coroutine and
+    waits for it to unwind, so those two dishonest writes land BEFORE the
+    timeout branch's. A stand-in without them would let the guard pass even if
+    the fix wrote the honest status FIRST and got silently overwritten.
+    """
+    store = generate_routes.get_job_store()
+    try:
+        await asyncio.Event().wait()
+    except asyncio.CancelledError:
+        await store.push_event(
+            job_id,
+            {
+                "event": "error",
+                "data": {
+                    "job_id": job_id,
+                    "message": "job cancelled",
+                    "recoverable": False,
+                    "code": "CANCELLED",
+                },
+            },
+        )
+        await store.update_status(job_id, "cancelled", error="cancelled by client")
+        raise
 
 
 def test_generation_timeout_env_parsing_is_defensive(monkeypatch) -> None:
@@ -76,6 +108,11 @@ def test_generation_timeout_env_parsing_is_defensive(monkeypatch) -> None:
     assert generate_routes._generation_timeout_seconds() == 600.0
     monkeypatch.setenv("GENERATION_TIMEOUT_SECONDS", "45")
     assert generate_routes._generation_timeout_seconds() == 45.0
+    # The documented escape hatch: `inf` is NOT swallowed by the defensive
+    # fallback — it survives to `wait_for`, where an infinite timeout never
+    # fires. Pinned so the fallback can never quietly start capping it at 600s.
+    monkeypatch.setenv("GENERATION_TIMEOUT_SECONDS", "inf")
+    assert generate_routes._generation_timeout_seconds() == float("inf")
 
 
 async def test_hung_run_generation_ends_job_error_and_releases_credit(monkeypatch) -> None:
@@ -104,6 +141,33 @@ async def test_hung_run_generation_ends_job_error_and_releases_credit(monkeypatc
     assert store.status == "error"
     assert "exceeded" in store.error
     assert "0.05-second limit" in store.error
+
+    # Pin the ORDER, not just the endpoint: the pipeline's cancel handler runs
+    # first (wait_for cancels it and waits), the timeout branch writes second,
+    # and last-write-wins is the only reason `status` is honest. Assert the
+    # whole history so a future change that reverses the order — or drops the
+    # overwrite — fails here instead of silently reporting every timed-out job
+    # as "cancelled by client".
+    assert store.history == [
+        ("cancelled", "cancelled by client"),
+        ("error", "generation exceeded the 0.05-second limit"),
+    ]
+
+    # The event log is append-only, so the honest frame is APPENDED after the
+    # pipeline's dishonest one rather than replacing it. Both must be present,
+    # in that order, and the new one must carry code TIMEOUT (not CANCELLED) —
+    # that code is what lets a reader tell "the user cancelled this" apart from
+    # "this blew the time bound".
+    assert [e["data"]["code"] for e in store.events] == ["CANCELLED", "TIMEOUT"]
+    assert store.events[-1] == {
+        "event": "error",
+        "data": {
+            "job_id": "job-hung",
+            "message": "generation exceeded the 0.05-second limit",
+            "recoverable": False,
+            "code": "TIMEOUT",
+        },
+    }
 
     # The EXISTING _release_credit_if_undelivered path actually ran: it reads
     # the just-written status (not "done") and calls


### PR DESCRIPTION
v8 Lane 1.3b. `run_generation` is now bounded by `asyncio.wait_for` (env `GENERATION_TIMEOUT_SECONDS`, default 600, defensively parsed; `inf` documented as the explicit no-limit escape). On timeout: the pipeline's misleading 'cancelled by client' status is overwritten with the honest timeout error, a `TIMEOUT` event is pushed to the job log, and the existing `_release_credit_if_undelivered` path restores the payer's credit — the 7-minute-hang-then-charged case from the external review can no longer occur.

**Honesty note (from the fixer's own correction of the fix list):** an already-connected SSE client still sees the pipeline's earlier CANCELLED frame — the stream returns at its first terminal event; the TIMEOUT event serves the job record and reconnecting clients. Follow-up candidate if we want the live frame corrected too.

**Pipeline provenance:** builder → Opus review (independently drove `_run_with_cleanup` with a faithful pipeline stand-in; found the SSE gap + an unpinned test ordering) → fixer applied all items with 4 product mutations each demonstrated to fail. Full CI suite 3,901 passed; hermetic gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7