### PR TITLE
[agent-native] ERC-8004 identity scaffold (#1527): registration files, manifest block, register script, agent quickstart

### DIFF
--- a/backend/archimedes/api/agent_manifest_routes.py
+++ b/backend/archimedes/api/agent_manifest_routes.py
@@ -26,6 +26,13 @@ makes no claim about marketplace payment/billing settlement (that is tracked
 separately and out of scope for this file — see the ``auth`` block below, which
 advertises no payment scheme).
 
+The ``erc8004`` block (#1527) is the on-chain identity leg and is deliberately the
+weakest claim in this document: the spec-typed registration file is published, and
+that is ALL it says. ``agentId``/``tokenURI`` are null and ``status`` is
+``registration_pending`` until an owner-signed ``register()`` lands on Arc — an agent
+reading this must not treat Archimedes as an ERC-8004-registered, reputed, or
+validated counterparty.
+
 ``auth_required`` is a per-GROUP flag, so a route belongs to the group whose gating it
 actually shares — the three ``/api/wallets/*`` routes all sit behind
 ``require_current_user`` and therefore live in ``walletLink`` (auth_required True), NOT
@@ -58,6 +65,64 @@ agent_manifest_router = APIRouter(prefix="/api/agent", tags=["agent"])
 # the value the rest of the backend actually enforces.
 _CHAIN_ID = int(os.getenv("ARC_CHAIN_ID", "5042002"))
 
+# ── ERC-8004 identity (#1527) ────────────────────────────────────────────────
+#
+# Arc names ERC-8004 as its on-chain agent-identity standard (docs/arc-integration.md →
+# submodules/context-arc/.../build/agentic-economy.md). This block advertises the leg
+# that EXISTS today — the spec-typed registration file and the registry we would
+# register against — and asserts nothing beyond it.
+#
+# Registration is an owner-signed on-chain transaction (``register(string agentURI)``,
+# planned by ``scripts/register_erc8004_identity.py``). Until the owner sends it there
+# is no agentId and no tokenURI, so both are ``None`` here rather than guessed,
+# defaulted to 0, or read from an env var a deploy could set with no receipt behind
+# it. ``status`` is derived from ``_ERC8004_AGENT_ID`` rather than written separately,
+# so "registered" cannot be claimed while the id is absent.
+_ERC8004_IDENTITY_REGISTRY = os.getenv("ERC8004_IDENTITY_REGISTRY", "0x8004A818BFB912233c491871b3d84c89A494BD9e")
+
+# The URL an ``agentURI`` would point at — the ERC-8004 registration file served from
+# ui/public/.well-known/. It is NOT a tokenURI: nothing on-chain references it yet.
+_ERC8004_REGISTRATION_URI = "https://archimedes-arc.com/.well-known/agent-registration.json"
+
+# Both stay None until a real ``Registered(agentId, agentURI, owner)`` event exists.
+# Filling them is a reviewed code change carrying the transaction hash, never a
+# config flip — see test_erc8004_identity.py, which fails if either is set without
+# the registration file's ``registrations`` list agreeing.
+_ERC8004_AGENT_ID: int | None = None
+_ERC8004_TOKEN_URI: str | None = None
+
+_ERC8004_PENDING_NOTE = (
+    "Not registered on-chain: no register() transaction has been sent, so agentId and "
+    "tokenURI are null and NO ERC-8004 identity, reputation, or validation claim is made. "
+    "Publishing a spec-typed registration file at registrationUri is not the same as "
+    "being registered. Plan the call with scripts/register_erc8004_identity.py --plan."
+)
+
+
+def erc8004_identity() -> dict:
+    """The ERC-8004 identity block, shared by every discovery surface.
+
+    One builder so the served manifest, the static agent card, and the two
+    registration files cannot disagree about whether we are registered — the
+    exact failure mode #1448 caught between the first two surfaces.
+    """
+    registered = _ERC8004_AGENT_ID is not None
+    return {
+        "chain": f"eip155:{_CHAIN_ID}",
+        "identityRegistry": _ERC8004_IDENTITY_REGISTRY,
+        "agentId": _ERC8004_AGENT_ID,
+        "tokenURI": _ERC8004_TOKEN_URI,
+        "status": "registered" if registered else "registration_pending",
+        "registrationUri": _ERC8004_REGISTRATION_URI,
+        "note": (
+            f"Registered as agent {_ERC8004_AGENT_ID} on {_ERC8004_IDENTITY_REGISTRY}. "
+            "Registration is an identity record only — it asserts nothing about reputation "
+            "or validation, neither of which this agent claims."
+            if registered
+            else _ERC8004_PENDING_NOTE
+        ),
+    }
+
 
 @agent_manifest_router.get("/manifest")
 async def get_agent_manifest():
@@ -77,8 +142,11 @@ async def get_agent_manifest():
         "docs": {
             "llms_txt": "/llms.txt",
             "agent_api": "https://github.com/a-apin/archimedes/blob/main/docs/agent-api.md",
+            "quickstart": "https://github.com/a-apin/archimedes/blob/main/docs/agent-quickstart.md",
             "agent_card": "/.well-known/agent.json",
         },
+        # On-chain identity leg — pending, and says so. See erc8004_identity().
+        "erc8004": erc8004_identity(),
         "auth": {
             "scheme": "Better Auth session",
             "methods": ["emailPassword", "google", "github"],

--- a/backend/tests/test_agent_manifest.py
+++ b/backend/tests/test_agent_manifest.py
@@ -16,7 +16,9 @@ async def test_agent_manifest_returns_200_with_expected_top_level_keys():
 
     assert resp.status_code == 200
     data = resp.json()
-    assert set(data.keys()) == {"name", "blurb", "docs", "auth", "endpoints", "faucet"}
+    # "erc8004" joined this set in #1527 — the on-chain identity leg. Its own shape,
+    # and the honesty invariants around it, live in test_erc8004_identity.py.
+    assert set(data.keys()) == {"name", "blurb", "docs", "auth", "endpoints", "faucet", "erc8004"}
     assert data["name"] == "Archimedes"
 
 

--- a/backend/tests/test_agent_quickstart_drift.py
+++ b/backend/tests/test_agent_quickstart_drift.py
@@ -1,0 +1,176 @@
+"""``docs/agent-quickstart.md`` must describe routes that exist, with curls that match.
+
+The quickstart is the one document written for an agent that has never seen this API and
+will do exactly what the page says, in order. That makes a stale line there more expensive
+than anywhere else in ``docs/``: the reader has no prior to correct against, spends a
+request, gets a 404, and cannot tell "wrong path" from "endpoint down" — the #1293
+dogfood finding, in its purest form.
+
+Same guard shape as its two neighbours, extended one step:
+
+- ``test_agent_discovery.py`` asserts the discovery documents' routes resolve against the
+  live app. This file reuses that module's ``unresolved_routes`` helper and its single
+  ``/api/auth/`` exemption rather than re-deriving either — the exemption stays narrow in
+  one place, and widening it there is still the only way to disable both guards.
+- ``test_api_docs_drift.py`` parses ``### METHOD /path`` headings out of ``docs/api/*.md``.
+  The quickstart is a walkthrough, not a reference, so its routes live in a step table and
+  in prose backticks instead of in headings — hence a different parser, same contract.
+
+The step this file adds is **curl-vs-prose**: every ``curl`` on the page must call a route
+the page also names. A worked example that quietly drifts from the table above it is the
+failure mode a heading parser cannot see, and the one a copy-pasting reader hits first.
+
+Hermetic: TESTING=1 import of ``archimedes.main`` (conftest sets it) plus in-memory regex
+parsing of two committed markdown files. No DB / Redis / RPC / network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests.test_agent_discovery import _EXTERNALLY_SERVED_PREFIXES, _openapi_index, unresolved_routes
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART = REPO_ROOT / "docs" / "agent-quickstart.md"
+DOCS_INDEX = REPO_ROOT / "docs" / "README.md"
+
+# "GET /api/thing" inside a backtick span — the step table's cells and the prose both use
+# that form, so one pattern covers the whole page.
+_BACKTICKED_ROUTE_RE = re.compile(r"`(GET|POST|PUT|PATCH|DELETE) (/[^`\s]+)`")
+
+# A fenced shell block. Only these are treated as executable examples.
+_FENCE_RE = re.compile(r"```(?:bash|sh|console)\n(.*?)```", re.DOTALL)
+
+# The URL a curl actually calls, and the method it calls it with.
+_CURL_URL_RE = re.compile(r"\$BASE(/[^\s\\\"']*)")
+_CURL_METHOD_RE = re.compile(r"-X\s+([A-Z]+)")
+
+
+def _text() -> str:
+    assert QUICKSTART.exists(), f"{QUICKSTART} is missing — the doc index promises it"
+    return QUICKSTART.read_text(encoding="utf-8")
+
+
+def _normalize(path: str) -> str:
+    """Collapse every path parameter to ``{}`` so ``{job_id}`` and ``$JOB_ID`` compare.
+
+    The page writes parameters two ways on purpose — ``{job_id}`` when naming the route,
+    ``$JOB_ID`` when showing the command — and both are correct for their context. This is
+    the only place the two spellings have to be reconciled.
+    """
+    segments = []
+    for segment in path.split("/"):
+        segments.append(
+            "{}" if segment.startswith("$") or (segment.startswith("{") and segment.endswith("}")) else segment
+        )
+    return "/".join(segments)
+
+
+def declared_routes(text: str) -> set[str]:
+    """``{"METHOD /path", …}`` — every route the page names in prose or in its step table."""
+    return {f"{method} {path}" for method, path in _BACKTICKED_ROUTE_RE.findall(text)}
+
+
+def curl_calls(text: str) -> set[str]:
+    """``{"METHOD /path", …}`` — every call the page's shell examples actually make."""
+    calls: set[str] = set()
+    for block in _FENCE_RE.findall(text):
+        if "curl" not in block:
+            continue
+        method_match = _CURL_METHOD_RE.search(block)
+        method = method_match.group(1) if method_match else "GET"
+        for path in _CURL_URL_RE.findall(block):
+            calls.add(f"{method} {path.split('?')[0]}")
+    return calls
+
+
+# ── the exemption is inherited, not re-declared ──────────────────────────────
+
+
+def test_the_better_auth_exemption_is_the_shared_one():
+    """Reusing the sibling's constant is the point: one place to widen, one place to audit."""
+    assert _EXTERNALLY_SERVED_PREFIXES == ("/api/auth/",)
+
+
+# ── (a) every route the page names exists on the app ─────────────────────────
+
+
+def test_the_quickstart_names_the_routes_the_journey_needs():
+    """A cheap sanity floor before the resolution check: the spine must be on the page.
+
+    Without this, deleting the whole step table would leave the guard below vacuously
+    green — an empty set has no unresolved members.
+    """
+    declared = declared_routes(_text())
+    for route in (
+        "GET /api/agent/manifest",
+        "GET /api/generate/quote",
+        "POST /api/auth/sign-in/email",
+        "GET /api/auth/get-session",
+        "POST /api/generate/start",
+        "GET /api/generate/jobs/{job_id}/candidates",
+        "GET /api/strategies/{strategy_id}",
+        "POST /api/paper/deployments",
+        "GET /api/paper/deployments/{deployment_id}",
+    ):
+        assert route in declared, f"docs/agent-quickstart.md no longer names {route}"
+
+
+def test_every_route_the_quickstart_names_resolves_against_the_live_openapi():
+    """The docs cannot promise a route archimedes.main does not serve."""
+    declared = sorted(declared_routes(_text()))
+    assert declared, "parsed no routes at all — the parser or the page changed shape"
+    unresolved = unresolved_routes(declared, _openapi_index())
+    assert unresolved == [], (
+        "docs/agent-quickstart.md names routes that do NOT exist on the running app — an "
+        "agent following this page would 404 with no way to diagnose it:\n  " + "\n  ".join(unresolved)
+    )
+
+
+# ── (b) the worked examples match the routes the page names ──────────────────
+
+
+def test_every_curl_calls_a_route_the_page_also_names():
+    """A copy-pasteable command that drifts from its own documentation is the worst case.
+
+    Compared after normalizing parameters, so ``$JOB_ID`` in the command matches
+    ``{job_id}`` in the table — the difference this page makes on purpose.
+    """
+    text = _text()
+    declared = {_normalize(route) for route in declared_routes(text)}
+    calls = {_normalize(call) for call in curl_calls(text)}
+
+    assert calls, "parsed no curl commands — the parser or the page changed shape"
+    undocumented = sorted(calls - declared)
+    assert not undocumented, (
+        "docs/agent-quickstart.md runs curls against routes it never names in its step "
+        "table or prose (add the route to the page, or fix the command):\n  " + "\n  ".join(undocumented)
+    )
+
+
+def test_every_curl_target_also_resolves_against_the_live_openapi():
+    """The commands are checked against the app directly, not only against the prose.
+
+    Belt and braces on purpose: the check above would stay green if a route were wrong in
+    the table AND in the command in the same way, which is exactly how a bad rename lands.
+    """
+    text = _text()
+    # Recover the parameter spelling from the declared set so a curl's ``$JOB_ID`` can be
+    # resolved: the OpenAPI index is keyed by ``{job_id}``, and only the page knows which
+    # declared route a given command corresponds to.
+    by_normalized = {_normalize(route): route for route in declared_routes(text)}
+    targets = [by_normalized[key] for call in curl_calls(text) if (key := _normalize(call)) in by_normalized]
+
+    assert targets, "no curl target could be mapped to a declared route"
+    assert unresolved_routes(targets, _openapi_index()) == []
+
+
+# ── the doc index ────────────────────────────────────────────────────────────
+
+
+def test_the_quickstart_is_listed_in_the_docs_index():
+    """CLAUDE.md's rule, asserted: "a doc not listed there does not exist"."""
+    assert "agent-quickstart.md" in DOCS_INDEX.read_text(encoding="utf-8"), (
+        "docs/agent-quickstart.md has no row in docs/README.md — add one in the same commit."
+    )

--- a/backend/tests/test_erc8004_identity.py
+++ b/backend/tests/test_erc8004_identity.py
@@ -187,6 +187,100 @@ def test_supported_trust_claims_nothing_this_agent_has_not_earned():
     )
 
 
+# ── the x402 payment claim ───────────────────────────────────────────────────
+#
+# ``x402Support`` shipped as ``false`` while the deployment serving this file was charging
+# $2.00 a generation for real and settling it. The field is a bool, so the shape assertion
+# above waved either value through — nothing connected the claim to the runtime it
+# describes. That is the #1448 drift shape one level down: not two documents disagreeing
+# with each other, but every document agreeing with the *source defaults* instead of with
+# the deployment.
+#
+# The runtime reading itself cannot be pinned from inside the repo — tests are hermetic and
+# a deployed flag is not in the tree — so ``X402_PRICE`` is the deliberate seam: re-reading
+# ``GET /api/generate/quote`` and editing one literal is the act. What IS checkable, and is
+# what these guards enforce, is that no surface prices generation differently from the
+# others, and that ``true`` is backed by prose citing the endpoint it was read from.
+
+QUICKSTART = REPO_ROOT / "docs" / "agent-quickstart.md"
+
+# What https://archimedes-arc.com/api/generate/quote answered on 2026-08-30. Deliberately
+# NOT imported from ``generation_payment.DEFAULT_PRICE_USD``: the default and the
+# deployment agree on the price today and disagree on the flags, and it is the deployment
+# these documents describe. Binding to the default would re-create the exact bug.
+X402_PRICE = "$2.000000"
+
+# A circlekit price string, the "$X.XXXXXX" form ``generation_payment._price`` emits.
+_PRICE_RE = re.compile(r"\$\d+\.\d{6}")
+
+
+def _priced_surfaces() -> dict[str, str]:
+    """Every committed surface that tells a caller what a generation costs."""
+    return {
+        "agent-registration.json → _note.x402Support": _json(REGISTRATION_FILE)["_note"]["x402Support"],
+        "agent.json → endpoints.generate.note": _json(AGENT_CARD)["endpoints"]["generate"]["note"],
+        "docs/agent-quickstart.md": QUICKSTART.read_text(encoding="utf-8"),
+    }
+
+
+def test_every_surface_that_prices_generation_quotes_the_same_price():
+    """One price, stated in three places. A fix that moves one of them is the defect."""
+    for name, text in _priced_surfaces().items():
+        found = set(_PRICE_RE.findall(text))
+        assert found, f"{name} no longer states a price at all — it is what a caller budgets against"
+        assert found == {X402_PRICE}, (
+            f"{name} prices generation at {sorted(found)}, but the recorded quote is "
+            f"{X402_PRICE}. Re-read GET /api/generate/quote and move ALL of "
+            f"{sorted(_priced_surfaces())} plus X402_PRICE together, or one surface sends "
+            "a caller to sign the wrong amount."
+        )
+
+
+def test_the_price_reader_actually_rejects_a_divergent_price():
+    """Guard on the guard: a reader that matched nothing would pass vacuously.
+
+    The failing input is the realistic one — a single surface edited to a new price while
+    the others keep the old one, which is how the last drift happened.
+    """
+    assert _PRICE_RE.findall(f'"price": "{X402_PRICE}"') == [X402_PRICE]
+    assert set(_PRICE_RE.findall('"price": "$0.150000"')) != {X402_PRICE}
+    # Prose prices ("$2.00 testnet USDC") are not the machine-readable form and must not
+    # be mistaken for a divergent quote.
+    assert _PRICE_RE.findall("charges $2.00 testnet USDC per run") == []
+
+
+def test_x402_support_true_is_backed_by_prose_citing_the_runtime_it_was_read_from():
+    """``true`` is a claim about a deployment, so it must say which reading produced it.
+
+    Written as an implication so it keeps guarding if the flag is ever turned back off:
+    ``false`` has to be equally explicit that the paywall's absence is a deploy state and
+    not a property of the code.
+    """
+    doc = _json(REGISTRATION_FILE)
+    note = doc["_note"]["x402Support"]
+
+    assert "/api/generate/quote" in note, (
+        "the x402Support note must name the endpoint the claim was read from — it is the "
+        "only thing a consumer can re-check it against."
+    )
+    assert "GENERATION_PAYMENT_REQUIRED" in note, (
+        "the note must name the deploy flag, so a reader knows the value describes this "
+        "deployment and not the repo's default."
+    )
+
+    if doc["x402Support"]:
+        for required in ("payment_required: true", "dry_run: false", X402_PRICE):
+            assert required in note, (
+                f"x402Support is true but the note never states {required!r}. "
+                "A bare true is the same unbacked claim as the bare false it replaced."
+            )
+    else:
+        assert "payment_required: true" not in note, (
+            "x402Support is false while the note quotes a live paywall — one of the two is "
+            "stale. Re-read GET /api/generate/quote and fix both together."
+        )
+
+
 # ── the honesty invariants (these survive a real registration) ───────────────
 
 

--- a/backend/tests/test_erc8004_identity.py
+++ b/backend/tests/test_erc8004_identity.py
@@ -1,0 +1,295 @@
+"""The ERC-8004 identity leg must never claim more than it has (#1527).
+
+Four surfaces describe this agent's on-chain identity:
+
+- ``GET /api/agent/manifest`` → ``erc8004`` (built by ``agent_manifest_routes.erc8004_identity``)
+- ``ui/public/.well-known/agent.json`` → ``erc8004`` (static, CDN-served)
+- ``ui/public/.well-known/agent-registration.json`` — the spec-typed registration file
+  an ``agentURI`` would resolve to
+- ``ui/public/.well-known/agent-registration.domain.json`` — the EIP's optional
+  domain-ownership variant, for a second endpoint-domain
+
+#1448 is the precedent for why they are checked against each other rather than each
+against a hand-kept list: the served manifest and the static card drifted for over a
+month because nothing connected them.
+
+The load-bearing property here is narrower than consistency, though. **Registration is
+an owner-signed on-chain transaction this repo cannot perform.** Until it lands there is
+no agentId and no tokenURI, and the honest word is ``registration_pending``. The
+invariants below are written so they keep holding *after* a real registration — they
+assert the surfaces move together, not that the values are frozen — except for one
+deliberately frozen assertion at the bottom that fails the day the state changes, so the
+change has to be made on purpose.
+
+Hermetic: TESTING=1 ASGI call into ``archimedes.main`` (conftest sets it) plus reading
+four committed JSON files. No DB / Redis / RPC / network.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from httpx import ASGITransport, AsyncClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WELL_KNOWN = REPO_ROOT / "ui" / "public" / ".well-known"
+AGENT_CARD = WELL_KNOWN / "agent.json"
+REGISTRATION_FILE = WELL_KNOWN / "agent-registration.json"
+DOMAIN_VARIANT = WELL_KNOWN / "agent-registration.domain.json"
+
+# The exact string ERC-8004 requires. Not a prefix match, not a substring: a file typed
+# with a near-miss is a file no ERC-8004 consumer will accept.
+SPEC_TYPE = "https://eips.ethereum.org/EIPS/eip-8004#registration-v1"
+
+# The five keys #1527 specifies, plus the two this repo adds (registrationUri, note).
+# Frozen so a key cannot be dropped from one surface and quietly kept on another.
+IDENTITY_KEYS = {"chain", "identityRegistry", "agentId", "tokenURI", "status", "registrationUri", "note"}
+
+_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+_CAIP2_RE = re.compile(r"^eip155:[1-9][0-9]*$")
+
+# Words that, said about ourselves, are the exact overclaim this issue's anti-goal names.
+_CLAIM_WORDS = ("registered", "verified", "validated", "attested")
+
+
+def _json(path: Path) -> dict:
+    assert path.exists(), f"{path} is missing — the surface it backs would 404"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+async def _manifest() -> dict:
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/agent/manifest")
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def _all_identity_blocks() -> dict[str, dict]:
+    """Every STATIC surface's identity block, keyed by filename for readable failures."""
+    return {
+        AGENT_CARD.name: _json(AGENT_CARD)["erc8004"],
+        REGISTRATION_FILE.name: _json(REGISTRATION_FILE)["erc8004"],
+        DOMAIN_VARIANT.name: _json(DOMAIN_VARIANT)["erc8004"],
+    }
+
+
+# ── shape ────────────────────────────────────────────────────────────────────
+
+
+async def test_manifest_carries_a_well_shaped_erc8004_block():
+    """The served block exists, has exactly the agreed keys, and is typed correctly."""
+    block = (await _manifest())["erc8004"]
+
+    assert set(block) == IDENTITY_KEYS, f"unexpected key set: {sorted(block)}"
+    assert _CAIP2_RE.match(block["chain"]), f"chain must be an eip155 CAIP-2 id, got {block['chain']!r}"
+    assert _ADDRESS_RE.match(block["identityRegistry"]), block["identityRegistry"]
+    assert block["agentId"] is None or (isinstance(block["agentId"], int) and not isinstance(block["agentId"], bool))
+    assert block["tokenURI"] is None or isinstance(block["tokenURI"], str)
+    assert block["status"] in {"registration_pending", "registered"}
+    assert block["registrationUri"].startswith("https://")
+    assert block["registrationUri"].endswith("/.well-known/agent-registration.json")
+
+
+async def test_manifest_chain_is_derived_from_the_configured_arc_chain_id():
+    """The CAIP-2 id must be BUILT from ``_CHAIN_ID``, not a parallel literal —
+    the same rule ``auth.chain_id`` already lives under."""
+    from archimedes.api.agent_manifest_routes import _CHAIN_ID
+
+    block = (await _manifest())["erc8004"]
+    assert block["chain"] == f"eip155:{_CHAIN_ID}"
+    assert block["chain"].split(":")[1] == str((await _manifest())["auth"]["chain_id"])
+
+
+# ── cross-surface agreement ──────────────────────────────────────────────────
+
+
+async def test_every_surface_publishes_the_identical_identity_block():
+    """Manifest, agent card, registration file and domain variant must agree byte-for-byte.
+
+    Two discovery documents that disagree about whether an agent is registered are worse
+    than one — a consumer has no way to tell which is stale.
+    """
+    served = (await _manifest())["erc8004"]
+    for name, block in _all_identity_blocks().items():
+        assert block == served, (
+            f"{name} carries an erc8004 block that differs from the served manifest.\n"
+            f"  static: {json.dumps(block, sort_keys=True)}\n"
+            f"  served: {json.dumps(served, sort_keys=True)}\n"
+            "Regenerate the static block from agent_manifest_routes.erc8004_identity()."
+        )
+
+
+def test_registration_uri_points_at_the_file_this_repo_actually_publishes():
+    """A tokenURI that resolves to nothing is a registration that proves nothing."""
+    block = _json(AGENT_CARD)["erc8004"]
+    assert block["registrationUri"].endswith(f"/.well-known/{REGISTRATION_FILE.name}")
+    assert REGISTRATION_FILE.exists()
+
+
+# ── the registration files ───────────────────────────────────────────────────
+
+
+def test_registration_files_are_spec_typed_json():
+    for path in (REGISTRATION_FILE, DOMAIN_VARIANT):
+        doc = _json(path)
+        assert doc["type"] == SPEC_TYPE, f"{path.name} has type {doc.get('type')!r}, expected {SPEC_TYPE!r}"
+        assert isinstance(doc["registrations"], list), f"{path.name}: registrations must be a list"
+
+
+def test_primary_registration_file_carries_the_fields_a_consumer_reads():
+    """The EIP's registration-file fields, with types an ERC-8004 client can rely on."""
+    doc = _json(REGISTRATION_FILE)
+    assert doc["name"] == "Archimedes"
+    assert isinstance(doc["description"], str) and doc["description"]
+    assert doc["image"].startswith("https://")
+    assert isinstance(doc["active"], bool)
+    assert isinstance(doc["x402Support"], bool)
+    assert isinstance(doc["supportedTrust"], list)
+
+    services = doc["services"]
+    assert services, "a registration file with no services describes no agent"
+    for service in services:
+        assert set(service) == {"name", "endpoint"}, service
+        assert service["endpoint"].startswith("https://"), service
+
+    # The services must include the two surfaces this document is discovered through,
+    # or a consumer that starts from the registry cannot find the API at all.
+    endpoints = {s["endpoint"] for s in services}
+    assert "https://archimedes-arc.com/api/agent/manifest" in endpoints
+    assert "https://archimedes-arc.com/.well-known/agent.json" in endpoints
+
+
+def test_domain_variant_is_the_minimal_file_the_eip_describes():
+    """ "…containing at least a registrations list" — at least, and here exactly.
+
+    The variant deliberately does NOT restate name/description/services: a second copy of
+    those is a second thing to go stale, and the EIP asks for none of it.
+    """
+    doc = _json(DOMAIN_VARIANT)
+    assert set(doc) == {"type", "registrations", "erc8004", "_note"}, sorted(doc)
+
+
+def test_supported_trust_claims_nothing_this_agent_has_not_earned():
+    """``supportedTrust`` is an on-chain-trust-model claim. We make none.
+
+    If a model is ever listed here it must be one the EIP defines AND one that is
+    actually wired — this assertion is the place that conversation happens.
+    """
+    trust = _json(REGISTRATION_FILE)["supportedTrust"]
+    assert trust == [], (
+        f"supportedTrust claims {trust}. ERC-8004 trust models (reputation, "
+        "crypto-economic, tee-attestation) are none of them implemented here; listing one "
+        "advertises a guarantee a counterparty could rely on and lose money to."
+    )
+
+
+# ── the honesty invariants (these survive a real registration) ───────────────
+
+
+async def test_no_surface_says_registered_while_the_agent_id_is_absent():
+    """The anti-goal, enforced: agentId absent ⇒ status pending, everywhere.
+
+    Written as an implication rather than an equality so it still holds — and still
+    guards — after the owner registers for real.
+    """
+    surfaces = dict(_all_identity_blocks())
+    surfaces["GET /api/agent/manifest"] = (await _manifest())["erc8004"]
+
+    for name, block in surfaces.items():
+        if block["agentId"] is None:
+            assert block["status"] == "registration_pending", (
+                f"{name} has no agentId but reports status {block['status']!r} — that is a "
+                "registration claim with no registration behind it."
+            )
+            assert block["tokenURI"] is None, (
+                f"{name} has no agentId but carries a tokenURI — nothing on-chain references it."
+            )
+
+
+async def test_a_registered_status_requires_a_real_id_a_uri_and_a_registrations_entry():
+    """The mirror implication: claiming registered obliges every other surface to prove it.
+
+    This is what makes flipping ``_ERC8004_AGENT_ID`` a whole-commit act — the manifest,
+    both registration files, and the agent card have to move together or CI fails.
+    """
+    served = (await _manifest())["erc8004"]
+    if served["status"] != "registered":
+        return  # nothing to prove today; the implication above covers the pending state
+
+    agent_id = served["agentId"]
+    assert isinstance(agent_id, int) and not isinstance(agent_id, bool) and agent_id >= 0
+    assert isinstance(served["tokenURI"], str) and served["tokenURI"].startswith("https://")
+
+    expected = {"agentId": agent_id, "agentRegistry": f"{served['chain']}:{served['identityRegistry']}"}
+    for path in (REGISTRATION_FILE, DOMAIN_VARIANT):
+        registrations = _json(path)["registrations"]
+        assert expected in registrations, (
+            f"{path.name} does not list the registered agent. ERC-8004 requires the "
+            f"registration file to carry a registrations entry matching the on-chain agent; "
+            f"expected {expected} in {registrations}. "
+            "scripts/register_erc8004_identity.py --print-followup <agentId> prints it."
+        )
+
+
+def test_registrations_entries_are_never_half_filled():
+    """Whatever is listed must be listable: both mandatory EIP fields, correctly typed.
+
+    An entry with a null agentId is not a placeholder, it is a malformed registration —
+    and it is exactly the shape a well-meaning edit reaches for while waiting to register.
+    """
+    for path in (REGISTRATION_FILE, DOMAIN_VARIANT):
+        for entry in _json(path)["registrations"]:
+            assert set(entry) >= {"agentId", "agentRegistry"}, f"{path.name}: {entry}"
+            assert isinstance(entry["agentId"], int) and not isinstance(entry["agentId"], bool), (
+                f"{path.name}: agentId must be the integer the registry minted, got {entry['agentId']!r}"
+            )
+            namespace, chain_id, address = entry["agentRegistry"].split(":")
+            assert namespace == "eip155" and chain_id.isdigit() and _ADDRESS_RE.match(address), entry
+
+
+def test_prose_on_these_surfaces_never_asserts_a_registration_we_do_not_have():
+    """Guard the *words*, not just the fields.
+
+    A status field can stay ``registration_pending`` while a note beside it reads "our
+    registered agent identity" — same file, same overclaim, and no structural assertion
+    catches it. Every claim word in the free text must be negated or hypothetical.
+    """
+    if _json(AGENT_CARD)["erc8004"]["agentId"] is not None:
+        return  # once registered, "registered" is simply true
+
+    for path in (AGENT_CARD, REGISTRATION_FILE, DOMAIN_VARIANT):
+        text = path.read_text(encoding="utf-8").lower()
+        for sentence in re.split(r"(?<=[.;])\s+", text):
+            for word in _CLAIM_WORDS:
+                if word not in sentence:
+                    continue
+                assert any(
+                    marker in sentence
+                    for marker in ("not ", "no ", "never", "until", "once", "pending", "would", "empty", "cannot")
+                ), (
+                    f"{path.name} says {word!r} in a sentence that reads as a claim, while "
+                    f"agentId is null:\n  {sentence.strip()[:300]}"
+                )
+
+
+# ── the one frozen assertion ─────────────────────────────────────────────────
+
+
+async def test_the_shipped_state_is_pending():
+    """Today, on main, nothing is registered. Frozen on purpose.
+
+    If this fails because a real ``register()`` landed: good — update this test in the
+    SAME commit as the transaction hash and the ``registrations`` entries, and leave the
+    implication tests above untouched. If it fails for any other reason, someone claimed
+    a registration that did not happen.
+    """
+    block = (await _manifest())["erc8004"]
+    assert block["status"] == "registration_pending"
+    assert block["agentId"] is None
+    assert block["tokenURI"] is None
+    assert _json(REGISTRATION_FILE)["registrations"] == []
+    assert _json(DOMAIN_VARIANT)["registrations"] == []

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 |---|---|---|---|---|
 | [`user-stories.md`](user-stories.md) | current | Dan Browne | 2026-05-20 | The locked product spine. Canonical statement of what the product is. |
 | [`agent-api.md`](agent-api.md) | current | Dan Browne | — | Driving the full journey programmatically; the agent-native surface. |
+| [`agent-quickstart.md`](agent-quickstart.md) | current | Dan Browne | 2026-08-30 | Zero to paper-traded for an external agent: eleven steps, one `curl` each, exact response shapes, and an error table (401/402/422/429). Narrower than `agent-api.md` on purpose — no wallet, no chain, no money. Route strings and worked commands are drift-guarded by `backend/tests/test_agent_quickstart_drift.py`. |
 | [`asset-universe.md`](asset-universe.md) | current | Dan Browne | — | Tradable universe and how it is assembled. |
 | [`demo-script-lepton.md`](demo-script-lepton.md) | current | Dan Browne | 2026-07-06 | Current demo video script. |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 |---|---|---|---|---|
 | [`user-stories.md`](user-stories.md) | current | Dan Browne | 2026-05-20 | The locked product spine. Canonical statement of what the product is. |
 | [`agent-api.md`](agent-api.md) | current | Dan Browne | — | Driving the full journey programmatically; the agent-native surface. |
-| [`agent-quickstart.md`](agent-quickstart.md) | current | Dan Browne | 2026-08-30 | Zero to paper-traded for an external agent: eleven steps, one `curl` each, exact response shapes, and an error table (401/402/422/429). Narrower than `agent-api.md` on purpose — no wallet, no chain, no money. Route strings and worked commands are drift-guarded by `backend/tests/test_agent_quickstart_drift.py`. |
+| [`agent-quickstart.md`](agent-quickstart.md) | current | Dan Browne | 2026-08-30 | Zero to paper-traded for an external agent: eleven steps, exact response shapes, and an error table (401/402/409/422/429). Includes the live x402 paywall — production charges $2.00 USDC per generation, so steps 6a–6b link a wallet and pay. Narrower than `agent-api.md` on purpose: no vault, no capital deployed. Route strings and worked commands are drift-guarded by `backend/tests/test_agent_quickstart_drift.py`. |
 | [`asset-universe.md`](asset-universe.md) | current | Dan Browne | — | Tradable universe and how it is assembled. |
 | [`demo-script-lepton.md`](demo-script-lepton.md) | current | Dan Browne | 2026-07-06 | Current demo video script. |
 

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -6,13 +6,24 @@
 
 You are an autonomous agent that has never seen this API. This page is the shortest
 deterministic path from "no account" to "a strategy running in a paper-trading ledger you
-can read back." Eleven steps, one `curl` each, every expected response shape taken from
-the route that produces it.
+can read back." Eleven numbered steps, roughly one `curl` each, plus three lettered
+detours you take only when the runtime says you need them — 6a/6b for the paywall, 7b for
+polling. Every expected response shape is taken from the route that produces it.
 
 **Read this if you want to run the journey. Read [`agent-api.md`](agent-api.md) if you
-want the full surface** — the wallet link, the real on-chain vault, the marketplace, the
-`agent_journey.py` reference harness. This page is deliberately narrower: nothing here
-touches a wallet, a chain, or a cent of real money.
+want the full surface** — the wallet-link handshake in detail, the real on-chain vault,
+the marketplace, the `agent_journey.py` reference harness. This page is narrower: nothing
+below creates a vault or puts capital on-chain.
+
+**It is not free.** Generation sits behind a live x402 paywall in production:
+`GET /api/generate/quote` answers `payment_required: true`, `dry_run: false`,
+`price: "$2.000000"` — so step 6 charges **$2.00 testnet USDC per run and settles for
+real**, from a wallet you link and fund first (steps 6a–6b). The code *defaults* are the
+opposite of that — the paywall is off and dry-run is on unless a deploy turns them on —
+so a local checkout is free while production is not, and **step 1 against the host you
+are actually calling is the only thing that tells you which one you are on.** One step is
+not autonomous: funding the wallet goes through Circle's faucet, which today needs a
+human.
 
 Conventions used below:
 
@@ -21,6 +32,8 @@ Conventions used below:
   only auth mechanism (there is no bearer token for this API).
 - Response bodies are shown **shape-first**: field names and types are exact, values are
   illustrative. `…` means "more fields of the same kind that this page does not depend on."
+  **The one exception is step 1** — its values are the live production ones, because there
+  the value *is* the decision.
 - A non-browser `User-Agent` classifies you as an external agent in the telemetry
   middleware. Send one; it costs nothing and makes your traffic legible.
 
@@ -37,6 +50,8 @@ Conventions used below:
 | 4 | Confirm the session | `GET /api/auth/get-session` | cookie |
 | 5 | Check your quota | `GET /api/account/usage` | cookie |
 | 6 | Submit the brief | `POST /api/generate/start` | cookie |
+| 6a | Link a wallet — once, if step 1 said `true` | `POST /api/wallets/challenge` then `POST /api/wallets/verify` | cookie |
+| 6b | Pay the $2 and retry | `POST /api/generate/start` + `Payment-Signature` | cookie + wallet |
 | 7 | Watch it run | `GET /api/generate/stream/{job_id}` | cookie |
 | 7b | …or poll instead | `GET /api/generate/jobs/{job_id}` | cookie |
 | 8 | Read the verdict | `GET /api/generate/jobs/{job_id}/candidates` | cookie |
@@ -79,22 +94,35 @@ curl -sS $BASE/api/generate/quote
 
 ```json
 {
-  "payment_required": false,
+  "payment_required": true,
   "pricing_model": "flat_v1",
-  "price": "$0.150000",
+  "price": "$2.000000",
   "asset": "USDC",
-  "chain": "…",
-  "recipient": null,
-  "dry_run": true,
+  "chain": "arcTestnet",
+  "recipient": "0xffa7abba5f17cb8471ebf150bf808bd6fb8856c1",
+  "dry_run": false,
   "how": "POST /api/generate/start without a Payment-Signature header returns 402 with these requirements in the PAYMENT-REQUIRED header; sign them (x402 / Circle Gateway) and retry with Payment-Signature."
 }
 ```
 
-Public on purpose: price the run before you hold a session. **`payment_required` is the
-runtime truth** — when it is `false`, step 6 needs no wallet and no payment. When it is
-`true`, step 6 additionally requires a linked, funded wallet (`409
-wallet_link_required` first, then `402`) — that path is
-[`agent-api.md`](agent-api.md#optional-eip-4361-wallet-link), not this page.
+Public on purpose: price the run before you hold a session. **This is the one response on
+this page whose values are not illustrative** — the block above is what
+`https://archimedes-arc.com` actually returned on 2026-08-30, and those values decide
+whether the rest of the journey costs money.
+
+`payment_required` and `dry_run` are the runtime truth, and they are the truth *of the
+host you asked*:
+
+- **`payment_required: true`** (production today) — step 6 needs a linked, funded wallet
+  and a signed payment. Unlinked → `409 wallet_link_required`; linked but unsigned →
+  `402`. Steps 6a and 6b are that path, and **`dry_run: false` means the $2 settles for
+  real** rather than being waved through unverified.
+- **`payment_required: false`** — step 6 needs no wallet and no payment; skip 6a and 6b.
+
+Do not carry an answer over from another host or from the source. The code *defaults* are
+`GENERATION_PAYMENT_REQUIRED` unset (paywall off) and `PAYMENTS_DRY_RUN=true` (nothing
+settles), which is the opposite of what production serves — a deployment sets both, so
+the default tells you nothing about the deployment. Re-read this endpoint per host.
 
 ### 2. Create an account
 
@@ -154,13 +182,17 @@ curl -sS -b /tmp/agora.jar $BASE/api/account/usage
   "user_id": "…",
   "user": { "used": 0, "cap": 10, "unlimited": false, "remaining": 10, "error": null },
   "ip":   { "used": 0, "cap": 25, "unlimited": false, "remaining": 25, "error": null },
-  "quote": { "payment_required": false, "…": "the same object step 1 returned" }
+  "quote": { "payment_required": true, "…": "the same object step 1 returned" }
 }
 ```
 
 Both caps must pass. `used: null` with `error: "quota_backend_unavailable"` is an honest
 "we could not read the counter", never a fabricated `0`. Reading this is a peek — it never
 increments anything.
+
+The caps are stacked **underneath** the paywall and enforced **before** it, so a
+quota-blocked caller is refused `429` without ever being asked to pay. Passing them is not
+a free run: on a `payment_required: true` host you still owe the $2 at step 6.
 
 ### 6. Submit the brief
 
@@ -182,6 +214,83 @@ Field bounds, enforced (violating any of them is a 422 — see the error table):
 control characters. `model` is optional and defaults to the server's free model — naming a
 premium model without an entitlement is a **402**, and the request is refused rather than
 silently downgraded.
+
+**HTTP 202 is only what a `payment_required: false` host returns here.** Against
+production, this exact call answers `409 wallet_link_required` (no wallet on the account)
+or `402` (wallet linked, nothing signed) — those are the paywall, not an error in your
+request, and your brief was not run. Steps 6a and 6b clear them; the body above is
+unchanged and gets replayed verbatim at 6b.
+
+The server refuses in a deliberate order, so read the status before reacting: `429` for the
+daily cap, then `429 generation_queue_full`, then `409`, then `402`. **You are never asked
+to pay for a slot that does not exist, and a quota-blocked or queue-blocked call takes no
+money** — the `generation_queue_full` body says so in as many words.
+
+### 6a. Link a wallet — once per account, if step 1 said `true`
+
+Skip this entirely when `payment_required` is `false`. You need a wallet you control the
+key for; `provider: "headless"` is the one of the four an API caller can use.
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/wallets/challenge \
+  -H 'Content-Type: application/json' \
+  -d '{"address":"0xYOUR_WALLET","chain_id":5042002,"provider":"headless"}'
+```
+
+Returns an EIP-4361 (SIWE) message to sign. Sign it with that wallet's key — that step is
+local to you, not an API call — and hand back the signature:
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/wallets/verify \
+  -H 'Content-Type: application/json' \
+  -d '{"address":"0xYOUR_WALLET","signature":"0x…"}'
+```
+
+`GET /api/wallets` reads the links back. Message construction, nonce handling, and the
+exact field names are in
+[`agent-api.md`](agent-api.md#optional-eip-4361-wallet-link) — this page shows only where
+the two calls sit in the journey.
+
+**The wallet must also hold testnet USDC, and that is the one step you cannot do
+yourself.** Arc testnet USDC comes from <https://faucet.circle.com/>, which currently
+requires a human. Linking an empty wallet gets you past the `409` and straight into a
+payment you cannot sign.
+
+### 6b. Pay the $2 and retry
+
+With a linked wallet, step 6 returns **402** carrying the machine-readable x402
+requirements in a `PAYMENT-REQUIRED` header, and the human-readable quote in the body:
+
+```json
+{ "detail": { "reason": "payment_required", "message": "…", "quote": { "price": "$2.000000", "…": "the step-1 object" } } }
+```
+
+Sign those requirements (x402 / Circle Gateway, EIP-3009 authorization) with the linked
+wallet and replay the **identical** step-6 request with the signature attached:
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/generate/start \
+  -H 'Content-Type: application/json' \
+  -H "Payment-Signature: $SIGNED_X402_PAYLOAD" \
+  -H "Idempotency-Key: $A_STABLE_KEY_YOU_CHOSE" \
+  -d '{"brief":{"intent":"diversified low-volatility strategy for idle USDC","risk_appetite":"moderate","max_papers":5},"n_candidates":1}'
+```
+
+Now you get the **202** and the `job_id` from step 6. A settlement receipt comes back in a
+`PAYMENT-RESPONSE` header.
+
+**Do not blind-retry a payment — send an `Idempotency-Key`, as above.** x402 is not
+crash-retry-idempotent: a naive retry signs a *fresh* EIP-3009 authorization, and a second
+settled authorization is a second real $2. A retry under the same key spends what you
+already paid instead of charging again; reusing a key whose generation already started is
+a deliberate `409 idempotency_key_already_used`.
+
+**A paid run that never delivers is repaid as a credit, not a refund** — Circle's
+facilitator settles one way and there is no reverse call, so promising a refund would be a
+promise the code cannot keep
+([ADR](adr/generation-payment-credit-not-refund.md)). The credit is durable and
+automatic: your next `POST /api/generate/start` spends it and skips the paywall entirely,
+so a payer whose last generation died is never asked for money twice.
 
 ### 7. Watch it run (SSE)
 
@@ -337,7 +446,9 @@ curl -sS -b /tmp/agora.jar -X POST $BASE/api/paper/deployments/$DEPLOYMENT_ID/st
 ```
 
 You are done. A strategy was generated from research, graded by a gate that is allowed to
-say no, and is now running in a ledger you can read. Nothing above touched a wallet.
+say no, and is now running in a ledger you can read. On a `payment_required: true` host
+that cost you one real $2.00 USDC settlement at step 6b and nothing else — no vault was
+created and no capital was deployed, because paper trading is free and simulated.
 
 ---
 
@@ -354,7 +465,8 @@ you will only see after step 3 succeeds. Fix the session first, then re-read the
 | Status | Body | What happened | Fix |
 |---|---|---|---|
 | **401** | `{"detail": "Authentication required"}` + `WWW-Authenticate: Session` | No valid session cookie on a cookie-gated route | Redo steps 3–4. Signing up (step 2) does **not** sign you in; only step 3 sets the cookie. Check the jar is passed with `-b`. |
-| **402** | `{"detail": {"reason": "payment_required", "message": "…", "quote": {…}}}` + `PAYMENT-REQUIRED` header | The generation paywall is on and no `Payment-Signature` was presented | Sign the x402 requirements in the header with your **linked** wallet and retry with `Payment-Signature`. Check `GET /api/generate/quote` → `payment_required` first; when it is `false` this cannot happen. |
+| **402** | `{"detail": {"reason": "payment_required", "message": "…", "quote": {…}}}` + `PAYMENT-REQUIRED` header | The generation paywall is on and no `Payment-Signature` was presented | **Expected on production** — step 6b, not a bug. Sign the x402 requirements in the header with your **linked** wallet and retry with `Payment-Signature` (plus an `Idempotency-Key`). `GET /api/generate/quote` → `payment_required` tells you which host you are on; only when it is `false` can this not happen. |
+| **409** | `{"detail": {"reason": "idempotency_key_already_used", "message": "…"}}` | The `Idempotency-Key` you replayed already paid for a generation that started | Do not re-sign. That run exists — find it via `GET /api/generate/jobs/{job_id}`; use a fresh key for a genuinely new run. |
 | **402** | `{"detail": "Model '…' is a premium (Anthropic) model and requires an entitlement. …"}` | You named a premium `model` without entitlement | Omit `model` (the free default is used) or name an allowlisted free model. The request is **not** silently downgraded. |
 | **422** | `{"detail": [{"type": "…", "loc": ["body", "brief", "max_papers"], "msg": "…", "input": …}]}` | Request body failed validation | Read `loc` — it names the exact field. Common causes: `max_papers` outside [2, 6], `n_candidates` outside [1, 5], an unknown `risk_appetite`. |
 | **422** | `{"detail": "strategy_id is required"}` | `POST /api/paper/deployments` with an empty or missing `strategy_id` | Send `{"strategy_id": "<id from step 8>"}`. |
@@ -363,7 +475,7 @@ you will only see after step 3 succeeds. Fix the session first, then re-read the
 | **429** | `{"detail": {"reason": "generation_daily_cap", "scope": "user", "cap": 10, "message": "…"}}` | Daily generation cap hit, per account (`scope: "user"`) or per IP (`scope: "ip"`) | Wait for the daily reset. Call step 5 **before** step 6 to see this coming; the caps it reports are the caps enforced. |
 | **429** | `{"detail": {"reason": "generation_queue_full", "message": "… No payment was taken. …"}}` | The generation wait queue is full | Retry in a few minutes. No payment was taken — admission control runs before the paywall. |
 | **429** | `{"detail": "Rate limit exceeded. Please slow down and try again later."}` + `X-RateLimit-*` | Per-route request-rate limit (`/api/generate/start` 5/min, `/api/paper/deployments` 10/min) | Back off. This is requests-per-minute, distinct from the daily cap above — same status, different `detail` shape, different fix. |
-| **409** | `{"detail": {"reason": "wallet_link_required", "message": "…"}}` | Payment is required but your account has no linked wallet | Link one via `POST /api/wallets/challenge` → `/api/wallets/verify` ([`agent-api.md`](agent-api.md#optional-eip-4361-wallet-link)). Funding the wallet currently needs a human at the faucet. |
+| **409** | `{"detail": {"reason": "wallet_link_required", "message": "…"}}` | Payment is required but your account has no linked wallet | **Expected on production** — do step 6a: `POST /api/wallets/challenge` → `POST /api/wallets/verify` ([`agent-api.md`](agent-api.md#optional-eip-4361-wallet-link)). Funding the wallet currently needs a human at the faucet, so linking an empty one only moves you to the 402. |
 | **404** | `{"detail": "Strategy not found"}` / `{"detail": "Paper deployment not found"}` | Missing **or** not yours — the two are deliberately indistinguishable | Confirm the id came from a call made with this same session. Existence is private; a 404 here is not proof the id is wrong. |
 | **503** | `{"detail": {"reason": "payment_config_missing", "message": "…"}}` | Payments are enabled but not fully configured server-side | Not caller-fixable. Retry later; it fails closed rather than letting the request through free. |
 
@@ -371,6 +483,12 @@ you will only see after step 3 succeeds. Fix the session first, then re-read the
 
 ## Anti-goals for an agent driving this API
 
+- **Do not assume generation is free, and do not assume it is paid.** Both are true of some
+  host. `GET /api/generate/quote` is the only authority, it is public, and it costs you
+  nothing to ask — the source defaults disagree with production on purpose, so reading the
+  code instead of the endpoint gets you the wrong answer.
+- **Do not re-sign an x402 payment to retry.** A fresh signature is a fresh real charge.
+  Carry an `Idempotency-Key`, and let an undelivered run's credit pay for the next attempt.
 - **Do not treat a `pending` or `fail` rigor gate as a pass.** A gate that never says no is
   not a gate; this one says no, on real strategies, on purpose.
 - **Do not confuse the two verdicts.** Step 8's is generation-time; step 9's is the live
@@ -390,6 +508,16 @@ Every route string here is asserted against the running app's route table by
 than an undocumented one, so the drift fails CI instead of an agent's retry loop. The
 response shapes were read off the routes that build them:
 `api/generate_routes.py`, `api/paper_routes.py`, `api/strategies_routes.py`,
-`api/account_usage_routes.py`, `api/account_auth.py`,
-`services/generation_payment.py`, `services/generation_quota.py`, and the Better Auth
-sidecar contract in [`api/auth-and-accounts.md`](api/auth-and-accounts.md).
+`api/account_usage_routes.py`, `api/account_auth.py`, `api/wallet_routes.py`,
+`services/generation_payment.py`, `services/generation_credits.py`,
+`services/generation_quota.py`, the credit-vs-refund decision in
+[`adr/generation-payment-credit-not-refund.md`](adr/generation-payment-credit-not-refund.md),
+and the Better Auth sidecar contract in
+[`api/auth-and-accounts.md`](api/auth-and-accounts.md).
+
+**Step 1's values are the exception to that rule, and are sourced differently.** They are
+a live reading of `GET https://archimedes-arc.com/api/generate/quote` taken on 2026-08-30,
+not a transcription of `generation_payment.py`'s defaults — those defaults say the paywall
+is off and dry-run is on, which is the opposite of what production serves. No CI check can
+pin a deployed flag from inside the repo, so that block is dated on purpose: **re-read the
+endpoint rather than trusting the date.**

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -1,0 +1,395 @@
+# Agent quickstart — zero to paper-traded, one curl per step
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-30
+
+You are an autonomous agent that has never seen this API. This page is the shortest
+deterministic path from "no account" to "a strategy running in a paper-trading ledger you
+can read back." Eleven steps, one `curl` each, every expected response shape taken from
+the route that produces it.
+
+**Read this if you want to run the journey. Read [`agent-api.md`](agent-api.md) if you
+want the full surface** — the wallet link, the real on-chain vault, the marketplace, the
+`agent_journey.py` reference harness. This page is deliberately narrower: nothing here
+touches a wallet, a chain, or a cent of real money.
+
+Conventions used below:
+
+- `$BASE` is `https://archimedes-arc.com` in production, `http://localhost:8080` locally.
+- `-c/-b /tmp/agora.jar` is the session cookie jar. One jar for the whole run; it is the
+  only auth mechanism (there is no bearer token for this API).
+- Response bodies are shown **shape-first**: field names and types are exact, values are
+  illustrative. `…` means "more fields of the same kind that this page does not depend on."
+- A non-browser `User-Agent` classifies you as an external agent in the telemetry
+  middleware. Send one; it costs nothing and makes your traffic legible.
+
+---
+
+## The path
+
+| # | Step | Call | Auth |
+|---|---|---|---|
+| 0 | Discover | `GET /api/agent/manifest` | none |
+| 1 | Price the run | `GET /api/generate/quote` | none |
+| 2 | Create an account | `POST /api/auth/sign-up/email` | none |
+| 3 | Sign in (get the cookie) | `POST /api/auth/sign-in/email` | none |
+| 4 | Confirm the session | `GET /api/auth/get-session` | cookie |
+| 5 | Check your quota | `GET /api/account/usage` | cookie |
+| 6 | Submit the brief | `POST /api/generate/start` | cookie |
+| 7 | Watch it run | `GET /api/generate/stream/{job_id}` | cookie |
+| 7b | …or poll instead | `GET /api/generate/jobs/{job_id}` | cookie |
+| 8 | Read the verdict | `GET /api/generate/jobs/{job_id}/candidates` | cookie |
+| 9 | Read the **authoritative** gate | `GET /api/strategies/{strategy_id}` | none |
+| 10 | Paper-deploy | `POST /api/paper/deployments` | cookie |
+| 11 | Read the ledger back | `GET /api/paper/deployments/{deployment_id}` | cookie |
+
+Step 9 is not optional. Step 8's verdict is the *generation-time* one; step 9 is the live
+gate the server enforces. They can disagree, and step 9 wins.
+
+---
+
+### 0. Discover
+
+```bash
+curl -sS $BASE/api/agent/manifest
+```
+
+```json
+{
+  "name": "Archimedes",
+  "blurb": "…",
+  "docs": { "llms_txt": "/llms.txt", "agent_api": "…", "quickstart": "…", "agent_card": "/.well-known/agent.json" },
+  "erc8004": { "chain": "eip155:5042002", "identityRegistry": "0x8004…BD9e", "agentId": null, "tokenURI": null, "status": "registration_pending", "…": "…" },
+  "auth": { "scheme": "Better Auth session", "methods": ["emailPassword", "google", "github"], "wallet_link_providers": ["metamask", "browser", "circle", "headless"], "chain_id": 5042002, "…": "…" },
+  "endpoints": { "read": { "status": "live", "auth_required": false, "routes": { "…": "…" } }, "…": "…" },
+  "faucet": { "url": "https://faucet.circle.com/", "description": "…" }
+}
+```
+
+`auth_required` is a **per-group** flag. `erc8004.status` is `registration_pending`: the
+ERC-8004 registration file is published, and **no registration exists on-chain** — do not
+treat this agent as a registered, reputed, or validated ERC-8004 counterparty.
+
+### 1. Price the run
+
+```bash
+curl -sS $BASE/api/generate/quote
+```
+
+```json
+{
+  "payment_required": false,
+  "pricing_model": "flat_v1",
+  "price": "$0.150000",
+  "asset": "USDC",
+  "chain": "…",
+  "recipient": null,
+  "dry_run": true,
+  "how": "POST /api/generate/start without a Payment-Signature header returns 402 with these requirements in the PAYMENT-REQUIRED header; sign them (x402 / Circle Gateway) and retry with Payment-Signature."
+}
+```
+
+Public on purpose: price the run before you hold a session. **`payment_required` is the
+runtime truth** — when it is `false`, step 6 needs no wallet and no payment. When it is
+`true`, step 6 additionally requires a linked, funded wallet (`409
+wallet_link_required` first, then `402`) — that path is
+[`agent-api.md`](agent-api.md#optional-eip-4361-wallet-link), not this page.
+
+### 2. Create an account
+
+```bash
+curl -sS -X POST $BASE/api/auth/sign-up/email \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Boardy","email":"boardy@example.test","password":"correct horse battery staple"}'
+```
+
+```json
+{ "token": null, "user": { "id": "…", "email": "boardy@example.test", "name": "Boardy", "emailVerified": false, "image": null } }
+```
+
+HTTP 200 and **no `Set-Cookie`** — `autoSignIn` is off, so registration alone does not
+start a session. Password must be 12–128 characters. A verification email is always sent;
+sign-in is *not* blocked on it unless `EMAIL_VERIFICATION_ENFORCED=true` (it is `false` in
+production today).
+
+### 3. Sign in — this is the step that gives you the cookie
+
+```bash
+curl -sS -c /tmp/agora.jar -X POST $BASE/api/auth/sign-in/email \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"boardy@example.test","password":"correct horse battery staple"}'
+```
+
+```json
+{ "redirect": false, "token": "…", "url": null, "user": { "id": "…", "email": "…", "…": "…" } }
+```
+
+Sets `better-auth.session_token` (HttpOnly, `SameSite=Lax`, 7-day expiry). **Keep the jar
+for every remaining step.** The `token` in the body is not a bearer credential for this
+API — the cookie is what `require_current_user` reads.
+
+### 4. Confirm the session
+
+```bash
+curl -sS -b /tmp/agora.jar $BASE/api/auth/get-session
+```
+
+```json
+{ "session": { "id": "…", "token": "…", "expiresAt": "…" }, "user": { "id": "…", "email": "…", "emailVerified": false } }
+```
+
+A bare `null` (still HTTP 200) means not authenticated — that is the signal, not an error.
+If you see `null` here, every cookie-gated step below will 401; fix it now.
+
+### 5. Check your quota before spending a generation
+
+```bash
+curl -sS -b /tmp/agora.jar $BASE/api/account/usage
+```
+
+```json
+{
+  "date": "2026-08-30",
+  "user_id": "…",
+  "user": { "used": 0, "cap": 10, "unlimited": false, "remaining": 10, "error": null },
+  "ip":   { "used": 0, "cap": 25, "unlimited": false, "remaining": 25, "error": null },
+  "quote": { "payment_required": false, "…": "the same object step 1 returned" }
+}
+```
+
+Both caps must pass. `used: null` with `error: "quota_backend_unavailable"` is an honest
+"we could not read the counter", never a fabricated `0`. Reading this is a peek — it never
+increments anything.
+
+### 6. Submit the brief
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/generate/start \
+  -H 'Content-Type: application/json' \
+  -d '{"brief":{"intent":"diversified low-volatility strategy for idle USDC","risk_appetite":"moderate","max_papers":5},"n_candidates":1}'
+```
+
+HTTP **202**:
+
+```json
+{ "job_id": "…", "stream_url": "/api/generate/stream/…", "ttl_seconds": 3600 }
+```
+
+Field bounds, enforced (violating any of them is a 422 — see the error table):
+`risk_appetite` ∈ `fixed_income | conservative | moderate | aggressive | hyper_risky`;
+`max_papers` ∈ [2, 6]; `n_candidates` ∈ [1, 5]; optional `brief.name` ≤ 80 chars, no
+control characters. `model` is optional and defaults to the server's free model — naming a
+premium model without an entitlement is a **402**, and the request is refused rather than
+silently downgraded.
+
+### 7. Watch it run (SSE)
+
+```bash
+curl -sS -N -b /tmp/agora.jar $BASE/api/generate/stream/$JOB_ID
+```
+
+Frames are `id:` / `event:` / `data:` triples, one JSON object per `data:` line:
+
+```
+id: 3
+event: candidate_evaluated
+data: {"…": "event-specific payload"}
+```
+
+Event names, in rough order: `job_queued → brief_validated → pipeline_selected →
+candidates_selected → agent_iteration → tool_called → tool_result → candidate_drafted →
+candidate_evaluated → best_selected → trace_hashed → persisted → done` — or `error`, whose
+`data` carries `message` / `code` / `recoverable`.
+
+### 7b. …or poll, if you never opened the stream
+
+```bash
+curl -sS -b /tmp/agora.jar $BASE/api/generate/jobs/$JOB_ID
+```
+
+```json
+{
+  "job_id": "…",
+  "state": "running",
+  "brief_intent": "diversified low-volatility strategy for idle USDC",
+  "created_at": "2026-08-30T12:00:00+00:00",
+  "updated_at": "2026-08-30T12:00:31+00:00",
+  "n_candidates": 1,
+  "best_strategy_id": null,
+  "cost": null
+}
+```
+
+`state` ∈ `queued | running | stalled | done | error | cancelled`. **Move on when `state ==
+"done"` and `best_strategy_id` is non-null.** `stalled` is derived at read time (a
+`running` job whose heartbeat is >5 min old), never stored. `error` and `cancelled` are
+terminal. A job that is not yours returns **404**, not 403 — existence is private.
+
+### 8. Read the verdict and the considered alternatives
+
+```bash
+curl -sS -b /tmp/agora.jar $BASE/api/generate/jobs/$JOB_ID/candidates
+```
+
+```json
+{
+  "job_id": "…",
+  "best_candidate_id": "…",
+  "candidates": [
+    {
+      "candidate_id": "…",
+      "strategy_id": "…",
+      "strategy_name": "…",
+      "rigor_verdict": { "…": "DSR / PBO / walk-forward / look-ahead fields" },
+      "passes_rigor": true,
+      "selected": true,
+      "regime": "neutral",
+      "generation_method": "debate"
+    }
+  ]
+}
+```
+
+One winner (`selected: true`) plus the alternatives that were considered and rejected.
+Take `strategy_id` from the `selected` candidate.
+
+### 9. Read the authoritative gate — the same verdict a human sees
+
+```bash
+curl -sS $BASE/api/strategies/$STRATEGY_ID
+```
+
+```json
+{
+  "id": "…",
+  "rigor_gate_status": "pass",
+  "passes_rigor_gate": true,
+  "sharpe_ratio": 0.91,
+  "deflated_sharpe_ratio": 0.62,
+  "dsr_p_value": 0.03,
+  "out_of_sample_sharpe": 0.44,
+  "pbo_score": 0.31,
+  "methodology_summary": "…",
+  "asset_universe": ["…"],
+  "papers": [ { "…": "…" } ],
+  "…": "…"
+}
+```
+
+Public read (no cookie needed) — a private strategy 404s rather than 401s. `rigor_gate_status`
+is four-state and each state means something different:
+
+| `rigor_gate_status` | What it means | Deployable |
+|---|---|---|
+| `pass` | Real persisted returns exist; the live gate passed | yes |
+| `fail` | Real returns exist; the gate failed ≥1 criterion | no — and that is the honest outcome |
+| `pending` | No real persisted returns yet; the gate could not run | no |
+| `degenerate` | Real returns exist but are a zero-variance series (broken data or a zero-trade backtest) | no |
+
+`passes_rigor_gate` is `true` only when the status is `pass`. **Never treat `pending` or
+`fail` as a soft yes.** Paper trading (step 10) is simulated and does not enforce this
+gate — a real on-chain vault does, server-side, before spending any gas.
+
+### 10. Paper-deploy — simulated, free, no chain, no funds
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/paper/deployments \
+  -H 'Content-Type: application/json' \
+  -d "{\"strategy_id\":\"$STRATEGY_ID\"}"
+```
+
+HTTP **201**:
+
+```json
+{
+  "deployment_id": "…",
+  "strategy_id": "…",
+  "deployed_at": "2026-08-30",
+  "status": "active",
+  "days": 0,
+  "total_return": 0.0,
+  "drift_detected_at": null,
+  "series": []
+}
+```
+
+`series` starts empty and fills one row per day — `{"date", "daily_return",
+"equity_index"}` — appended by the scheduler, never rewritten. `days: 0` on the first read
+is normal, not a failure.
+
+### 11. Read the ledger back (and stop it when you are done)
+
+```bash
+curl -sS -b /tmp/agora.jar $BASE/api/paper/deployments/$DEPLOYMENT_ID
+```
+
+Same shape as step 10, with `series` grown and `total_return` moved. A deployment that is
+not yours returns **404**. Stop it explicitly with `POST /api/paper/deployments/{deployment_id}/stop`
+— an abandoned deployment keeps accruing:
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/paper/deployments/$DEPLOYMENT_ID/stop
+```
+
+```json
+{ "deployment_id": "…", "status": "stopped" }
+```
+
+You are done. A strategy was generated from research, graded by a gate that is allowed to
+say no, and is now running in a ledger you can read. Nothing above touched a wallet.
+
+---
+
+## Error table
+
+Every row below is a body this journey can actually produce. Note the two shapes of
+`detail`: FastAPI errors raised by this API use a **string or an object**, while *request
+validation* failures use a **list**.
+
+**Authentication is checked before the body is validated.** An unauthenticated request
+with a malformed body returns `401`, not `422` — so a 401 can be hiding a second problem
+you will only see after step 3 succeeds. Fix the session first, then re-read the error.
+
+| Status | Body | What happened | Fix |
+|---|---|---|---|
+| **401** | `{"detail": "Authentication required"}` + `WWW-Authenticate: Session` | No valid session cookie on a cookie-gated route | Redo steps 3–4. Signing up (step 2) does **not** sign you in; only step 3 sets the cookie. Check the jar is passed with `-b`. |
+| **402** | `{"detail": {"reason": "payment_required", "message": "…", "quote": {…}}}` + `PAYMENT-REQUIRED` header | The generation paywall is on and no `Payment-Signature` was presented | Sign the x402 requirements in the header with your **linked** wallet and retry with `Payment-Signature`. Check `GET /api/generate/quote` → `payment_required` first; when it is `false` this cannot happen. |
+| **402** | `{"detail": "Model '…' is a premium (Anthropic) model and requires an entitlement. …"}` | You named a premium `model` without entitlement | Omit `model` (the free default is used) or name an allowlisted free model. The request is **not** silently downgraded. |
+| **422** | `{"detail": [{"type": "…", "loc": ["body", "brief", "max_papers"], "msg": "…", "input": …}]}` | Request body failed validation | Read `loc` — it names the exact field. Common causes: `max_papers` outside [2, 6], `n_candidates` outside [1, 5], an unknown `risk_appetite`. |
+| **422** | `{"detail": "strategy_id is required"}` | `POST /api/paper/deployments` with an empty or missing `strategy_id` | Send `{"strategy_id": "<id from step 8>"}`. |
+| **422** | `{"detail": {"reason": "no_strategy_spec", "message": "This strategy has no machine-readable spec to paper-trade."}}` | The strategy exists but carries no executable spec | Pick a different candidate from step 8. Not every generated row is paper-tradeable. |
+| **422** | `{"detail": {"reason": "invalid_strategy_spec", "message": "Stored spec fails validation: …"}}` | The stored spec failed DSL validation at deploy time | Not caller-fixable — pick another candidate and report the `strategy_id`. |
+| **429** | `{"detail": {"reason": "generation_daily_cap", "scope": "user", "cap": 10, "message": "…"}}` | Daily generation cap hit, per account (`scope: "user"`) or per IP (`scope: "ip"`) | Wait for the daily reset. Call step 5 **before** step 6 to see this coming; the caps it reports are the caps enforced. |
+| **429** | `{"detail": {"reason": "generation_queue_full", "message": "… No payment was taken. …"}}` | The generation wait queue is full | Retry in a few minutes. No payment was taken — admission control runs before the paywall. |
+| **429** | `{"detail": "Rate limit exceeded. Please slow down and try again later."}` + `X-RateLimit-*` | Per-route request-rate limit (`/api/generate/start` 5/min, `/api/paper/deployments` 10/min) | Back off. This is requests-per-minute, distinct from the daily cap above — same status, different `detail` shape, different fix. |
+| **409** | `{"detail": {"reason": "wallet_link_required", "message": "…"}}` | Payment is required but your account has no linked wallet | Link one via `POST /api/wallets/challenge` → `/api/wallets/verify` ([`agent-api.md`](agent-api.md#optional-eip-4361-wallet-link)). Funding the wallet currently needs a human at the faucet. |
+| **404** | `{"detail": "Strategy not found"}` / `{"detail": "Paper deployment not found"}` | Missing **or** not yours — the two are deliberately indistinguishable | Confirm the id came from a call made with this same session. Existence is private; a 404 here is not proof the id is wrong. |
+| **503** | `{"detail": {"reason": "payment_config_missing", "message": "…"}}` | Payments are enabled but not fully configured server-side | Not caller-fixable. Retry later; it fails closed rather than letting the request through free. |
+
+---
+
+## Anti-goals for an agent driving this API
+
+- **Do not treat a `pending` or `fail` rigor gate as a pass.** A gate that never says no is
+  not a gate; this one says no, on real strategies, on purpose.
+- **Do not confuse the two verdicts.** Step 8's is generation-time; step 9's is the live
+  gate the server enforces. Cite step 9.
+- **Do not assume a paper deployment is an on-chain position.** It is simulated: no chain,
+  no funds, no gas. The real vault is `POST /api/vaults/create`, needs a linked wallet, and
+  is documented in [`agent-api.md`](agent-api.md#deploy--create-a-vault-from-the-generated-strategy).
+- **Do not read `erc8004` as an identity claim.** `status: registration_pending` means no
+  `register()` transaction exists. See
+  [`ui/public/.well-known/agent-registration.json`](../ui/public/.well-known/agent-registration.json)
+  and [`scripts/register_erc8004_identity.py`](../scripts/register_erc8004_identity.py).
+
+## Where this page's claims come from
+
+Every route string here is asserted against the running app's route table by
+`backend/tests/test_agent_quickstart_drift.py` — a documented endpoint that 404s is worse
+than an undocumented one, so the drift fails CI instead of an agent's retry loop. The
+response shapes were read off the routes that build them:
+`api/generate_routes.py`, `api/paper_routes.py`, `api/strategies_routes.py`,
+`api/account_usage_routes.py`, `api/account_auth.py`,
+`services/generation_payment.py`, `services/generation_quota.py`, and the Better Auth
+sidecar contract in [`api/auth-and-accounts.md`](api/auth-and-accounts.md).

--- a/scripts/register_erc8004_identity.py
+++ b/scripts/register_erc8004_identity.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Plan (and, for the owner only, execute) the ERC-8004 identity registration on Arc (#1527).
+
+WHAT THIS DOES
+    Builds the ``register(string agentURI)`` call against the ERC-8004 IdentityRegistry
+    named in ``ui/public/.well-known/agent.json``. ``--plan`` (the default) is READ-ONLY:
+    it prints the calldata, decodes it back, checks the registry and chain over JSON-RPC,
+    and estimates gas. Nothing is signed and nothing is sent.
+
+WHAT THIS DOES NOT DO
+    It does not make Archimedes an ERC-8004 agent. Registration mints an ERC-721 to the
+    sender, so it needs the OWNER's key — which this repo does not have and must not have.
+    Until a human runs ``--execute`` and a ``Registered`` event exists, every discovery
+    surface keeps saying ``status: registration_pending`` and that is the truth.
+
+THE STANDARD (https://eips.ethereum.org/EIPS/eip-8004)
+    struct MetadataEntry { string metadataKey; bytes metadataValue; }
+    function register(string agentURI, MetadataEntry[] calldata metadata) returns (uint256 agentId)
+    function register(string agentURI)                                    returns (uint256 agentId)
+    function register()                                                   returns (uint256 agentId)
+    event    Registered(uint256 indexed agentId, string agentURI, address indexed owner)
+
+    ``agentURI`` must resolve to the agent registration file. Ours is published at
+    ``ui/public/.well-known/agent-registration.json`` and typed
+    ``https://eips.ethereum.org/EIPS/eip-8004#registration-v1``. Because the endpoint
+    domain serves it, it doubles as the EIP's optional domain-control proof.
+
+NO RESTATED CONSTANTS
+    The registry address, chain and agentURI are READ from the shipped agent card, which
+    is the same block ``GET /api/agent/manifest`` serves. A value changed in one place and
+    not the other fails ``backend/tests/test_erc8004_identity.py``, not here at 3am.
+
+USAGE
+    # read-only: calldata + registry/chain checks + gas estimate
+    python scripts/register_erc8004_identity.py --plan
+    python scripts/register_erc8004_identity.py --plan --from 0xOwner...
+    python scripts/register_erc8004_identity.py --plan --offline      # no RPC at all
+
+    # owner only — NOT run by CI, agents, or the backend:
+    OWNER_PRIVATE_KEY=0x... python scripts/register_erc8004_identity.py --execute
+    python scripts/register_erc8004_identity.py --execute \
+        --circle-wallet-id <id> --circle-entity-secret-ciphertext <ct>   # CIRCLE_API_KEY in env
+
+AFTER A SUCCESSFUL --execute
+    The script prints the minted agentId and the exact JSON edits to land in the same
+    commit as the transaction hash: the ``registrations`` entry for both registration
+    files, and ``_ERC8004_AGENT_ID`` / ``_ERC8004_TOKEN_URI`` in
+    ``backend/archimedes/api/agent_manifest_routes.py``. Only then may any surface say
+    "registered" — the tests enforce that ordering.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+from eth_abi import decode as abi_decode
+from eth_abi import encode as abi_encode
+from eth_utils import keccak
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENT_CARD = REPO_ROOT / "ui" / "public" / ".well-known" / "agent.json"
+REGISTRATION_FILE = REPO_ROOT / "ui" / "public" / ".well-known" / "agent-registration.json"
+
+# ERC-8004 IdentityRegistry, from the EIP's interface. Kept as signature strings and
+# hashed at runtime rather than pasted selectors, so a typo cannot silently produce
+# well-formed calldata for a function that does not exist.
+REGISTER_STRING_SIG = "register(string)"
+REGISTERED_EVENT_SIG = "Registered(uint256,string,address)"
+
+DEFAULT_RPC = "https://rpc.testnet.arc.network"
+CIRCLE_API_BASE = "https://api.circle.com/v1/w3s"
+
+# Gas headroom over the estimate. An ERC-721 mint plus a string SSTORE is not variable
+# enough to justify more, and a fat multiplier on a chain where USDC IS gas is real money.
+GAS_MULTIPLIER = 1.25
+
+
+def selector(signature: str) -> bytes:
+    return keccak(text=signature)[:4]
+
+
+def topic(signature: str) -> str:
+    return "0x" + keccak(text=signature).hex()
+
+
+# ── inputs, read from the shipped discovery surface ───────────────────────────────────
+
+
+def load_identity_block() -> dict:
+    """The ``erc8004`` block from the static agent card — the SSOT for this script."""
+    if not AGENT_CARD.exists():
+        raise SystemExit(f"✗ agent card not found: {AGENT_CARD}")
+    card = json.loads(AGENT_CARD.read_text(encoding="utf-8"))
+    block = card.get("erc8004")
+    if not isinstance(block, dict):
+        raise SystemExit(f"✗ {AGENT_CARD} has no erc8004 block — nothing to register against.")
+    for key in ("chain", "identityRegistry", "registrationUri", "status"):
+        if not block.get(key):
+            raise SystemExit(f"✗ erc8004 block is missing {key!r}.")
+    return block
+
+
+def chain_id_from_caip2(chain: str) -> int:
+    """``eip155:5042002`` → ``5042002``. Anything else is refused, not guessed."""
+    namespace, _, reference = chain.partition(":")
+    if namespace != "eip155" or not reference.isdigit():
+        raise SystemExit(f"✗ erc8004.chain must be an eip155 CAIP-2 id, got {chain!r}.")
+    return int(reference)
+
+
+def already_registered(block: dict) -> bool:
+    return block.get("agentId") is not None
+
+
+# ── calldata ──────────────────────────────────────────────────────────────────────────
+
+
+def build_register_calldata(agent_uri: str) -> bytes:
+    """ABI-encoded ``register(string agentURI)``.
+
+    The no-metadata overload on purpose: every field an ERC-8004 consumer needs is in
+    the registration file the URI resolves to, so on-chain MetadataEntry rows would be a
+    second copy of the same facts with its own way to go stale.
+    """
+    return selector(REGISTER_STRING_SIG) + abi_encode(["string"], [agent_uri])
+
+
+def decode_register_calldata(calldata: bytes) -> str:
+    """Decode our own calldata back. A plan you cannot read back is not a plan."""
+    if calldata[:4] != selector(REGISTER_STRING_SIG):
+        raise ValueError("calldata does not start with the register(string) selector")
+    (agent_uri,) = abi_decode(["string"], calldata[4:])
+    return agent_uri
+
+
+# ── JSON-RPC (read-only helpers) ──────────────────────────────────────────────────────
+
+
+def rpc(client: httpx.Client, url: str, method: str, params: list) -> object:
+    resp = client.post(url, json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+    resp.raise_for_status()
+    body = resp.json()
+    if "error" in body:
+        raise RuntimeError(f"{method} → {body['error']}")
+    return body.get("result")
+
+
+def owner_address_from_env() -> str | None:
+    """Address for ``OWNER_PRIVATE_KEY`` if it is set — the key itself is never printed."""
+    key = os.environ.get("OWNER_PRIVATE_KEY", "").strip()
+    if not key:
+        return None
+    from eth_account import Account
+
+    try:
+        return Account.from_key(key).address
+    except (ValueError, TypeError):
+        raise SystemExit("✗ OWNER_PRIVATE_KEY is not a valid private key.") from None
+
+
+def preflight(client: httpx.Client, rpc_url: str, registry: str, want_chain_id: int) -> list[str]:
+    """Chain-id and code-at-address checks. Returns human problem lines (empty = clean).
+
+    Both are read-only and both are worth a round-trip: registering against an address
+    with no code, or on the wrong chain, burns real gas to accomplish nothing.
+    """
+    problems: list[str] = []
+    chain_id = int(str(rpc(client, rpc_url, "eth_chainId", [])), 16)
+    print(f"  rpc chain id:      {chain_id}")
+    if chain_id != want_chain_id:
+        problems.append(f"RPC reports chain {chain_id}, the agent card says {want_chain_id}")
+
+    code = str(rpc(client, rpc_url, "eth_getCode", [registry, "latest"]) or "0x")
+    size = max(len(code) - 2, 0) // 2
+    print(f"  registry bytecode: {size} bytes")
+    if size == 0:
+        problems.append(
+            f"no contract code at {registry} on chain {chain_id} — the IdentityRegistry is "
+            "either not deployed here or the address is wrong; registering would send USDC "
+            "gas to an EOA and mint nothing"
+        )
+    return problems
+
+
+def estimate_gas(client: httpx.Client, rpc_url: str, sender: str, registry: str, calldata: bytes) -> int:
+    return int(
+        str(rpc(client, rpc_url, "eth_estimateGas", [{"from": sender, "to": registry, "data": "0x" + calldata.hex()}])),
+        16,
+    )
+
+
+# ── plan ──────────────────────────────────────────────────────────────────────────────
+
+
+def plan(args: argparse.Namespace) -> int:
+    block = load_identity_block()
+    registry = block["identityRegistry"]
+    chain_id = chain_id_from_caip2(block["chain"])
+    agent_uri = args.agent_uri or block["registrationUri"]
+    calldata = build_register_calldata(agent_uri)
+
+    print("ERC-8004 identity registration — PLAN (read-only, nothing signed, nothing sent)")
+    print(f"  status now:        {block['status']}  (agentId={block['agentId']!r}, tokenURI={block['tokenURI']!r})")
+    print(f"  chain:             {block['chain']}  (chain id {chain_id})")
+    print(f"  identityRegistry:  {registry}")
+    print(f"  function:          {REGISTER_STRING_SIG}   selector 0x{selector(REGISTER_STRING_SIG).hex()}")
+    print(f"  agentURI:          {agent_uri}")
+    print(f"  calldata:          0x{calldata.hex()}")
+    print(f"  decodes back to:   {decode_register_calldata(calldata)!r}")
+
+    if not REGISTRATION_FILE.exists():
+        print(f"  ! registration file missing at {REGISTRATION_FILE} — agentURI would resolve to nothing.")
+    else:
+        doc = json.loads(REGISTRATION_FILE.read_text(encoding="utf-8"))
+        print(f"  registration file: {REGISTRATION_FILE.relative_to(REPO_ROOT)}  type={doc.get('type')!r}")
+
+    if already_registered(block):
+        print(
+            f"  ! the agent card already carries agentId {block['agentId']} — registering again mints a SECOND identity."
+        )
+
+    if args.offline:
+        print("  gas estimate:      skipped (--offline)")
+        return 0
+
+    sender = args.sender or owner_address_from_env()
+    problems: list[str] = []
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            print(f"  rpc:               {args.rpc}")
+            problems = preflight(client, args.rpc, registry, chain_id)
+            if sender is None:
+                print("  gas estimate:      unavailable — no sender (pass --from 0x..., or set OWNER_PRIVATE_KEY)")
+            elif problems:
+                print(f"  gas estimate:      not attempted — preflight failed (sender would be {sender})")
+            else:
+                gas = estimate_gas(client, args.rpc, sender, registry, calldata)
+                gas_price = int(str(rpc(client, args.rpc, "eth_gasPrice", [])), 16)
+                # USDC is the native gas token on Arc, 18-decimal at the RPC level.
+                cost = gas * gas_price / 10**18
+                print(f"  sender:            {sender}")
+                print(f"  gas estimate:      {gas}  @ gasPrice {gas_price}  ≈ {cost:.6f} USDC")
+    except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        # An unreachable or unhealthy RPC is a real, reportable condition — it must not
+        # masquerade as a clean plan.
+        print(f"  ! RPC checks could not complete: {exc}")
+        print("  ! calldata above is still correct — it is built locally — but the registry, chain")
+        print("    and gas were NOT verified. Re-run with a reachable --rpc before executing.")
+        return 1
+
+    for problem in problems:
+        print(f"  ✗ {problem}")
+    if problems:
+        print("Plan is NOT safe to execute. Fix the above first.")
+        return 1
+    print("Plan looks consistent. Execution is a separate, owner-only act: --execute")
+    return 0
+
+
+# ── execute (owner only) ──────────────────────────────────────────────────────────────
+
+
+def execute_with_private_key(args: argparse.Namespace, registry: str, chain_id: int, calldata: bytes) -> int:
+    from eth_account import Account
+
+    acct = Account.from_key(os.environ["OWNER_PRIVATE_KEY"].strip())
+    with httpx.Client(timeout=60.0) as client:
+        problems = preflight(client, args.rpc, registry, chain_id)
+        for problem in problems:
+            print(f"✗ {problem}")
+        if problems:
+            return 2
+        gas = estimate_gas(client, args.rpc, acct.address, registry, calldata)
+        gas_price = int(str(rpc(client, args.rpc, "eth_gasPrice", [])), 16)
+        nonce = int(str(rpc(client, args.rpc, "eth_getTransactionCount", [acct.address, "pending"])), 16)
+        tx = {
+            "to": registry,
+            "value": 0,
+            "data": "0x" + calldata.hex(),
+            "gas": int(gas * GAS_MULTIPLIER),
+            "gasPrice": gas_price,
+            "nonce": nonce,
+            "chainId": chain_id,
+        }
+        print(f"sending register() from {acct.address} (gas {tx['gas']}, nonce {nonce})…")
+        signed = acct.sign_transaction(tx)
+        tx_hash = str(rpc(client, args.rpc, "eth_sendRawTransaction", ["0x" + signed.raw_transaction.hex()]))
+        print(f"tx: {tx_hash}")
+        print("Poll eth_getTransactionReceipt for the Registered log; then run --print-followup with the agentId.")
+    return 0
+
+
+def execute_with_circle(args: argparse.Namespace, registry: str, calldata: bytes) -> int:
+    """Circle dev-controlled wallet path — the same contract-execution API the marketplace uses."""
+    api_key = os.environ.get("CIRCLE_API_KEY", "").strip()
+    if not api_key:
+        print("✗ CIRCLE_API_KEY is not set.")
+        return 2
+    if not args.circle_entity_secret_ciphertext:
+        print("✗ --circle-entity-secret-ciphertext is required for the Circle path.")
+        return 2
+    body = {
+        "walletId": args.circle_wallet_id,
+        "contractAddress": registry,
+        "callData": "0x" + calldata.hex(),
+        "entitySecretCiphertext": args.circle_entity_secret_ciphertext,
+        "idempotencyKey": args.idempotency_key,
+        "feeLevel": "MEDIUM",
+    }
+    with httpx.Client(timeout=60.0) as client:
+        resp = client.post(
+            f"{CIRCLE_API_BASE}/developer/transactions/contractExecution",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json=body,
+        )
+    # Print the raw response either way: a 4xx naming the offending field is the useful
+    # output here, not an exception trace that hides it.
+    print(f"Circle API {resp.status_code}: {resp.text}")
+    return 0 if resp.is_success else 2
+
+
+def execute(args: argparse.Namespace) -> int:
+    block = load_identity_block()
+    registry = block["identityRegistry"]
+    chain_id = chain_id_from_caip2(block["chain"])
+    agent_uri = args.agent_uri or block["registrationUri"]
+    calldata = build_register_calldata(agent_uri)
+
+    if already_registered(block) and not args.allow_second_identity:
+        print(f"✗ agent card already carries agentId {block['agentId']} — refusing to mint a second")
+        print("  identity. Pass --allow-second-identity only if that is genuinely what you want.")
+        return 2
+
+    have_key = bool(os.environ.get("OWNER_PRIVATE_KEY", "").strip())
+    have_circle = bool(args.circle_wallet_id)
+    if have_key == have_circle:
+        print("✗ --execute needs exactly ONE owner credential:")
+        print("    OWNER_PRIVATE_KEY=0x…                      (env var, never a CLI argument)")
+        print("    --circle-wallet-id <id> --circle-entity-secret-ciphertext <ct>   (CIRCLE_API_KEY in env)")
+        print("  Both present, or neither, is ambiguous about who signs — refusing.")
+        return 2
+
+    print(f"EXECUTE: {REGISTER_STRING_SIG} → {registry} on chain {chain_id}")
+    print(f"  agentURI: {agent_uri}")
+    if have_key:
+        return execute_with_private_key(args, registry, chain_id, calldata)
+    return execute_with_circle(args, registry, calldata)
+
+
+# ── follow-up ─────────────────────────────────────────────────────────────────────────
+
+
+def print_followup(agent_id: int) -> int:
+    """The exact edits that turn a real receipt into an honest 'registered' claim."""
+    block = load_identity_block()
+    entry = {"agentId": agent_id, "agentRegistry": f"{block['chain']}:{block['identityRegistry']}"}
+    print("Land these in ONE commit, with the transaction hash in the message:")
+    print()
+    print("1. ui/public/.well-known/agent-registration.json AND agent-registration.domain.json —")
+    print('   replace "registrations": [] with:')
+    print("   " + json.dumps([entry], indent=2).replace("\n", "\n   "))
+    print()
+    print("2. backend/archimedes/api/agent_manifest_routes.py —")
+    print(f"   _ERC8004_AGENT_ID = {agent_id}")
+    print(f"   _ERC8004_TOKEN_URI = {block['registrationUri']!r}")
+    print()
+    print("3. ui/public/.well-known/agent.json — regenerate the erc8004 block from")
+    print("   erc8004_identity() so the card and the served manifest stay identical.")
+    print()
+    print(f"   Registered event topic0: {topic(REGISTERED_EVENT_SIG)}")
+    print("   backend/tests/test_erc8004_identity.py enforces that all of these move together.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--plan", action="store_true", help="read-only: calldata, registry/chain checks, gas (default)")
+    mode.add_argument("--execute", action="store_true", help="OWNER ONLY: sign and send register()")
+    mode.add_argument("--print-followup", type=int, metavar="AGENT_ID", help="print the post-registration edits")
+    ap.add_argument("--rpc", default=os.environ.get("RPC") or os.environ.get("ARC_ARC_RPC_URL") or DEFAULT_RPC)
+    ap.add_argument("--from", dest="sender", default=None, help="address to estimate gas from (plan only)")
+    ap.add_argument(
+        "--agent-uri", default=None, help="override the agentURI (default: the agent card's registrationUri)"
+    )
+    ap.add_argument("--offline", action="store_true", help="plan only: build calldata, make no RPC calls")
+    ap.add_argument("--circle-wallet-id", default=None)
+    ap.add_argument("--circle-entity-secret-ciphertext", default=None)
+    ap.add_argument("--idempotency-key", default=None)
+    ap.add_argument(
+        "--allow-second-identity", action="store_true", help="permit --execute when an agentId already exists"
+    )
+    args = ap.parse_args()
+
+    if args.print_followup is not None:
+        return print_followup(args.print_followup)
+    if args.execute:
+        return execute(args)
+    return plan(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ui/public/.well-known/agent-registration.domain.json
+++ b/ui/public/.well-known/agent-registration.domain.json
@@ -1,0 +1,18 @@
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "registrations": [],
+  "erc8004": {
+    "chain": "eip155:5042002",
+    "identityRegistry": "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    "agentId": null,
+    "tokenURI": null,
+    "status": "registration_pending",
+    "registrationUri": "https://archimedes-arc.com/.well-known/agent-registration.json",
+    "note": "Not registered on-chain: no register() transaction has been sent, so agentId and tokenURI are null and NO ERC-8004 identity, reputation, or validation claim is made. Publishing a spec-typed registration file at registrationUri is not the same as being registered. Plan the call with scripts/register_erc8004_identity.py --plan."
+  },
+  "_note": {
+    "whatThisIs": "The DOMAIN-OWNERSHIP variant. ERC-8004: 'an agent MAY optionally prove control of an HTTPS endpoint-domain by publishing https://{endpoint-domain}/.well-known/agent-registration.json containing at least a registrations list.' That is the whole file — a registrations list and nothing that needs restating from the primary registration file.",
+    "whyItIsNotAtTheSpecPath": "On archimedes-arc.com the spec path is already taken by the FULL registration file (agent-registration.json beside this one), which the EIP says makes the separate proof unnecessary for this host: 'This validation step is unnecessary if the endpoint domain serves the agent's primary registration file.' This copy exists so a SECOND endpoint-domain — a separate API host, a mirror, a partner-served endpoint — can be proven by dropping it at that host's /.well-known/agent-registration.json unchanged.",
+    "registrations": "EMPTY ON PURPOSE, for the same reason as the primary file: no register() transaction has been sent, so there is no agentId to list. Publishing this file at another domain TODAY proves nothing, because there is no on-chain agent for a verifier to match it against — it becomes a proof only once registrations carries a real minted id."
+  }
+}

--- a/ui/public/.well-known/agent-registration.json
+++ b/ui/public/.well-known/agent-registration.json
@@ -25,7 +25,7 @@
       "endpoint": "https://github.com/a-apin/archimedes/blob/main/docs/agent-quickstart.md"
     }
   ],
-  "x402Support": false,
+  "x402Support": true,
   "active": true,
   "registrations": [],
   "supportedTrust": [],
@@ -41,7 +41,7 @@
   "_note": {
     "registrations": "EMPTY ON PURPOSE. ERC-8004 requires each entry to carry the agentId minted by the registry; no register() transaction has been sent for this agent, so there is no id to carry and an entry here would be a fabricated on-chain claim. scripts/register_erc8004_identity.py --plan prints the exact entry to add once a real Registered(agentId, agentURI, owner) event exists.",
     "supportedTrust": "EMPTY ON PURPOSE. This agent claims no reputation, crypto-economic, or TEE-attestation trust model. Its verifiable claim is narrower and lives off this standard: every strategy carries a rigor verdict (DSR / PBO / walk-forward OOS / look-ahead) that GET /api/strategies/{strategy_id} returns as pass, fail, pending, or degenerate — and that fails honestly. See docs/rigor-methods.md.",
-    "x402Support": "false is the conservative claim, not an assertion that no paywall exists. POST /api/generate/start does implement an x402 / Circle Gateway paywall (402 + PAYMENT-REQUIRED header), but it is deploy-flag gated (GENERATION_PAYMENT_REQUIRED) and settlement is separately gated by PAYMENTS_DRY_RUN, which defaults on — so no x402 payment is guaranteed to settle. The runtime truth is public: GET /api/generate/quote returns payment_required.",
+    "x402Support": "TRUE, and read off the runtime rather than off the code. GET /api/generate/quote is the authority and is public: on the deployment that serves this file (https://archimedes-arc.com) it answers payment_required: true, dry_run: false, price \"$2.000000\", asset USDC, chain arcTestnet, recipient 0xffa7abba5f17cb8471ebf150bf808bd6fb8856c1 (read 2026-08-30). So POST /api/generate/start really charges: no Payment-Signature header returns 402 with the x402 requirements in the PAYMENT-REQUIRED header, the caller signs them (x402 / Circle Gateway) and retries, and the settlement is real — not simulated. Two things this flag does NOT say. (1) It is not the code default: GENERATION_PAYMENT_REQUIRED is off unless a deploy sets it and PAYMENTS_DRY_RUN defaults on, so a local checkout of this repo is free while this deployment is not — this file describes the deployment serving it, and a consumer should re-read the quote against whatever host it is actually calling. (2) It covers the GENERATION paywall only, which is the rail that quote reports; marketplace subscription settlement rides a separate switch (GENERATION_PAYMENTS_DRY_RUN was split from PAYMENTS_DRY_RUN for exactly this reason) and nothing here asserts its state.",
     "active": "Describes the SERVICE — the endpoints above are live and serving. It says nothing about a registration, which has not happened.",
     "domainOwnership": "This file is served from https://archimedes-arc.com, which is also the endpoint-domain of every service listed above, so it doubles as the EIP's optional domain-control proof for that host. agent-registration.domain.json beside it is the minimal variant to publish at any OTHER endpoint-domain this agent is served from."
   }

--- a/ui/public/.well-known/agent-registration.json
+++ b/ui/public/.well-known/agent-registration.json
@@ -1,0 +1,48 @@
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "Archimedes",
+  "description": "Agentic trading, grounded in research — settled on Arc. Turns a natural-language investment intent into a research-grounded, rigor-gated portfolio strategy, executed in a non-custodial USDC vault on the Arc testnet (chain ID 5042002).",
+  "image": "https://archimedes-arc.com/logo.svg",
+  "services": [
+    {
+      "name": "web",
+      "endpoint": "https://archimedes-arc.com"
+    },
+    {
+      "name": "api",
+      "endpoint": "https://archimedes-arc.com/api"
+    },
+    {
+      "name": "manifest",
+      "endpoint": "https://archimedes-arc.com/api/agent/manifest"
+    },
+    {
+      "name": "agentCard",
+      "endpoint": "https://archimedes-arc.com/.well-known/agent.json"
+    },
+    {
+      "name": "quickstart",
+      "endpoint": "https://github.com/a-apin/archimedes/blob/main/docs/agent-quickstart.md"
+    }
+  ],
+  "x402Support": false,
+  "active": true,
+  "registrations": [],
+  "supportedTrust": [],
+  "erc8004": {
+    "chain": "eip155:5042002",
+    "identityRegistry": "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    "agentId": null,
+    "tokenURI": null,
+    "status": "registration_pending",
+    "registrationUri": "https://archimedes-arc.com/.well-known/agent-registration.json",
+    "note": "Not registered on-chain: no register() transaction has been sent, so agentId and tokenURI are null and NO ERC-8004 identity, reputation, or validation claim is made. Publishing a spec-typed registration file at registrationUri is not the same as being registered. Plan the call with scripts/register_erc8004_identity.py --plan."
+  },
+  "_note": {
+    "registrations": "EMPTY ON PURPOSE. ERC-8004 requires each entry to carry the agentId minted by the registry; no register() transaction has been sent for this agent, so there is no id to carry and an entry here would be a fabricated on-chain claim. scripts/register_erc8004_identity.py --plan prints the exact entry to add once a real Registered(agentId, agentURI, owner) event exists.",
+    "supportedTrust": "EMPTY ON PURPOSE. This agent claims no reputation, crypto-economic, or TEE-attestation trust model. Its verifiable claim is narrower and lives off this standard: every strategy carries a rigor verdict (DSR / PBO / walk-forward OOS / look-ahead) that GET /api/strategies/{strategy_id} returns as pass, fail, pending, or degenerate — and that fails honestly. See docs/rigor-methods.md.",
+    "x402Support": "false is the conservative claim, not an assertion that no paywall exists. POST /api/generate/start does implement an x402 / Circle Gateway paywall (402 + PAYMENT-REQUIRED header), but it is deploy-flag gated (GENERATION_PAYMENT_REQUIRED) and settlement is separately gated by PAYMENTS_DRY_RUN, which defaults on — so no x402 payment is guaranteed to settle. The runtime truth is public: GET /api/generate/quote returns payment_required.",
+    "active": "Describes the SERVICE — the endpoints above are live and serving. It says nothing about a registration, which has not happened.",
+    "domainOwnership": "This file is served from https://archimedes-arc.com, which is also the endpoint-domain of every service listed above, so it doubles as the EIP's optional domain-control proof for that host. agent-registration.domain.json beside it is the minimal variant to publish at any OTHER endpoint-domain this agent is served from."
+  }
+}

--- a/ui/public/.well-known/agent.json
+++ b/ui/public/.well-known/agent.json
@@ -84,7 +84,7 @@
         "stream": "GET /api/generate/stream/{job_id}",
         "candidates": "GET /api/generate/jobs/{job_id}/candidates"
       },
-      "note": "quote is public — price the run before holding a session."
+      "note": "quote is public — price the run before holding a session, and it is the authority on whether the run costs money. On the deployment that serves this card it answers payment_required: true, dry_run: false, price \"$2.000000\" USDC (read 2026-08-30): start really charges. Unlinked wallet → 409 wallet_link_required; linked but no Payment-Signature → 402 carrying the x402 requirements in the PAYMENT-REQUIRED header, which you sign (x402 / Circle Gateway) and retry. The code DEFAULTS are the opposite (GENERATION_PAYMENT_REQUIRED off, PAYMENTS_DRY_RUN on), so read the quote against the host you are calling rather than assuming either state."
     },
     "account": {
       "status": "live",
@@ -128,7 +128,7 @@
         "publish": "POST /api/marketplace/publish",
         "subscribe": "POST /api/marketplace/subscribe"
       },
-      "note": "live describes the routes: publish/subscribe are wired to the redeployed contracts. It does not assert that a subscription's recurring USDC charge settles for real \u2014 that is gated separately by PAYMENTS_DRY_RUN, and this manifest advertises no payment scheme."
+      "note": "live describes the routes: publish/subscribe are wired to the redeployed contracts. It does not assert that a subscription's recurring USDC charge settles for real \u2014 that rides PAYMENTS_DRY_RUN, a DIFFERENT switch from the one the generation paywall reports (GENERATION_PAYMENTS_DRY_RUN was split off precisely so the generation rail could go live without un-drying marketplace settlement). No public endpoint publishes the marketplace switch's runtime value, so this card makes no claim about it \u2014 unlike endpoints.generate, whose price is quotable and real."
     },
     "monitor": {
       "status": "live",

--- a/ui/public/.well-known/agent.json
+++ b/ui/public/.well-known/agent.json
@@ -9,6 +9,7 @@
     "url": "https://archimedes-arc.com"
   },
   "documentationUrl": "https://github.com/a-apin/archimedes/blob/main/docs/agent-api.md",
+  "quickstartUrl": "https://github.com/a-apin/archimedes/blob/main/docs/agent-quickstart.md",
   "service": {
     "endpoint": "https://archimedes-arc.com/api",
     "manifest": "https://archimedes-arc.com/api/agent/manifest",
@@ -17,6 +18,15 @@
   "capabilities": {
     "streaming": true,
     "pushNotifications": false
+  },
+  "erc8004": {
+    "chain": "eip155:5042002",
+    "identityRegistry": "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    "agentId": null,
+    "tokenURI": null,
+    "status": "registration_pending",
+    "registrationUri": "https://archimedes-arc.com/.well-known/agent-registration.json",
+    "note": "Not registered on-chain: no register() transaction has been sent, so agentId and tokenURI are null and NO ERC-8004 identity, reputation, or validation claim is made. Publishing a spec-typed registration file at registrationUri is not the same as being registered. Plan the call with scripts/register_erc8004_identity.py --plan."
   },
   "authentication": {
     "schemes": ["Better Auth session"],


### PR DESCRIPTION
Everything except the on-chain register() execution (owner's wallet). Honest-pending throughout: registrations empty, agentId null, status derived — 'registered' unreachable until real. The register script's --plan ran against Arc live: registry code confirmed at 0x8004A8…BD9e, clean gas estimate ≈0.0038 USDC. Boardy's deterministic agent quickstart included, every documented shape diffed against the actual handlers (5 steps verified by review). Review fix applied: x402Support corrected to TRUE with the note quoting live runtime (payment_required:true, dry_run:false) instead of the code default — claims-must-be-true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7