### PR TITLE
[rigor][api] Left-behind batch-close: audit table columns + backtest provenance surfaced

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -219,6 +219,19 @@ def _to_strategy_response(
             if s.real_backtest_end
             else (bt.backtest_end.isoformat() if bt and bt.backtest_end else None)
         ),
+        # ── Engine attribution (left-behind batch close, docs/sprint/a6-rerun.md /
+        # sprint README row 5) ────────────────────────────────────────────────
+        # Both columns have lived on BacktestResultRecord since the cost SSOT /
+        # 2026-08-03 provenance audit and are already declared on StrategyResponse
+        # (see schemas.py "Engine attribution"), but no construction site ever
+        # populated them — the values stopped at the DB. `bt` here is the
+        # BacktestResult dataclass hydrated straight off the latest
+        # BacktestResultRecord row (BacktestResultRecord.to_backtest_result(),
+        # via LocalStrategyProvider.get_backtest_result), so these are real,
+        # never fabricated: None when no persisted backtest exists, or when the
+        # row predates the column (both honest NULLs, never a guessed engine).
+        backtest_engine=(bt.backtest_engine if bt else None),
+        cost_model_id=(bt.cost_model_id if bt else None),
         regime_tag=s.regime_tag,
         return_source=return_source,
         return_source_note=return_source_note,

--- a/backend/archimedes/scripts/audit_backtest_universe.py
+++ b/backend/archimedes/scripts/audit_backtest_universe.py
@@ -47,7 +47,7 @@ import sys
 from pathlib import Path
 
 from archimedes.db import get_session, init_db
-from archimedes.services.backtest_repository import get_daily_returns
+from archimedes.services.backtest_repository import get_daily_returns, latest_backtests_by_strategy
 from archimedes.services.rigor_evaluator import load_daily_returns_store
 from archimedes.services.strategy_provider import default_provider
 from archimedes.services.vol_plausibility import (
@@ -80,7 +80,25 @@ def _repo_root() -> Path:
 
 
 class StrategyAuditRow:
-    """One printable row: a strategy's declared universe vs. its persisted reality."""
+    """One printable row: a strategy's declared universe vs. its persisted reality.
+
+    Also carries the before/after rigor metrics ``docs/sprint/a6-rerun.md`` named as
+    this script's deliverable table: Sharpe, DSR p, PBO, OOS — read straight off the
+    latest ``BacktestResultRecord`` (``backtest_repository.latest_backtests_by_strategy``),
+    the same store the module docstring above already grades against. Two of the
+    named columns, turnover and cost drag, are deliberately NOT added: the analytics
+    engine computes ``turnover_annualized`` / ``cost_drag_annual_pct`` per-run
+    (``analytics-engine/.../engine.py::BacktestResult``), but
+    ``backtest_mapper.EngineMetricsModel`` declares ``extra="ignore"`` and does not
+    define either field, so they are dropped before ever reaching ``backtest_results``
+    — persisted rows structurally never carry them. Adding a column for a field that
+    does not exist on the model would render '—' for every row forever, which reads as
+    "measured but missing" when the truth is "never captured" — the fabrication this
+    module's docstring (and CLAUDE.md's hard constraint) warns against. Tracked as a
+    follow-up: persist the two fields on ``BacktestResultRecord`` (or read them back out
+    of ``artifact_json``, which does still carry them raw, the same way
+    ``get_daily_returns`` recovers ``daily_returns``) before adding those columns here.
+    """
 
     def __init__(
         self,
@@ -91,6 +109,10 @@ class StrategyAuditRow:
         asset_universe: list[str],
         verdict: PlausibilityVerdict | None,
         cross_store_vol: float | None,
+        sharpe_ratio: float | None = None,
+        dsr_p_value: float | None = None,
+        pbo_score: float | None = None,
+        out_of_sample_sharpe: float | None = None,
     ) -> None:
         self.name = name
         self.strategy_id = strategy_id
@@ -98,6 +120,13 @@ class StrategyAuditRow:
         self.asset_universe = asset_universe
         self.verdict = verdict  # None means "skipped: no persisted backtest_results row"
         self.cross_store_vol = cross_store_vol
+        # Before/after rigor metrics (a6-rerun.md deliverable table) — read directly
+        # off the latest backtest_results row, independent of the vol-plausibility
+        # verdict above. None means "no persisted BacktestResultRecord", NOT zero.
+        self.sharpe_ratio = sharpe_ratio
+        self.dsr_p_value = dsr_p_value
+        self.pbo_score = pbo_score
+        self.out_of_sample_sharpe = out_of_sample_sharpe
 
     @property
     def status(self) -> str:
@@ -152,6 +181,10 @@ class StrategyAuditRow:
             "cross_store_large_delta": self.cross_store_large_delta,
             "reasons": list(v.reasons) if v else [],
             "needs_attention": self.needs_attention,
+            "sharpe_ratio": self.sharpe_ratio,
+            "dsr_p_value": self.dsr_p_value,
+            "pbo_score": self.pbo_score,
+            "out_of_sample_sharpe": self.out_of_sample_sharpe,
         }
 
 
