### PR TITLE
[frontend][data] Citation truth: real paper titles in the Library + the impossible-drawdown root cause

### DIFF
--- a/analytics-engine/src/archimedes_analytics_engine/data.py
+++ b/analytics-engine/src/archimedes_analytics_engine/data.py
@@ -32,6 +32,34 @@ def normalize_ohlcv(data: pd.DataFrame, *, symbol: str) -> pd.DataFrame:
         # silently shorten the series, misaligning cross-strategy PBO splits.
         logger.warning("normalize_ohlcv(%s): dropped %d row(s) with NaN values", symbol, dropped)
 
+    # Non-positive marks. Every runner in engine.py models a position as an
+    # unlevered cash-equity holding: backtrader's stock-like commission scheme
+    # marks it at `size * price`, and `broker.getvalue()` = cash + that mark is
+    # the equity curve every metric is computed from. A non-positive price is
+    # outside that model — the mark goes NEGATIVE, so mark-to-market "equity"
+    # stops being the account's equity and can cross zero, which is what makes
+    # an impossible >100% drawdown come out the other end. This is not
+    # hypothetical for the declared universe: OIL resolves to `CL=F`, whose
+    # front-month settled at -$37.63 on 2020-04-20. Note the PCA stat-arb
+    # strategy already refuses to build a RETURN from a non-positive price
+    # (`if prev <= 0: return None`) — the signal path was guarded and the
+    # marking path was not. Drop the bars, loudly, so the two agree.
+    price_cols = [c for c in ("Open", "High", "Low", "Close") if c in out.columns]
+    if price_cols:
+        positive = (out[price_cols] > 0).all(axis=1)
+        n_bad = int((~positive).sum())
+        if n_bad:
+            bad_dates = [str(d) for d in out.index[~positive][:5]]
+            logger.warning(
+                "normalize_ohlcv(%s): dropped %d bar(s) with a non-positive price (first: %s) — "
+                "the engine marks positions as unlevered cash equity (size * price), so a "
+                "non-positive mark would corrupt portfolio value and every metric derived from it",
+                symbol,
+                n_bad,
+                ", ".join(bad_dates),
+            )
+            out = out[positive]
+
     # yfinance occasionally returns duplicate or out-of-order timestamps (seen
     # on some corporate-action dates); a non-monotonic index makes backtrader's
     # PandasData feed advance incorrectly and introduces look-ahead bias.

--- a/analytics-engine/src/archimedes_analytics_engine/engine.py
+++ b/analytics-engine/src/archimedes_analytics_engine/engine.py
@@ -512,11 +512,44 @@ def _extract_result(
     sharpe_raw = strategy.analyzers.sharpe.get_analysis().get("sharperatio")
     sharpe = float(sharpe_raw) if sharpe_raw is not None else None
 
-    dd_analysis = strategy.analyzers.dd.get_analysis()
-    max_dd_pct_raw = _safe_get(dd_analysis, "max", "drawdown")
-    max_dd_len_raw = _safe_get(dd_analysis, "max", "len")
-    max_dd_pct = float(max_dd_pct_raw) if max_dd_pct_raw is not None else None
-    max_dd_len = int(max_dd_len_raw) if max_dd_len_raw is not None else None
+    # Derive the reported drawdown from the REPORTED equity curve.
+    #
+    # This is a single-source refactor, NOT a behaviour change: it used to read
+    # ``bt.analyzers.DrawDown``, which measures backtrader's own bar-by-bar
+    # ``broker.getvalue()`` path, while ``equity_curve`` above is rebuilt by
+    # compounding TimeReturn's per-bar returns off ``initial_cash``. Those two
+    # series are equal by algebraic identity — compounding
+    # ``v[i-1] * (v[i] / v[i-1])`` returns ``v[i]`` whatever the sign — so the
+    # numbers agreed, and ``test_drawdown_invariant.py`` pins that they still
+    # do (randomized equivalence + a direct cross-check against the analyzer,
+    # which stays registered as the external ground truth).
+    #
+    # What changes is that the agreement no longer rests on that identity. It
+    # is undefined at ``v[i-1] == 0`` — exactly the neighbourhood this metric
+    # gets read in when a run approaches ruin — and it left the shipped
+    # artifact carrying a drawdown that no reader could check against the
+    # series shipped beside it. Reading it off the curve makes the bound exact
+    # rather than incidental: ``max_drawdown_pct`` can exceed 100% if and only
+    # if the reported curve itself went non-positive. Ruin stays reportable —
+    # clamping the number would hide it — but it can no longer be reported
+    # spuriously, and a reader holding the curve can verify the claim.
+    #
+    # It also unifies the runners: ``combine_universe_results`` already
+    # computed its drawdown this way, so single-asset and composite results
+    # are no longer produced by two methods on two curves.
+    max_dd_pct, max_dd_len = _max_drawdown_from_curve(equity_curve)
+    if any(v <= 0.0 for v in equity_curve):
+        # Ruin. Every bar after the crossing is fiction — a real account cannot
+        # keep trading from negative equity — so say so loudly rather than let
+        # a >100% drawdown pass for an unusually bad but survivable loss.
+        logger.warning(
+            "_extract_result: equity curve went non-positive (min=%.2f of %.2f initial) — the account is "
+            "ruined at that bar and every later bar is fiction; max_drawdown_pct=%.2f is a RUIN marker, "
+            "not a survivable loss",
+            min(equity_curve),
+            initial_cash,
+            max_dd_pct if max_dd_pct is not None else float("nan"),
+        )
 
     cagr = _compute_cagr(initial_cash, final_value, bars)
 
@@ -749,6 +782,11 @@ def _add_analyzers(cerebro: bt.Cerebro) -> None:
         annualize=True,
         riskfreerate=RF_ANNUAL,
     )
