### PR TITLE
[payments] Generation credits visible: API + honest banner

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -33,6 +33,7 @@ from archimedes.api.funnel_middleware import record_funnel
 from archimedes.api.generate_schemas import (
     CandidatesListResponse,
     CandidateSummary,
+    CreditSummary,
     GenerateBrief,
     GenerateStartRequest,
     GenerateStartResponse,
@@ -321,6 +322,35 @@ async def get_generation_quote():
     ``generation_payment.quote()``, whose flat price is the seam #1217's
     measured budget later replaces."""
     return generation_payment.quote()
+
+
+@generate_router.get("/credits", response_model=list[CreditSummary])
+async def list_generation_credits(
+    user: CurrentUser = Depends(require_current_user),
+) -> list[CreditSummary]:
+    """The calling user's own generation-credit ledger (v8 Lane 1.3a).
+
+    Makes visible what ``_paywall_with_credit`` already does silently: an
+    unspent (``available``) credit from an earlier paid-but-undelivered run
+    pays for the NEXT generation, with no new charge (#1441). Requires
+    sign-in — unlike ``/quote``, a credit belongs to a specific account, so
+    there is nothing honest to show before auth.
+
+    A bare list, not the wrapped ``{jobs: [...]}`` shape sibling listings use
+    — the frontend's only question is "does an unspent credit exist", so
+    there is no envelope worth adding.
+    """
+    rows = generation_credits.list_credits(user.id)
+    return [
+        CreditSummary(
+            id=row["id"],
+            status=row["status"],
+            created_at=row["created_at"],
+            job_id=row["job_id"],
+            amount_usdc=(round(row["amount_base_units"] / 10**6, 2) if row["amount_base_units"] is not None else None),
+        )
+        for row in rows
+    ]
 
 
 @generate_router.post("/start", response_model=GenerateStartResponse, status_code=202)

--- a/backend/archimedes/api/generate_schemas.py
+++ b/backend/archimedes/api/generate_schemas.py
@@ -217,3 +217,20 @@ class CandidatesListResponse(BaseModel):
     job_id: str
     best_candidate_id: str | None
     candidates: list[CandidateSummary]
+
+
+class CreditSummary(BaseModel):
+    """One row of the calling user's own generation-credit ledger (#1441 ->
+    v8 Lane 1.3a: make it visible, not just correct). Deliberately narrower
+    than ``GenerationCreditRecord.to_payload()`` — payer_wallet, network, and
+    settlement_ref are payment-plumbing internals the UI has no use for;
+    only what a human needs to recognize "I have an unspent credit" ships.
+    """
+
+    id: int
+    status: Literal["pending", "available", "consumed", "void"]
+    created_at: str | None = None
+    job_id: str | None = None
+    # USDC dollars, derived from the ledger's raw base units — None until a
+    # claim settles (mirrors the nullability of amount_base_units itself).
+    amount_usdc: float | None = None

--- a/backend/archimedes/services/generation_credits.py
+++ b/backend/archimedes/services/generation_credits.py
@@ -28,11 +28,18 @@ from decimal import Decimal
 from archimedes.models.generation_credit import (
     claim_credit,
     consume_credit,
-    list_credits as _list_credit_rows,
     mark_credit_settled,
     restore_credit_for_job,
     take_available_credit,
     void_credit,
+)
+
+# Separate statement, not folded into the block above: ruff's isort leaves
+# combine-as-imports off (ruff.toml), so an aliased name inside a multi-name
+# from-import is an I001 violation. Aliased because this module exports its
+# own `list_credits` wrapper over the model-layer one.
+from archimedes.models.generation_credit import (
+    list_credits as _list_credit_rows,
 )
 
 logger = logging.getLogger(__name__)

--- a/backend/archimedes/services/generation_credits.py
+++ b/backend/archimedes/services/generation_credits.py
@@ -28,6 +28,7 @@ from decimal import Decimal
 from archimedes.models.generation_credit import (
     claim_credit,
     consume_credit,
+    list_credits as _list_credit_rows,
     mark_credit_settled,
     restore_credit_for_job,
     take_available_credit,
@@ -155,6 +156,22 @@ def consume(credit_id: int, *, job_id: str) -> None:
             job_id,
             exc_info=True,
         )
+
+
+def list_credits(user_id: str) -> list[dict]:
+    """Newest-first ledger rows for *user_id* — the calling user's own
+    credits, surfaced by ``GET /api/generate/credits`` (v8 Lane 1.3a).
+
+    Quiet on failure like ``take_credit``: a broken read here must not break
+    the page that displays it, it just renders no credits — the ledger
+    itself (and what a real submit does with it) is unaffected either way.
+    """
+    try:
+        with _session() as session:
+            return _list_credit_rows(session, user_id)
+    except Exception:
+        logger.exception("generation credit list failed for user %s — returning empty", user_id)
+        return []
 
 
 def restore_for_job(job_id: str) -> bool:

--- a/backend/tests/test_generate_credits_route.py
+++ b/backend/tests/test_generate_credits_route.py
@@ -1,0 +1,158 @@
+"""Route test for GET /api/generate/credits (v8 Lane 1.3a: make credits visible).
+
+The ledger's write-side transitions (claim/settle/consume/restore/void, and
+the paywall window they close) are already covered end-to-end by
+``test_generate_job_liveness.py``. This file's job is narrower: does the new
+read-only listing endpoint return the CALLING user's own credits, shaped
+honestly, and never another user's.
+
+Hermetic: tmp-file SQLite (``redirect_to_tmp_sqlite``) + a dependency-
+overridden ``require_current_user`` — the same two idioms
+``test_generate_job_liveness.py`` and ``test_risk_routes.py`` use
+respectively. No live DB/Redis/network.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from archimedes.api.account_auth import CurrentUser, require_current_user
+from archimedes.db import get_session
+from archimedes.models.generation_credit import (
+    claim_credit,
+    consume_credit,
+    mark_credit_settled,
+)
+from httpx import ASGITransport, AsyncClient
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+USER_A = "user-credits-a"
+USER_B = "user-credits-b"
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@contextmanager
+def _as_user(user_id: str):
+    """Dependency-override ``require_current_user`` for one request, then restore.
+
+    Mirrors ``test_generate_job_liveness.py``'s ``_authenticated_account``,
+    parameterized on user id so the ownership test below can act as two
+    different callers.
+    """
+    from archimedes.main import app
+
+    app.dependency_overrides[require_current_user] = lambda: CurrentUser(
+        user_id, "Credits Test", f"{user_id}@example.com", True
+    )
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(require_current_user, None)
+
+
+def _make_credit(user_id: str, *, settle: bool = True, consume: bool = False, job_id: str = "job-x") -> int:
+    with get_session() as session:
+        _, credit = claim_credit(session, user_id=user_id, idempotency_key=None)
+        if settle:
+            mark_credit_settled(
+                session,
+                credit.id,
+                payer_wallet="0x" + "aa" * 20,
+                amount_base_units=2_000_000,  # $2.00 at USDC's 6 decimals
+                price_usd="$2.00",
+                network="eip155:5042002",
+                settlement_ref="ref-1",
+            )
+        if consume:
+            consume_credit(session, credit.id, job_id=job_id)
+        session.commit()
+        return credit.id
+
+
+async def _get_credits():
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.get("/api/generate/credits")
+
+
+@pytest.mark.asyncio
+async def test_requires_sign_in():
+    """No auth override active: the router-level gate must 401, never
+    default to an empty list for an anonymous caller."""
+    resp = await _get_credits()
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_no_credits_is_an_empty_list_not_an_error():
+    with _as_user(USER_A):
+        resp = await _get_credits()
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_an_available_credit_is_shaped_honestly():
+    credit_id = _make_credit(USER_A)
+    with _as_user(USER_A):
+        resp = await _get_credits()
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["id"] == credit_id
+    assert row["status"] == "available"
+    assert row["created_at"] is not None
+    assert row["job_id"] is None
+    assert row["amount_usdc"] == 2.0
+    # Only the honest, UI-relevant subset ships — no payer_wallet/network/
+    # settlement_ref leaking payment-plumbing internals into the response.
+    assert set(row.keys()) == {"id", "status", "created_at", "job_id", "amount_usdc"}
+
+
+@pytest.mark.asyncio
+async def test_a_consumed_credit_still_lists_with_its_job_id():
+    credit_id = _make_credit(USER_A, consume=True, job_id="job-consumed")
+    with _as_user(USER_A):
+        resp = await _get_credits()
+    row = resp.json()[0]
+    assert row["id"] == credit_id
+    assert row["status"] == "consumed"
+    assert row["job_id"] == "job-consumed"
+
+
+@pytest.mark.asyncio
+async def test_a_pending_unsettled_claim_reports_no_amount():
+    """A ``pending`` row exists precisely because nothing has settled yet —
+    the amount must read None, never a fabricated $0.00."""
+    _make_credit(USER_A, settle=False)
+    with _as_user(USER_A):
+        resp = await _get_credits()
+    row = resp.json()[0]
+    assert row["status"] == "pending"
+    assert row["amount_usdc"] is None
+
+
+@pytest.mark.asyncio
+async def test_never_leaks_another_users_credit():
+    """The guard this file exists to pin: the endpoint must scope to the
+    CALLING user (``user.id`` from the auth dependency), not return the
+    whole ledger table."""
+    _make_credit(USER_A)
+    _make_credit(USER_B)
+
+    with _as_user(USER_A):
+        rows_a = (await _get_credits()).json()
+    with _as_user(USER_B):
+        rows_b = (await _get_credits()).json()
+
+    assert len(rows_a) == 1
+    assert len(rows_b) == 1
+    assert rows_a[0]["id"] != rows_b[0]["id"]