@@ -165,6 +198,7 @@ def run_audit(*, repo_root: Path | None = None, margin: float = BAND_MARGIN) -> 
 
     with get_session() as session:
         daily_by_strategy_id = {s.id: get_daily_returns(session, s.id) for s in strategies}
+        latest_by_strategy_id = latest_backtests_by_strategy(session, [s.id for s in strategies])
         cross_store, cross_store_vintage = load_daily_returns_store(session)
 
     if cross_store_vintage:
@@ -195,6 +229,12 @@ def run_audit(*, repo_root: Path | None = None, margin: float = BAND_MARGIN) -> 
             cross_stats = compute_vol_stats(cross_entry["daily_returns"])
             cross_store_vol = cross_stats.annualized_vol
 
+        # Before/after rigor metrics — read off the SAME latest row get_daily_returns
+        # resolved above, independent of whether the vol-plausibility verdict below
+        # runs (e.g. a persisted row with an unparseable daily_returns series would
+        # still have real sharpe_ratio/dsr_p_value/pbo_score/out_of_sample_sharpe).
+        latest_record = latest_by_strategy_id.get(strategy.id)
+
         if not daily_returns:
             # No persisted backtest_results row for this strategy — skipped, not
             # crashed, and not counted as a failure (nothing to grade yet).
@@ -206,6 +246,10 @@ def run_audit(*, repo_root: Path | None = None, margin: float = BAND_MARGIN) -> 
                     asset_universe=list(strategy.asset_universe),
                     verdict=None,
                     cross_store_vol=cross_store_vol,
+                    sharpe_ratio=latest_record.sharpe_ratio if latest_record else None,
+                    dsr_p_value=latest_record.dsr_p_value if latest_record else None,
+                    pbo_score=latest_record.pbo_score if latest_record else None,
+                    out_of_sample_sharpe=latest_record.out_of_sample_sharpe if latest_record else None,
                 )
             )
             continue
@@ -219,6 +263,10 @@ def run_audit(*, repo_root: Path | None = None, margin: float = BAND_MARGIN) -> 
                 asset_universe=list(strategy.asset_universe),
                 verdict=verdict,
                 cross_store_vol=cross_store_vol,
+                sharpe_ratio=latest_record.sharpe_ratio if latest_record else None,
+                dsr_p_value=latest_record.dsr_p_value if latest_record else None,
+                pbo_score=latest_record.pbo_score if latest_record else None,
+                out_of_sample_sharpe=latest_record.out_of_sample_sharpe if latest_record else None,
             )
         )
 
@@ -229,8 +277,29 @@ def _fmt_pct(value: float | None) -> str:
     return f"{value * 100:.2f}%" if value is not None else "—"
 
 
+def _fmt_num(value: float | None, decimals: int = 2) -> str:
+    """Plain-decimal formatter for ratio/probability fields (Sharpe, DSR p, PBO,
+    OOS Sharpe) — matches the UI convention (StrategyPassport.jsx / Leaderboard.jsx
+    render these with `fmt()`, not as a percentage). '—' for None; never fabricated."""
+    return f"{value:.{decimals}f}" if value is not None else "—"
+
+
 def render_table(rows: list[StrategyAuditRow]) -> str:
-    headers = ["strategy", "universe", "status", "n", "vol", "return", "baseline_Δ", "cross_Δ", "reason"]
+    headers = [
+        "strategy",
+        "universe",
+        "status",
+        "n",
+        "vol",
+        "return",
+        "sharpe",
+        "dsr_p",
+        "pbo",
+        "oos",
+        "baseline_Δ",
+        "cross_Δ",
+        "reason",
+    ]
     out_rows: list[list[str]] = []
     for row in rows:
         v = row.verdict
@@ -240,6 +309,10 @@ def render_table(rows: list[StrategyAuditRow]) -> str:
         n_obs = str(v.vol_stats.n_obs) if v else "—"
         vol = _fmt_pct(v.vol_stats.annualized_vol) if v else "—"
         ret = _fmt_pct(v.vol_stats.annualized_return) if v else "—"
+        sharpe = _fmt_num(row.sharpe_ratio)
+        dsr_p = _fmt_num(row.dsr_p_value, decimals=3)
+        pbo = _fmt_num(row.pbo_score)
+        oos = _fmt_num(row.out_of_sample_sharpe)
         baseline_delta = _fmt_pct(v.baseline_delta) if (v and v.baseline_delta is not None) else "—"
         cross_delta = _fmt_pct(row.cross_store_delta) if row.cross_store_delta is not None else "—"
         cross_flag = "!" if row.cross_store_large_delta else ""
@@ -255,6 +328,10 @@ def render_table(rows: list[StrategyAuditRow]) -> str:
                 n_obs,
                 vol,
                 ret,
+                sharpe,
+                dsr_p,
+                pbo,
+                oos,
                 baseline_delta,
                 f"{cross_delta}{cross_flag}",
                 reason,

--- a/backend/tests/test_audit_backtest_universe.py
+++ b/backend/tests/test_audit_backtest_universe.py
@@ -344,3 +344,99 @@ def test_render_table_does_not_crash_on_empty_or_mixed_rows(_db, tmp_path) -> No
     table = audit_mod.render_table(rows)
     assert "only_strategy" in table
     assert "skipped" in table
+
+
+def test_before_after_rigor_columns_are_populated_from_backtest_results(_db, tmp_path) -> None:
+    """docs/sprint/a6-rerun.md's named deliverable: the before/after table must
+    carry Sharpe / DSR p / PBO / OOS straight off the persisted backtest_results
+    row (real field names: sharpe_ratio, dsr_p_value, pbo_score,
+    out_of_sample_sharpe) — never fabricated, never left off silently."""
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "pipeline_buy_hold.py", asset_universe=["SPY"], regime_tag="bull")
+
+    returns = _spy_like_returns()
+    SessionLocal = _db
+    provider = default_provider(repo_root=tmp_path)
+    (strategy,) = provider.list_strategies()
+
+    result = BacktestResult(
+        strategy_id=strategy.id,
+        sharpe_ratio=1.2345,
+        sortino_ratio=0.5,
+        max_drawdown=0.2,
+        cagr=0.1,
+        calmar_ratio=0.5,
+        win_rate=0.5,
+        profit_factor=1.2,
+        total_trades=10,
+        avg_holding_period_days=5.0,
+        correlation_to_spy=0.3,
+        correlation_to_btc=0.1,
+        equity_curve=_equity_curve_from_returns(returns),
+        monthly_returns=[0.01],
+        dsr_p_value=0.9678,
+        pbo_score=0.4321,
+        out_of_sample_sharpe=0.789,
+        backtest_engine="backtrader",
+    )
+
+    with SessionLocal() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategy.id,
+            content_hash="h1",
+            result=result,
+            artifact_json=_artifact_json_with_daily_returns(returns),
+            source_pipeline="test",
+        )
+        session.commit()
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+    assert len(rows) == 1
+    row = rows[0]
+
+    # Real values, read from the persisted row, not from the vol-plausibility verdict.
+    assert row.sharpe_ratio == pytest.approx(1.2345)
+    assert row.dsr_p_value == pytest.approx(0.9678)
+    assert row.pbo_score == pytest.approx(0.4321)
+    assert row.out_of_sample_sharpe == pytest.approx(0.789)
+
+    d = row.to_dict()
+    assert d["sharpe_ratio"] == pytest.approx(1.2345)
+    assert d["dsr_p_value"] == pytest.approx(0.9678)
+    assert d["pbo_score"] == pytest.approx(0.4321)
+    assert d["out_of_sample_sharpe"] == pytest.approx(0.789)
+
+    table = audit_mod.render_table(rows)
+    assert "sharpe" in table and "dsr_p" in table and "pbo" in table and "oos" in table
+    assert "1.23" in table  # sharpe_ratio, 2dp
+    assert "0.968" in table  # dsr_p_value, 3dp
+    assert "0.43" in table  # pbo_score, 2dp
+    assert "0.79" in table  # out_of_sample_sharpe, 2dp
+
+
+def test_before_after_rigor_columns_render_em_dash_when_never_persisted(_db, tmp_path) -> None:
+    """A strategy with no persisted backtest_results row at all (status
+    'skipped') must render '—' for the new columns, never a fabricated 0."""
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "brand_new_strategy.py", asset_universe=["SPY"])
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+    assert len(rows) == 1
+    row = rows[0]
+
+    assert row.sharpe_ratio is None
+    assert row.dsr_p_value is None
+    assert row.pbo_score is None
+    assert row.out_of_sample_sharpe is None
+
+    table = audit_mod.render_table(rows)
+    lines = [ln for ln in table.splitlines() if "brand_new_strategy" in ln]
+    assert len(lines) == 1
+    # The row's sharpe/dsr_p/pbo/oos cells must all be the em-dash placeholder,
+    # not "0.00" or "None".
+    assert "0.00" not in lines[0]
+    assert "None" not in lines[0]
+    assert "—" in lines[0]

