### PR TITLE
[generation] Capture and persist the debate transcript — stop discarding the product's best artifact

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -722,9 +722,14 @@ async def _run_debate_leaderboard(
         result_summary=f"pool_size={pool_size} actionable+conformant specs",
     )
 
-    # Step 2 — best-effort adversarial transcript (never gates).
+    # Step 2 — best-effort adversarial transcript (never gates). The return
+    # value is a real, paid 4-turn bull/bear transcript — captured here (not
+    # discarded) and stamped onto every leaderboard entry below, so it
+    # survives past this function into persistence (debate_transcripts,
+    # #<transcript-capture>). It never gates: build_leaderboard is called
+    # below whether this list is empty or not.
     with cost_meter.stage("debate_transcript"):
-        await _debate_round(pool, model, emit, candidate_id)
+        transcript = await _debate_round(pool, model, emit, candidate_id)
 
     # Step 3a — C-prov (non-votable, Xia 1/2/4): cull candidates citing outside the
     # embargo+decay surface. Does NOT change pool_size (the DSR denominator counts
@@ -776,6 +781,14 @@ async def _run_debate_leaderboard(
         regime_force_abstain=regime_gate["force_abstain"],
         regime_reason=regime_gate["reason"],
     )
+    # Stamp the ONE transcript this run produced onto every entry (winner AND
+    # the tail Considered Alternatives) — build_leaderboard is pure and knows
+    # nothing about the debate, so this is the single attachment point. Every
+    # entry shares the same list object: one debate happened, not one per
+    # candidate.
+    if transcript:
+        for entry in leaderboard:
+            entry.debate_transcript = transcript
     leader = leaderboard[0]
     await emit.emit(
         "tool_result",

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -255,6 +255,14 @@ class _CandidateResult:
     # vector. None on the fixture/buy-and-hold-weights path (there is no DSL
     # spec to carry — it re-derives its universe from ``weights`` instead).
     strategy_spec: dict[str, Any] | None = None
+    # The society's own bull/bear debate transcript (debate path only —
+    # ``_run_debate_leaderboard`` stamps the SAME transcript object onto every
+    # leaderboard entry it returns, winner and alternates alike, since the
+    # debate runs once over the whole pool before C-null picks a winner).
+    # ``None`` on every non-debate path (fusion, fixture, single-agent) — there
+    # is no debate on those paths, so there is nothing to attach. Read by
+    # ``_persist_debate_transcripts`` below; never touches ``_HASH_FIELDS``.
+    debate_transcript: list[dict[str, Any]] | None = None
 
 
 def _is_deployable(c: _CandidateResult) -> bool:
@@ -789,6 +797,59 @@ async def _persist_generation_cost(
         logger.warning("cost record: durable persist failed for job %s (non-blocking)", job_id, exc_info=True)
 
 
+async def _persist_debate_transcripts(
+    *,
+    job_id: str,
+    candidates: list[_CandidateResult],
+    strategy_ids: dict[str, str],
+) -> None:
+    """Persist each candidate's debate transcript, keyed to (generation, candidate).
+
+    Every leaderboard entry a debate run produces carries the SAME transcript
+    (``_run_debate_leaderboard`` stamps it onto every entry it returns, since
+    the debate runs once over the whole pool before C-null picks a winner) —
+    so a single pass over ``candidates`` here persists it for the K=1 winner
+    (with its real ``strategy_id`` from ``strategy_ids``) AND every
+    final-round loser (``strategy_id=None`` — losers are never threaded into
+    ``strategy_store``; see ``_persist_candidate``'s K=1 docstring), entirely
+    from data already collected by the time this is called. Non-debate
+    candidates (fusion, fixture, single-agent) carry ``debate_transcript=None``
+    and are skipped — there is nothing to persist for them.
+
+    Best-effort, like the sibling :func:`_persist_generation_cost`: this runs
+    after the winner's strategy row already landed, so a failure here must
+    never fail (or retroactively un-succeed) a generation that already
+    succeeded.
+    """
+    to_write = [c for c in candidates if c.debate_transcript]
+    if not to_write:
+        return
+
+    def _write() -> int:
+        from archimedes.db import get_session
+        from archimedes.models.debate_transcript import record_debate_transcript
+
+        written = 0
+        with get_session() as session:
+            for c in to_write:
+                record_debate_transcript(
+                    session,
+                    strategy_id=strategy_ids.get(c.candidate_id),
+                    generation_id=job_id,
+                    candidate_id=c.candidate_id,
+                    transcript=c.debate_transcript,
+                )
+                written += 1
+            session.commit()
+        return written
+
+    try:
+        count = await asyncio.to_thread(_write)
+        logger.info("debate transcript: persisted %d row(s) for job %s", count, job_id)
+    except (Exception, asyncio.CancelledError):
+        logger.warning("debate transcript: persist failed for job %s (non-blocking)", job_id, exc_info=True)
+
+
 async def run_generation(
     *,
     job_id: str,
@@ -1271,6 +1332,12 @@ async def run_generation(
                 meter.record_write("strategy_proposals")
         except Exception:
             pass  # Non-blocking per spec
+
+        # Debate transcript capture: persist each candidate's bull/bear debate
+        # transcript (winner + final-round losers) — see
+        # _persist_debate_transcripts's docstring for why one pass over
+        # `candidates` covers both. No-op on every non-debate path.
+        await _persist_debate_transcripts(job_id=job_id, candidates=candidates, strategy_ids=strategy_ids)
 
         # Stash the full candidate list on the job for /candidates retrieval.
         # update_terminal_status (not update_status): a Cancel request can flip

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2253,6 +2253,60 @@ async def get_strategy_returns(strategy_id: str, request: Request):
     )
 
 
+@strategies_router.get("/{strategy_id}/debate")
+async def get_strategy_debate(strategy_id: str, request: Request):
+    """Return the persisted bull/bear debate transcript for a generated strategy.
+
+    Response shape: ``{strategy_id, generation_id, candidate_id, created_at,
+    transcript: [{role, round, verdict, claims}, ...]}``.
+
+    Auth mirrors ``GET /api/strategies/{id}/returns`` and the plain detail
+    route exactly: curated strategies are always public; a generated
+    strategy's transcript is 404 unless the caller owns the row (existence
+    stays hidden either way — never a 403).
+
+    404 with ``{"detail": "no debate transcript"}`` when the strategy exists
+    and is visible but no transcript was ever persisted for it — every
+    strategy generated before this table existed, every curated strategy
+    (the debate society never ran for those), and any run whose debate step
+    genuinely produced nothing (no LLM backend reachable). Never fabricates a
+    transcript.
+    """
+    from fastapi import HTTPException
+
+    from archimedes.db import get_session
+
+    # ── 1. Existence + ownership gate (mirrors get_strategy / get_strategy_returns) ──
+    strat = strategy_provider().get_strategy(strategy_id)
+    is_curated = strat is not None
+
+    if not is_curated:
+        from archimedes.api.auth_siwe import get_verified_wallet
+        from archimedes.models.strategy_store import StrategyRecord
+        from archimedes.services.strategy_visibility import is_strategy_visible
+
+        with get_session() as session:
+            row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
+            caller = get_verified_wallet(request)
+            user = get_current_user(request)
+            if not is_strategy_visible(row, caller, caller_user_id=user.id if user else None):
+                raise HTTPException(status_code=404, detail="Strategy not found")
+
+    # ── 2. Load the persisted transcript ──────────────────────────────────
+    from archimedes.models.debate_transcript import debate_transcript_for_strategy
+
+    try:
+        with get_session() as session:
+            payload = debate_transcript_for_strategy(session, strategy_id)
+    except Exception as exc:
+        logger.warning("debate endpoint DB read failed for %s: %s", strategy_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to load debate transcript") from exc
+
+    if payload is None:
+        raise HTTPException(status_code=404, detail="no debate transcript")
+    return payload
+
+
 @strategies_router.get("/{strategy_id}", response_model=StrategyResponse)
 async def get_strategy(strategy_id: str, request: Request):
     """Get a single strategy by ID. Tries LocalStrategyProvider (curated)

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -27,6 +27,7 @@ from archimedes.models.backtest_store import BacktestResultRecord
 from archimedes.models.chat import Base
 from archimedes.models.corpus_store import CorpusMetaRecord, PaperRecord
 from archimedes.models.daily_returns_store import StrategyDailyReturn
+from archimedes.models.debate_transcript import DebateTranscriptRecord
 from archimedes.models.generation_cost import GenerationCostRecord
 from archimedes.models.generation_credit import GenerationCreditRecord
 from archimedes.models.identity import ControlledWallet, IdentityEvent, WalletIdentity
@@ -59,6 +60,7 @@ __all__ = [
     "Base",
     "ControlledWallet",
     "CorpusMetaRecord",
+    "DebateTranscriptRecord",
     "GenerationCostRecord",
     "GenerationCreditRecord",
     "IdentityEvent",

--- a/backend/archimedes/models/debate_transcript.py
+++ b/backend/archimedes/models/debate_transcript.py
@@ -1,0 +1,205 @@
+"""Persisted debate transcripts — the bull/bear adversarial round the society
+runs before C-null selects a winner (v8 Lane 2.3).
+
+``_run_debate_leaderboard`` has always run a real 4-turn LLM debate
+(``_debate_round``) — paid backend output, one bull + one bear verdict per
+round, with a visible round-2 rebuttal — but the caller discarded the return
+value outright: ``debate_engine.py`` used to read
+``await _debate_round(pool, model, emit, candidate_id)`` with no assignment,
+so the transcript vanished the instant the coroutine returned. This module is
+where it survives.
+
+Every leaderboard entry produced by ONE debate run shares the SAME
+transcript: the debate happens once, over the whole proposed pool, BEFORE
+C-null culls it down to a winner (see ``_run_debate_leaderboard``'s step
+ordering, where step 2 — the debate — runs ahead of steps 3-5). A row here is
+therefore keyed to ``(generation_id, candidate_id)``, not to a strategy:
+
+* The K=1 winner's row also carries a ``strategy_id`` (the ``strategy_store``
+  row ``_persist_candidate`` created for it).
+* Final-round losers — the Considered Alternatives — are never threaded into
+  ``strategy_store`` (K=1 persistence; see ``_persist_candidate``'s own
+  docstring), so their row carries ``strategy_id=None``. NULL means "this
+  candidate was a considered alternative, not the winner", never "unknown" or
+  "write failed".
+
+Sanitization happens at WRITE time, not read time (see ``sanitize_transcript``
+below): every string field of every turn is stripped of internal-jargon
+patterns before the JSON is serialized, so the stored column is never the
+place a leak has to be caught — a raw read of ``transcript_json`` is already
+safe.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Index, Integer, String, Text
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from archimedes.models.chat import Base
+
+logger = logging.getLogger(__name__)
+
+# Defensive, not exhaustive: internal roadmap vocabulary an LLM debate turn
+# could echo back from system-prompt bleed-through or corpus-context leakage.
+# Each match is replaced, never silently dropped — see sanitize_debate_text.
+_JARGON_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"T\d\.\d"),  # tier/milestone codes, e.g. "T3.5", "T1.1"
+    re.compile(r"cutover", re.IGNORECASE),
+    re.compile(r"Phase-\w*"),  # "Phase-3", "Phase-4a", or a bare "Phase-"
+)
+
+_REDACTED = "[redacted]"
+
+
+def sanitize_debate_text(text: str) -> str:
+    """Strip internal-jargon patterns from one string. Idempotent; never raises.
+
+    Non-string / empty input passes through unchanged — this is a text
+    scrubber, not a validator; callers decide what counts as absent.
+    """
+    if not text:
+        return text
+    out = text
+    for pattern in _JARGON_PATTERNS:
+        out = pattern.sub(_REDACTED, out)
+    return out
+
+
+def sanitize_transcript(transcript: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Apply :func:`sanitize_debate_text` to every string field of every turn.
+
+    Only the two fields ``_debate_round`` actually emits per turn — ``verdict``
+    (a string) and ``claims`` (a list of strings) — are scrubbed; everything
+    else on a turn dict (``role``, ``round``) passes through untouched. A
+    non-dict entry is dropped rather than raising, matching the "best-effort,
+    never gates" posture of the debate round itself.
+    """
+    sanitized: list[dict[str, Any]] = []
+    for turn in transcript:
+        if not isinstance(turn, dict):
+            continue
+        new_turn = dict(turn)
+        verdict = new_turn.get("verdict")
+        if isinstance(verdict, str):
+            new_turn["verdict"] = sanitize_debate_text(verdict)
+        claims = new_turn.get("claims")
+        if isinstance(claims, list):
+            new_turn["claims"] = [sanitize_debate_text(c) if isinstance(c, str) else c for c in claims]
+        sanitized.append(new_turn)
+    return sanitized
+
+
+class DebateTranscriptRecord(Base):
+    """One debate run's bull/bear transcript, keyed to (generation, candidate).
+
+    ``strategy_id`` carries no foreign key — mirrors ``generation_costs`` /
+    ``paper_deployments``, the sibling tables that also reference
+    ``strategy_store.id`` without a constraint — and is nullable for the
+    reason in the module docstring: only the K=1 winner is ever threaded into
+    ``strategy_store``.
+    """
+
+    __tablename__ = "debate_transcripts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    strategy_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    generation_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    candidate_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    transcript_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        Index("ix_debate_transcripts_strategy", "strategy_id"),
+        Index("ix_debate_transcripts_generation_candidate", "generation_id", "candidate_id"),
+    )
+
+    # ── Readout ──────────────────────────────────────────────────────────
+
+    def to_payload(self) -> dict[str, Any] | None:
+        """The API shape, or ``None`` when the stored JSON cannot be decoded.
+
+        A corrupt ``transcript_json`` yields ``None`` rather than an empty
+        transcript — the row exists to carry a transcript, so one we cannot
+        decode is an absence (``CLAUDE.md`` § fail-soft), not a fabricated
+        empty list.
+        """
+        try:
+            transcript = json.loads(self.transcript_json)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("debate_transcripts: corrupt transcript_json for id=%s — treating as absent", self.id)
+            return None
+        if not isinstance(transcript, list):
+            return None
+        return {
+            "strategy_id": self.strategy_id,
+            "generation_id": self.generation_id,
+            "candidate_id": self.candidate_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "transcript": transcript,
+        }
+
+
+def record_debate_transcript(
+    session: Session,
+    *,
+    strategy_id: str | None,
+    generation_id: str,
+    candidate_id: str,
+    transcript: list[dict[str, Any]],
+) -> DebateTranscriptRecord:
+    """Insert one sanitized transcript row.
+
+    Not an upsert: a job never re-runs the same ``(generation_id,
+    candidate_id)`` pair, so unlike ``generation_costs`` (whose job can
+    legitimately retry) there is nothing to dedup against.
+
+    Raises ``ValueError`` on a missing ``generation_id``/``candidate_id`` or a
+    non-list ``transcript`` — writing a row nothing could ever look back up
+    would be strictly worse than not writing it.
+    """
+    if not generation_id:
+        raise ValueError("record_debate_transcript requires a generation_id")
+    if not candidate_id:
+        raise ValueError("record_debate_transcript requires a candidate_id")
+    if not isinstance(transcript, list):
+        raise ValueError(f"record_debate_transcript requires a list transcript, got {type(transcript).__name__}")
+
+    sanitized = sanitize_transcript(transcript)
+    transcript_json = json.dumps(sanitized, sort_keys=True, ensure_ascii=False, default=str)
+
+    record = DebateTranscriptRecord(
+        strategy_id=strategy_id,
+        generation_id=generation_id,
+        candidate_id=candidate_id,
+        transcript_json=transcript_json,
+        created_at=datetime.now(UTC),
+    )
+    session.add(record)
+    session.flush()
+    return record
+
+
+def debate_transcript_for_strategy(session: Session, strategy_id: str) -> dict[str, Any] | None:
+    """The most recently recorded transcript for a strategy's row, or ``None``.
+
+    Only the K=1 winner ever carries a non-NULL ``strategy_id`` on this table
+    (see the module docstring), so this is the only lookup the read API
+    needs — a considered-alternative has no ``strategy_id`` to look up by in
+    the first place, and ``None`` here is the honest answer for every
+    strategy generated before this table existed, and for every curated one.
+    """
+    if not strategy_id:
+        return None
+    record = (
+        session.query(DebateTranscriptRecord)
+        .filter_by(strategy_id=strategy_id)
+        .order_by(DebateTranscriptRecord.created_at.desc(), DebateTranscriptRecord.id.desc())
+        .first()
+    )
+    return record.to_payload() if record is not None else None

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -53,6 +53,7 @@ from archimedes.models.backtest_store import BacktestResultRecord  # noqa: E402
 from archimedes.models.chat import Base  # noqa: E402
 from archimedes.models.corpus_store import CorpusMetaRecord, PaperRecord  # noqa: E402
 from archimedes.models.daily_returns_store import StrategyDailyReturn  # noqa: E402
+from archimedes.models.debate_transcript import DebateTranscriptRecord  # noqa: E402
 from archimedes.models.generation_cost import GenerationCostRecord  # noqa: E402
 from archimedes.models.identity import ControlledWallet, IdentityEvent, WalletIdentity  # noqa: E402
 from archimedes.models.kg import KGEntity, KGRelation  # noqa: E402
@@ -90,6 +91,7 @@ __all__ = [
     "Base",
     "ControlledWallet",
     "CorpusMetaRecord",
+    "DebateTranscriptRecord",
     "GenerationCostRecord",
     "IdentityEvent",
     "KGEntity",

--- a/backend/migrations/versions/5728d9ef1901_add_debate_transcripts.py
+++ b/backend/migrations/versions/5728d9ef1901_add_debate_transcripts.py
@@ -1,0 +1,94 @@
+"""add debate_transcripts — persist the bull/bear debate transcript (v8 Lane 2.3)
+
+``_run_debate_leaderboard`` has always run a real 4-turn LLM debate
+(``_debate_round``) — one bull + one bear verdict per round, with a visible
+round-2 rebuttal — before C-null culls the pool down to a winner. The caller
+discarded the return value outright: ``debate_engine.py`` used to read
+``await _debate_round(pool, model, emit, candidate_id)`` with no assignment,
+so a real, paid LLM transcript vanished the instant the coroutine returned.
+This table is where it survives.
+
+Every leaderboard entry from ONE debate run shares the SAME transcript (the
+debate runs once, over the whole pool, before C-null picks a winner), so a
+row is keyed to ``(generation_id, candidate_id)``, not to a strategy:
+
+  - The K=1 winner's row also carries a ``strategy_id`` (its
+    ``strategy_store`` row).
+  - Final-round losers (Considered Alternatives) are never threaded into
+    ``strategy_store`` — K=1 persistence, see ``_persist_candidate`` — so
+    their row carries ``strategy_id=NULL``. NULL means "considered
+    alternative, not the winner", never "write failed".
+
+``strategy_id`` carries no foreign key, mirroring ``generation_costs`` /
+``paper_deployments`` — the sibling tables that also reference
+``strategy_store.id`` without a constraint: a purge of the strategy row must
+not delete the record that a debate produced it.
+
+Sanitization (internal-jargon stripping) happens at WRITE time in
+``archimedes.models.debate_transcript.record_debate_transcript``, not as a
+migration concern — this file only creates the shape the sanitized JSON lands
+in.
+
+BACKFILL (migrations-ship-with-their-data rule): **none, and none is
+possible.** Every debate that ran before this revision had its transcript
+discarded at the call site the moment it returned — there is no recoverable
+copy anywhere to backfill from. Strategies generated before this lands render
+as "no debate transcript" (404 on the read route), which is the honest state.
+
+Revision ID: 5728d9ef1901
+Revises: a3f19c7d2e84
+Create Date: 2026-08-30 00:00:00.000000
+
+SEQUENCING: chained onto ``a3f19c7d2e84`` (add_generation_credits), the chain
+head at authoring time. If another migration lands on main first, re-point
+``down_revision`` at the new head — ``.github/scripts/migration_chain_guard.py``
+catches a fork.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5728d9ef1901"
+down_revision: str | Sequence[str] | None = "a3f19c7d2e84"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "debate_transcripts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("strategy_id", sa.String(length=64), nullable=True),
+        sa.Column("generation_id", sa.String(length=64), nullable=False),
+        sa.Column("candidate_id", sa.String(length=64), nullable=False),
+        sa.Column("transcript_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_debate_transcripts_strategy", "debate_transcripts", ["strategy_id"])
+    op.create_index(
+        "ix_debate_transcripts_generation_candidate",
+        "debate_transcripts",
+        ["generation_id", "candidate_id"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Dropping the table discards every debate transcript recorded while this
+    revision was live. There is nowhere else they were kept — the whole point
+    of this revision is that the pipeline discarded them before this table
+    existed — so a downgrade is a deliberate loss, not a reversible move.
+    """
+    op.drop_index("ix_debate_transcripts_generation_candidate", table_name="debate_transcripts")
+    op.drop_index("ix_debate_transcripts_strategy", table_name="debate_transcripts")
+    op.drop_table("debate_transcripts")

--- a/backend/tests/test_debate_engine.py
+++ b/backend/tests/test_debate_engine.py
@@ -528,6 +528,97 @@ async def test_debate_round_degrades_when_backend_unavailable(monkeypatch):
     assert transcript == []  # never gates; no backend → empty best-effort transcript
 
 
+# ── Transcript capture (debate-transcript-capture): the return value of
+#    _debate_round used to be discarded outright at the _run_debate_leaderboard
+#    call site (`await _debate_round(...)` with no assignment) — a real, paid
+#    4-turn bull/bear transcript vanished the instant the coroutine returned.
+#    This is the end-to-end regression guard: run the FULL leaderboard builder
+#    (not just _debate_round in isolation, which was already covered above)
+#    and assert every entry — winner AND the tail alternate — carries it. ────
+
+
+async def test_run_debate_leaderboard_attaches_transcript_to_every_entry(monkeypatch, corpus):
+    """Stashing the capture line in debate_engine.py (reverting to a bare
+    `await _debate_round(...)`) makes this fail: every entry's
+    `debate_transcript` stays at its dataclass default of None. See the PR
+    description / task report for the actual stash-and-rerun demonstration."""
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.RISK_ON)  # non-crisis: must not force ABSTAIN
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+    monkeypatch.setattr("archimedes.agents.strategy_fusion.load_corpus", lambda *a, **k: corpus)
+
+    debate_backend = _DebateBackend()
+    monkeypatch.setattr("archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: debate_backend)
+
+    pool = [
+        _fake_proposal("A", ["2401.00001", "2402.00001"]),
+        _fake_proposal("B", ["2401.00002", "2402.00002"]),
+    ]
+
+    async def _fake_propose_pool(brief, model, corpus_arg):
+        return pool
+
+    monkeypatch.setattr(de, "_propose_pool", _fake_propose_pool)
+
+    _call_n = {"i": 0}
+
+    def _fake_eval(spec, *, num_trials=None, **kw):
+        _call_n["i"] += 1
+        # Distinct DSR per candidate so build_leaderboard produces a real
+        # winner + a real (non-abstain) alternate, not a tie or a cull-to-one.
+        return _fake_ev(cagr=0.2, dsr=float(_call_n["i"]), num_trials=num_trials)
+
+    monkeypatch.setattr("archimedes.services.fusion_evaluator.evaluate_fusion_spec", _fake_eval)
+
+    brief = GenerateBrief(intent="momentum equities", max_papers=4)
+    leaderboard = await de._run_debate_leaderboard(candidate_id="cand_1", brief=brief, emit=_FakeEmit())
+
+    assert len(leaderboard) == 2, "need winner + one alternate to prove BOTH carry the transcript"
+    expected_roles = [("bull", 1), ("bear", 1), ("bull", 2), ("bear", 2)]
+    for entry in leaderboard:
+        assert entry.debate_transcript is not None, (
+            f"{entry.candidate_id} lost its debate transcript — the exact discard this guards against"
+        )
+        assert [(t["role"], t["round"]) for t in entry.debate_transcript] == expected_roles
+    # One debate happened, not one per candidate: every entry shares the SAME
+    # transcript object (the debate runs once, over the whole pool, before
+    # C-null culls it to a winner).
+    assert leaderboard[0].debate_transcript is leaderboard[1].debate_transcript
+
+
+async def test_run_debate_leaderboard_abstain_entry_still_carries_transcript(monkeypatch, corpus):
+    """The C-regime ABSTAIN path builds its result via `_abstain_result`, a
+    different code path than the normal survivor path — must not skip the
+    transcript stamp just because it takes the early-return branch."""
+    from archimedes.models.regime import Regime
+
+    _patch_regime(monkeypatch, Regime.CRISIS)  # forces ABSTAIN
+    monkeypatch.setattr(de.asyncio, "to_thread", _passthrough_to_thread)
+    monkeypatch.setattr("archimedes.agents.strategy_fusion.load_corpus", lambda *a, **k: corpus)
+
+    debate_backend = _DebateBackend()
+    monkeypatch.setattr("archimedes.services.llm_backend.make_llm_backend", lambda model=None, **k: debate_backend)
+
+    pool = [_fake_proposal("A", ["2401.00001", "2402.00001"])]
+
+    async def _fake_propose_pool(brief, model, corpus_arg):
+        return pool
+
+    monkeypatch.setattr(de, "_propose_pool", _fake_propose_pool)
+    monkeypatch.setattr(
+        "archimedes.services.fusion_evaluator.evaluate_fusion_spec",
+        lambda spec, *, num_trials=None, **kw: _fake_ev(cagr=0.2, num_trials=num_trials),
+    )
+
+    brief = GenerateBrief(intent="momentum equities", max_papers=4)
+    leaderboard = await de._run_debate_leaderboard(candidate_id="cand_1", brief=brief, emit=_FakeEmit())
+
+    assert len(leaderboard) == 1
+    assert leaderboard[0].generation_method == "debate_abstain"
+    assert leaderboard[0].debate_transcript is not None
+
+
 # ── Review fixes: pool-max bound + leaderboard top-N cap ──────────────────────
 
 

--- a/backend/tests/test_debate_transcript_model.py
+++ b/backend/tests/test_debate_transcript_model.py
@@ -1,0 +1,232 @@
+"""Debate transcript persistence — the bull/bear round the society always ran
+but the pipeline used to discard the instant it returned
+(``debate_engine.py`` used to ``await _debate_round(...)`` with no
+assignment). Hermetic: tmp-file sqlite via ``redirect_to_tmp_sqlite``, no
+Postgres / Redis / LLM / network.
+
+Guards demonstrated with the input that SHOULD fail them (CLAUDE.md rule 4):
+
+* **Sanitization is real, not a no-op.** Text carrying the exact internal-
+  jargon patterns named in the issue (``T\\d\\.\\d`` tier codes, "cutover",
+  "Phase-" labels) is redacted; ordinary text is untouched.
+* **``strategy_id`` is honestly nullable.** A considered-alternative's row
+  (no strategy ever persisted for it) is a real, queryable NULL — not an
+  empty string, not a sentinel.
+* **A corrupt row reads as absent, never as an empty transcript** — the
+  fail-soft rule from CLAUDE.md § fail-soft.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.models.debate_transcript import (
+    DebateTranscriptRecord,
+    debate_transcript_for_strategy,
+    record_debate_transcript,
+    sanitize_debate_text,
+    sanitize_transcript,
+)
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+_TRANSCRIPT = [
+    {"role": "bull", "round": 1, "verdict": "act", "claims": ["momentum persists in cross-section"]},
+    {"role": "bear", "round": 1, "verdict": "decline", "claims": ["drawdown risk in crowded factor"]},
+    {"role": "bull", "round": 2, "verdict": "act", "claims": ["rebuttal: liquidity supports the trade"]},
+    {"role": "bear", "round": 2, "verdict": "decline", "claims": ["rebuttal: still crowded post-2020"]},
+]
+
+
+# ── Sanitization: the adversarial input SHOULD be redacted ──────────────────
+
+
+class TestSanitizeDebateText:
+    @pytest.mark.parametrize(
+        ("jargon", "label"),
+        [
+            ("Ship this ahead of T3.5.", "tier code T3.5"),
+            ("Ship this ahead of T1.1.", "tier code T1.1"),
+            ("We need the cutover before Friday.", "lowercase cutover"),
+            ("We need the CUTOVER before Friday.", "uppercase CUTOVER"),
+            ("This lands in Phase-3 of the rollout.", "Phase-3 label"),
+            ("A bare Phase- prefix with nothing after it.", "bare Phase-"),
+        ],
+    )
+    def test_jargon_pattern_is_redacted(self, jargon, label):
+        out = sanitize_debate_text(jargon)
+        assert "[redacted]" in out, f"{label} was not redacted: {out!r}"
+        # None of the raw jargon survives.
+        for leak in ("T3.5", "T1.1", "cutover", "CUTOVER", "Phase-3", "Phase-"):
+            if leak.lower() in jargon.lower():
+                assert leak.lower() not in out.lower() or "[redacted]" in out
+
+    def test_ordinary_debate_text_is_untouched(self):
+        text = "Momentum persists in the cross-section of large-cap equities."
+        assert sanitize_debate_text(text) == text
+
+    def test_empty_and_none_pass_through(self):
+        assert sanitize_debate_text("") == ""
+
+    def test_sanitize_transcript_scrubs_verdict_and_claims_only(self):
+        dirty = [
+            {
+                "role": "bull",
+                "round": 1,
+                "verdict": "act — ship ahead of the T3.5 cutover",
+                "claims": ["cites Phase-4 rollout data", "genuine claim about momentum"],
+            }
+        ]
+        clean = sanitize_transcript(dirty)
+        assert clean[0]["role"] == "bull"  # non-jargon fields untouched
+        assert clean[0]["round"] == 1
+        assert "T3.5" not in clean[0]["verdict"]
+        assert "cutover" not in clean[0]["verdict"].lower()
+        assert "Phase-4" not in clean[0]["claims"][0]
+        assert clean[0]["claims"][1] == "genuine claim about momentum"  # untouched
+
+    def test_sanitize_transcript_drops_non_dict_entries(self):
+        assert sanitize_transcript(["not a dict", 42, None]) == []
+
+    def test_sanitize_transcript_tolerates_missing_fields(self):
+        # A turn with neither verdict nor claims (or the wrong type) must not raise.
+        out = sanitize_transcript([{"role": "bull", "round": 1}, {"role": "bear", "round": 1, "claims": "not-a-list"}])
+        assert out[0] == {"role": "bull", "round": 1}
+        assert out[1]["claims"] == "not-a-list"  # left alone, not coerced
+
+
+# ── record_debate_transcript / debate_transcript_for_strategy round trip ────
+
+
+class TestRecordAndRead:
+    def test_winner_row_carries_a_real_strategy_id(self):
+        from archimedes.db import get_session
+
+        with get_session() as session:
+            record_debate_transcript(
+                session,
+                strategy_id="strat-winner-1",
+                generation_id="job-1",
+                candidate_id="cand_neutral",
+                transcript=_TRANSCRIPT,
+            )
+            session.commit()
+
+        with get_session() as session:
+            payload = debate_transcript_for_strategy(session, "strat-winner-1")
+        assert payload is not None
+        assert payload["strategy_id"] == "strat-winner-1"
+        assert payload["generation_id"] == "job-1"
+        assert payload["candidate_id"] == "cand_neutral"
+        assert [t["role"] for t in payload["transcript"]] == ["bull", "bear", "bull", "bear"]
+
+    def test_loser_row_has_a_real_queryable_null_strategy_id(self):
+        """A considered-alternative never gets a strategy_store row — its
+        transcript row must carry an HONEST NULL, not '' or a sentinel."""
+        from archimedes.db import get_session
+
+        with get_session() as session:
+            rec = record_debate_transcript(
+                session,
+                strategy_id=None,
+                generation_id="job-2",
+                candidate_id="cand_neutral_alt1",
+                transcript=_TRANSCRIPT,
+            )
+            session.commit()
+            rec_id = rec.id
+
+        with get_session() as session:
+            row = session.query(DebateTranscriptRecord).filter_by(id=rec_id).first()
+            assert row.strategy_id is None
+            # A loser is never looked up by strategy_id (it has none) — the
+            # strategy-keyed reader must not accidentally match on NULL/None.
+            assert debate_transcript_for_strategy(session, "") is None
+
+    def test_unknown_strategy_reads_as_none_not_empty(self):
+        from archimedes.db import get_session
+
+        with get_session() as session:
+            assert debate_transcript_for_strategy(session, "does-not-exist") is None
+
+    def test_written_transcript_is_sanitized_at_rest(self):
+        """The stored column itself must be clean — sanitization happens at
+        WRITE time, so a raw read of transcript_json is already safe."""
+        from archimedes.db import get_session
+
+        dirty = [{"role": "bull", "round": 1, "verdict": "ship before T3.5 cutover", "claims": ["Phase-3 data"]}]
+        with get_session() as session:
+            record_debate_transcript(
+                session, strategy_id="strat-dirty", generation_id="job-3", candidate_id="c1", transcript=dirty
+            )
+            session.commit()
+
+        with get_session() as session:
+            row = session.query(DebateTranscriptRecord).filter_by(strategy_id="strat-dirty").first()
+            assert "T3.5" not in row.transcript_json
+            assert "cutover" not in row.transcript_json.lower()
+            assert "Phase-3" not in row.transcript_json
+
+    def test_newest_row_wins_when_a_strategy_has_more_than_one(self):
+        from archimedes.db import get_session
+
+        with get_session() as session:
+            record_debate_transcript(
+                session, strategy_id="strat-multi", generation_id="job-old", candidate_id="c1", transcript=_TRANSCRIPT
+            )
+            record_debate_transcript(
+                session, strategy_id="strat-multi", generation_id="job-new", candidate_id="c1", transcript=_TRANSCRIPT
+            )
+            session.commit()
+
+        with get_session() as session:
+            payload = debate_transcript_for_strategy(session, "strat-multi")
+        assert payload["generation_id"] == "job-new"
+
+    def test_corrupt_json_reads_as_absent_not_empty(self):
+        """Fail-soft rule (CLAUDE.md): a row that cannot be decoded is an
+        absence, never a fabricated empty transcript."""
+        from archimedes.db import get_session
+
+        with get_session() as session:
+            rec = record_debate_transcript(
+                session, strategy_id="strat-corrupt", generation_id="job-4", candidate_id="c1", transcript=_TRANSCRIPT
+            )
+            session.commit()
+            rec_id = rec.id
+
+        with get_session() as session:
+            row = session.query(DebateTranscriptRecord).filter_by(id=rec_id).first()
+            row.transcript_json = "{not valid json"
+            session.commit()
+
+        with get_session() as session:
+            assert debate_transcript_for_strategy(session, "strat-corrupt") is None
+
+    @pytest.mark.parametrize(
+        ("kwargs", "why"),
+        [
+            (
+                {"strategy_id": None, "generation_id": "", "candidate_id": "c1", "transcript": []},
+                "missing generation_id",
+            ),
+            (
+                {"strategy_id": None, "generation_id": "j1", "candidate_id": "", "transcript": []},
+                "missing candidate_id",
+            ),
+            (
+                {"strategy_id": None, "generation_id": "j1", "candidate_id": "c1", "transcript": "not-a-list"},
+                "non-list transcript",
+            ),
+        ],
+    )
+    def test_missing_required_fields_raise(self, kwargs, why):
+        from archimedes.db import get_session
+
+        with get_session() as session, pytest.raises(ValueError):
+            record_debate_transcript(session, **kwargs)

--- a/backend/tests/test_debate_transcript_persistence.py
+++ b/backend/tests/test_debate_transcript_persistence.py
@@ -1,0 +1,102 @@
+"""``_persist_debate_transcripts`` (debate-transcript-capture): the
+``run_generation``-level glue that writes a ``debate_transcripts`` row for the
+K=1 winner AND every final-round loser, purely from data ``run_generation``
+already has in scope by the time it is called (``job_id``, the full
+``candidates`` leaderboard, ``strategy_ids``) — no new threading through
+``_persist_candidate``/``_do_persist``.
+
+Hermetic: tmp-file sqlite via ``redirect_to_tmp_sqlite``. No LLM, no network,
+no Redis.
+"""
+
+from __future__ import annotations
+
+import pytest
+from archimedes.agents.generation_pipeline import _CandidateResult, _persist_debate_transcripts
+from archimedes.models.debate_transcript import DebateTranscriptRecord
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+_TRANSCRIPT = [{"role": "bull", "round": 1, "verdict": "act", "claims": ["c1"]}]
+
+
+def _mk_candidate(candidate_id: str, *, transcript=None, generation_method: str = "debate") -> _CandidateResult:
+    return _CandidateResult(
+        candidate_id=candidate_id,
+        strategy_name=f"Strategy {candidate_id}",
+        thesis="t",
+        asset_universe=["SPY"],
+        source_papers=[],
+        weights={"SPY": 1.0},
+        reasoning="r",
+        rigor_verdict={"passing": True},
+        passes_rigor=True,
+        generation_method=generation_method,
+        debate_transcript=transcript,
+    )
+
+
+async def test_persists_winner_with_strategy_id_and_loser_with_null_strategy_id():
+    """The single write site: one pass over `candidates` covers the K=1
+    winner (real strategy_id, threaded via `strategy_ids`) AND the
+    final-round loser (never threaded into strategy_store -> NULL)."""
+    from archimedes.db import get_session
+
+    winner = _mk_candidate("cand_neutral", transcript=_TRANSCRIPT)
+    loser = _mk_candidate("cand_neutral_alt1", transcript=_TRANSCRIPT)
+
+    await _persist_debate_transcripts(
+        job_id="job-1",
+        candidates=[winner, loser],
+        strategy_ids={"cand_neutral": "strat-abc"},  # only the winner is ever in here
+    )
+
+    with get_session() as session:
+        rows = {r.candidate_id: r for r in session.query(DebateTranscriptRecord).filter_by(generation_id="job-1").all()}
+    assert set(rows) == {"cand_neutral", "cand_neutral_alt1"}
+    assert rows["cand_neutral"].strategy_id == "strat-abc"
+    assert rows["cand_neutral_alt1"].strategy_id is None
+
+
+async def test_skips_candidates_with_no_transcript():
+    """Fusion / fixture / single-agent candidates carry
+    debate_transcript=None (no debate ran) — must not write a row for them."""
+    from archimedes.db import get_session
+
+    fusion_cand = _mk_candidate("cand_1", transcript=None, generation_method="fusion")
+    await _persist_debate_transcripts(job_id="job-2", candidates=[fusion_cand], strategy_ids={"cand_1": "strat-x"})
+
+    with get_session() as session:
+        assert session.query(DebateTranscriptRecord).filter_by(generation_id="job-2").count() == 0
+
+
+async def test_empty_candidate_list_is_a_clean_noop():
+    from archimedes.db import get_session
+
+    await _persist_debate_transcripts(job_id="job-3", candidates=[], strategy_ids={})
+
+    with get_session() as session:
+        assert session.query(DebateTranscriptRecord).filter_by(generation_id="job-3").count() == 0
+
+
+async def test_persist_failure_is_swallowed_non_blocking(monkeypatch):
+    """CLAUDE.md guard 4 / mirrors the sibling `_persist_generation_cost`:
+    instrumentation must never fail a generation that already succeeded. A DB
+    session that raises must produce a log line, not an exception out of
+    `_persist_debate_transcripts` itself."""
+
+    def _raise(*a, **k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("archimedes.db.get_session", _raise)
+
+    cand = _mk_candidate("cand_neutral", transcript=_TRANSCRIPT)
+    # Must not raise — a caller in run_generation's success path calls this
+    # unconditionally after the winner is already durably persisted.
+    await _persist_debate_transcripts(job_id="job-4", candidates=[cand], strategy_ids={"cand_neutral": "s1"})

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -368,6 +368,85 @@ async def test_detail_published_is_public():
     assert resp.status_code == 200
 
 
+# ── GET /{strategy_id}/debate — auth consistent with the plain detail route ──
+
+
+def _mk_debate_transcript(sid: str, *, generation_id: str = "job-x", candidate_id: str = "cand_neutral"):
+    from archimedes.models.debate_transcript import record_debate_transcript
+
+    transcript = [
+        {"role": "bull", "round": 1, "verdict": "act", "claims": ["momentum persists"]},
+        {"role": "bear", "round": 1, "verdict": "decline", "claims": ["crowded factor"]},
+    ]
+    with db.get_session() as session:
+        record_debate_transcript(
+            session,
+            strategy_id=sid,
+            generation_id=generation_id,
+            candidate_id=candidate_id,
+            transcript=transcript,
+        )
+        session.commit()
+
+
+async def test_debate_unpublished_404_unless_owner():
+    sid = "dbt00000000000001"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    _mk_debate_transcript(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = await client.get(f"/api/strategies/{sid}/debate")
+        other = await client.get(f"/api/strategies/{sid}/debate", cookies=_siwe_cookies(_W_OTHER))
+        owner = await client.get(f"/api/strategies/{sid}/debate", cookies=_siwe_cookies(_W_OWNER))
+    assert anon.status_code == 404
+    assert other.status_code == 404  # 404, not 403 — existence stays hidden, same as GET /{id}
+    assert owner.status_code == 200
+    body = owner.json()
+    assert body["strategy_id"] == sid
+    assert body["candidate_id"] == "cand_neutral"
+    assert [t["role"] for t in body["transcript"]] == ["bull", "bear"]
+
+
+async def test_debate_published_is_public():
+    sid = "dbt00000000000002"
+    _mk_strategy(sid, owner=_W_OWNER, published=True)
+    _mk_debate_transcript(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}/debate")
+    assert resp.status_code == 200
+    assert resp.json()["strategy_id"] == sid
+
+
+async def test_debate_404_when_strategy_exists_but_no_transcript_was_persisted():
+    """Distinct from the auth-hiding 404 above: the strategy IS visible to the
+    owner, but nothing was ever persisted for it (e.g. generated before this
+    table existed, or the debate step produced nothing) — the route must say
+    "no debate transcript", never fabricate an empty one."""
+    sid = "dbt00000000000003"
+    _mk_strategy(sid, owner=_W_OWNER, published=False)
+    # No _mk_debate_transcript(sid) call — nothing persisted.
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}/debate", cookies=_siwe_cookies(_W_OWNER))
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "no debate transcript"
+
+
+async def test_debate_nonexistent_strategy_404():
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/does-not-exist-at-all/debate")
+    assert resp.status_code == 404
+
+
 # ── Owner-gated rename ────────────────────────────────────────────────────
 
 

--- a/docs/api/strategies-and-rigor.md
+++ b/docs/api/strategies-and-rigor.md
@@ -141,6 +141,24 @@ Errors: 404 `Strategy not found` (nonexistent, or private and caller is not the 
 curl -s https://archimedes-arc.com/api/strategies/<strategy_id>/returns
 ```
 
+### GET /api/strategies/{strategy_id}/debate
+Return the persisted bull/bear debate transcript the society produced while
+generating this strategy (4 turns: bull-r1, bear-r1, then a visible round-2
+rebuttal of each other's round-1 claims). Debate-path strategies only — a
+curated strategy, or a generated one from before this table existed, genuinely
+has none; never fabricates a transcript. | **Auth**: anonymous
+(mirrors `GET /api/strategies/{strategy_id}` exactly — curated strategies are
+always public, a generated strategy's transcript is 404 unless the caller owns
+the row)
+
+Request: path `strategy_id`.
+Response: `{strategy_id: str|null, generation_id: str, candidate_id: str, created_at: str, transcript: [{role: "bull"|"bear", round: int, verdict: str, claims: [str]}]}` — `strategy_id` is `null` for a Considered-Alternative row (K=1: only the society's winner is ever persisted to `strategy_store`).
+Errors: 404 `Strategy not found` (nonexistent, or private and caller is not the owner — existence stays hidden, same as the plain detail route); 404 `no debate transcript` (strategy exists and is visible, but nothing was persisted for it); 500 `Failed to load debate transcript` (DB read failure).
+
+```bash
+curl -s https://archimedes-arc.com/api/strategies/<strategy_id>/debate
+```
+
 ### GET /api/strategies/{strategy_id}
 Get a single strategy by ID — tries the curated `LocalStrategyProvider` first,
 falls through to the `strategy_passports` table for fusion/architect-generated


### PR DESCRIPTION
v8 Lane 2.3 (M tier). The bull/bear debate — real 4-turn transcripts from paid LLM calls — was generated and thrown away (`debate_engine.py:727` dropped the return value; Redis events die in ~15 min). Now: the transcript is captured, sanitized at write time (internal-jargon redaction, unit-tested; deliberately over-redacts on the T\d.\d pattern — errs safe), persisted to a new `debate_transcripts` table, and served via `GET /api/strategies/{id}/debate`. UI panel is the scoped follow-up.

**Review verdict: READY** (the one first-pass READY of the wave). The Opus reviewer exercised the sanitizer, round-tripped persistence on scratch DB, and drove the route through the real app. Two reviewer notes riding here as accepted trade-offs: persistence sits on the success path (a generation that dies after the debate loses the losers' transcripts — the winner-keyed design makes this low-loss), and 't-stat of T2.5' would redact (over-redaction is the safe direction). Anti-goal verified by me: `_HASH_FIELDS` untouched — anchoring extension remains a separate owner-gated change.

Full pipeline provenance: Sonnet builder → Opus review (READY) → owner validation (hash-fields diff empty, capture line verified, 4/4 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7