### PR TITLE
[product][privacy] The user's brief on the passport — owner-gated

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1422,6 +1422,11 @@ async def _persist_candidate(
                 # strategy can be autonomously rebalanced by the agent runner.
                 # None on the fixture/buy-and-hold path — nothing to persist.
                 strategy_spec=c.strategy_spec,
+                # The user's own free-text ask (v8 Lane 3.3), surfaced on the
+                # passport as "Your brief" — already in hand here, no
+                # strategy_proposals lookup needed for a strategy persisted
+                # from this call.
+                brief_intent=brief.intent,
             )
             # Stamp the generating wallet so wallet_can_publish() returns True
             # for this wallet/strategy pair (D5 publish gate).

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -171,6 +171,15 @@ class StrategyResponse(BaseModel):
     id: str
     papers: list[PaperRefResponse] = []
     methodology_summary: str
+    # The user's own free-text ask that produced this strategy (v8 Lane 3.3),
+    # read from strategy_store.brief_intent — distinct from
+    # methodology_summary, which is the DERIVED writeup. Populated ONLY by
+    # the single-strategy detail route (``get_strategy``); the shared
+    # ``_passport_to_strategy_response``/``_passport_responses`` helpers that
+    # also back Library and the public leaderboard never set it, so it never
+    # reaches those list payloads. None = curated strategy (no brief) or a
+    # legacy generated row the backfill migration could not resolve.
+    brief_intent: str | None = None
     asset_universe: list[str]
     # Provenance of the asset_universe pick (#857): "user" | "model" | "full",
     # or None for rows written before this field existed (curated strategies,

--- a/backend/archimedes/api/schemas.py
+++ b/backend/archimedes/api/schemas.py
@@ -174,11 +174,14 @@ class StrategyResponse(BaseModel):
     # The user's own free-text ask that produced this strategy (v8 Lane 3.3),
     # read from strategy_store.brief_intent — distinct from
     # methodology_summary, which is the DERIVED writeup. Populated ONLY by
-    # the single-strategy detail route (``get_strategy``); the shared
+    # the single-strategy detail route (``get_strategy``), and there only for
+    # the row's OWNER — publishing a strategy shares the strategy, not the
+    # sentence its owner typed to ask for it. The shared
     # ``_passport_to_strategy_response``/``_passport_responses`` helpers that
     # also back Library and the public leaderboard never set it, so it never
-    # reaches those list payloads. None = curated strategy (no brief) or a
-    # legacy generated row the backfill migration could not resolve.
+    # reaches those list payloads. None = not the caller's row, a curated
+    # strategy (no brief), or a legacy generated row the backfill migration
+    # could not resolve.
     brief_intent: str | None = None
     asset_universe: list[str]
     # Provenance of the asset_universe pick (#857): "user" | "model" | "full",

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2295,7 +2295,31 @@ async def get_strategy(strategy_id: str, request: Request):
             # leaderboard (`_passport_responses` /
             # `_public_generated_strategy_responses`), and a user's free-text
             # brief has no business on either of those.
-            resp.brief_intent = row.brief_intent if row is not None else None
+            #
+            # OWNER-GATED, and deliberately STRICTER than the 404 visibility
+            # check above: `is_strategy_visible` lets ANYONE read a PUBLISHED
+            # row, but the brief is the user's own words, and publishing a
+            # strategy consents to sharing the STRATEGY, not the sentence its
+            # owner typed to ask for it (same reasoning as
+            # `_redact_owner_wallet` for owner_wallet). So the same #850
+            # predicate is re-asked in ownership-only form — `is_example` and
+            # `is_published` pinned False in the row_view so neither
+            # public-visibility clause can grant it — which is exactly the
+            # shape `_owned_generated_strategy_responses` uses for the
+            # leaderboard's "own" scope. Never re-implement the owner match
+            # at a call site; ask the one predicate. Non-owners and anonymous
+            # callers keep the schema default (None).
+            if row is not None and is_strategy_visible(
+                {
+                    "is_example": False,
+                    "is_published": False,
+                    "owner_user_id": row.owner_user_id,
+                    "owner_wallet": row.owner_wallet,
+                },
+                caller,
+                caller_user_id=user.id if user else None,
+            ):
+                resp.brief_intent = row.brief_intent
             return resp
 
     raise HTTPException(status_code=404, detail="Strategy not found")

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2285,7 +2285,18 @@ async def get_strategy(strategy_id: str, request: Request):
             raise HTTPException(status_code=404, detail="Strategy not found")
         record = get_passport(session, strategy_id)
         if record is not None:
-            return _passport_to_strategy_response(record, session=session)
+            resp = _passport_to_strategy_response(record, session=session)
+            # The user's own brief (v8 Lane 3.3) lives on strategy_store, not
+            # the strategy_passports row `_passport_to_strategy_response`
+            # reads — `row` (StrategyRecord) is already loaded above for the
+            # visibility check, so this is a free attribute read, not an
+            # extra query. Deliberately set HERE, not inside the shared
+            # helper: that helper also backs Library and the public
+            # leaderboard (`_passport_responses` /
+            # `_public_generated_strategy_responses`), and a user's free-text
+            # brief has no business on either of those.
+            resp.brief_intent = row.brief_intent if row is not None else None
+            return resp
 
     raise HTTPException(status_code=404, detail="Strategy not found")
 

--- a/backend/archimedes/models/strategy_store.py
+++ b/backend/archimedes/models/strategy_store.py
@@ -56,6 +56,13 @@ class StrategyRecord(Base):
     # Strategy definition
     strategy_name = Column(String(256), nullable=False, default="")
     thesis = Column(Text, nullable=False, default="")
+    # The user's own free-text ask that produced this strategy (v8 Lane 3.3) —
+    # distinct from `thesis`, which is the DERIVED methodology. Sourced from
+    # `GenerateBrief.intent` at generation time (`_persist_candidate`'s
+    # `_do_persist`). NULL for curated/example rows (which have no brief) and
+    # for legacy generated rows this column's migration could not resolve
+    # (see that migration's docstring for the backfill's honest boundary).
+    brief_intent = Column(Text, nullable=True)
     asset_universe = Column(Text, nullable=False, default="[]")  # JSON list
     risk_profile = Column(String(32), nullable=False, default="moderate")
     # Raw validated DSL spec JSON (rebalancer decouple, Part A #1 of