--- a/backend/tests/test_audit_backtest_universe.py
+++ b/backend/tests/test_audit_backtest_universe.py
@@ -8,6 +8,7 @@ factory and the strategies directory — never internals.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import numpy as np
@@ -81,6 +82,32 @@ def _spy_like_returns(n: int = 5659, seed: int = 20260727) -> list[float]:
 def _near_zero_returns(n: int = 5659, seed: int = 7) -> list[float]:
     rng = np.random.default_rng(seed)
     return rng.normal(loc=0.00007, scale=0.0006, size=n).tolist()
+
+
+def _row_cells(table: str, stem: str) -> dict[str, str]:
+    """Parse ``render_table`` output into {header: cell} for one strategy's row.
+
+    ``render_table`` ljust-pads every cell and joins with a two-space separator,
+    so 2+ consecutive spaces is exactly the column boundary and no cell value
+    contains one (universe is comma-joined, reason is "; "-joined, the rest are
+    single tokens). Indexing the row by header name is what makes a column
+    assertion actually about THAT column: a bare ``"—" in line`` substring check
+    passes on any row that has an em-dash anywhere — including the n/vol/return
+    cells a skipped row always fills with '—' — so it would pass even if the new
+    sharpe/dsr_p/pbo/oos columns rendered "0.00" or were deleted outright.
+    """
+    lines = table.splitlines()
+    headers = re.split(r"\s{2,}", lines[0].strip())
+    matches = [ln for ln in lines[2:] if stem in ln]
+    assert len(matches) == 1, f"expected exactly one row for {stem!r}, got {len(matches)}"
+    # The strategy cell carries a leading needs-attention marker ('*' or ' ');
+    # strip() drops the blank marker so cell 0 lines up with headers[0].
+    cells = re.split(r"\s{2,}", matches[0].strip())
+    # The trailing 'reason' cell is empty for clean/skipped rows and vanishes in
+    # the strip(); pad so every header is addressable.
+    cells += [""] * (len(headers) - len(cells))
+    assert len(cells) == len(headers), f"row/header column mismatch: {cells} vs {headers}"
+    return dict(zip(headers, cells, strict=True))
 
 
 @pytest.fixture
