### PR TITLE
[docs][adr] Strategy DSL hardening over Lean 4 (decision: Dan, 2026-08-30)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 
 | Doc | Status | Owner | Last verified | What it is |
 |---|---|---|---|---|
-| [`adr/README.md`](adr/README.md) | current | Dan Browne | 2026-07-28 | ADR index and status vocabulary. All eighteen records are listed there. |
+| [`adr/README.md`](adr/README.md) | current | Dan Browne | 2026-08-30 | ADR index and status vocabulary. All twenty records are listed there. |
 | [`adr/unlicense-public-domain.md`](adr/unlicense-public-domain.md) | accepted | Dan Browne | initial commit | The Unlicense as a public-domain dedication, and its ownership/contributor consequences. |
 | [`adr/arc-settlement-chain.md`](adr/arc-settlement-chain.md) | accepted | Dan Browne | 2026-05-13 | Arc testnet 5042002; USDC as settlement asset and native gas token. |
 | [`adr/two-tier-marketplace.md`](adr/two-tier-marketplace.md) | accepted | Dan Browne | 2026-05-13 | Verified / Community tiers; rigor as the wedge. |
@@ -151,6 +151,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`adr/debate-society-sole-generation-pipeline.md`](adr/debate-society-sole-generation-pipeline.md) | accepted | Dan Browne | 2026-07-09 | The debate society is the only generation path; no fallback. |
 | [`adr/num-trials-self-containment.md`](adr/num-trials-self-containment.md) | accepted, **pending quant sign-off** | Dan Browne | 2026-07-09 | DSR trial count depends only on the strategy's own search; curated strategies grade at num_trials = 1. |
 | [`adr/aurora-postgres-alembic-datastore.md`](adr/aurora-postgres-alembic-datastore.md) | accepted | Dan Browne | 2026-07-28 | Aurora Serverless v2 (18.3) + Alembic; Redis 7.1 ephemeral-only. |
+| [`adr/strategy-dsl-hardening-over-lean4.md`](adr/strategy-dsl-hardening-over-lean4.md) | accepted | Dan Browne | 2026-08-30 | No Lean 4 on the emission path; harden the existing closed-enum DSL instead. Sandbox reserved for inexpressible shapes; languages re-evaluated only on a trigger. |
 
 ## Plans and roadmaps (intent, not state)
 
@@ -163,6 +164,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`plans/spine-plus-v2-plan.md`](plans/spine-plus-v2-plan.md) | plan | Dan Browne | — | Spine+ v2 phase plan. |
 | [`plans/second-wave-multi-asset-strategies.md`](plans/second-wave-multi-asset-strategies.md) | plan | Önder Akkaya | 2026-06-11 | Second-wave multi-asset strategies. |
 | [`plans/paper-replication-spec.md`](plans/paper-replication-spec.md) | plan | Önder Akkaya | — | Replication and original-extension workflow. |
+| [`plans/future-strategy-language-reeval-issue.md`](plans/future-strategy-language-reeval-issue.md) | draft issue | Dan Browne | 2026-08-30 | Unfiled Future Plans issue body: the trigger conditions under which the emission-language decision re-opens. Dormant by design — do not close for inactivity. |
 
 ## Sprint session cards (current)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-> **Status:** current (last updated 2026-07-28). The ADR pattern is: capture a non-trivial technical decision
+> **Status:** current (last updated 2026-08-30). The ADR pattern is: capture a non-trivial technical decision
 > once, with the alternatives considered and the reasoning, so future contributors can
 > understand the choice without needing to relitigate it. The records below were written
 > as decisions landed; the 2026-06-27 batch back-fills decisions that shipped before the
@@ -34,8 +34,10 @@ the review named in the code has not happened.
 
 ## Index
 
-Eighteen records. Status and date are authoritative in each ADR's front-matter block;
-this table mirrors them.
+Twenty records. Status and date are authoritative in each ADR's front-matter block;
+this table mirrors them. (The count read "eighteen" while the table already held nineteen —
+the `generation-payment-credit-not-refund` row landed 2026-08-29 without a count bump.
+Corrected here.)
 
 | ADR | Status | Date | Owner | Decision |
 |---|---|---|---|---|