@@ -236,6 +243,7 @@ def upsert_strategy(
     owner_wallet: str | None = None,
     owner_user_id: str | None = None,
     strategy_spec: dict | None = None,
+    brief_intent: str | None = None,
 ) -> StrategyRecord:
     """Idempotent upsert: same content → same row, no duplicates.
 
@@ -248,6 +256,10 @@ def upsert_strategy(
     content-hash match it is backfilled onto a row that lacks one, the same
     never-overwrite rule as ownership; an existing non-null spec is never
     replaced.
+
+    ``brief_intent`` is the user's own free-text ask (v8 Lane 3.3) — plain
+    text, left NULL otherwise. Same never-overwrite backfill rule: a
+    content-hash match only fills a NULL, never replaces an existing value.
     """
     owner_wallet = owner_wallet.lower() if owner_wallet else None
     content_hash = _compute_content_hash(
@@ -272,6 +284,11 @@ def upsert_strategy(
         # that's already there.
         if strategy_spec is not None and not existing.strategy_spec:
             existing.strategy_spec = json.dumps(strategy_spec)
+            existing.updated_at = datetime.now(UTC)
+            session.flush()
+        # Same never-overwrite backfill rule for the user's brief.
+        if brief_intent and not existing.brief_intent:
+            existing.brief_intent = brief_intent
             existing.updated_at = datetime.now(UTC)
             session.flush()
         # Update status/verdict if provided, but don't duplicate
@@ -311,6 +328,11 @@ def upsert_strategy(
         # bare truthiness check would silently drop an explicitly-provided
         # empty dict ({}) by storing NULL instead of the serialized "{}".
         strategy_spec=json.dumps(strategy_spec) if strategy_spec is not None else None,
+        # Truthiness here (unlike strategy_spec above) is correct: brief_intent
+        # is plain text, not a dict where {} is a meaningful distinct value
+        # from "absent" — an empty/whitespace brief has nothing to show either
+        # way, so it collapses to NULL like any other "nothing here".
+        brief_intent=brief_intent or None,
     )
     if rigor_verdict:
         # Same transition rule as the upsert-existing branch above

--- a/backend/archimedes/models/strategy_store.py
+++ b/backend/archimedes/models/strategy_store.py
@@ -260,8 +260,16 @@ def upsert_strategy(
     ``brief_intent`` is the user's own free-text ask (v8 Lane 3.3) — plain
     text, left NULL otherwise. Same never-overwrite backfill rule: a
     content-hash match only fills a NULL, never replaces an existing value.
+    Normalized once here (stripped; empty-or-whitespace → NULL) so BOTH write
+    branches below store the same thing: a blank brief has nothing to show,
+    and a row holding ``"   "`` would render an empty "Your brief" card on the
+    passport instead of no card at all.
     """
     owner_wallet = owner_wallet.lower() if owner_wallet else None
+    # Normalize before either branch reads it — see the docstring. Doing it in
+    # one place is what keeps the new-row branch and the backfill branch from
+    # disagreeing about what "no brief" means.
+    brief_intent = (brief_intent or "").strip() or None
     content_hash = _compute_content_hash(
         generation_method,
         strategy_name,
@@ -286,7 +294,9 @@ def upsert_strategy(
             existing.strategy_spec = json.dumps(strategy_spec)
             existing.updated_at = datetime.now(UTC)
             session.flush()
-        # Same never-overwrite backfill rule for the user's brief.
+        # Same never-overwrite backfill rule for the user's brief. `brief_intent`
+        # is already stripped-or-None at this point (top of the function), so a
+        # whitespace-only ask cannot backfill over a genuine NULL either.
         if brief_intent and not existing.brief_intent:
             existing.brief_intent = brief_intent
             existing.updated_at = datetime.now(UTC)
@@ -328,11 +338,11 @@ def upsert_strategy(
         # bare truthiness check would silently drop an explicitly-provided
         # empty dict ({}) by storing NULL instead of the serialized "{}".
         strategy_spec=json.dumps(strategy_spec) if strategy_spec is not None else None,
-        # Truthiness here (unlike strategy_spec above) is correct: brief_intent
-        # is plain text, not a dict where {} is a meaningful distinct value
-        # from "absent" — an empty/whitespace brief has nothing to show either
-        # way, so it collapses to NULL like any other "nothing here".
-        brief_intent=brief_intent or None,
+        # Already stripped-or-None at the top of the function (unlike
+        # strategy_spec above, where {} is a meaningful distinct value from
+        # "absent" and truthiness would be wrong): an empty or whitespace-only
+        # brief has nothing to show, so it is stored as NULL, not as blanks.
+        brief_intent=brief_intent,
     )
     if rigor_verdict:
         # Same transition rule as the upsert-existing branch above

--- a/backend/migrations/versions/5cb798feef58_add_brief_intent_to_strategy_store.py
+++ b/backend/migrations/versions/5cb798feef58_add_brief_intent_to_strategy_store.py
@@ -105,7 +105,13 @@ def upgrade() -> None:
             continue
         if not isinstance(payload, dict):
             continue
-        intent = payload.get("intent")
+        # Stripped, matching upsert_strategy's normalization of the same
+        # column — this backfill is the OTHER writer to brief_intent, and a
+        # whitespace-only logged intent must land as "no brief" (skipped
+        # below), not as a row of blanks that renders an empty "Your brief"
+        # card. `.strip()` before the truthiness check is what makes `"   "`
+        # (which is truthy) fall into that skip.
+        intent = (payload.get("intent") or "").strip()
         spec = payload.get("strategy_spec")
         if not intent or not isinstance(spec, dict):
             continue

--- a/backend/migrations/versions/5cb798feef58_add_brief_intent_to_strategy_store.py
+++ b/backend/migrations/versions/5cb798feef58_add_brief_intent_to_strategy_store.py
@@ -1,0 +1,154 @@
+"""add brief_intent to strategy_store
+
+The strategy passport shows the methodology derived FROM the user's ask, but
+never the ask itself — the free-text brief the user typed lives only in
+``strategy_proposals.payload["intent"]`` (an episodic, non-authoritative log:
+see ``strategy_memory.persist_proposal``), not on the persisted
+``StrategyRecord`` the passport route (``strategies_routes._passport_to_
+strategy_response`` / ``get_strategy``) actually reads. This revision adds a
+nullable ``brief_intent`` (free text, mirrors ``strategy_spec``'s Text-not-
+JSON-typed column for the same SQLite-portability reason) so a strategy can
+carry its own originating brief going forward — ``generation_pipeline.
+_persist_candidate`` writes it at generation time from the ``GenerateBrief``
+it already has in hand (no proposal lookup needed for NEW rows).
+
+BACKFILL (migrations-ship-with-their-data rule): attempted, partial, and
+honestly bounded — this is the "genuinely ambiguous" case the rule
+anticipates rather than a full backfill.
+
+There is no FK or shared id between ``strategy_store`` and
+``strategy_proposals``: a proposal is keyed by ``generation_id`` (== the
+generation job's ``job_id``), a strategy by its own content hash, and nothing
+on either row names the other directly. ``generation_costs`` links
+``job_id -> strategy_id``, but that table is brand new (``e2b7f4c81d93``,
+2026-08-20) and covers only post-instrumentation runs — using it alone would
+backfill a handful of the newest rows and call the rest unresolvable, which
+is not true.
+
+The reliable link is content: ``generation_pipeline.run_generation`` (and the
+older ``_run_fusion_job``) persist the SAME ``strategy_name``/``thesis`` pair
+into both tables in the same request — ``upsert_strategy(strategy_name=...,
+thesis=...)`` and, in the very same code path,
+``persist_proposal(strategy_spec={"strategy_name": ..., "thesis": ..., ...},
+intent=brief.intent)``. So this migration joins on that pair: for each
+``strategy_store`` row, find every ``strategy_proposals`` row whose
+``payload->strategy_spec`` carries the identical ``(strategy_name, thesis)``.
+Every proposal from the SAME generation shares one ``intent`` (it is the same
+brief for every candidate in that job), so the join does not even need to
+resolve to a single proposal row — only to a single DISTINCT intent value.
+
+A ``(strategy_name, thesis)`` pair is backfilled only when:
+  1. at least one ``strategy_proposals`` row matches it, AND
+  2. every matching row agrees on the SAME ``intent`` string.
+
+Rows failing either condition are left ``brief_intent IS NULL`` — no match
+(most likely: legacy strategies persisted before ``persist_proposal`` existed,
+or curated/example rows, which have no brief at all), or a genuine collision
+where two different generations coincidentally produced identical
+strategy_name/thesis text under two different briefs (most plausible for the
+deterministic fixture path, which can emit the same name/thesis regardless of
+input). Guessing which of two intents is right would put a fabricated brief
+on a passport — the thing this column exists to show honestly — so an
+ambiguous match is refused, not resolved by taking the first hit.
+
+Revision ID: 5cb798feef58
+Revises: a3f19c7d2e84
+Create Date: 2026-08-30 00:00:00.000000
+
+SEQUENCING: chained onto ``a3f19c7d2e84``, the chain head at authoring time.
+If another migration lands on main first, re-point ``down_revision`` at the
+new head — ``.github/scripts/migration_chain_guard.py`` catches a fork.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5cb798feef58"
+down_revision: str | Sequence[str] | None = "a3f19c7d2e84"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    """Add the column, then backfill unambiguous rows from strategy_proposals."""
+    with op.batch_alter_table("strategy_store", schema=None) as batch_op:
+        # Text, not a typed JSON column — matches strategy_spec/source_papers
+        # on this same table, hand-encoded Text for SQLite portability.
+        # Nullable: curated/example rows and any row this backfill cannot
+        # resolve have no brief to carry.
+        batch_op.add_column(sa.Column("brief_intent", sa.Text(), nullable=True))
+
+    bind = op.get_bind()
+
+    # ── Build (strategy_name, thesis) -> {distinct intents} from every
+    # proposal's payload. Bounded, one-time read: strategy_proposals is an
+    # episodic log, not a live-traffic table.
+    proposal_rows = bind.execute(sa.text("SELECT payload FROM strategy_proposals")).mappings().all()
+
+    intents_by_key: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for row in proposal_rows:
+        raw = row["payload"]
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        intent = payload.get("intent")
+        spec = payload.get("strategy_spec")
+        if not intent or not isinstance(spec, dict):
+            continue
+        name = spec.get("strategy_name")
+        thesis = spec.get("thesis")
+        if not name or not thesis:
+            continue
+        intents_by_key[(name, thesis)].add(intent)
+
+    # ── Resolve each strategy_store row against that map. Only a key whose
+    # matching proposals agree on ONE intent is trustworthy; a name/thesis
+    # pair that maps to more than one distinct intent is a genuine collision
+    # (most plausible cause: the deterministic fixture path can emit the same
+    # strategy_name/thesis regardless of the brief) and is left NULL rather
+    # than guessed.
+    strategy_rows = (
+        bind.execute(
+            sa.text(
+                "SELECT id, strategy_name, thesis FROM strategy_store "
+                "WHERE brief_intent IS NULL AND generation_method != 'curated'"
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    to_update: list[dict[str, str]] = []
+    for row in strategy_rows:
+        name, thesis = row["strategy_name"], row["thesis"]
+        if not name or not thesis:
+            continue
+        intents = intents_by_key.get((name, thesis))
+        if intents and len(intents) == 1:
+            to_update.append({"id": row["id"], "brief_intent": next(iter(intents))})
+
+    if to_update:
+        bind.execute(
+            sa.text("UPDATE strategy_store SET brief_intent = :brief_intent WHERE id = :id"),
+            to_update,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("strategy_store", schema=None) as batch_op:
+        batch_op.drop_column("brief_intent")

--- a/backend/migrations/versions/5cb798feef58_add_brief_intent_to_strategy_store.py
+++ b/backend/migrations/versions/5cb798feef58_add_brief_intent_to_strategy_store.py
@@ -71,7 +71,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "5cb798feef58"
-down_revision: str | Sequence[str] | None = "a3f19c7d2e84"
+down_revision: str | Sequence[str] | None = "5728d9ef1901"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -611,3 +611,225 @@ def test_dedupe_backtest_results_migration_upgrade_is_idempotent(tmp_path):
 
     rows_after_second = [dict(r) for r in _fetch_backtest_rows(db_path)]
     assert rows_after_second == rows_after_first, "re-running the dedupe migration changed already-deduped data"
+
+
+# ── strategy_store.brief_intent + its backfill (v8 Lane 3.3, dbrowneup/brief-on-passport) ──
+#
+# The revision (5cb798feef58) adds the column, then joins strategy_store to
+# strategy_proposals on the (strategy_name, thesis) pair the pipeline writes
+# identically to both tables, backfilling only when every matching proposal
+# agrees on ONE intent string — see that migration's own docstring for the
+# full "genuinely ambiguous" rationale this test suite exercises directly.
+
+_BRIEF_INTENT_MIGRATION_REVISION = "5cb798feef58"
+
+
+def _brief_intent_migration_down_revision() -> str:
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(Config(str(_BACKEND_DIR / "alembic.ini")))
+    target = script.get_revision(_BRIEF_INTENT_MIGRATION_REVISION).down_revision
+    assert isinstance(target, str), f"expected a single down_revision, got {target!r}"
+    return target
+
+
+def test_alembic_brief_intent_column_added_and_removed(tmp_path):
+    """Per-migration up/down/idempotent contract, exercised directly — same
+    derived-target discipline as the strategy_spec/generation_costs tests
+    above (never a hardcoded down_revision or a relative ``-1``)."""
+    db_path = tmp_path / "brief_intent_column.db"
+    database_url = f"sqlite:///{db_path}"
+
+    def _has_brief_intent_column() -> bool:
+        con = sqlite3.connect(str(db_path))
+        try:
+            cur = con.cursor()
+            cur.execute("PRAGMA table_info(strategy_store)")
+            return "brief_intent" in {row[1] for row in cur.fetchall()}
+        finally:
+            con.close()
+
+    target = _brief_intent_migration_down_revision()
+
+    upgrade = _run_alembic("upgrade", "head", database_url=database_url)
+    assert upgrade.returncode == 0, upgrade.stderr
+    assert _has_brief_intent_column()
+
+    downgrade = _run_alembic("downgrade", target, database_url=database_url)
+    assert downgrade.returncode == 0, downgrade.stderr
+    assert not _has_brief_intent_column()
+
+    reupgrade = _run_alembic("upgrade", "head", database_url=database_url)
+    assert reupgrade.returncode == 0, reupgrade.stderr
+    assert _has_brief_intent_column()
+
+    reupgrade_again = _run_alembic("upgrade", "head", database_url=database_url)
+    assert reupgrade_again.returncode == 0, reupgrade_again.stderr
+    assert _has_brief_intent_column()
+
+
+def _seed_pre_brief_intent_rows(db_path: Path) -> None:
+    """Seed strategy_store + strategy_proposals rows AS THEY WOULD HAVE BEEN
+    WRITTEN by the pipeline, at the schema state immediately BEFORE the
+    brief_intent migration runs (i.e. after upgrading only to its own
+    down_revision — strategy_store has no brief_intent column yet).
+
+    Four cases, one per strategy:
+      * unambiguous  — one proposal, one intent -> backfilled.
+      * ambiguous    — two proposals sharing the (name, thesis) key but
+                        DIFFERENT intents (the fixture-path collision this
+                        migration's docstring calls out) -> left NULL.
+      * no_match     — a strategy with no matching proposal at all
+                        (pre-persist_proposal legacy row) -> left NULL.
+      * curated       — generation_method='curated' -> never even considered,
+                        left NULL, even though its (name, thesis) happens to
+                        coincide with a real proposal.
+    """
+    import json as _json
+    from datetime import UTC, datetime
+
+    import sqlalchemy as sa
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+
+    metadata = sa.MetaData()
+    metadata.reflect(bind=engine, only=["strategy_store", "strategy_proposals"])
+    strategy_store = metadata.tables["strategy_store"]
+    strategy_proposals = metadata.tables["strategy_proposals"]
+
+    # A real datetime object, not an ISO string — Core insert against a
+    # DateTime column (unlike the ORM path elsewhere in this file) requires
+    # one, and SQLite's DBAPI adapter rejects a string outright.
+    now = datetime(2026, 8, 1, tzinfo=UTC)
+
+    def _strategy_row(sid: str, name: str, thesis: str, method: str = "debate") -> dict:
+        return {
+            "id": sid,
+            "content_hash": ("0x" + sid).ljust(66, "0"),
+            "generation_method": method,
+            "source_papers": "[]",
+            "strategy_name": name,
+            "thesis": thesis,
+            "asset_universe": "[]",
+            "risk_profile": "moderate",
+            "status": "candidate",
+            "is_example": False,
+            "is_published": False,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+    def _proposal_row(pid: str, gen_id: str, name: str, thesis: str, intent: str) -> dict:
+        payload = _json.dumps(
+            {
+                "intent": intent,
+                "strategy_spec": {"strategy_name": name, "thesis": thesis, "weights": {}, "asset_universe": []},
+                "papers": [],
+                "rigor_verdict": None,
+                "agent": "debate",
+            }
+        )
+        return {
+            "id": pid,
+            "generation_id": gen_id,
+            "proposal_id": pid,
+            "verdict": "selected",
+            "trust_level": "CANDIDATE",
+            "content_hash": ("0z" + pid).ljust(66, "0"),
+            "agent": "debate",
+            "payload": payload,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+    with engine.begin() as conn:
+        conn.execute(
+            strategy_store.insert(),
+            [
+                _strategy_row("unambig01", "Unambiguous Strategy", "Its thesis"),
+                _strategy_row("ambig0001", "Ambiguous Strategy", "Its thesis"),
+                _strategy_row("nomatch01", "No Match Strategy", "Its thesis"),
+                _strategy_row("curated01", "Ambiguous Strategy", "Its thesis", method="curated"),
+            ],
+        )
+        conn.execute(
+            strategy_proposals.insert(),
+            [
+                _proposal_row("p-unambig", "gen-1", "Unambiguous Strategy", "Its thesis", "Beat SPY in a downturn"),
+                # Two DIFFERENT jobs coincidentally produced the identical
+                # (name, thesis) pair under two DIFFERENT briefs — the
+                # collision case. Every real proposal write shares an intent
+                # with every OTHER proposal from the SAME job, but nothing
+                # stops two SEPARATE jobs from colliding on name/thesis text
+                # (most plausible with the deterministic fixture path).
+                _proposal_row("p-ambig-a", "gen-2", "Ambiguous Strategy", "Its thesis", "Brief A"),
+                _proposal_row("p-ambig-b", "gen-3", "Ambiguous Strategy", "Its thesis", "Brief B"),
+            ],
+        )
+
+    engine.dispose()
+
+
+def test_brief_intent_backfill_resolves_only_unambiguous_rows(tmp_path):
+    """Acceptance: unambiguous match backfilled; ambiguous, no-match, and
+    curated rows all left NULL — never guessed."""
+    db_path = tmp_path / "brief_intent_backfill.db"
+    database_url = f"sqlite:///{db_path}"
+
+    pre = _run_alembic("upgrade", _brief_intent_migration_down_revision(), database_url=database_url)
+    assert pre.returncode == 0, pre.stderr
+
+    _seed_pre_brief_intent_rows(db_path)
+
+    post = _run_alembic("upgrade", "head", database_url=database_url)
+    assert post.returncode == 0, f"brief_intent migration failed:\nSTDOUT:\n{post.stdout}\nSTDERR:\n{post.stderr}"
+
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.row_factory = sqlite3.Row
+        cur = con.cursor()
+        cur.execute("SELECT id, brief_intent FROM strategy_store ORDER BY id")
+        by_id = {row["id"]: row["brief_intent"] for row in cur.fetchall()}
+    finally:
+        con.close()
+
+    assert by_id["unambig01"] == "Beat SPY in a downturn"
+    assert by_id["ambig0001"] is None, "colliding (name, thesis) with two distinct intents must never be guessed"
+    assert by_id["nomatch01"] is None, "no matching proposal at all must stay NULL"
+    assert by_id["curated01"] is None, "curated rows are never considered, even on a coincidental name/thesis match"
+
+
+def test_brief_intent_backfill_migration_upgrade_is_idempotent(tmp_path):
+    """Running the backfill migration's upgrade a second time (downgrade to
+    its own down_revision, then upgrade to head again) must be a no-op:
+    identical resolved values, no error."""
+    db_path = tmp_path / "brief_intent_idempotent.db"
+    database_url = f"sqlite:///{db_path}"
+    down_revision = _brief_intent_migration_down_revision()
+
+    pre = _run_alembic("upgrade", down_revision, database_url=database_url)
+    assert pre.returncode == 0, pre.stderr
+    _seed_pre_brief_intent_rows(db_path)
+
+    first = _run_alembic("upgrade", "head", database_url=database_url)
+    assert first.returncode == 0, first.stderr
+
+    def _snapshot() -> dict[str, str | None]:
+        con = sqlite3.connect(str(db_path))
+        try:
+            con.row_factory = sqlite3.Row
+            cur = con.cursor()
+            cur.execute("SELECT id, brief_intent FROM strategy_store ORDER BY id")
+            return {row["id"]: row["brief_intent"] for row in cur.fetchall()}
+        finally:
+            con.close()
+
+    after_first = _snapshot()
+
+    second_down = _run_alembic("downgrade", down_revision, database_url=database_url)
+    assert second_down.returncode == 0, second_down.stderr
+    second_up = _run_alembic("upgrade", "head", database_url=database_url)
+    assert second_up.returncode == 0, f"second upgrade head failed:\n{second_up.stderr}"
+
+    assert _snapshot() == after_first, "re-running the brief_intent backfill changed already-resolved data"

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -675,7 +675,7 @@ def _seed_pre_brief_intent_rows(db_path: Path) -> None:
     brief_intent migration runs (i.e. after upgrading only to its own
     down_revision — strategy_store has no brief_intent column yet).
 
-    Four cases, one per strategy:
+    Six cases, one per strategy:
       * unambiguous  — one proposal, one intent -> backfilled.
       * ambiguous    — two proposals sharing the (name, thesis) key but
                         DIFFERENT intents (the fixture-path collision this
@@ -685,6 +685,14 @@ def _seed_pre_brief_intent_rows(db_path: Path) -> None:
       * curated       — generation_method='curated' -> never even considered,
                         left NULL, even though its (name, thesis) happens to
                         coincide with a real proposal.
+      * blank         — its one matching proposal logged a WHITESPACE-ONLY
+                        intent -> left NULL, not backfilled with blanks (this
+                        backfill is the second writer to the column and must
+                        normalize the same way ``upsert_strategy`` does; note
+                        ``"   "`` is truthy, so only the ``.strip()`` makes it
+                        fall out).
+      * padded        — a real intent with incidental surrounding whitespace
+                        -> backfilled TRIMMED.
     """
     import json as _json
     from datetime import UTC, datetime
@@ -751,6 +759,8 @@ def _seed_pre_brief_intent_rows(db_path: Path) -> None:
                 _strategy_row("ambig0001", "Ambiguous Strategy", "Its thesis"),
                 _strategy_row("nomatch01", "No Match Strategy", "Its thesis"),
                 _strategy_row("curated01", "Ambiguous Strategy", "Its thesis", method="curated"),
+                _strategy_row("blank0001", "Blank Brief Strategy", "Its thesis"),
+                _strategy_row("padded001", "Padded Brief Strategy", "Its thesis"),
             ],
         )
         conn.execute(
@@ -765,6 +775,12 @@ def _seed_pre_brief_intent_rows(db_path: Path) -> None:
                 # (most plausible with the deterministic fixture path).
                 _proposal_row("p-ambig-a", "gen-2", "Ambiguous Strategy", "Its thesis", "Brief A"),
                 _proposal_row("p-ambig-b", "gen-3", "Ambiguous Strategy", "Its thesis", "Brief B"),
+                # Whitespace-only and padded intents — the migration must
+                # normalize both the way upsert_strategy does.
+                _proposal_row("p-blank00", "gen-4", "Blank Brief Strategy", "Its thesis", "   \n\t "),
+                _proposal_row(
+                    "p-padded0", "gen-5", "Padded Brief Strategy", "Its thesis", "  Beat SPY in a drawdown \n"
+                ),
             ],
         )
 
@@ -798,6 +814,8 @@ def test_brief_intent_backfill_resolves_only_unambiguous_rows(tmp_path):
     assert by_id["ambig0001"] is None, "colliding (name, thesis) with two distinct intents must never be guessed"
     assert by_id["nomatch01"] is None, "no matching proposal at all must stay NULL"
     assert by_id["curated01"] is None, "curated rows are never considered, even on a coincidental name/thesis match"
+    assert by_id["blank0001"] is None, "a whitespace-only logged intent must stay NULL, not land as a row of blanks"
+    assert by_id["padded001"] == "Beat SPY in a drawdown", "a padded intent must be backfilled trimmed"
 
 
 def test_brief_intent_backfill_migration_upgrade_is_idempotent(tmp_path):

--- a/backend/tests/test_brief_on_passport.py
+++ b/backend/tests/test_brief_on_passport.py
@@ -1,0 +1,235 @@
+"""User's brief surfaced on the strategy passport (v8 Lane 3.3, dbrowneup/brief-on-passport).
+
+The free-text brief that produced a generated strategy previously lived only
+in ``strategy_proposals.payload["intent"]`` — an episodic, non-authoritative
+log the passport route never reads. This adds ``strategy_store.brief_intent``
+(written at generation time by ``generation_pipeline._persist_candidate``) and
+surfaces it as "Your brief" on ``GET /api/strategies/{id}`` ONLY.
+
+Three contracts under test:
+
+  1. Pipeline — ``run_generation`` (fixture path) threads ``brief.intent``
+     through ``_persist_candidate`` into ``StrategyRecord.brief_intent``.
+  2. Isolation (the anti-goal) — the SHARED response builder
+     (``_passport_to_strategy_response``, which also backs Library and the
+     public leaderboard via ``_passport_responses`` /
+     ``_public_generated_strategy_responses`` / ``_owned_generated_strategy_
+     responses``) never sets ``brief_intent``, even when the underlying
+     ``StrategyRecord`` carries a real one. Only ``get_strategy`` (the
+     single-strategy detail route) attaches it, from ``StrategyRecord`` it has
+     already loaded for the visibility check.
+  3. Wire-level confirmation — ``GET /api/strategies/{id}`` exposes it;
+     ``GET /api/leaderboard`` (which re-shapes into the disjoint
+     ``LeaderboardEntry`` schema) never does, for the SAME underlying strategy.
+
+Two hermetic patterns, matching what's already established in this suite:
+  - In-memory sqlite + ``Base.metadata.create_all`` for the direct
+    ``_passport_to_strategy_response`` unit check (test_multipaper_passport.py).
+  - tmp-sqlite-file + ``db.init_db()`` + ``httpx.ASGITransport`` for the
+    full-app route checks (test_strategy_ownership.py /
+    test_leaderboard_single_user_scope.py).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from archimedes.main import app
+from archimedes.models.chat import Base
+from archimedes.models.strategy_passport_record import StrategyPassportRecord
+from archimedes.models.strategy_store import StrategyRecord
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# ── 1. Pipeline: brief.intent reaches StrategyRecord.brief_intent ─────────
+
+
+class _FakeStore:
+    """In-memory JobStore stand-in (mirrors test_strategy_ownership.py)."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.status: list[tuple[str, dict | None, str]] = []
+        self.current_status: str | None = None
+
+    async def push_event(self, job_id, payload):
+        self.events.append(payload)
+        return len(self.events)
+
+    async def update_status(self, job_id, status, *, result=None, error=""):
+        self.status.append((status, result, error))
+        self.current_status = status
+
+    async def update_terminal_status(self, job_id, status, *, result=None, error=""):
+        if self.current_status == "cancelled":
+            return False
+        await self.update_status(job_id, status, result=result, error=error)
+        return True
+
+
+@pytest.fixture
+def _tmp_db(tmp_path, monkeypatch):
+    """Point the DB at a FRESH temp sqlite (rebinds db.engine + db.SessionLocal),
+    same pattern as test_strategy_ownership.py."""
+    import archimedes.db as db
+
+    url = f"sqlite:///{tmp_path / 'brief_on_passport.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    return db
+
+
+async def test_run_generation_persists_brief_intent_to_store(_tmp_db, monkeypatch):
+    """Fixture-path run_generation stamps brief.intent onto every persisted
+    strategy_store row (K=1: exactly the winner)."""
+    import archimedes.db as db
+    from archimedes.agents.generation_pipeline import run_generation
+    from archimedes.api.generate_schemas import GenerateBrief
+    from unittest.mock import AsyncMock, patch
+
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+    async def _inline(fn, *a, **k):
+        return fn(*a, **k)
+
+    monkeypatch.setattr("archimedes.agents.generation_pipeline.asyncio.to_thread", _inline)
+
+    store = _FakeStore()
+    brief = GenerateBrief(intent="Something that beats SPY in a recession", risk_appetite="conservative")
+
+    with patch("archimedes.agents.generation_pipeline._backtest_and_persist", new=AsyncMock()):
+        await run_generation(job_id="job_brief_1", brief=brief, store=store)
+
+    with db.get_session() as session:
+        rows = session.query(StrategyRecord).filter(StrategyRecord.is_example.is_(False)).all()
+        assert rows, "pipeline persisted no strategies"
+        for row in rows:
+            assert row.brief_intent == "Something that beats SPY in a recession"
+
+
+# ── 2. Isolation: the shared response builder never surfaces it ───────────
+
+
+@pytest.fixture
+def _mem_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    sess = SessionLocal()
+    yield sess
+    sess.close()
+
+
+def _seed_pair(session: Session, sid: str, *, brief_intent: str | None) -> StrategyPassportRecord:
+    """A StrategyRecord (carrying brief_intent) + its StrategyPassportRecord
+    mirror under the SAME id — exactly what ``_persist_candidate`` writes."""
+    session.add(
+        StrategyRecord(
+            id=sid,
+            content_hash=("0x" + sid).ljust(66, "0"),
+            generation_method="debate",
+            source_papers="[]",
+            strategy_name="Test Strategy",
+            thesis="test thesis",
+            asset_universe="[]",
+            risk_profile="moderate",
+            status="candidate",
+            is_example=False,
+            is_published=True,
+            brief_intent=brief_intent,
+        )
+    )
+    passport = StrategyPassportRecord(
+        id=sid,
+        generation_method="debate",
+        methodology_summary="Test methodology",
+        asset_universe="[]",
+        position_sizing="equal_weight",
+        rebalance_frequency="weekly",
+        status="candidate",
+        regime_tag="regime_neutral",
+        passes_rigor_gate=False,
+    )
+    session.add(passport)
+    session.flush()
+    return passport
+
+
+def test_passport_to_strategy_response_never_sets_brief_intent(_mem_session):
+    """GUARD: the response builder shared by Library / leaderboard / risk
+    surfaces (``_passport_responses`` and everything that calls it) must NEVER
+    read brief_intent — even though the row it's building from HAS one.
+
+    This is the anti-goal ("do not touch the leaderboard payloads") pinned at
+    exactly the boundary that matters: if a future edit moves the brief_intent
+    lookup INTO this shared function, this assertion catches it before it ever
+    reaches a list/leaderboard response.
+    """
+    from archimedes.api.strategies_routes import _passport_to_strategy_response
+
+    passport = _seed_pair(_mem_session, "brief-guard-1", brief_intent="A private brief that must not leak")
+
+    resp = _passport_to_strategy_response(passport, session=_mem_session)
+    assert resp.brief_intent is None
+
+
+# ── 3. Wire-level: detail exposes it, leaderboard doesn't ─────────────────
+
+
+def _client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def test_get_strategy_route_exposes_brief_intent(_tmp_db):
+    import archimedes.db as db
+
+    with db.get_session() as session:
+        _seed_pair(session, "brief-detail-1", brief_intent="Low-vol income for retirement")
+        session.commit()
+
+    async with _client() as client:
+        resp = await client.get("/api/strategies/brief-detail-1")
+    assert resp.status_code == 200
+    assert resp.json()["brief_intent"] == "Low-vol income for retirement"
+
+
+async def test_get_strategy_route_reports_none_when_no_brief_recorded(_tmp_db):
+    """A legacy/curated row with no brief reports None, not a fabricated string."""
+    import archimedes.db as db
+
+    with db.get_session() as session:
+        _seed_pair(session, "brief-detail-2", brief_intent=None)
+        session.commit()
+
+    async with _client() as client:
+        resp = await client.get("/api/strategies/brief-detail-2")
+    assert resp.status_code == 200
+    assert resp.json()["brief_intent"] is None
+
+
+async def test_leaderboard_never_exposes_brief_intent(_tmp_db):
+    """The SAME published strategy that carries a real brief on the detail
+    route (above) must not leak it through the leaderboard's ``scope=curated``
+    cohort, which re-shapes into the disjoint LeaderboardEntry schema via the
+    exact same ``_passport_to_strategy_response``/``_passport_responses``
+    helpers Test 2 pins directly. Asserting on the raw response text (not
+    just "no brief_intent key") also catches a future refactor that free-forms
+    extra fields onto an entry instead of using the typed schema."""
+    import archimedes.db as db
+
+    secret_brief = "A private brief that must never reach the public board"
+    with db.get_session() as session:
+        _seed_pair(session, "brief-board-1", brief_intent=secret_brief)
+        session.commit()
+
+    async with _client() as client:
+        resp = await client.get("/api/leaderboard?scope=curated")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert secret_brief not in resp.text
+    entry = next((e for e in body["entries"] if e["id"] == "brief-board-1"), None)
+    assert entry is not None, "seeded published strategy did not reach the curated board"
+    assert "brief_intent" not in entry

--- a/backend/tests/test_brief_on_passport.py
+++ b/backend/tests/test_brief_on_passport.py
@@ -4,9 +4,10 @@ The free-text brief that produced a generated strategy previously lived only
 in ``strategy_proposals.payload["intent"]`` — an episodic, non-authoritative
 log the passport route never reads. This adds ``strategy_store.brief_intent``
 (written at generation time by ``generation_pipeline._persist_candidate``) and
-surfaces it as "Your brief" on ``GET /api/strategies/{id}`` ONLY.
+surfaces it as "Your brief" on ``GET /api/strategies/{id}`` — **to the row's
+OWNER only**.
 
-Three contracts under test:
+Four contracts under test:
 
   1. Pipeline — ``run_generation`` (fixture path) threads ``brief.intent``
      through ``_persist_candidate`` into ``StrategyRecord.brief_intent``.
@@ -18,28 +19,59 @@ Three contracts under test:
      ``StrategyRecord`` carries a real one. Only ``get_strategy`` (the
      single-strategy detail route) attaches it, from ``StrategyRecord`` it has
      already loaded for the visibility check.
-  3. Wire-level confirmation — ``GET /api/strategies/{id}`` exposes it;
-     ``GET /api/leaderboard`` (which re-shapes into the disjoint
-     ``LeaderboardEntry`` schema) never does, for the SAME underlying strategy.
+  3. Owner gate (the privacy contract) — ``GET /api/strategies/{id}`` returns
+     the brief to the OWNER, and returns ``null`` to everyone else, INCLUDING
+     on a PUBLISHED row that the same request is otherwise allowed to read in
+     full. Publishing a strategy shares the strategy, not the sentence its
+     owner typed to ask for it (the same reasoning ``_redact_owner_wallet``
+     already applies to ``owner_wallet``). The gate is the shared #850
+     predicate ``is_strategy_visible`` asked in ownership-only form.
+  4. List surfaces — the Library list route (``GET /api/strategies/generated``,
+     which serializes ``StrategyRecord.to_dict()`` rather than the passport
+     response schema) never carries the brief, not even for the owner asking
+     about their own row. Only the detail route surfaces it.
 
 Two hermetic patterns, matching what's already established in this suite:
   - In-memory sqlite + ``Base.metadata.create_all`` for the direct
     ``_passport_to_strategy_response`` unit check (test_multipaper_passport.py).
   - tmp-sqlite-file + ``db.init_db()`` + ``httpx.ASGITransport`` for the
     full-app route checks (test_strategy_ownership.py /
-    test_leaderboard_single_user_scope.py).
+    test_leaderboard_single_user_scope.py), authenticated with the signed SIWE
+    fixture cookie that conftest's autouse ``_legacy_siwe_test_adapter`` maps
+    onto a canonical Better Auth user.
 """
 
 from __future__ import annotations
 
+import time
+
 import httpx
 import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
 from archimedes.main import app
 from archimedes.models.chat import Base
 from archimedes.models.strategy_passport_record import StrategyPassportRecord
 from archimedes.models.strategy_store import StrategyRecord
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+
+_W_OWNER = "0xAbC0000000000000000000000000000000000001"  # mixed case on purpose
+_W_STRANGER = "0x0000000000000000000000000000000000000002"
+
+
+def _legacy_user_id(wallet: str) -> str:
+    """The canonical user id conftest's ``_legacy_siwe_test_adapter`` mints for
+    a SIWE fixture cookie. Derived, not hard-coded, so it cannot silently drift
+    from the adapter (which builds ``legacy-test:{wallet}`` from
+    ``auth_siwe._verify_session``, whose payload is lower-cased at signing)."""
+    return f"legacy-test:{wallet.lower()}"
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """Valid signed SIWE session cookie for *wallet* — a real signed session,
+    not header spoofing (same helper shape as test_strategy_ownership.py)."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
 
 # ── 1. Pipeline: brief.intent reaches StrategyRecord.brief_intent ─────────
 
@@ -85,10 +117,11 @@ def _tmp_db(tmp_path, monkeypatch):
 async def test_run_generation_persists_brief_intent_to_store(_tmp_db, monkeypatch):
     """Fixture-path run_generation stamps brief.intent onto every persisted
     strategy_store row (K=1: exactly the winner)."""
+    from unittest.mock import AsyncMock, patch
+
     import archimedes.db as db
     from archimedes.agents.generation_pipeline import run_generation
     from archimedes.api.generate_schemas import GenerateBrief
-    from unittest.mock import AsyncMock, patch
 
     monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
 
@@ -123,9 +156,17 @@ def _mem_session() -> Session:
     sess.close()
 
 
-def _seed_pair(session: Session, sid: str, *, brief_intent: str | None) -> StrategyPassportRecord:
-    """A StrategyRecord (carrying brief_intent) + its StrategyPassportRecord
-    mirror under the SAME id — exactly what ``_persist_candidate`` writes."""
+def _seed_pair(
+    session: Session,
+    sid: str,
+    *,
+    brief_intent: str | None,
+    owner_user_id: str | None = None,
+    is_published: bool = False,
+) -> StrategyPassportRecord:
+    """A StrategyRecord (carrying brief_intent + ownership) + its
+    StrategyPassportRecord mirror under the SAME id — exactly what
+    ``_persist_candidate`` writes."""
     session.add(
         StrategyRecord(
             id=sid,
@@ -138,7 +179,8 @@ def _seed_pair(session: Session, sid: str, *, brief_intent: str | None) -> Strat
             risk_profile="moderate",
             status="candidate",
             is_example=False,
-            is_published=True,
+            is_published=is_published,
+            owner_user_id=owner_user_id,
             brief_intent=brief_intent,
         )
     )
@@ -152,6 +194,7 @@ def _seed_pair(session: Session, sid: str, *, brief_intent: str | None) -> Strat
         status="candidate",
         regime_tag="regime_neutral",
         passes_rigor_gate=False,
+        owner_user_id=owner_user_id,
     )
     session.add(passport)
     session.flush()
@@ -176,60 +219,143 @@ def test_passport_to_strategy_response_never_sets_brief_intent(_mem_session):
     assert resp.brief_intent is None
 
 
-# ── 3. Wire-level: detail exposes it, leaderboard doesn't ─────────────────
+# ── 3. Owner gate on the detail route ─────────────────────────────────────
 
 
-def _client() -> httpx.AsyncClient:
-    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+def _client(wallet: str | None = None) -> httpx.AsyncClient:
+    """ASGI client, optionally signed in as *wallet* (SIWE fixture cookie →
+    canonical user via conftest's autouse legacy adapter)."""
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        cookies=_siwe_cookies(wallet) if wallet else None,
+    )
 
 
-async def test_get_strategy_route_exposes_brief_intent(_tmp_db):
+async def test_get_strategy_route_returns_the_brief_to_its_owner(_tmp_db):
+    """The whole point of the feature: the owner asking about their own
+    strategy gets their own words back."""
     import archimedes.db as db
 
     with db.get_session() as session:
-        _seed_pair(session, "brief-detail-1", brief_intent="Low-vol income for retirement")
+        _seed_pair(
+            session,
+            "brief-detail-1",
+            brief_intent="Low-vol income for retirement",
+            owner_user_id=_legacy_user_id(_W_OWNER),
+        )
         session.commit()
 
-    async with _client() as client:
+    async with _client(_W_OWNER) as client:
         resp = await client.get("/api/strategies/brief-detail-1")
     assert resp.status_code == 200
     assert resp.json()["brief_intent"] == "Low-vol income for retirement"
 
 
-async def test_get_strategy_route_reports_none_when_no_brief_recorded(_tmp_db):
-    """A legacy/curated row with no brief reports None, not a fabricated string."""
+@pytest.mark.parametrize("caller_wallet", [_W_STRANGER, None], ids=["signed-in-stranger", "anonymous"])
+async def test_get_strategy_route_hides_the_brief_from_non_owners(_tmp_db, caller_wallet):
+    """PRIVACY GUARD — the negative half of the contract, and the one the
+    owner gate exists for.
+
+    The row is PUBLISHED, so ``is_strategy_visible`` grants the request in
+    full: the caller legitimately reads the strategy, gets a 200, and sees its
+    methodology. What they must NOT see is the owner's free-text brief.
+    Without the ownership check in ``get_strategy`` this returns the brief to
+    a stranger and to an anonymous visitor alike — every published strategy
+    leaking the sentence its owner typed.
+
+    Asserted on the raw response text as well as the field, so a future
+    refactor that free-forms the brief into some other key (a nested passport
+    blob, a debug echo) still trips this.
+    """
+    import archimedes.db as db
+
+    secret_brief = "A private brief that must never reach a stranger"
+    with db.get_session() as session:
+        _seed_pair(
+            session,
+            "brief-detail-published",
+            brief_intent=secret_brief,
+            owner_user_id=_legacy_user_id(_W_OWNER),
+            is_published=True,
+        )
+        session.commit()
+
+    async with _client(caller_wallet) as client:
+        resp = await client.get("/api/strategies/brief-detail-published")
+
+    assert resp.status_code == 200, "published row must stay readable — this is a redaction, not a 404"
+    body = resp.json()
+    assert body["id"] == "brief-detail-published"
+    assert body["methodology_summary"] == "Test methodology", "the strategy itself is still public"
+    assert body["brief_intent"] is None
+    assert secret_brief not in resp.text
+
+
+async def test_get_strategy_route_reports_none_to_the_owner_when_no_brief_recorded(_tmp_db):
+    """A legacy/curated row with no brief reports None, not a fabricated string.
+
+    Deliberately asked AS THE OWNER: with the owner gate in place, a
+    non-owner request would return None whatever the column holds, so an
+    anonymous caller here would prove nothing about the no-brief case.
+    """
     import archimedes.db as db
 
     with db.get_session() as session:
-        _seed_pair(session, "brief-detail-2", brief_intent=None)
+        _seed_pair(
+            session,
+            "brief-detail-2",
+            brief_intent=None,
+            owner_user_id=_legacy_user_id(_W_OWNER),
+        )
         session.commit()
 
-    async with _client() as client:
+    async with _client(_W_OWNER) as client:
         resp = await client.get("/api/strategies/brief-detail-2")
     assert resp.status_code == 200
     assert resp.json()["brief_intent"] is None
 
 
-async def test_leaderboard_never_exposes_brief_intent(_tmp_db):
-    """The SAME published strategy that carries a real brief on the detail
-    route (above) must not leak it through the leaderboard's ``scope=curated``
-    cohort, which re-shapes into the disjoint LeaderboardEntry schema via the
-    exact same ``_passport_to_strategy_response``/``_passport_responses``
-    helpers Test 2 pins directly. Asserting on the raw response text (not
-    just "no brief_intent key") also catches a future refactor that free-forms
-    extra fields onto an entry instead of using the typed schema."""
+# ── 4. List surfaces: the Library list never carries the brief ────────────
+
+
+async def test_library_list_route_never_exposes_brief_intent(_tmp_db):
+    """The Library list (``GET /api/strategies/generated``) serializes
+    ``StrategyRecord.to_dict()`` — the same ORM row the detail route reads the
+    brief off — so it is the one list surface that could pick the column up by
+    accident, simply by someone adding a ``"brief_intent"`` key to
+    ``to_dict()``.
+
+    Asked as the OWNER on purpose: this is not the ownership gate under test
+    (the owner is entitled to their brief), it is the surface rule — the brief
+    belongs on the single-strategy passport and nowhere else, so even the
+    owner's own Library row must not carry it.
+
+    (This replaces an earlier leaderboard assertion that could not fail: the
+    leaderboard re-shapes into the disjoint ``LeaderboardEntry`` schema, which
+    has no ``brief_intent`` field to populate and no ORM row to leak from, so
+    "brief_intent not in entry" held regardless of what the code under test
+    did. Test 2 above already pins the shared passport-response helper the
+    leaderboard actually goes through.)
+    """
     import archimedes.db as db
 
-    secret_brief = "A private brief that must never reach the public board"
+    secret_brief = "A private brief that belongs only on the passport"
     with db.get_session() as session:
-        _seed_pair(session, "brief-board-1", brief_intent=secret_brief)
+        _seed_pair(
+            session,
+            "brief-library-1",
+            brief_intent=secret_brief,
+            owner_user_id=_legacy_user_id(_W_OWNER),
+        )
         session.commit()
 
-    async with _client() as client:
-        resp = await client.get("/api/leaderboard?scope=curated")
+    async with _client(_W_OWNER) as client:
+        resp = await client.get("/api/strategies/generated")
+
     assert resp.status_code == 200
     body = resp.json()
+    row = next((r for r in body["strategies"] if r["id"] == "brief-library-1"), None)
+    assert row is not None, "owner's own generated strategy did not reach their Library list"
+    assert "brief_intent" not in row
     assert secret_brief not in resp.text
-    entry = next((e for e in body["entries"] if e["id"] == "brief-board-1"), None)
-    assert entry is not None, "seeded published strategy did not reach the curated board"
-    assert "brief_intent" not in entry

--- a/backend/tests/test_strategy_store.py
+++ b/backend/tests/test_strategy_store.py
@@ -418,21 +418,100 @@ class TestBriefIntentPersistence:
         )
         assert r.brief_intent is None
 
-    def test_insert_with_empty_string_brief_collapses_to_null(self, session):
+    @pytest.mark.parametrize(
+        ("name", "brief"),
+        [
+            ("Empty Brief Explicitly Provided", ""),
+            ("Whitespace Brief Spaces", "   "),
+            ("Whitespace Brief Newlines And Tabs", "\n\t \r\n"),
+        ],
+    )
+    def test_insert_with_blank_brief_collapses_to_null(self, session, name, brief):
         """Unlike strategy_spec's `is not None` (where {} is a meaningful
-        distinct payload), brief_intent is plain text — an empty/whitespace
-        string carries nothing to show and is treated as absent, matching the
-        `brief_intent or None` truthiness check in upsert_strategy."""
+        distinct payload), brief_intent is plain text — an empty OR
+        whitespace-only string carries nothing to show and is stored as NULL,
+        not as blanks.
+
+        The whitespace cases are the ones that matter: `"" or None` is already
+        None by truthiness, but `"   "` is TRUTHY, so without the explicit
+        `.strip()` in upsert_strategy a row of blanks reaches the DB and the
+        passport renders an empty "Your brief" card (StrategyPassport.jsx
+        guards on `s.brief_intent`, which a blank string satisfies).
+        """
         r = upsert_strategy(
             session,
             generation_method="debate",
-            strategy_name="Empty Brief Explicitly Provided",
+            strategy_name=name,
             thesis="X",
             source_papers=PAPERS_A,
             asset_universe=["SPY"],
-            brief_intent="",
+            brief_intent=brief,
         )
         assert r.brief_intent is None
+
+    def test_brief_is_stripped_before_persisting(self, session):
+        """A real brief with incidental surrounding whitespace is stored
+        trimmed — the same normalization, applied to the non-blank case."""
+        r = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Padded Brief",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="  Low-vol income for retirement\n",
+        )
+        assert r.brief_intent == "Low-vol income for retirement"
+
+    def test_whitespace_only_brief_never_backfills_an_existing_row(self, session):
+        """The OTHER write branch: a content-hash match whose incoming brief is
+        whitespace-only must leave the existing NULL alone, not fill it with
+        blanks. `"   "` is truthy, so this branch's `if brief_intent and not
+        existing.brief_intent` would happily write it without the shared
+        normalization."""
+        r1 = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Blank Backfill Attempt",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+        )
+        assert r1.brief_intent is None
+
+        r2 = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Blank Backfill Attempt",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="   \n ",
+        )
+        assert r1.id == r2.id
+        assert r2.brief_intent is None
+
+    def test_content_hash_match_backfill_strips_the_brief(self, session):
+        """The backfill branch normalizes too: a padded real brief lands
+        trimmed on the existing row, not with its whitespace intact."""
+        upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Padded Backfill",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+        )
+        r2 = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Padded Backfill",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="\t Beat SPY in a drawdown  ",
+        )
+        assert r2.brief_intent == "Beat SPY in a drawdown"
 
     def test_content_hash_match_backfills_missing_brief(self, session):
         """Same content, first call with no brief, second call WITH one —

--- a/backend/tests/test_strategy_store.py
+++ b/backend/tests/test_strategy_store.py
@@ -390,6 +390,101 @@ class TestStrategySpecPersistence:
         assert json.loads(r2.strategy_spec) == DSL_SPEC  # unchanged, not other_spec
 
 
+class TestBriefIntentPersistence:
+    """v8 Lane 3.3: the user's own free-text ask, persisted alongside the
+    derived thesis. Same never-overwrite backfill contract as strategy_spec
+    above, exercised the same way."""
+
+    def test_insert_with_brief_persists(self, session):
+        r = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Momentum Clone",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="Something that beats SPY in a recession",
+        )
+        assert r.brief_intent == "Something that beats SPY in a recession"
+
+    def test_insert_without_brief_is_null(self, session):
+        r = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="No Brief Debate",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+        )
+        assert r.brief_intent is None
+
+    def test_insert_with_empty_string_brief_collapses_to_null(self, session):
+        """Unlike strategy_spec's `is not None` (where {} is a meaningful
+        distinct payload), brief_intent is plain text — an empty/whitespace
+        string carries nothing to show and is treated as absent, matching the
+        `brief_intent or None` truthiness check in upsert_strategy."""
+        r = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Empty Brief Explicitly Provided",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="",
+        )
+        assert r.brief_intent is None
+
+    def test_content_hash_match_backfills_missing_brief(self, session):
+        """Same content, first call with no brief, second call WITH one —
+        the existing row is backfilled (never a duplicate row)."""
+        r1 = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Backfill My Brief",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+        )
+        assert r1.brief_intent is None
+
+        r2 = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Backfill My Brief",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="Low-vol income strategy",
+        )
+        assert r1.id == r2.id
+        assert session.query(StrategyRecord).count() == 1
+        assert r2.brief_intent == "Low-vol income strategy"
+
+    def test_content_hash_match_never_overwrites_existing_brief(self, session):
+        """A row that already has a brief keeps it — a later upsert (even
+        with a DIFFERENT brief string) never clobbers the persisted one."""
+        r1 = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Keep My Brief",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="Original brief",
+        )
+        r2 = upsert_strategy(
+            session,
+            generation_method="debate",
+            strategy_name="Keep My Brief",
+            thesis="X",
+            source_papers=PAPERS_A,
+            asset_universe=["SPY"],
+            brief_intent="A different brief entirely",
+        )
+        assert r1.id == r2.id
+        assert r2.brief_intent == "Original brief"  # unchanged, not the second call's text
+
+
 class TestToStrategyPassport:
     """StrategyRecord -> StrategyPassport adapter (used by the live agent
     runner to evaluate a generated strategy's own DSL spec)."""

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -397,6 +397,23 @@ export default function StrategyPassport({
 				<div className="passport-evidence">
 					{/* Methodology + source paper(s) */}
 					<div className="passport-sources fade-up fade-up-3">
+						{/* The user's own free-text ask (v8 Lane 3.3) — distinct from
+						    Methodology below, which is the DERIVED writeup. Only the
+						    single-strategy detail fetch populates this field, and only
+						    when the brief is known, so this renders for neither a
+						    curated strategy nor a legacy generated one the backfill
+						    could not resolve. */}
+						{s.brief_intent && (
+							<div className="card passport-panel">
+								<div className="label mb-2">Your brief</div>
+								<p
+									className="body leading-relaxed"
+									style={{ fontStyle: "italic" }}
+								>
+									"{s.brief_intent}"
+								</p>
+							</div>
+						)}
 						<div className="card passport-panel">
 							<div className="label mb-3">Methodology</div>
 							<p className="body leading-relaxed">

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -399,10 +399,15 @@ export default function StrategyPassport({
 					<div className="passport-sources fade-up fade-up-3">
 						{/* The user's own free-text ask (v8 Lane 3.3) — distinct from
 						    Methodology below, which is the DERIVED writeup. Only the
-						    single-strategy detail fetch populates this field, and only
-						    when the brief is known, so this renders for neither a
-						    curated strategy nor a legacy generated one the backfill
-						    could not resolve. */}
+						    single-strategy detail fetch populates this field, only for
+						    the row's OWNER (the server redacts it for everyone else,
+						    published rows included), and only when the brief is known —
+						    so this renders for neither someone else's strategy, nor a
+						    curated one, nor a legacy generated one the backfill could
+						    not resolve. No viewer-side ownership check is needed or
+						    wanted here: the redaction is the server's, and this guard
+						    only declines to draw an empty card. That is what keeps the
+						    "Your brief" copy literally true for whoever is reading. */}
 						{s.brief_intent && (
 							<div className="card passport-panel">
 								<div className="label mb-2">Your brief</div>

--- a/ui/test/brief-on-passport.test.js
+++ b/ui/test/brief-on-passport.test.js
@@ -23,8 +23,14 @@ test("StrategyPassport.jsx does not render the brief unconditionally", () => {
 	// guard (e.g. moving the JSX but leaving the condition behind) — the
 	// label must appear strictly after a brief_intent truthiness check, not
 	// as a bare unconditional block.
-	const label = passport.indexOf("Your brief");
-	assert.notEqual(label, -1, "expected a 'Your brief' label in the source");
+	//
+	// Anchored on the RENDERED label (`>Your brief<`), not on the first
+	// occurrence of the words anywhere in the file: the explanatory comment
+	// above the card also names the copy, and a plain indexOf would find that
+	// instead and then look for a guard that legitimately sits after it.
+	const rendered = /> *Your brief *</.exec(passport);
+	assert.notEqual(rendered, null, "expected a rendered 'Your brief' label in the JSX");
+	const label = rendered.index;
 	const guard = passport.lastIndexOf("s.brief_intent &&", label);
 	assert.notEqual(guard, -1, "expected a `s.brief_intent &&` guard before the label");
 	// Nothing between the guard's `(` and the label must close that

--- a/ui/test/brief-on-passport.test.js
+++ b/ui/test/brief-on-passport.test.js
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Static-source pins for the "Your brief" card (v8 Lane 3.3), same pattern as
+// ui/test/generation-cost.test.js's wiring tests — there is no jsdom render
+// harness in this suite, so the contract is pinned against the component's
+// own source text.
+
+const passport = readFileSync(
+	new URL("../src/components/StrategyPassport.jsx", import.meta.url),
+	"utf8",
+);
+
+test("StrategyPassport.jsx renders the user's brief only when non-empty", () => {
+	assert.match(passport, /\{s\.brief_intent\s*&&\s*\(/);
+	assert.match(passport, />\s*Your brief\s*</);
+	assert.match(passport, /\{s\.brief_intent\}/);
+});
+
+test("StrategyPassport.jsx does not render the brief unconditionally", () => {
+	// Guard against a regression that hoists the brief card above its `&&`
+	// guard (e.g. moving the JSX but leaving the condition behind) — the
+	// label must appear strictly after a brief_intent truthiness check, not
+	// as a bare unconditional block.
+	const label = passport.indexOf("Your brief");
+	assert.notEqual(label, -1, "expected a 'Your brief' label in the source");
+	const guard = passport.lastIndexOf("s.brief_intent &&", label);
+	assert.notEqual(guard, -1, "expected a `s.brief_intent &&` guard before the label");
+	// Nothing between the guard's `(` and the label must close that
+	// conditional early (a stray `)}` would end-run the guard).
+	const between = passport.slice(guard, label);
+	assert.doesNotMatch(between, /\)\}/);
+});


### PR DESCRIPTION
strategy_store.brief_intent (migration + unambiguous backfill from strategy_proposals) · persisted at generation · shown as 'Your brief' on the passport — **owner-only**: the Opus review caught the original exposing briefs to any caller on published rows and proved the leaderboard guard tautological; the fix re-asks the #850 visibility predicate in ownership-only form ('publishing a strategy consents to sharing the STRATEGY, not the sentence its owner typed'). Negative tests (non-owner + anonymous get null) adversarially demonstrated. Owner spot-check re-ran the gate tests (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7