@@ -410,10 +437,16 @@ def test_before_after_rigor_columns_are_populated_from_backtest_results(_db, tmp
 
     table = audit_mod.render_table(rows)
     assert "sharpe" in table and "dsr_p" in table and "pbo" in table and "oos" in table
-    assert "1.23" in table  # sharpe_ratio, 2dp
-    assert "0.968" in table  # dsr_p_value, 3dp
-    assert "0.43" in table  # pbo_score, 2dp
-    assert "0.79" in table  # out_of_sample_sharpe, 2dp
+    # Column-indexed, not substring-in-table. ``assert "1.23" in table`` only
+    # says the digits appear SOMEWHERE in the rendered output — it does not bind
+    # a value to the column meant to carry it. Transpose two of these columns in
+    # ``render_table`` and all four ``in table`` checks still pass while the
+    # table reports each strategy's PBO under the Sharpe heading.
+    cells = _row_cells(table, "pipeline_buy_hold")
+    assert cells["sharpe"] == "1.23"  # sharpe_ratio, 2dp
+    assert cells["dsr_p"] == "0.968"  # dsr_p_value, 3dp
+    assert cells["pbo"] == "0.43"  # pbo_score, 2dp
+    assert cells["oos"] == "0.79"  # out_of_sample_sharpe, 2dp
 
 
 def test_before_after_rigor_columns_render_em_dash_when_never_persisted(_db, tmp_path) -> None:
@@ -433,10 +466,92 @@ def test_before_after_rigor_columns_render_em_dash_when_never_persisted(_db, tmp
     assert row.out_of_sample_sharpe is None
 
     table = audit_mod.render_table(rows)
-    lines = [ln for ln in table.splitlines() if "brand_new_strategy" in ln]
-    assert len(lines) == 1
-    # The row's sharpe/dsr_p/pbo/oos cells must all be the em-dash placeholder,
-    # not "0.00" or "None".
-    assert "0.00" not in lines[0]
-    assert "None" not in lines[0]
-    assert "—" in lines[0]
+    cells = _row_cells(table, "brand_new_strategy")
+    # Index the four NEW columns specifically. A bare ``"—" in line`` check would
+    # pass on this row no matter what those four cells contained: a skipped row's
+    # n / vol / return / baseline_Δ / cross_Δ cells are all '—' already.
+    assert cells["sharpe"] == "—"
+    assert cells["dsr_p"] == "—"
+    assert cells["pbo"] == "—"
+    assert cells["oos"] == "—"
+    assert "None" not in table
+
+
+def test_measured_zero_rigor_metrics_render_as_zero_not_em_dash(_db, tmp_path) -> None:
+    """A measured 0.0 must render '0.00'; only a NULL may render '—'.
+
+    ``pbo_score == 0.0`` ("no overfit detected across the CSCV splits") and
+    ``sharpe_ratio == 0.0`` ("this strategy is flat") are real, expensive
+    measurements. ``dsr_p_value``/``out_of_sample_sharpe`` being NULL on the same
+    row means those legs never ran. The table must keep the two apart, so
+    ``_fmt_num``'s guard has to stay an identity check against None: rewrite it as
+    a truthiness test (``if value`` / ``value or "—"``) and every measured zero
+    silently becomes "never measured" — fabrication by omission, the defect this
+    module's docstring exists to prevent. No other test in this file constrains
+    that: the sibling tests use non-zero values throughout, so a truthiness
+    rewrite passes all of them.
+    """
+    strategies_dir = tmp_path / "analytics-engine" / "strategies"
+    strategies_dir.mkdir(parents=True)
+    _write_strategy(strategies_dir / "measured_zero_strategy.py", asset_universe=["SPY"], regime_tag="bull")
+
+    returns = _spy_like_returns()
+    SessionLocal = _db
+    provider = default_provider(repo_root=tmp_path)
+    (strategy,) = provider.list_strategies()
+
+    result = BacktestResult(
+        strategy_id=strategy.id,
+        # Measured zeros — real numbers off a real run.
+        sharpe_ratio=0.0,
+        pbo_score=0.0,
+        # Never measured — honest NULLs.
+        dsr_p_value=None,
+        out_of_sample_sharpe=None,
+        sortino_ratio=0.5,
+        max_drawdown=0.2,
+        cagr=0.1,
+        calmar_ratio=0.5,
+        win_rate=0.5,
+        profit_factor=1.2,
+        total_trades=10,
+        avg_holding_period_days=5.0,
+        correlation_to_spy=0.3,
+        correlation_to_btc=0.1,
+        equity_curve=_equity_curve_from_returns(returns),
+        monthly_returns=[0.01],
+        backtest_engine="backtrader",
+    )
+
+    with SessionLocal() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategy.id,
+            content_hash="h-measured-zero",
+            result=result,
+            artifact_json=_artifact_json_with_daily_returns(returns),
+            source_pipeline="test",
+        )
+        session.commit()
+
+    rows = audit_mod.run_audit(repo_root=tmp_path)
+    assert len(rows) == 1
+    row = rows[0]
+
+    # The zeros survive the round-trip as 0.0, not as None.
+    assert row.sharpe_ratio == 0.0
+    assert row.pbo_score == 0.0
+    assert row.dsr_p_value is None
+    assert row.out_of_sample_sharpe is None
+
+    d = row.to_dict()
+    assert d["sharpe_ratio"] == 0.0
+    assert d["pbo_score"] == 0.0
+    assert d["dsr_p_value"] is None
+    assert d["out_of_sample_sharpe"] is None
+
+    cells = _row_cells(audit_mod.render_table(rows), "measured_zero_strategy")
+    assert cells["sharpe"] == "0.00", "a measured zero Sharpe must print as 0.00, never as the missing-value dash"
+    assert cells["pbo"] == "0.00", "a measured zero PBO must print as 0.00, never as the missing-value dash"
+    assert cells["dsr_p"] == "—", "an unmeasured DSR p must print as the dash, never as a fabricated 0.000"
+    assert cells["oos"] == "—", "an unmeasured OOS Sharpe must print as the dash, never as a fabricated 0.00"

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -881,6 +881,66 @@ def test_to_strategy_response_serves_null_not_bt_fixture_without_live_rigor_resu
     )
 
 