+    # Kept registered although _extract_result now derives the reported
+    # drawdown from the equity curve: this analyzer is the external ground
+    # truth the curve-derived number is cross-validated against (see
+    # tests/test_drawdown_invariant.py), and dropping it would remove the only
+    # independent check on that arithmetic.
     cerebro.addanalyzer(bt.analyzers.DrawDown, _name="dd")
     cerebro.addanalyzer(bt.analyzers.TradeAnalyzer, _name="trades")
     cerebro.addanalyzer(TurnoverAnalyzer, _name="turnover")

--- a/analytics-engine/tests/test_drawdown_invariant.py
+++ b/analytics-engine/tests/test_drawdown_invariant.py
@@ -1,0 +1,303 @@
+"""The reported max drawdown must be the drawdown of the reported equity curve.
+
+Hermetic: synthetic in-memory frames only, no network, no yfinance.
+
+Background — the defect these tests pin. A real library run
+(``avellaneda_lee_2010_pca_statarb``, audited in
+``docs/audits/2026-07-09-curated-consolidation.md`` §2.4) reported
+``max_drawdown_pct = 130.3``. A >100% drawdown means the account's equity went
+NEGATIVE, which for the engine's model of a position — unlevered cash equity,
+marked ``size * price`` — cannot happen while prices are positive.
+
+**The root cause is the price feed, not the arithmetic.** ``normalize_ohlcv``
+validated NaNs and timestamp ordering but never that a price was positive.
+``OIL`` in that strategy's declared universe resolves to ``CL=F``, whose front
+month settled at **-$37.63 on 2020-04-20**; a held position marked at a negative
+price drags portfolio value straight through zero, which is how a 1.0x-gross,
+dollar-neutral book reached ruin. The strategy's own signal path already refused
+to build a return from a non-positive price (``if prev <= 0: return None``) —
+the marking path did not. It does now, and
+``test_negative_price_bar_drives_portfolio_value_negative_when_not_filtered``
+shows what that guard is holding back.
+
+Second, smaller change, and it is a **refactor, not a guard**:
+``_extract_result`` reported ``bt.analyzers.DrawDown``'s number (measured on
+backtrader's ``broker.getvalue()`` path) while shipping an ``equity_curve``
+rebuilt by compounding TimeReturn's returns. The two series are equal by
+algebraic identity, so no number moved — ``test_reported_drawdown_matches_*``
+below pin exactly that. What it buys is that the agreement no longer rests on an
+identity that is undefined at ``v[i-1] == 0``, and the bound becomes exact:
+
+    max_drawdown_pct < 100  <=>  the reported equity curve stayed positive
+
+Nothing here clamps a displayed number: a curve that genuinely goes non-positive
+still reports >100%, because that is the truth about that curve.
+"""
+
+from __future__ import annotations
+
+import random
+
+import backtrader as bt
+import pandas as pd
+import pytest
+from archimedes_analytics_engine.data import normalize_ohlcv
+from archimedes_analytics_engine.engine import (
+    BuyAndHoldStrategy,
+    _max_drawdown_from_curve,
+    run_backtest,
+)
+
+
+def _frame(closes: list[float], start: str = "2020-04-01") -> pd.DataFrame:
+    idx = pd.date_range(start, periods=len(closes), freq="D")
+    return pd.DataFrame(
+        {
+            "Open": closes,
+            "High": [c + abs(c) * 0.01 for c in closes],
+            "Low": [c - abs(c) * 0.01 for c in closes],
+            "Close": closes,
+            "Volume": [1_000_000] * len(closes),
+        },
+        index=idx,
+    )
+
+
+# ── The invariant, as a property ────────────────────────────────────────────
+
+
+def _random_curve(rng: random.Random, *, allow_ruin: bool) -> list[float]:
+    """A positive-start equity curve; ``allow_ruin`` lets it cross zero."""
+    curve = [rng.uniform(1.0, 1_000_000.0)]
+    floor = -2.0 if allow_ruin else 0.001
+    for _ in range(rng.randint(1, 60)):
+        step = rng.uniform(floor, 0.5)
+        curve.append(max(curve[-1] * (1.0 + step), floor * abs(curve[0])))
+    return curve
+
+
+@pytest.mark.parametrize("seed", range(200))
+def test_max_drawdown_exceeds_100pct_exactly_when_equity_goes_non_positive(seed: int) -> None:
+    """Property: for ANY equity curve with a positive start, the computed max
+    drawdown is shallower than 100% **if and only if** the curve never touches
+    zero or goes below it.
+
+    Stated in the sign convention the UI renders (``-max_drawdown_pct``):
+    the displayed drawdown is > -100% exactly when equity never goes <= 0.
+    This is the whole point of deriving the number from the curve — the reader
+    holding the curve can check the claim, and an impossible drawdown can only
+    mean a genuinely ruined account, never a measurement artifact.
+    """
+    rng = random.Random(seed)
+    curve = _random_curve(rng, allow_ruin=bool(seed % 2))
+    assert curve[0] > 0
+
+    max_dd_pct, _ = _max_drawdown_from_curve(curve)
+    assert max_dd_pct is not None
+
+    survived = min(curve) > 0
+    assert (max_dd_pct < 100.0) is survived, (
+        f"seed={seed}: max_dd={max_dd_pct!r} but min(curve)={min(curve)!r} — "
+        "the >100% bound and the ruin condition must be the same fact"
+    )
+    # And it is never nonsense in the survivable direction.
+    assert max_dd_pct >= 0.0
+
+
+def test_property_sampler_actually_produces_both_regimes() -> None:
+    """Guard against a vacuous property test: the sampler above must generate
+    both surviving and ruined curves, or the iff is only ever checked on one
+    side and the test proves nothing."""
+    survived = ruined = 0
+    for seed in range(200):
+        curve = _random_curve(random.Random(seed), allow_ruin=bool(seed % 2))
+        if min(curve) > 0:
+            survived += 1
+        else:
+            ruined += 1
+    assert survived > 10, f"only {survived} surviving curves sampled"
+    assert ruined > 10, f"only {ruined} ruined curves sampled"
+
+
+# ── The -130% shape, as a regression ────────────────────────────────────────
+
+
+def test_130_percent_drawdown_shape_requires_a_negative_equity_curve() -> None:
+    """The exact audited number, reproduced from the only curve that can produce
+    it: peak 100,000 -> trough -30,300 is (100000 - -30300) / 100000 = 130.3%.
+
+    Pins the direction of the implication the fix establishes. Reading 130.3%
+    off an artifact now tells you something specific and checkable about the
+    equity curve shipped with it — that it went below zero — instead of being a
+    number from a series nobody can see.
+    """
+    ruined = [100_000.0, 80_000.0, 20_000.0, -30_300.0, -5_000.0]
+    max_dd_pct, _ = _max_drawdown_from_curve(ruined)
+    assert max_dd_pct == pytest.approx(130.3)
+    assert min(ruined) <= 0
+
+    # The same peak-to-trough magnitude is unreachable while equity survives:
+    # the deepest a positive curve can go is asymptotically 100%.
+    survivor = [100_000.0, 80_000.0, 20_000.0, 0.01, 5_000.0]
+    survivor_dd, _ = _max_drawdown_from_curve(survivor)
+    assert survivor_dd < 100.0
+
+
+def test_negative_price_bar_drives_portfolio_value_negative_when_not_filtered() -> None:
+    """The mechanism, demonstrated end to end: feed backtrader a bar with a
+    NEGATIVE close (the CL=F 2020-04-20 shape) and a long position is marked at
+    ``size * -37.63``, dragging portfolio value below zero and producing exactly
+    the impossible >100% drawdown. This is what ``normalize_ohlcv`` now stops
+    at the boundary — the test asserts the raw, unfiltered behaviour so the
+    guard below is provably load-bearing rather than decorative.
+    """
+    closes = [20.0, 18.0, 15.0, -37.63, 10.0, 12.0]
+    result = run_backtest(
+        _frame(closes),
+        strategy_cls=BuyAndHoldStrategy,
+        initial_cash=10_000.0,
+        transaction_cost_bps=0,
+    )
+    assert min(result.equity_curve) <= 0.0, "expected the negative mark to ruin the account"
+    assert result.max_drawdown_pct is not None
+    assert result.max_drawdown_pct > 100.0
+    # ...and the invariant still holds on that run: the impossible number and
+    # the non-positive curve are the same fact, reported consistently.
+    recomputed, _ = _max_drawdown_from_curve(result.equity_curve)
+    assert result.max_drawdown_pct == pytest.approx(recomputed)
+
+
+def test_zero_price_bar_crashes_the_run_outright_without_the_guard() -> None:
+    """A zero mark is worse than a negative one: backtrader's TimeReturn divides
+    by the previous portfolio value, so a bar that zeroes equity takes the whole
+    run down with ZeroDivisionError. Second concrete consequence of admitting a
+    non-positive price, and the second thing the boundary guard prevents."""
+    with pytest.raises(ZeroDivisionError):
+        run_backtest(
+            _frame([20.0, 20.0, 0.0, 10.0, 12.0]),
+            strategy_cls=BuyAndHoldStrategy,
+            initial_cash=10_000.0,
+            transaction_cost_bps=0,
+        )
+
+    survives = run_backtest(
+        normalize_ohlcv(_frame([20.0, 20.0, 0.0, 10.0, 12.0]), symbol="ZERO"),
+        strategy_cls=BuyAndHoldStrategy,
+        initial_cash=10_000.0,
+        transaction_cost_bps=0,
+    )
+    assert min(survives.equity_curve) > 0
+
+
+def test_ruin_is_reported_loudly_rather_than_clamped(caplog) -> None:
+    """A curve that genuinely goes non-positive keeps its >100% drawdown — the
+    number is the truth about that run — but the engine says out loud that the
+    account was ruined, so the figure cannot be misread as a survivable loss."""
+    with caplog.at_level("WARNING", logger="archimedes_analytics_engine.engine"):
+        result = run_backtest(
+            _frame([20.0, 18.0, 15.0, -37.63, 10.0, 12.0]),
+            strategy_cls=BuyAndHoldStrategy,
+            initial_cash=10_000.0,
+            transaction_cost_bps=0,
+        )
+
+    assert result.max_drawdown_pct > 100.0  # not clamped
+    assert any("ruined" in r.getMessage() for r in caplog.records), caplog.text
+
+
+def test_normalize_ohlcv_drops_non_positive_price_bars() -> None:
+    """The guard: a non-positive mark never reaches the broker."""
+    raw = _frame([20.0, 18.0, 15.0, -37.63, 10.0, 12.0])
+    cleaned = normalize_ohlcv(raw, symbol="CL=F")
+
+    assert len(cleaned) == 5
+    assert (cleaned[["Open", "High", "Low", "Close"]] > 0).all().all()
+    assert pd.Timestamp("2020-04-04") not in cleaned.index  # the negative bar
+
+    # A zero close is just as unmarkable as a negative one.
+    with_zero = normalize_ohlcv(_frame([20.0, 0.0, 15.0]), symbol="ZERO")
+    assert len(with_zero) == 2
+
+
+def test_cleaned_feed_cannot_produce_an_impossible_drawdown() -> None:
+    """The two fixes composed: run the SAME series through the boundary guard
+    and the reported drawdown lands back inside the possible range."""
+    cleaned = normalize_ohlcv(_frame([20.0, 18.0, 15.0, -37.63, 10.0, 12.0]), symbol="CL=F")
+    result = run_backtest(
+        cleaned,
+        strategy_cls=BuyAndHoldStrategy,
+        initial_cash=10_000.0,
+        transaction_cost_bps=0,
+    )
+    assert min(result.equity_curve) > 0
+    assert result.max_drawdown_pct is not None
+    assert result.max_drawdown_pct < 100.0
+
+
+# ── The reported number still matches backtrader's, where both are defined ──
+
+
+def _analyzer_drawdown(prices: pd.DataFrame, *, commission: float, slippage: float) -> tuple[float, int]:
+    """``bt.analyzers.DrawDown`` on its own cerebro — the external ground truth."""
+    cerebro = bt.Cerebro(stdstats=False)
+    cerebro.broker.setcash(10_000.0)
+    cerebro.broker.setcommission(commission=commission)
+    if slippage > 0:
+        cerebro.broker.set_slippage_perc(perc=slippage)
+    cerebro.adddata(bt.feeds.PandasData(dataname=prices))
+    cerebro.addstrategy(BuyAndHoldStrategy)
+    cerebro.addanalyzer(bt.analyzers.DrawDown, _name="dd")
+    worst = cerebro.run()[0].analyzers.dd.get_analysis()["max"]
+    return float(worst["drawdown"]), int(worst["len"])
+
+
+def test_reported_drawdown_matches_bt_drawdown_analyzer_on_a_surviving_run() -> None:
+    """Deriving the drawdown from the reported curve did not change the number.
+
+    This is the behaviour-preservation check on that refactor, not a guard —
+    while broker value stays positive the compounded curve reproduces the
+    broker path exactly, so the curve-derived drawdown and
+    ``bt.analyzers.DrawDown`` (still registered as the external ground truth)
+    must agree in BOTH magnitude and duration.
+    """
+    closes = [100.0, 100.0, 90.0, 80.0, 90.0, 100.0, 95.0, 90.0, 100.0, 110.0, 100.0]
+    prices = _frame(closes, start="2022-01-01")
+
+    result = run_backtest(
+        prices,
+        strategy_cls=BuyAndHoldStrategy,
+        initial_cash=10_000.0,
+        transaction_cost_bps=0,
+    )
+    analyzer_dd, analyzer_len = _analyzer_drawdown(prices, commission=0.0, slippage=0.0)
+
+    assert result.max_drawdown_pct is not None
+    assert result.max_drawdown_pct > 0.0  # not a vacuous pass on a flat curve
+    assert result.max_drawdown_pct == pytest.approx(analyzer_dd, rel=1e-9)
+    assert result.max_drawdown_duration_bars == analyzer_len
+
+
+@pytest.mark.parametrize("seed", range(25))
+def test_reported_drawdown_matches_the_analyzer_across_random_series(seed: int) -> None:
+    """The same equivalence over randomized price paths, WITH commissions and
+    slippage on, so the refactor is pinned across the parameter space the
+    library actually runs in rather than on one hand-picked curve."""
+    rng = random.Random(seed)
+    price = 100.0
+    closes = [price]
+    for _ in range(rng.randint(5, 40)):
+        price *= 1.0 + rng.uniform(-0.3, 0.3)
+        closes.append(round(price, 4))
+    prices = _frame(closes, start="2020-01-01")
+
+    result = run_backtest(
+        prices,
+        strategy_cls=BuyAndHoldStrategy,
+        initial_cash=10_000.0,
+        transaction_cost_bps=10,
+        slippage_bps=5,
+    )
+    analyzer_dd, analyzer_len = _analyzer_drawdown(prices, commission=0.001, slippage=0.0005)
+
+    assert result.max_drawdown_pct == pytest.approx(analyzer_dd, rel=1e-9)
+    assert result.max_drawdown_duration_bars == analyzer_len

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -665,13 +665,27 @@ async def list_generated_strategies(
             from archimedes.models.generation_cost import generation_costs_for_strategies
 
             costs = generation_costs_for_strategies(session, [r.id for r in records])
-            rows = []
+            page = []
             for r in records:
                 d = r.to_dict()
                 d["can_publish"] = bool(caller) and wallet_can_publish(
                     session, strategy_id=r.id, wallet_address=caller, is_example=False
                 )
                 d["generation_cost"] = costs.get(r.id)
+                page.append(d)
+            # Citation truth: ``StrategyRecord.to_dict()`` returns source_papers
+            # exactly as stored — arxiv_id, no title — so the Library card had no
+            # real paper title to print and printed the generated strategy's own
+            # name in the cited-paper column. Resolve real titles here, against
+            # the SAME papers table the passport path reads, in ONE query for the
+            # whole page (see _corpus_paper_meta) rather than one per row.
+            corpus_meta = _corpus_paper_meta(
+                [p.get("arxiv_id") for d in page for p in (d.get("source_papers") or []) if isinstance(p, dict)],
+                session,
+            )
+            rows = []
+            for d in page:
+                d["source_papers"] = _resolve_source_papers(d.get("source_papers"), corpus_meta)
                 rows.append(_redact_owner_wallet(d, caller))
     except Exception as exc:
         # Full exception detail is logged server-side only — never echoed to
@@ -1761,6 +1775,44 @@ async def get_strategy_passport(request: Request, strategy_id: str):
         return _redact_owner_wallet(record.to_dict(), caller)
 
 
+def _year_from_published(published: str | None) -> int | None:
+    """Publication year from a corpus ``published`` stamp, or None.
+
+    ``PaperRecord.published`` is a free-form arXiv date string ("2019",
+    "2019-03-11", "2019-03-11T00:00:00Z"). Only a leading 4-digit year is
+    trusted; anything else yields None, because a guessed year on a citation
+    is the same class of lie as a guessed title.
+    """
+    head = (published or "").strip()[:4]
+    if len(head) == 4 and head.isdigit():
+        return int(head)
+    return None
+
+
+def _corpus_paper_meta(arxiv_ids: list[str | None], session) -> dict[str, dict]:
+    """Batch-resolve arXiv ids → ``{"title": str, "year": int | None}`` from the corpus.
+
+    ONE query for every id handed in — callers pass a whole page's ids at once,
+    never one call per row. Non-fatal by design: any DB error returns an empty
+    map so the caller degrades to its own honest "unresolved" rendering rather
+    than failing a list read over a decoration.
+
+    This is the single papers-table lookup shared by the passport path
+    (:func:`_enrich_paper_titles_from_corpus`) and the generated-strategy list
+    route, so both resolve a citation the same way.
+    """
+    ids = [i for i in dict.fromkeys(arxiv_ids) if i]
+    if not ids:
+        return {}
+    try:
+        from archimedes.models.corpus_store import PaperRecord
+
+        rows = session.query(PaperRecord).filter(PaperRecord.arxiv_id.in_(ids)).all()
+    except Exception:
+        return {}
+    return {row.arxiv_id: {"title": row.title, "year": _year_from_published(row.published)} for row in rows}
+
+
 def _enrich_paper_titles_from_corpus(
     refs: list,
     session,
@@ -1775,13 +1827,38 @@ def _enrich_paper_titles_from_corpus(
     missing_ids = list(dict.fromkeys(r.arxiv_id for r in refs if r.arxiv_id and not (r.title or "").strip()))
     if not missing_ids:
         return {}
-    try:
-        from archimedes.models.corpus_store import PaperRecord
+    meta = _corpus_paper_meta(missing_ids, session)
+    return {arxiv_id: m["title"] for arxiv_id, m in meta.items() if m["title"]}
 
-        rows = session.query(PaperRecord).filter(PaperRecord.arxiv_id.in_(missing_ids)).all()
-        return {row.arxiv_id: row.title for row in rows if row.title}
-    except Exception:
-        return {}
+
+def _resolve_source_papers(source_papers, corpus_meta: dict[str, dict]) -> list[dict]:
+    """Stamp each generated-row citation with a RESOLVED paper title and year.
+
+    ``StrategyRecord.source_papers`` entries carry an ``arxiv_id`` but usually
+    no ``title``, so the Library card had nothing real to print and printed the
+    generated STRATEGY NAME in the cited-paper column instead — a fabricated
+    citation. Resolution order matches the passport's ``_resolved_title``:
+    stored title wins, the corpus fills a blank one, and when neither has one
+    ``resolved_title`` stays **None**. None is the honest answer; the frontend
+    renders it as "title unavailable — arXiv:<id>", never as the strategy name.
+
+    ``resolved_year`` is the CITED PAPER's publication year, which is not the
+    row's ``created_at`` — that is when the strategy was generated.
+    """
+    resolved: list[dict] = []
+    for paper in source_papers or []:
+        if not isinstance(paper, dict):
+            continue
+        entry = dict(paper)
+        arxiv_id = (entry.get("arxiv_id") or "").strip()
+        meta = corpus_meta.get(arxiv_id) or {}
+        stored_title = (entry.get("title") or "").strip()
+        corpus_title = (meta.get("title") or "").strip()
+        entry["resolved_title"] = stored_title or corpus_title or None
+        stored_year = entry.get("year")
+        entry["resolved_year"] = stored_year if isinstance(stored_year, int) else meta.get("year")
+        resolved.append(entry)
+    return resolved
 
 
 def _generation_cost_for(strategy_id: str, session) -> dict | None:

--- a/backend/tests/test_generated_citation_truth.py
+++ b/backend/tests/test_generated_citation_truth.py
@@ -1,0 +1,251 @@
+"""GET /api/strategies/generated must cite the PAPER, not name the strategy.
+
+Hermetic (tmp-sqlite, no .env / network / Redis); DB fixture copies the
+`_use_tmp_db` pattern from test_strategy_ownership.py.
+
+The defect: ``StrategyRecord.to_dict()`` returns ``source_papers`` exactly as
+stored — an ``arxiv_id`` and, usually, no ``title`` — so the Library card had no
+paper title to render and rendered the generated STRATEGY NAME in the
+cited-paper slot instead (``coerceGenerated``'s
+``paper_title: row.strategy_name``, under a panel headed "Source paper"). That
+is a fabricated citation, which is worse than a missing one: a reader cannot
+tell it apart from a real one.
+
+The route now resolves real titles against the same ``papers`` corpus table the
+passport path reads, in ONE query for the whole page, and leaves
+``resolved_title`` **None** when the corpus genuinely doesn't know — the
+frontend renders that as "title unavailable — arXiv:<id>", never as a name.
+"""
+
+from __future__ import annotations
+
+import time
+
+import archimedes.db as db
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from archimedes.api.strategies_routes import (
+    _corpus_paper_meta,
+    _resolve_source_papers,
+    _year_from_published,
+)
+from httpx import ASGITransport, AsyncClient
+
+_W_OWNER = "0xAbC0000000000000000000000000000000000001"
+
+_STRATEGY_NAME = "Adaptive Cross-Sectional Momentum Overlay"
+_REAL_TITLE = "Deep Learning Statistical Arbitrage"
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'citations.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _mk_strategy(sid: str, *, source_papers: str, name: str = _STRATEGY_NAME):
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with db.get_session() as session:
+        session.add(
+            StrategyRecord(
+                id=sid,
+                content_hash=("0x" + sid).ljust(66, "0"),
+                generation_method="fusion",
+                source_papers=source_papers,
+                strategy_name=name,
+                thesis="test thesis",
+                asset_universe="[]",
+                risk_profile="moderate",
+                status="candidate",
+                is_example=False,
+                owner_wallet=_W_OWNER.lower(),
+                is_published=False,
+            )
+        )
+        session.commit()
+
+
+def _mk_paper(arxiv_id: str, *, title: str, published: str = "2021-06-14"):
+    from archimedes.models.corpus_store import PaperRecord
+
+    with db.get_session() as session:
+        session.add(PaperRecord(arxiv_id=arxiv_id, title=title, published=published))
+        session.commit()
+
+
+# ── Pure helpers ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("published", "expected"),
+    [
+        ("2021-06-14", 2021),
+        ("2021", 2021),
+        ("2021-06-14T00:00:00Z", 2021),
+        ("", None),
+        (None, None),
+        ("n/a", None),
+        ("21-06", None),  # not a 4-digit leading year — guessing one is a lie
+    ],
+)
+def test_year_from_published(published, expected):
+    assert _year_from_published(published) == expected
+
+
+def test_resolve_source_papers_prefers_the_stored_title():
+    resolved = _resolve_source_papers(
+        [{"arxiv_id": "2106.04028", "title": "Stored Title"}],
+        {"2106.04028": {"title": "Corpus Title", "year": 2021}},
+    )
+    assert resolved[0]["resolved_title"] == "Stored Title"
+    assert resolved[0]["resolved_year"] == 2021
+
+
+def test_resolve_source_papers_falls_back_to_the_corpus():
+    resolved = _resolve_source_papers(
+        [{"arxiv_id": "2106.04028", "title": "   "}],
+        {"2106.04028": {"title": _REAL_TITLE, "year": 2021}},
+    )
+    assert resolved[0]["resolved_title"] == _REAL_TITLE
+
+
+def test_resolve_source_papers_leaves_none_when_unresolvable():
+    """The load-bearing case: with nothing to cite, the field is None. The
+    frontend turns None into 'title unavailable — arXiv:<id>'. Anything else
+    here — most of all the strategy's own name — would be a fabrication."""
+    resolved = _resolve_source_papers([{"arxiv_id": "9999.99999"}], {})
+    assert resolved[0]["resolved_title"] is None
+    assert resolved[0]["resolved_year"] is None
+    assert resolved[0]["arxiv_id"] == "9999.99999"
+
+
+def test_resolve_source_papers_survives_a_malformed_entry():
+    assert _resolve_source_papers(["not-a-dict", None], {}) == []
+    assert _resolve_source_papers(None, {}) == []
+
+
+# ── Corpus lookup is batched, not N+1 ───────────────────────────────────────
+
+
+def test_corpus_paper_meta_is_one_query_for_the_whole_page():
+    """The page's citations resolve in a SINGLE papers-table query. A per-row
+    lookup would put a query on every Library render, scaling with page size."""
+    from sqlalchemy import event
+
+    for i in range(8):
+        _mk_paper(f"2106.0400{i}", title=f"Paper {i}", published="2021-06-14")
+
+    statements: list[str] = []
+
+    def _record(_conn, _cursor, statement, *_rest):
+        statements.append(statement)
+
+    with db.get_session() as session:
+        event.listen(session.bind, "before_cursor_execute", _record)
+        try:
+            meta = _corpus_paper_meta([f"2106.0400{i}" for i in range(8)], session)
+        finally:
+            event.remove(session.bind, "before_cursor_execute", _record)
+
+    assert len(meta) == 8
+    selects = [s for s in statements if s.lstrip().upper().startswith("SELECT")]
+    assert len(selects) == 1, f"expected 1 batched SELECT, got {len(selects)}: {selects}"
+
+
+def test_corpus_paper_meta_short_circuits_on_no_ids():
+    with db.get_session() as session:
+        assert _corpus_paper_meta([], session) == {}
+        assert _corpus_paper_meta([None, ""], session) == {}
+
+
+def test_corpus_paper_meta_returns_empty_map_on_db_error():
+    """Non-fatal by contract: a citation decoration must never take down a list
+    read. The caller then renders the honest 'unavailable' fallback."""
+
+    class _Boom:
+        def query(self, *_a, **_k):
+            raise RuntimeError("db down")
+
+    assert _corpus_paper_meta(["2106.04028"], _Boom()) == {}
+
+
+# ── The route ───────────────────────────────────────────────────────────────
+
+
+async def test_generated_route_serves_the_resolved_paper_title():
+    _mk_paper("2106.04028", title=_REAL_TITLE, published="2021-06-14")
+    _mk_strategy("cit00000000000001", source_papers='[{"arxiv_id": "2106.04028"}]')
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    papers = resp.json()["strategies"][0]["source_papers"]
+    assert papers[0]["resolved_title"] == _REAL_TITLE
+    assert papers[0]["resolved_year"] == 2021
+
+
+async def test_generated_route_never_serves_the_strategy_name_as_a_title():
+    """The regression that matters: with the paper absent from the corpus, the
+    resolved title stays None. It must NOT quietly become the strategy name —
+    which is exactly what the pre-fix Library card printed."""
+    _mk_strategy("cit00000000000002", source_papers='[{"arxiv_id": "9999.99999"}]')
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+
+    row = resp.json()["strategies"][0]
+    assert row["strategy_name"] == _STRATEGY_NAME  # still there, in its own field
+    papers = row["source_papers"]
+    assert papers[0]["resolved_title"] is None
+    assert _STRATEGY_NAME not in str(papers)
+
+
+async def test_generated_route_resolves_titles_across_the_whole_page():
+    """Every row on the page is resolved, not just the first — the batch must
+    cover the page, and a row whose paper is missing must not poison the rest."""
+    _mk_paper("2106.04028", title=_REAL_TITLE, published="2021-06-14")
+    _mk_paper("2202.11111", title="Another Real Paper", published="2022")
+    _mk_strategy("cit00000000000003", source_papers='[{"arxiv_id": "2106.04028"}]')
+    _mk_strategy("cit00000000000004", source_papers='[{"arxiv_id": "2202.11111"}]')
+    _mk_strategy("cit00000000000005", source_papers='[{"arxiv_id": "0000.00000"}]')
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+
+    by_id = {r["id"]: r["source_papers"][0] for r in resp.json()["strategies"]}
+    assert by_id["cit00000000000003"]["resolved_title"] == _REAL_TITLE
+    assert by_id["cit00000000000004"]["resolved_title"] == "Another Real Paper"
+    assert by_id["cit00000000000004"]["resolved_year"] == 2022
+    assert by_id["cit00000000000005"]["resolved_title"] is None
+
+
+async def test_generated_route_handles_a_row_with_no_source_papers():
+    _mk_strategy("cit00000000000006", source_papers="[]")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    assert resp.json()["strategies"][0]["source_papers"] == []

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -41,7 +41,12 @@ function downloadStrategy(strategy, format) {
   } else {
     const rows = [
       ['Field', 'Value'],
-      ['Title', strategy.paper_title],
+      // Two distinct facts, exported as two rows. 'Paper Title' sits directly
+      // above the paper's authors and year, so labelling it 'Title' while a
+      // generated row's own name occupied it made the export claim the
+      // strategy name was the citation.
+      ...(strategy.strategy_name ? [['Strategy Name', strategy.strategy_name]] : []),
+      ['Paper Title', strategy.paper_title],
       ['Authors', strategy.paper_authors?.join(', ')],
       ['Year', strategy.paper_year],
       ['Status', strategy.status],
@@ -139,6 +144,13 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
     s.paper_authors?.[0]?.split(' ').pop(),
     s.paper_year && `(${s.paper_year})`,
   ].filter(Boolean).join(' ')
+  // A generated row carries its own name (the LLM's name for the strategy),
+  // which is a DIFFERENT fact from the title of the paper it cites. Curated
+  // rows have no separate name — there the paper title IS the strategy's
+  // identity — so `strategy_name` is absent and nothing below changes for
+  // them. See coerceGenerated: paper_title is the CITED PAPER, always.
+  const rowLabel = s.strategy_name || s.paper_title
+  const citedPaperTitle = s.strategy_name ? s.paper_title : null
 
   // Real API fields (backend/archimedes/api/schemas.py) — the singular-CI
   // and drift-boolean fields this used to read never existed in any API
@@ -185,7 +197,7 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
             onClick={(e) => { e.stopPropagation(); setOpen(o => !o) }}
           >
             <span aria-hidden="true" className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3 h-3 mr-1.5 text-[var(--text-4)] flex-shrink-0 inline-block`} />
-            {s.paper_title}
+            {rowLabel}
           </button>
           {(s.papers || []).length > 1 && (
             <span
@@ -197,7 +209,10 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
             </span>
           )}
         </td>
-        <td className="caption">{paperCite || (s.paper_year ? `(${s.paper_year})` : '—')}</td>
+        <td className="caption">
+          {citedPaperTitle && <div>{citedPaperTitle}</div>}
+          {paperCite || (citedPaperTitle ? null : (s.paper_year ? `(${s.paper_year})` : '—'))}
+        </td>
         <td>
           <div className="flex items-center gap-1.5 flex-wrap">
             <span
@@ -470,7 +485,10 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
       <div className="lib-card-header">
         <span className={`${open ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'} w-3.5 h-3.5 text-[var(--text-4)] flex-shrink-0`} />
         <div className="lib-card-title">
-          {s.paper_title}
+          {/* Same split as StrategyRow: the card's headline is the strategy's
+              own name when it has one; paper_title is the CITED PAPER and
+              belongs under the "Source paper" heading in the detail panel. */}
+          {s.strategy_name || s.paper_title}
           {(s.papers || []).length > 1 && (
             <span className="tag tag-accent" style={{ fontSize: '0.66rem', marginLeft: 6 }} title={`Fused from ${s.papers.length} papers`}>
               {s.papers.length} papers
@@ -586,8 +604,23 @@ function StrategyTable({ strategies, emptyState, highlightStrategyId, onOpenRigo
 // signal that fusion-to-backtest hasn't run yet.
 function coerceGenerated(row) {
   const sourcePapers = Array.isArray(row.source_papers) ? row.source_papers : []
-  const firstPaper = sourcePapers[0]?.arxiv_id || ''
-  const year = row.created_at ? new Date(row.created_at).getFullYear() : null
+  const citedPaper = sourcePapers[0] || null
+  const firstPaper = citedPaper?.arxiv_id || ''
+  // Citation truth: this column is the CITED PAPER's title. It used to be
+  // bound to row.strategy_name — the LLM's name for the strategy rendered
+  // where a real citation belongs, which is a fabricated citation, not a
+  // missing one. The backend now resolves real titles from the papers corpus
+  // (list_generated_strategies -> _resolve_source_papers). When resolution
+  // genuinely fails we say so and name the id a reader can look up; the one
+  // thing that must never appear here is the strategy's own name.
+  const resolvedTitle = (citedPaper?.resolved_title || '').trim()
+  const paperTitle = citedPaper
+    ? (resolvedTitle || `title unavailable — arXiv:${firstPaper || 'unknown'}`)
+    : 'no cited paper'
+  // Publication year of the CITED PAPER, resolved from the corpus alongside
+  // the title. Never row.created_at — that is when the STRATEGY was generated,
+  // and printing it under a paper citation invented a publication date.
+  const paperYear = typeof citedPaper?.resolved_year === 'number' ? citedPaper.resolved_year : null
   // rigor_verdict is the real shape the backend persists (see
   // StrategyRecord.to_dict() in backend/archimedes/models/strategy_store.py
   // and generation_pipeline.py ~line 1272): {dsr, dsr_p_value, pbo,
@@ -607,10 +640,13 @@ function coerceGenerated(row) {
     : (row.status || 'candidate')
   return {
     id: row.id,
-    paper_title: row.strategy_name || '(unnamed)',
+    // The strategy's OWN name, kept as its own field rather than smuggled into
+    // paper_title. It is the row's headline; the citation is paper_title.
+    strategy_name: row.strategy_name || '(unnamed)',
+    paper_title: paperTitle,
     paper_arxiv_id: firstPaper,
     paper_authors: [],
-    paper_year: year,
+    paper_year: paperYear,
     paper_venue: row.generation_method,
     methodology_summary: row.thesis || '',
     status: honestStatus,


### PR DESCRIPTION
v8 Lane 1.4 code half, both defects from the external review.

**Citations:** the Library wrote the generated strategy's own name where the cited paper's title belongs (`coerceGenerated` at Strategies.jsx:610 — the raw list endpoint carried no title to bind). Now `list_generated_strategies` resolves real titles/years against the papers corpus in one batched query via a resolver shared with the passport path; the UI binds resolved fields with the honest fallback `title unavailable — arXiv:<id>`, never the strategy name. One judgment call flagged for review: the card headline keeps the strategy's name and the paper title moves to the Paper column (curated rows byte-identical).

**Impossible drawdown — root cause corrects the earlier investigation:** not `dsl_to_backtrader` (it contains no metrics). The −130% was *correct arithmetic on poisoned data*: `normalize_ohlcv` never validated price positivity, and `avellaneda_lee_2010`'s OIL resolves to CL=F — which settled at −$37.63 on 2020-04-20 — ruining the marked equity. Positivity is now validated at normalization (drop + loud log), drawdown derives from the reported equity curve (behavior-preserving refactor, pinned by a randomized equivalence test), and ruin is logged loudly, never clamped.

**Verification:** three adversarial demonstrations (positivity guard dropped → ZeroDivisionError + ruined equity named; raw source_papers served → KeyError ×3; batching regressed → 'expected 1 batched SELECT, got 8'). analytics-engine 482 passed; full CI suite 3,917 passed; hermetic gate clean; anti-goals held (Leaderboard untouched, no schema changes).

Built by an Opus builder, validated in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7