--- a/backend/tests/test_generate_credits_route.py
+++ b/backend/tests/test_generate_credits_route.py
@@ -145,14 +145,18 @@ async def test_never_leaks_another_users_credit():
     """The guard this file exists to pin: the endpoint must scope to the
     CALLING user (``user.id`` from the auth dependency), not return the
     whole ledger table."""
-    _make_credit(USER_A)
-    _make_credit(USER_B)
+    a_id = _make_credit(USER_A)
+    b_id = _make_credit(USER_B)
+    assert a_id != b_id  # the fixture itself must not hand back one id twice
 
     with _as_user(USER_A):
         rows_a = (await _get_credits()).json()
     with _as_user(USER_B):
         rows_b = (await _get_credits()).json()
 
-    assert len(rows_a) == 1
-    assert len(rows_b) == 1
-    assert rows_a[0]["id"] != rows_b[0]["id"]
+    # Bind each response to the id its OWNER was issued. `rows_a[0]["id"] !=
+    # rows_b[0]["id"]` alone would also pass if the endpoint returned the whole
+    # table sliced differently per caller, or swapped the two users' rows —
+    # both of which are the exact leak this test exists to catch.
+    assert [row["id"] for row in rows_a] == [a_id]
+    assert [row["id"] for row in rows_b] == [b_id]