+def test_to_strategy_response_surfaces_backtest_provenance(monkeypatch):
+    """Left-behind batch close (docs/sprint/a6-rerun.md / sprint README row 5):
+    ``backtest_engine`` and ``cost_model_id`` have lived on ``BacktestResultRecord``
+    since the cost SSOT / 2026-08-03 provenance audit and were already declared on
+    ``StrategyResponse``, but no construction site in strategies_routes.py ever
+    populated them from ``bt`` — the values stopped at the DB. Same
+    monkeypatch-the-provider pattern as the #1187 sibling tests above: a
+    ``BacktestResult`` carrying real engine/cost-model values is what
+    ``strategy_provider().get_backtest_result`` returns, and both must reach the
+    served response verbatim.
+
+    Adversarial check: with the two ``backtest_engine=``/``cost_model_id=`` kwargs
+    removed from ``_to_strategy_response``'s ``StrategyResponse(...)`` call, this
+    test fails — it would observe ``None`` for both instead of the real values.
+    """
+    from archimedes.api.strategies_routes import _to_strategy_response, strategy_provider
+    from archimedes.models.backtest import BacktestResult
+    from archimedes.models.strategy import Strategy
+    from archimedes.services.live_rigor_gate import RigorGateVerdict
+
+    s = Strategy(id="test-provenance-bt-stub")
+    bt = BacktestResult(
+        strategy_id=s.id,
+        sharpe_ratio=1.0,
+        sortino_ratio=1.0,
+        max_drawdown=0.1,
+        cagr=0.1,
+        calmar_ratio=1.0,
+        win_rate=0.5,
+        profit_factor=1.5,
+        total_trades=10,
+        avg_holding_period_days=5.0,
+        correlation_to_spy=0.5,
+        correlation_to_btc=0.0,
+        backtest_engine="backtrader",
+        cost_model_id="cm1:d10:s5",
+    )
+    monkeypatch.setattr(strategy_provider(), "get_backtest_result", lambda strategy_id: bt)
+
+    resp = _to_strategy_response(s, verdict=RigorGateVerdict.pending(), rigor_result=None)
+
+    assert resp.backtest_engine == "backtrader"
+    assert resp.cost_model_id == "cm1:d10:s5"
+
+
+def test_to_strategy_response_backtest_provenance_is_none_without_persisted_backtest():
+    """No BacktestResultRecord row (``bt is None``) must serve None for both
+    provenance fields — never a fabricated engine name or cost-model id."""
+    from archimedes.api.strategies_routes import _to_strategy_response
+    from archimedes.models.strategy import Strategy
+    from archimedes.services.live_rigor_gate import RigorGateVerdict
+
+    s = Strategy(id="test-provenance-no-bt")
+
+    resp = _to_strategy_response(s, verdict=RigorGateVerdict.pending(), rigor_result=None)
+
+    assert resp.backtest_engine is None
+    assert resp.cost_model_id is None
+
+
 @pytest.mark.asyncio
 async def test_leaderboard_serves_null_not_fixture_without_real_returns(monkeypatch):
     """End-to-end companion to the unit test above, over the REAL curated

--- a/backend/tests/test_strategies_routes.py
+++ b/backend/tests/test_strategies_routes.py
@@ -941,6 +941,68 @@ def test_to_strategy_response_backtest_provenance_is_none_without_persisted_back
     assert resp.cost_model_id is None
 
 
+def test_to_strategy_response_provenance_from_real_persisted_backtest_row():
+    """The same claim as the monkeypatched test above, but end-to-end through the
+    REAL stack: a row written by ``insert_backtest_if_missing`` into the actual
+    ``backtest_results`` table, read back by the real
+    ``LocalStrategyProvider.get_backtest_result``.
+
+    The monkeypatched sibling stubs ``get_backtest_result`` to hand back a
+    hand-built ``BacktestResult``, so it only proves ``_to_strategy_response``
+    copies two attributes off whatever object it is given — it cannot see a break
+    anywhere in the chain that actually carries the values:
+    ``BacktestResultRecord.from_backtest_result`` (write) →
+    ``backtest_results.backtest_engine`` / ``.cost_model_id`` (columns) →
+    ``latest_backtests_by_strategy`` (read) →
+    ``BacktestResultRecord.to_backtest_result`` (hydrate). Drop either column
+    from either mapper and the stubbed test still passes; this one fails.
+    """
+    from archimedes.api._route_helpers import strategy_provider
+    from archimedes.api.strategies_routes import _to_strategy_response
+    from archimedes.db import get_session
+    from archimedes.models.backtest import BacktestResult
+    from archimedes.models.strategy import Strategy
+    from archimedes.services.backtest_repository import insert_backtest_if_missing
+    from archimedes.services.live_rigor_gate import RigorGateVerdict
+
+    strategy_id = "test-provenance-real-db-row"
+    result = BacktestResult(
+        strategy_id=strategy_id,
+        sharpe_ratio=1.0,
+        sortino_ratio=1.0,
+        max_drawdown=0.1,
+        cagr=0.1,
+        calmar_ratio=1.0,
+        win_rate=0.5,
+        profit_factor=1.5,
+        total_trades=10,
+        avg_holding_period_days=5.0,
+        correlation_to_spy=0.5,
+        correlation_to_btc=0.0,
+        backtest_engine="vectorbt",
+        cost_model_id="cm2:d20:s7",
+    )
+    with get_session() as session:
+        insert_backtest_if_missing(
+            session,
+            strategy_id=strategy_id,
+            content_hash="provenance-real-db-h1",
+            result=result,
+            source_pipeline="test",
+        )
+        session.commit()
+
+    # Fresh provider: LocalStrategyProvider memoises ``_backtests`` per instance,
+    # and the lru_cached singleton may already have been built (and its cache
+    # populated) by an earlier test in this module.
+    strategy_provider.cache_clear()
+
+    resp = _to_strategy_response(Strategy(id=strategy_id), verdict=RigorGateVerdict.pending(), rigor_result=None)
+
+    assert resp.backtest_engine == "vectorbt"
+    assert resp.cost_model_id == "cm2:d20:s7"
+
+
 @pytest.mark.asyncio
 async def test_leaderboard_serves_null_not_fixture_without_real_returns(monkeypatch):
     """End-to-end companion to the unit test above, over the REAL curated


### PR DESCRIPTION
Closes two sprint-doc commitments: audit_backtest_universe gains DSR-p/PBO/OOS columns (em-dash for never-measured, 0.00 preserved for measured zeros — the distinction now pinned by a mutation-demonstrated test) and backtest_engine/cost_model_id threaded onto strategy responses with a real-DB assertion. Honest label: one pre-existing shape test noted as characterization, not regression guard. Owner-ratify ask in-body: turnover/cost-drag columns omitted (fields not persisted) — ratify or file the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7