@@ -58,6 +60,7 @@ this table mirrors them.
 | [`debate-society-sole-generation-pipeline.md`](debate-society-sole-generation-pipeline.md) | Accepted | 2026-07-09 | Dan Browne | Why the **debate society is the only generation path** — no routing tree, no flag, no silent fallback (#1064/#1074) |
 | [`num-trials-self-containment.md`](num-trials-self-containment.md) | **Accepted, pending quant sign-off** | 2026-07-09 | Dan Browne (quant reviewer: Önder Akkaya) | Why a strategy's DSR trial count depends **only on that strategy** — never `N + library_size`; curated single-paper strategies grade at `num_trials = 1` |
 | [`aurora-postgres-alembic-datastore.md`](aurora-postgres-alembic-datastore.md) | Accepted | 2026-07-28 | Dan Browne | Why **Aurora PostgreSQL Serverless v2 (18.3)** is the system of record, **Alembic** the only schema-change mechanism, **Redis 7.1** ephemeral-only |
+| [`strategy-dsl-hardening-over-lean4.md`](strategy-dsl-hardening-over-lean4.md) | Accepted | 2026-08-30 | Dan Browne | Why the generator's emission target stays the **closed-enum JSON DSL, hardened**, and **not Lean 4** — the no-generated-code property is already structural; a restricted sandbox is reserved for shapes the DSL cannot express |
 
 ### Open review debt
 

--- a/docs/adr/strategy-dsl-hardening-over-lean4.md
+++ b/docs/adr/strategy-dsl-hardening-over-lean4.md
@@ -155,6 +155,12 @@ Each option is scored 1–5 on eight criteria; 40 is the maximum.
 | Ongoing maintenance burden | 3 | 4 | 2 | 4 |
 | **Total** | **33** | **32** | **27** | **26** |
 
+Also screened and scored below the cut in the same evaluation: Composer-style
+declarative JSON **26** (a UX pattern with no open spec or parser to adopt),
+Pine Script **17** and MQL5 **13** (retail/vendor-hosted DSLs with no path
+into the backtrader-based rigor gate). Recorded so the ranking is complete
+and no rejected option invites relitigation as an oversight.
+
 **1. Harden the existing DSL — 33. Chosen.** Loses badly on expressiveness and that is the
 honest cost. Wins everywhere else, and wins the one criterion that decided it: it is the
 only option that reaches a state we can describe truthfully in days rather than months,

--- a/docs/adr/strategy-dsl-hardening-over-lean4.md
+++ b/docs/adr/strategy-dsl-hardening-over-lean4.md
@@ -1,0 +1,264 @@
+# ADR: Harden the strategy DSL; no Lean 4 on the emission path
+
+> **Audience:** Archimedes team
+> **Status:** **Accepted**
+> **Date:** 2026-08-30
+> **Owner:** Dan Browne
+> **Supersedes:** —
+> **Superseded-by:** —
+> **Question being decided:** The generator emits machine-readable strategies. Should that emission target become a formally verified language — specifically Lean 4 — or should the existing closed-enum JSON DSL be hardened in place?
+> **Related:** [`strategy_dsl.py`](../../backend/archimedes/services/strategy_dsl.py), [`dsl_to_backtrader.py`](../../backend/archimedes/services/dsl_to_backtrader.py), [`strategy-dsl-spec.md`](../specs/strategy-dsl-spec.md), [`debate-society-sole-generation-pipeline.md`](debate-society-sole-generation-pipeline.md), [`backtrader-backtest-engine.md`](backtrader-backtest-engine.md), [`rigor-gate-unification.md`](rigor-gate-unification.md), [`future-strategy-language-reeval-issue.md`](../plans/future-strategy-language-reeval-issue.md).
+
+## TL;DR
+
+**No Lean 4 on the emission path. Harden the DSL we already have.** The safety property
+people reach for Lean to get — *generated content cannot execute arbitrary code* — is
+already structural here: the generator emits constrained JSON, and a fixed hand-written
+interpreter turns it into a `backtrader.Strategy`. There is nothing to prove because there
+is nothing to run. What the DSL is actually weak on is **honesty about its own limits**, and
+that is fixed with four concrete pieces of work, not with a proof assistant. A sandboxed
+execution path stays reserved for strategy shapes the DSL genuinely cannot express. Lean 4's
+only plausible future role here is proving a small hand-written verifier core — never the
+emitter's output.
+
+## Context
+
+### What the DSL is today
+
+Real, live, and narrow. [`strategy_dsl.py`](../../backend/archimedes/services/strategy_dsl.py)
+defines a closed-enum JSON grammar: five indicator stems (`sma`, `ema`, `rsi`,
+`realized_vol`, `momentum`), four comparison operators, three logic operators, three
+rebalance cadences, four declared position-sizing types. Conditions are a small tree
+(`{"gt": ["close", "sma_200"]}`), validated node by node, and every unknown operator or
+operand is a `DSLError`.
+[`dsl_to_backtrader.interpret_spec()`](../../backend/archimedes/services/dsl_to_backtrader.py)
+turns a validated spec into a `bt.Strategy` subclass via `type()` with closures — its
+docstring says it plainly: *"No eval/exec/importlib."*
+
+That is the whole security story, and it is a good one. **The generated artifact is data,
+not code.** The interpreter is hand-written, fixed, reviewed, and in the tree. A malicious
+or confused emission cannot do more than describe a strategy the interpreter already knows
+how to build. No sandbox, no proof, no capability audit is required to establish that,
+because the property is structural rather than argued.
+
+The narrowness is equally real. The condition tree reads a **single price series** — every
+operand resolves against `self.data`, so no condition can reference another asset. A
+multi-symbol `asset_universe` is not a cross-sectional strategy; it is run as independent
+per-symbol backtests and equal-weighted
+([`fusion_evaluator.py`](../../backend/archimedes/services/fusion_evaluator.py) →
+`run_dsl_backtest_portfolio`). Positions are long-flat. There is no ranking, no pair, no
+short leg, no cross-asset signal.
+
+### What the evaluation found about Lean 4
+
+Four things, and any one of them would have been enough.
+
+**Frontier models cannot reliably write Lean 4.** Public benchmark reporting at the time of
+the decision put frontier-model success at producing correct Lean 4 proofs of
+competition-grade statements in roughly the **4–11%** band. *[The specific benchmark
+citation is not pinned in this record — unestablished, needs Dan.]* The number matters less
+than its order of magnitude: a path where the best available models succeed one time in
+ten to one time in twenty-five is not an emission path, it is a research project.
+
+**And our emitter is not a frontier model.** The live generator runs
+`amazon.nova-micro-v1:0` ([`glm-to-bedrock-llm-migration.md`](glm-to-bedrock-llm-migration.md)).
+Whatever the frontier number is, ours is below it. Nova Micro emits the current JSON grammar
+reliably because that grammar is small and closed; asking it for dependently-typed proof
+terms is not the same task with a harder target, it is a different task it cannot do at all.
+
+**The numeric ecosystem is pre-production.** Lean 4's strength is pure mathematics. What a
+strategy needs proved is about floating-point series, rolling windows, and sample
+boundaries. Bridging real-number reasoning to the `float64` a backtest actually computes on
+is an open problem in that ecosystem, not a library call.
+
+**There is no clean Python bridge.** The entire evaluation stack — backtrader, the rigor
+gate, the passport — is Python
+([`backtrader-backtest-engine.md`](backtrader-backtest-engine.md)). A Lean 4 emission would
+need extraction or an FFI to become something backtrader can run, and that translation step
+is unverified by construction. A proof about the Lean artifact would say nothing about the
+Python that actually produced the published Sharpe. The proof and the numbers would be about
+different objects.
+
+### So what is the actual problem?
+
+Not safety. **Honesty.** The audit that prompted this decision found the DSL claiming more
+than it delivers, in four specific places — each one a "claims must be true" violation of
+exactly the shape [`rigor-gate-unification.md`](rigor-gate-unification.md) exists to prevent:
+
+- **`look_ahead_safe` is self-declared.** The validator checks only that the field is a
+  boolean and that its value is `true` — a spec asserting its own innocence is admitted on
+  that assertion. The pipeline is honest about this downstream
+  (`look_ahead_audit_source="self_attested"` in
+  [`generation_pipeline.py`](../../backend/archimedes/agents/generation_pipeline.py), and the
+  distinct `look_ahead_label` in
+  [`strategies_routes.py`](../../backend/archimedes/api/strategies_routes.py)), which is
+  correct labelling of a weak signal but does not make the signal strong.
+- **Two of the four position-sizing types are not implemented.**
+  `POSITION_SIZING_TYPES` advertises `full_invested_when_in_market`, `equal_weight`,
+  `inverse_vol`, `volatility_target`. `_enter_position` implements the first and the last;
+  `equal_weight` falls through to the `else` branch and full-invests, and `inverse_vol` has
+  no branch at all and does the same. A passport can therefore record `inverse_vol` over a
+  run that was fully invested.
+- **`realized_vol` validates but blows up at backtest time.** It is in `INDICATOR_NAMES`, so
+  `realized_vol_20` parses, and `interpret_spec` returns a strategy class without complaint.
+  The failure lands later: indicators are wired in the generated class's `__init__`, so
+  `_make_indicator` raises `DSLError("unsupported indicator: realized_vol")` when backtrader
+  instantiates the strategy inside `cerebro.run()`. A validation-time rejection has become a
+  run-time crash. This is currently worked around rather than fixed — the debate engine
+  carries a `_CONFORMANT_INDICATORS` filter
+  ([`debate_engine.py`](../../backend/archimedes/agents/debate_engine.py)) that drops such
+  specs from the pool before they reach the evaluator. (That filter's comment locates the
+  raise "inside `interpret_spec`"; the effect is as described but the location is one call
+  later — worth correcting when the filter is retired.)
+- **The spec doc describes a schema that does not exist.**
+  [`strategy-dsl-spec.md`](../specs/strategy-dsl-spec.md)'s "Schema" and "Closed-enum
+  vocabulary" sections document an older grammar —
+  `{indicator, operator, threshold, secondary_indicator}`, indicators `macd_line` /
+  `bb_upper` / `atr`, `position_sizing` as a bare string `full_capital` / `kelly` /
+  `atr_sized`, a `params.period` block. None of it is accepted by the live validator. Only
+  the later "Parameter variants" section reflects what actually ships.
+
+None of those four is a problem a proof assistant solves. Three are missing
+implementations and one is a stale document.
+
+## Alternatives considered
+
+**A note on the name, because it caused real confusion in the evaluation.** Two unrelated
+things are called "LEAN":
+
+- **Lean 4** — a dependently-typed programming language and interactive theorem prover
+  (Mathlib, `sorry`, proof terms). This is what "formally verified strategies" meant.
+- **QuantConnect LEAN** — an open-source algorithmic-trading backtesting and live-trading
+  engine, C# core with a Python API. It proves nothing about anything; it is a competitor to
+  backtrader.
+
+They share four letters and nothing else. Both were on the table and they are scored
+separately below.
+
+**Lean 4 itself is not a row in the matrix**, because it did not survive screening. The
+matrix scores *emission targets* — things the generator can produce that end in a graded
+backtest. Lean 4 has no execution path to a backtest at all without an extraction step that
+would itself be unverified, so there was nothing to score. That is the finding, not an
+omission.
+
+Each option is scored 1–5 on eight criteria; 40 is the maximum.
+
+| Criterion | Harden DSL | Restricted Python sandbox | Checked AST subset | QuantConnect LEAN |
+|---|---|---|---|---|
+| Expressiveness for strategies we actually want | 2 | 5 | 4 | 5 |
+| Safety of the execution boundary | **5** | 3 | 4 | 3 |
+| Fit with the live emitter (Nova Micro) | **5** | 4 | 3 | 3 |
+| Time to a state we can describe honestly | **5** | 3 | 2 | 1 |
+| Verifiability of the no-lookahead property | 4 | 3 | 4 | 3 |
+| Numeric / financial ecosystem maturity | 4 | 5 | 4 | 5 |
+| Integration cost against backtrader + the rigor gate | **5** | 5 | 4 | 2 |
+| Ongoing maintenance burden | 3 | 4 | 2 | 4 |
+| **Total** | **33** | **32** | **27** | **26** |
+
+**1. Harden the existing DSL — 33. Chosen.** Loses badly on expressiveness and that is the
+honest cost. Wins everywhere else, and wins the one criterion that decided it: it is the
+only option that reaches a state we can describe truthfully in days rather than months,
+without giving up the structural safety property we already have for free.
+
+**2. Restricted Python sandbox — 32.** The closest call, and it is close for good reasons:
+maximum expressiveness, native fit with backtrader, an emitter that writes Python far better
+than it writes anything else. It loses on the execution boundary. Today "generated content
+cannot execute code" is a *structural* fact; under a sandbox it becomes an *argued* one,
+resting on a containment configuration that has to be right and stay right. Trading a
+structural guarantee for a configured one, to buy expressiveness we do not yet have a
+strategy demanding, is the wrong trade **now**. It is not the wrong trade forever — see the
+decision below.
+
+**3. Checked AST subset — 27.** Generate Python, parse it, walk the AST against a whitelist,
+execute what passes. Sounds like the best of both and is the worst of both: still executing
+generated code, so the boundary is argued rather than structural, but with a whitelist that
+must be exhaustively correct against the entire Python grammar forever. Every language
+feature is a potential hole and the maintenance burden never ends. It is a worse DSL and a
+worse sandbox at the same time.
+
+**4. QuantConnect LEAN engine — 26.** A mature, genuinely capable engine. Adopting it means
+replacing backtrader — the engine the rigor gate, the passport schema, and the
+`backtest_results.backtest_engine` provenance column are all built around
+([`backtrader-backtest-engine.md`](backtrader-backtest-engine.md)) — with a C#-cored,
+Docker-deployed system carrying its own data model and its own cost assumptions. That is a
+platform migration, and it answers no question we are currently stuck on. Recorded as
+considered and declined; not re-opened here.
+
+## Decision
+
+**Harden the DSL. Four pieces of work, all of which close a gap between what the DSL claims
+and what it does.**
+
+1. **Time bounds become part of the spec.** A spec must declare the evaluation window it is
+   meant for, and indicator periods must be bounded against the sample rather than against a
+   constant. Today `_parse_indicator_operand` accepts any period in `1..10_000` — around
+   forty years of daily bars, longer than the 5,560-bar SPY fixture the DSL is verified
+   against — so a spec can validate with a warmup that swallows its entire sample and still
+   be graded. Relatedly, the cadence table is trading-day proxies (`weekly` = 5 bars,
+   `monthly` = 21 bars), not calendar dates; that is a defensible choice but it must be
+   stated rather than discovered.
+2. **Real sizing implementations, or a smaller enum.** `equal_weight` and `inverse_vol` get
+   implemented, or they come out of `POSITION_SIZING_TYPES`. Both are acceptable; silently
+   full-investing under another label is not. The same rule settles `realized_vol`:
+   implement it in `_make_indicator` or remove it from `INDICATOR_NAMES`, and retire the
+   `_CONFORMANT_INDICATORS` filter that exists only to route around the mismatch.
+3. **A derived no-lookahead check replaces the self-declared boolean.** This is the item that
+   makes the whole decision coherent. Because the grammar is closed and the interpreter is
+   fixed, the property is *decidable from the spec* — every operand either reads the current
+   bar or an indicator over a bounded trailing window, and the interpreter is the only thing
+   that ever evaluates them. So compute it: walk the condition tree, confirm every operand
+   resolves to a value available at decision time, and emit a **derived** verdict.
+   `look_ahead_safe` stops being an input the emitter asserts and becomes an output the
+   validator computes. That is the formal-verification benefit people wanted from Lean,
+   obtained by keeping the language small enough that a hand-written checker is sufficient.
+4. **An honest spec doc.** [`strategy-dsl-spec.md`](../specs/strategy-dsl-spec.md) gets
+   rewritten to the grammar that actually ships, including the limits: single price series,
+   long-flat only, no cross-asset conditions, multi-symbol universes evaluated as
+   equal-weighted independent runs.
+
+**The sandbox path is reserved, not rejected.** It scored one point behind. When a strategy
+shape we genuinely want cannot be expressed — a long/short pair, a cross-sectional rank, a
+signal reading two series at once — the answer is the restricted sandbox, entered
+deliberately for that reason and with the boundary argued explicitly. It is not the answer
+to "the DSL is a bit awkward here."
+
+**Lean 4's only future role is proving a hand-written verifier core.** If the no-lookahead
+checker in item 3 becomes load-bearing enough that we want a proof of *it* — a few hundred
+lines of hand-written Python over a closed grammar, a genuinely tractable target — that is a
+reasonable use of a theorem prover. Proving properties of a small artifact a human wrote is
+the thing Lean is actually good at. Having an LLM emit Lean is not, and that door is closed.
+
+## Consequences
+
+**Good.** The structural safety property survives untouched: generated content stays data,
+the interpreter stays hand-written, `eval`/`exec` stay absent. Every claim the DSL makes
+becomes one the code keeps, which is the repo's first rule applied to the generation path.
+The no-lookahead signal is upgraded from an emitter's self-assertion to a derived fact, which
+strengthens the rigor gate's most-questioned input without touching the gate. And the work is
+small and local — no engine migration, no new runtime, no dependency.
+
+**The cost, stated plainly.** The DSL stays narrow, deliberately. Long/short, cross-sectional,
+and multi-leg strategies remain inexpressible, and that ceiling is now a recorded decision
+rather than an accident. Some fraction of the strategies a paper corpus can motivate cannot be
+emitted at all — the pipeline will keep declining them, and it should keep declining them
+loudly rather than emitting a degraded approximation under the paper's name.
+
+**Between now and the hardening landing, three things are still not true.** `inverse_vol` and
+`equal_weight` passports describe sizing that did not happen; `realized_vol` specs are
+filtered out by a workaround rather than supported or rejected at the source; and the spec doc
+misdescribes the schema. Those are named here so nobody has to rediscover them, and none of
+them should be cited as working until the corresponding item ships.
+
+**What this does not decide.** Whether the sandbox eventually gets built, and what its
+containment boundary looks like. That is a separate decision with a separate ADR, triggered by
+a real strategy shape rather than by discomfort with the grammar.
+
+## Re-evaluation
+
+Deliberately not "never." The trigger conditions, the evidence to gather, and the shape of
+the re-evaluation are drafted as a Future Plans issue:
+[`future-strategy-language-reeval-issue.md`](../plans/future-strategy-language-reeval-issue.md).
+In short: revisit when property tests stop catching real violations, when a cross-asset
+grammar starts pushing the DSL toward general-purpose, or when LLM-Lean writability moves by
+an order of magnitude. Until one of those fires, this record is in force and the language
+question is closed.

--- a/docs/plans/future-strategy-language-reeval-issue.md
+++ b/docs/plans/future-strategy-language-reeval-issue.md
@@ -1,0 +1,186 @@
+# Future Plans issue draft — re-evaluate the strategy emission language
+
+> **Status:** draft issue body, not yet filed
+> **Owner:** Dan Browne
+> **Updated:** 2026-08-30
+> **Superseded-by:** —
+>
+> **What this is:** the body text for a Future Plans GitHub issue that has not been opened
+> yet. It exists as a file because the session that drafted it could not post to GitHub.
+> **When it is filed, replace this front-matter block with the issue link and leave the file
+> as the record of what was asked.** Nothing here is a commitment to do the work — it is a
+> commitment to re-open the question if, and only if, one of the triggers below fires.
+>
+> **Parent decision:** [`adr/strategy-dsl-hardening-over-lean4.md`](../adr/strategy-dsl-hardening-over-lean4.md)
+> (Accepted 2026-08-30). That ADR is in force. This issue does not relitigate it and must not
+> be read as doing so.
+
+---
+
+## Title
+
+`APIN - Strategy Engine - Re-evaluate the emission language (trigger-gated)`
+
+## Summary
+
+On 2026-08-30 we decided **no Lean 4 on the emission path** and committed to hardening the
+existing closed-enum JSON DSL instead
+([ADR](../adr/strategy-dsl-hardening-over-lean4.md)). That decision was correct **for the
+evidence available at the time**, and every piece of that evidence is the kind that can
+change.
+
+This issue exists so the question re-opens on a **signal** rather than on a mood. It should
+sit open and quiet, possibly for a long time. Nobody should work it until a trigger below
+actually fires — and when one does, the first job is to prove the trigger fired, not to start
+writing a new language.
+
+**Do not close this issue for inactivity.** Its whole function is to be dormant.
+
+## Trigger conditions
+
+Any **one** of these justifies re-opening the language question. Each is stated so that
+"has it fired?" is a question with evidence behind it rather than a matter of opinion.
+
+### Trigger 1 — property tests stop catching real violations
+
+The hardening plan replaces the self-declared `look_ahead_safe` boolean with a **derived**
+check computed from the condition tree (ADR decision item 3). The plan is to back that
+checker with hypothesis-based property tests over generated condition trees.
+
+**The trigger fires if those property tests repeatedly pass while real lookahead
+violations reach a graded backtest.** That would mean the property-based approach is not
+sound over the grammar we actually have, and hand-written checking has hit its ceiling —
+which is the specific circumstance in which a proof assistant starts to earn its cost.
+
+Evidence to attach when claiming this trigger:
+
+- At least two distinct violations that reached grading with the derived check reporting
+  clean. One is an ordinary bug; the pattern is the signal.
+- The property-test run that should have caught each, showing why it did not.
+- Confirmation the checker was not simply misconfigured or bypassed. A disabled guard is a
+  disabled guard, not evidence against the approach.
+
+**Anti-trigger:** a single escaped bug that a new property test then catches. That is the
+system working.
+
+### Trigger 2 — a cross-asset grammar pushes the DSL general-purpose
+
+Today every DSL operand resolves against a **single price series**; multi-symbol universes
+are run as independent per-symbol backtests and equal-weighted
+([`fusion_evaluator.py`](../../backend/archimedes/services/fusion_evaluator.py) →
+`run_dsl_backtest_portfolio`). Positions are long-flat. This is the ADR's recorded ceiling.
+
+Genuine cross-asset strategies — cross-sectional ranking, long/short pairs, conditions
+reading two series at once — require operands that reference *other assets*. Adding that
+means adding scope, binding, and iteration to the grammar. **At that point the DSL stops
+being a closed enum and starts being a programming language**, and the argument that made it
+safe (it is data, not code; a fixed hand-written interpreter is sufficient) weakens with each
+addition.
+
+**The trigger fires when a cross-asset grammar extension is actually proposed with a real
+strategy behind it.** Not when someone observes that cross-asset strategies exist.
+
+Evidence to attach:
+
+- The specific strategy shape and the paper motivating it.
+- The grammar extension it needs, concretely.
+- An honest assessment of whether the hand-written interpreter can still cover the extended
+  grammar — because if it can, this trigger has **not** fired and the extension is just
+  ordinary DSL work.
+
+**Note the branch here.** This trigger does not point at Lean by default. The ADR reserves
+the **restricted Python sandbox** (scored 32 vs the DSL's 33 — one point) as the intended
+answer for shapes the DSL cannot express. Trigger 2 most likely re-opens *sandbox vs. wider
+DSL*, and only reaches the verification question if the sandbox's argued containment boundary
+is judged unacceptable.
+
+### Trigger 3 — LLM-Lean writability materially improves
+
+The decisive evidence against Lean 4 was that models cannot reliably write it. Public
+benchmark reporting at decision time put frontier-model success at correct Lean 4 proofs of
+competition-grade statements in roughly the **4–11%** band — and our live emitter is
+`amazon.nova-micro-v1:0`, well below frontier
+([`adr/glm-to-bedrock-llm-migration.md`](../adr/glm-to-bedrock-llm-migration.md)).
+
+**The trigger fires when that changes by an order of magnitude** — meaning both of:
+
+- Frontier success on comparable benchmarks reaches roughly **50%+**, sustained across more
+  than one model family, not a single headline result.
+- A model **we can actually afford to run on the emission path** is at or near that level.
+  Frontier capability we cannot pay for on every generation is a fact about the field, not
+  about our pipeline.
+
+Even then, two ADR findings survive independently and must be re-checked rather than
+assumed obsolete:
+
+- **The numeric ecosystem.** Reasoning about `float64` rolling windows, not real analysis,
+  is what a strategy needs proved. Has that gap actually closed?
+- **The Python bridge.** A proof about a Lean artifact says nothing about the backtrader run
+  that produced the published Sharpe unless the translation between them is itself verified.
+  Without that, the proof and the numbers describe different objects.
+
+A trigger-3 re-evaluation that does not address both is incomplete.
+
+## Evidence links
+
+**The decision and its reasoning**
+
+- [`adr/strategy-dsl-hardening-over-lean4.md`](../adr/strategy-dsl-hardening-over-lean4.md) —
+  the ADR, including the four-option scored matrix (harden-DSL 33 · sandbox 32 · checked-AST
+  27 · QuantConnect LEAN 26) and the Lean 4 / QuantConnect LEAN disambiguation.
+
+**The DSL as it stands**
+
+- [`backend/archimedes/services/strategy_dsl.py`](../../backend/archimedes/services/strategy_dsl.py)
+  — the closed enums, the condition-tree validator, and the `look_ahead_safe` admission
+  check that trigger 1 is about replacing.
+- [`backend/archimedes/services/dsl_to_backtrader.py`](../../backend/archimedes/services/dsl_to_backtrader.py)
+  — the fixed interpreter. `interpret_spec`'s "No eval/exec/importlib" is the structural
+  safety property; `_enter_position` is where the unimplemented sizing types live.
+- [`backend/archimedes/services/fusion_evaluator.py`](../../backend/archimedes/services/fusion_evaluator.py)
+  — `run_dsl_backtest_portfolio`, the equal-weighted per-symbol path that trigger 2 is about.
+- [`backend/archimedes/agents/debate_engine.py`](../../backend/archimedes/agents/debate_engine.py)
+  — `_CONFORMANT_INDICATORS`, the filter that routes around `realized_vol` validating cleanly
+  and then raising inside `cerebro.run()`. Retiring it is ADR decision item 2.
+- [`docs/specs/strategy-dsl-spec.md`](../specs/strategy-dsl-spec.md) — the spec doc, which
+  currently describes a schema the validator does not accept. ADR decision item 4 rewrites
+  it; **re-read the rewritten version, not this one, when the trigger fires.**
+
+**Where the self-attestation surfaces today**
+
+- [`backend/archimedes/agents/generation_pipeline.py`](../../backend/archimedes/agents/generation_pipeline.py)
+  — `look_ahead_audit_source="self_attested"`.
+- [`backend/archimedes/api/strategies_routes.py`](../../backend/archimedes/api/strategies_routes.py)
+  — `look_ahead_label`, the honest label distinguishing self-attestation from the AST audit.
+
+**Adjacent decisions that constrain any answer**
+
+- [`adr/backtrader-backtest-engine.md`](../adr/backtrader-backtest-engine.md) — why the
+  evaluation stack is Python, and the engine-provenance column any replacement inherits.
+- [`adr/debate-society-sole-generation-pipeline.md`](../adr/debate-society-sole-generation-pipeline.md)
+  — the sole generation path; a new emission language lands here or nowhere.
+- [`adr/rigor-gate-unification.md`](../adr/rigor-gate-unification.md) — one authoritative
+  gate. A new language does not get its own.
+- [`adr/glm-to-bedrock-llm-migration.md`](../adr/glm-to-bedrock-llm-migration.md) — the live
+  model, which is the emitter trigger 3 is measured against.
+
+## Out of scope
+
+- **Relitigating the ADR.** It is `Accepted`. If it turns out to be wrong, the mechanism is a
+  superseding ADR, not a comment thread on this issue.
+- **The restricted-Python-sandbox decision.** Reserved by the ADR for shapes the DSL cannot
+  express; it gets its own ADR when a real strategy demands it. Trigger 2 may point at it, but
+  this issue does not decide it.
+- **Doing the DSL hardening.** Items 1–4 of the ADR are ordinary work tracked separately.
+  This issue is only about whether the *language choice* should re-open.
+
+## Acceptance
+
+This issue is worked only when a trigger fires, and "worked" means producing **one of**:
+
+- A superseding ADR that changes the language decision, with the trigger evidence in its
+  Context; or
+- A comment recording that the trigger fired, was evaluated, and the existing decision stands
+  — with the evidence, so the next person does not re-run the same analysis.
+
+Closing it any other way loses the reason it was opened.


### PR DESCRIPTION
Records tonight's owner decision: NO-GO on Lean 4 for the emission path; harden the existing DSL (matrix 33/40, full ranking incl. below-cut options); future re-evaluation issue draft with trigger conditions. Pipeline: Opus builder → Opus review (every evidence number reconciled, house style verified) → one review fix applied. docs-check 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7