--- a/docs/api/generation.md
+++ b/docs/api/generation.md
@@ -134,6 +134,20 @@ Errors: 404 `job {job_id} not found or expired` (unknown, or not owned).
 curl -s -b /tmp/session.jar https://archimedes-arc.com/api/generate/jobs/<job_id>/candidates
 ```
 
+### GET /api/generate/credits
+The caller's own generation-credit ledger, newest-first (v8 Lane 1.3a) — makes
+visible what `_paywall_with_credit` already does silently: an `available`
+credit from an earlier paid-but-undelivered run pays for the NEXT generation,
+with no new charge (#1441). | **Auth**: account-session
+
+Request: none.
+Response: `[{id: int, status: "pending"|"available"|"consumed"|"void", created_at: str|null, job_id: str|null, amount_usdc: float|null}]`. Narrower than the full ledger row — `payer_wallet`/`network`/`settlement_ref` are payment-plumbing internals the UI has no use for. `amount_usdc` is `null` until the underlying claim settles (mirrors `amount_base_units`'s own nullability), never a fabricated `0.0`.
+Errors: none beyond the global 401.
+
+```bash
+curl -s -b /tmp/session.jar https://archimedes-arc.com/api/generate/credits
+```
+
 ### GET /api/payments/receipts
 The caller's own settled generation-payment receipts, newest-first (Dan's
 directive, 2026-08-21: "we must provide people with their receipts"). Written

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -173,9 +173,13 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// ── The caller's own generation-credit ledger (v8 Lane 1.3a) ──
 	// Surfaces what `_paywall_with_credit` already does silently server-side:
 	// an unspent ("available") credit from an earlier paid-but-undelivered
-	// run pays for the NEXT generation, no new charge (#1441). Fetched
+	// run pays for the NEXT generation, no new charge (#1441). The FETCH runs
 	// independently of GENERATION_QUOTE_ENABLED — a credit is a real balance
-	// regardless of whether the upfront quote card renders.
+	// regardless of whether the upfront quote card renders. The NOTICE below
+	// additionally needs the quote's payment_required, so with the quote flag
+	// explicitly off (it defaults on, featureFlags.js) the balance is still
+	// read but nothing is claimed about it — the honest degraded state here is
+	// silence, not an unverified "no new charge".
 	const [credits, setCredits] = useState([]);
 	const [creditNoticeDismissed, setCreditNoticeDismissed] = useState(false);
 
@@ -250,9 +254,12 @@ export default function Generate({ onNavigate, onStageChange }) {
 		};
 	}, [paymentActive, quote?.payment_required]);
 
-	// The oldest still-spendable credit, if any — mirrors the ledger's own
-	// oldest-first draining (models/generation_credit.take_available_credit),
-	// though only its PRESENCE (not which one) matters for the notice.
+	// A still-spendable credit, if any. Note the route lists NEWEST-first
+	// (models/generation_credit.list_credits orders created_at DESC) while the
+	// ledger drains OLDEST-first (take_available_credit orders created_at
+	// ASC) — so this is NOT necessarily the credit the next submit spends.
+	// That's fine: only its PRESENCE drives the notice, never its identity,
+	// and the notice must not name or price a specific credit for that reason.
 	const unspentCredit = useMemo(() => credits.find((c) => c.status === "available") ?? null, [credits]);
 
 	const quoteView = useMemo(() => deriveQuoteView(quote), [quote]);
@@ -1002,9 +1009,20 @@ export default function Generate({ onNavigate, onStageChange }) {
 					    _paywall_with_credit already spends an unspent credit
 					    silently, BEFORE the paywall even runs — this just makes
 					    that real behavior visible instead of leaving the payer
-					    to discover it only from the receipt list. */}
-					{unspentCredit && !creditNoticeDismissed && (
-						<div className="info-box mb-3 flex items-center justify-between gap-2">
+					    to discover it only from the receipt list.
+
+					    Gated on quote.payment_required as well as the credit:
+					    "no new charge" only says something true when there is a
+					    charge to avoid. With the paywall flag off there is no
+					    charge either way, and the sentence would imply the payer
+					    is being spared one — so the notice stays out of the way
+					    entirely rather than being softened into vagueness. */}
+					{unspentCredit && quote?.payment_required && !creditNoticeDismissed && (
+						<div
+							className="info-box mb-3 flex items-center justify-between gap-2"
+							role="status"
+							aria-live="polite"
+						>
 							<span>
 								You have a paid generation credit — this run will use
 								it, no new charge.

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -170,6 +170,26 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// the response carried one (only true payments settled — live mode).
 	const [receipt, setReceipt] = useState(null);
 
+	// ── The caller's own generation-credit ledger (v8 Lane 1.3a) ──
+	// Surfaces what `_paywall_with_credit` already does silently server-side:
+	// an unspent ("available") credit from an earlier paid-but-undelivered
+	// run pays for the NEXT generation, no new charge (#1441). Fetched
+	// independently of GENERATION_QUOTE_ENABLED — a credit is a real balance
+	// regardless of whether the upfront quote card renders.
+	const [credits, setCredits] = useState([]);
+	const [creditNoticeDismissed, setCreditNoticeDismissed] = useState(false);
+
+	const fetchCredits = useCallback(() => {
+		apiGet("/api/generate/credits")
+			.then((data) => setCredits(Array.isArray(data) ? data : []))
+			.catch(() => {
+				// Quiet on failure (e.g. not signed in yet) — this is a
+				// nice-to-have notice, not a gate; nothing here may block or
+				// error the page.
+				setCredits([]);
+			});
+	}, []);
+
 	const fetchQuote = useCallback(() => {
 		if (!GENERATION_QUOTE_ENABLED) return;
 		setQuoteStatus("loading");
@@ -189,6 +209,10 @@ export default function Generate({ onNavigate, onStageChange }) {
 	useEffect(() => {
 		fetchQuote();
 	}, [fetchQuote]);
+
+	useEffect(() => {
+		fetchCredits();
+	}, [fetchCredits]);
 
 	// Wallet connect/disconnect is a global event (config.js), not React
 	// state — re-derive our copy on change so the payer-mismatch note and
@@ -225,6 +249,11 @@ export default function Generate({ onNavigate, onStageChange }) {
 			cancelled = true;
 		};
 	}, [paymentActive, quote?.payment_required]);
+
+	// The oldest still-spendable credit, if any — mirrors the ledger's own
+	// oldest-first draining (models/generation_credit.take_available_credit),
+	// though only its PRESENCE (not which one) matters for the notice.
+	const unspentCredit = useMemo(() => credits.find((c) => c.status === "available") ?? null, [credits]);
 
 	const quoteView = useMemo(() => deriveQuoteView(quote), [quote]);
 	// The price/asset/chain/dry_run to show in the payment step: the upfront
@@ -357,6 +386,9 @@ export default function Generate({ onNavigate, onStageChange }) {
 			// Re-quote for the next generation — flat pricing has nothing to
 			// consume, but the flag/dry_run/recipient could change underneath.
 			if (GENERATION_QUOTE_ENABLED) fetchQuote();
+			// A just-spent credit (or a fresh one this run settled but didn't
+			// spend) changes the ledger — refresh regardless of the quote flag.
+			fetchCredits();
 			// Stay on the page — the job table will show the new row.
 		} catch (e) {
 			const dryRun = e?.detail?.quote?.dry_run ?? quote?.dry_run;
@@ -404,6 +436,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 			resetPaymentStepState();
 			setNoSettlementNotice(!settledReceipt);
 			if (GENERATION_QUOTE_ENABLED) fetchQuote();
+			fetchCredits();
 			return null;
 		} catch (e) {
 			const fresh = derivePaymentRequirements(extractPaymentRequiredHeader(e.headers));
@@ -448,6 +481,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 		resetPaymentStepState();
 		setNoSettlementNotice(!settledReceipt);
 		if (GENERATION_QUOTE_ENABLED) fetchQuote();
+		fetchCredits();
 	};
 
 	// ── One tap when funded: the signing ceremony runs FIRST, inside the
@@ -505,6 +539,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 				resetPaymentStepState();
 				setNoSettlementNotice(!settledReceipt);
 				if (GENERATION_QUOTE_ENABLED) fetchQuote();
+				fetchCredits();
 				return;
 			}
 
@@ -960,6 +995,36 @@ export default function Generate({ onNavigate, onStageChange }) {
 									)}
 								</div>
 							)}
+						</div>
+					)}
+
+					{/* ── Paid generation credit notice (v8 Lane 1.3a) ──
+					    _paywall_with_credit already spends an unspent credit
+					    silently, BEFORE the paywall even runs — this just makes
+					    that real behavior visible instead of leaving the payer
+					    to discover it only from the receipt list. */}
+					{unspentCredit && !creditNoticeDismissed && (
+						<div className="info-box mb-3 flex items-center justify-between gap-2">
+							<span>
+								You have a paid generation credit — this run will use
+								it, no new charge.
+							</span>
+							<button
+								type="button"
+								onClick={() => setCreditNoticeDismissed(true)}
+								className="caption"
+								aria-label="Dismiss credit notice"
+								style={{
+									background: "none",
+									border: "none",
+									cursor: "pointer",
+									color: "var(--text-3)",
+									padding: 0,
+									flexShrink: 0,
+								}}
+							>
+								Dismiss
+							</button>
 						</div>
 					)}
 

--- a/ui/test/generation-credits.test.js
+++ b/ui/test/generation-credits.test.js
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Source-regex pins on Generate.jsx's new credit-visibility notice (v8 Lane
+// 1.3a). Same idiom as ui/test/generate-quote.test.js's "Wiring" section and
+// ui/test/payment-receipts.test.js: readFileSync + regex/substring
+// assertions on the rendered source, confirming the fetch is wired to the
+// real credentialed helper and the endpoint, the notice is gated on a real
+// unspent credit, it is dismissable, and its copy actually describes what
+// `_paywall_with_credit` (backend/archimedes/api/generate_routes.py) does.
+
+const generate = readFileSync(
+	new URL("../src/components/Generate.jsx", import.meta.url),
+	"utf8",
+);
+
+// ── Fetches the owner-scoped credits endpoint via the shared apiGet helper ──
+
+test("fetches GET /api/generate/credits via the shared apiGet helper, not a bare fetch", () => {
+	// apiGet (src/api.js) sends credentials:'include', which is what makes the
+	// request owner-scoped server-side (require_current_user reads the Better
+	// Auth session cookie) — pin the real helper call, not a copy/paste fetch.
+	assert.match(generate, /apiGet\(\s*["']\/api\/generate\/credits["']\s*\)/);
+});
+
+test("fetches credits on mount, independently of GENERATION_QUOTE_ENABLED", () => {
+	// A credit is a real balance regardless of whether the upfront quote card
+	// is shown — the fetch must not be nested inside the quote flag's gate.
+	const fetchCallIdx = generate.indexOf("fetchCredits();");
+	assert.ok(fetchCallIdx !== -1, "fetchCredits() must be called somewhere");
+	assert.match(generate, /useEffect\(\(\) => \{\s*fetchCredits\(\);\s*\}, \[fetchCredits\]\);/);
+});
+
+test("re-fetches credits after every successful /start (a credit may have just been spent)", () => {
+	// Each of the four post-submitStart() success paths (plain start, the
+	// refetch-then-retry path, the held-requirements finish, and the
+	// smart-wallet finish) must refresh the ledger, not just the quote.
+	const matches = generate.match(/fetchCredits\(\);/g) || [];
+	// One for the mount effect's definition site is NOT counted here (that's
+	// the useEffect body, matched separately above) — this counts every call
+	// SITE, so >= 4 post-submit refreshes + the 1 mount-effect call.
+	assert.ok(matches.length >= 5, `expected >=5 fetchCredits() call sites, found ${matches.length}`);
+});
+
+// ── The notice: gated on a real unspent ("available") credit ─────────────
+
+test("derives the notice from an `available` credit, not merely a non-empty list", () => {
+	// A `pending`/`consumed`/`void` row must not trigger the notice — only a
+	// spendable one does (mirrors take_available_credit's status filter).
+	assert.match(generate, /credits\.find\(\(c\) => c\.status === ["']available["']\)/);
+});
+
+test("the notice is gated on the derived unspent credit AND the dismissed flag", () => {
+	assert.match(generate, /\{unspentCredit && !creditNoticeDismissed && \(/);
+});
+
+test("the notice has a working dismiss control (dismissable, per spec)", () => {
+	assert.match(generate, /creditNoticeDismissed/);
+	assert.match(generate, /setCreditNoticeDismissed\(true\)/);
+	assert.match(generate, /useState\(false\)/);
+});
+
+// ── Wording matches what _paywall_with_credit actually does ──────────────
+
+test("the notice's copy is the exact honest wording from the spec", () => {
+	// _paywall_with_credit (generate_routes.py) checks generation_credits.take_credit()
+	// BEFORE the paywall runs and, if an unspent credit exists, spends it
+	// instead of charging — this is the literal behavior the banner describes.
+	assert.match(
+		generate,
+		/You have a paid generation credit — this run will use\s+it, no new charge\./,
+	);
+});
+
+test("does not overclaim: never says the credit is a refund, discount, or free trial", () => {
+	// Loose but real anti-goal: this is a paid-and-banked credit being spent,
+	// not any of these other financial concepts that would misdescribe it.
+	assert.doesNotMatch(generate, /\brefund\b/i);
+	assert.doesNotMatch(generate, /\bdiscount\b/i);
+	assert.doesNotMatch(generate, /\bfree trial\b/i);
+});

--- a/ui/test/generation-credits.test.js
+++ b/ui/test/generation-credits.test.js
@@ -15,6 +15,31 @@ const generate = readFileSync(
 	"utf8",
 );
 
+// The notice's OWN JSX, sliced out of the 1300-line component: from its
+// opening comment marker to the next sibling block. The wording anti-goals
+// below are about THIS notice's copy — asserted against the whole file they
+// would also fail on an unrelated future "refund" elsewhere in Generate.jsx
+// (a false alarm) and would pass for the wrong reason if the notice were
+// deleted outright. Same indexOf/slice idiom as
+// ui/test/payment-receipts.test.js's settlement-reference pin.
+const NOTICE_START = "Paid generation credit notice";
+const NOTICE_END = "{/* Submit row */}";
+const noticeSlice = (() => {
+	const start = generate.indexOf(NOTICE_START);
+	assert.ok(start !== -1, `notice marker ${JSON.stringify(NOTICE_START)} not found`);
+	const end = generate.indexOf(NOTICE_END, start);
+	assert.ok(end !== -1, `sibling marker ${JSON.stringify(NOTICE_END)} not found after the notice`);
+	return generate.slice(start, end);
+})();
+
+test("the sliced notice region is the real notice (guards the slice itself)", () => {
+	// Without this, an empty or misaligned slice would make every
+	// doesNotMatch below pass vacuously — the classic "guard that guards
+	// nothing" failure. Pin that the slice actually contains the copy.
+	assert.ok(noticeSlice.includes("paid generation credit"), "slice must contain the notice copy");
+	assert.ok(noticeSlice.length > 100, `slice suspiciously short (${noticeSlice.length} chars)`);
+});
+
 // ── Fetches the owner-scoped credits endpoint via the shared apiGet helper ──
 
 test("fetches GET /api/generate/credits via the shared apiGet helper, not a bare fetch", () => {
@@ -52,7 +77,27 @@ test("derives the notice from an `available` credit, not merely a non-empty list
 });
 
 test("the notice is gated on the derived unspent credit AND the dismissed flag", () => {
-	assert.match(generate, /\{unspentCredit && !creditNoticeDismissed && \(/);
+	assert.match(
+		generate,
+		/\{unspentCredit && quote\?\.payment_required && !creditNoticeDismissed && \(/,
+	);
+});
+
+test("the notice is ALSO gated on payments actually being on", () => {
+	// "no new charge" only says something true when there is a charge to
+	// avoid. With GENERATION_PAYMENT_REQUIRED off, quote.payment_required is
+	// false and nothing is charged either way — showing the banner there would
+	// claim the payer was spared a cost that never existed. The gate must read
+	// the live quote, not a constant.
+	const gate = noticeSlice.match(/\{unspentCredit[^\n]*&& \(/);
+	assert.ok(gate, "notice gate expression not found inside the notice slice");
+	assert.match(gate[0], /quote\?\.payment_required/);
+});
+
+test("the notice is an announced live region (assistive tech hears it appear)", () => {
+	// Sibling pattern: the generate-submit-status live region below it.
+	assert.match(noticeSlice, /role="status"/);
+	assert.match(noticeSlice, /aria-live="polite"/);
 });
 
 test("the notice has a working dismiss control (dismissable, per spec)", () => {
@@ -76,7 +121,10 @@ test("the notice's copy is the exact honest wording from the spec", () => {
 test("does not overclaim: never says the credit is a refund, discount, or free trial", () => {
 	// Loose but real anti-goal: this is a paid-and-banked credit being spent,
 	// not any of these other financial concepts that would misdescribe it.
-	assert.doesNotMatch(generate, /\brefund\b/i);
-	assert.doesNotMatch(generate, /\bdiscount\b/i);
-	assert.doesNotMatch(generate, /\bfree trial\b/i);
+	// Scoped to the notice's own JSX (see noticeSlice above) — an unrelated
+	// "refund" elsewhere in this 1300-line component is not this notice
+	// overclaiming, and must not fail this test.
+	assert.doesNotMatch(noticeSlice, /\brefund\b/i);
+	assert.doesNotMatch(noticeSlice, /\bdiscount\b/i);
+	assert.doesNotMatch(noticeSlice, /\bfree trial\b/i);
 });


### PR DESCRIPTION
GET /api/generate/credits (user-scoped) + a dismissable notice when an unspent credit exists — gated on payments actually being on, so the copy is never false (reviewer-caught). Cross-user leak test proven non-tautological by injected-bug demonstration; a11y role=status added; 3,904 backend + 428 ui green. Provenance: builder → Opus review (FIX-FIRST ×5) → all fixes applied. Known pre-existing issue flagged in review, NOT fixed here: take_credit runs before settles_real_value(), so dry-run consumes a real credit — follow-up issue candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7