### PR TITLE
[chain] #714: remove the three pre-v1.5 publish fallbacks — SKIP traces are honestly unanchored

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -1434,9 +1434,10 @@ class StrategyRunner:
 
         Builds the canonical trace ONCE and commits its keccak256 via the registry's
         real ``commit()`` (with claimedExecutionTime and tradeId) so the same bytes
-        can be revealed after settlement and the on-chain hash binding holds. Falls
-        back to the v1 ``publishTrace`` anchor when the deployed registry is pre-v1.5
-        (#588 redeploy).
+        can be revealed after settlement and the on-chain hash binding holds. There is
+        no anchor of last resort: if the deployed registry has no ``commit()`` the tick
+        anchors NOTHING and logs it loudly — the v1 ``publishTrace`` fallback was
+        removed once the #588 redeploy landed (#714).
 
         Every hashed field — including ``portfolio_after`` — is FINAL here: mutating
         any of them after this point changes ``canonical_json()`` and the on-chain
@@ -1455,7 +1456,9 @@ class StrategyRunner:
         Returns (trace, on_chain_trace_id, commit_tx_hash, commit_block_number,
         claimed_execution_time, reverted). The trace is always returned so reveal()
         can submit the identical content; trace_id is None when commit-reveal is
-        unavailable (publishTrace fallback); claimed_execution_time is non-None only
+        unavailable, and so are commit_tx/commit_block — nothing was anchored at all,
+        rather than a v1 anchor standing in for a commitment (#714);
+        claimed_execution_time is non-None only
         on the real commit-reveal path so the reveal phase knows how long to wait.
         ``reverted`` is True only on a CONFIRMED on-chain revert of the commit tx —
         a reverted commit still has a real commit_tx_hash (diagnostic trail), so
@@ -1550,24 +1553,21 @@ class StrategyRunner:
                     )
                 return trace, trace_id, commit_tx, commit_block, claimed_execution_time, reverted
 
-            # Fallback: v1 publishTrace anchor (no temporal binding).
-            arc_tx = await trace_publisher.publish(trace)
-            commit_block = None
-            if arc_tx:
-                try:
-                    receipt = await chain_client.w3.eth.get_transaction_receipt(
-                        chain_client.w3.to_bytes(hexstr=arc_tx.removeprefix("0x"))
-                    )
-                    commit_block = receipt.blockNumber
-                except Exception as e:
-                    logger.warning("[tick %s] Cannot get commit block: %s", tick_id, e)
-                logger.info(
-                    "[tick %s] COMMIT anchored (publishTrace fallback): tx=%s block=%s",
-                    tick_id,
-                    arc_tx[:16],
-                    commit_block,
-                )
-            return trace, None, arc_tx, commit_block, None, False
+            # No commit-reveal on the deployed registry. Until the #588 redeploy this
+            # fell back to the v1 ``publishTrace`` anchor; that fallback is gone (#714).
+            # The redeploy landed 2026-07-09, so reaching here means the cached ABI in
+            # contracts/abis/ or the configured registry address is stale — a loud,
+            # visible absence is the correct degraded state, not a v1 anchor whose tx
+            # would then be persisted as ``commit_tx_hash`` while binding nothing
+            # (CLAUDE.md § fail-soft is wrong for anything a claim depends on).
+            logger.error(
+                "[tick %s] COMMIT SKIPPED: deployed ReasoningTraceRegistry exposes no "
+                "commit()/reveal() — nothing anchored this cycle. The registry is pre-v1.5; "
+                "the #588 redeploy landed 2026-07-09, so check the cached ABI and the "
+                "configured registry address.",
+                tick_id,
+            )
+            return trace, None, None, None, None, False
         except Exception as e:
             logger.error("[tick %s] COMMIT FAILED: %s", tick_id, e)
             return trace, None, None, None, None, False
@@ -1627,7 +1627,8 @@ class StrategyRunner:
             # the renewal loop's own clock — is caught before the write, not
             # just at the top of the tick.
             try:
-                if trace_id is not None and trace_publisher.supports_commit_reveal():
+                supports_commit_reveal = trace_publisher.supports_commit_reveal()
+                if trace_id is not None and supports_commit_reveal:
                     if claimed_execution_time is not None:
                         wait_s = claimed_execution_time + self._REVEAL_SKEW_BUFFER_S - datetime.now(UTC).timestamp()
                         if wait_s > 0:
@@ -1647,22 +1648,21 @@ class StrategyRunner:
                             "(fail-closed; the commit stays unrevealed until a fresh cycle)",
                             tick_id,
                         )
-                elif self._lease_ok:
-                    # Pre-v1.5 registry: anchor the canonical content via publishTrace.
-                    reveal_tx = await trace_publisher.publish(trace)
-                    if reveal_tx:
-                        try:
-                            receipt = await chain_client.w3.eth.get_transaction_receipt(
-                                chain_client.w3.to_bytes(hexstr=reveal_tx.removeprefix("0x"))
-                            )
-                            reveal_block = receipt.blockNumber
-                        except Exception:
-                            logger.debug("reveal receipt block lookup failed", exc_info=True)
                 else:
+                    # Nothing to reveal: either commit() never minted a trace id or the
+                    # deployed registry predates commit/reveal. Until the #588 redeploy
+                    # this anchored the canonical bytes via the v1 ``publishTrace`` path;
+                    # that fallback is gone (#714). A v1 anchor reveals no commitment, so
+                    # persisting its tx as ``reveal_tx_hash`` would report an unbound
+                    # anchor as a completed reveal — and would set ``is_verified`` true
+                    # for it. Leave the trace unanchored and say exactly why.
                     logger.error(
-                        "[tick %s] LEASE NOT HELD — skipping on-chain REVEAL (publishTrace fallback) "
-                        "this cycle (fail-closed)",
+                        "[tick %s] REVEAL SKIPPED: no on-chain commitment to reveal "
+                        "(trace_id=%s, commit_reveal_supported=%s) — trace persisted "
+                        "off-chain only, unanchored",
                         tick_id,
+                        trace_id,
+                        supports_commit_reveal,
                     )
                 if reveal_tx:
                     logger.info(
@@ -1703,10 +1703,11 @@ class StrategyRunner:
                 "ipfs_cid": ipfs_cid,
                 # Temporal binding fields. The "chain" source — and any True binding —
                 # require the REAL commit-reveal path: trace_id is non-None ONLY when
-                # ReasoningTraceRegistry.commit() minted an on-chain id (the publishTrace
-                # fallback returns trace_id=None but still carries a commit_block from its
-                # receipt). Gating on trace_id stops a fallback anchor's blocks from
-                # masquerading as a verified temporal binding (#714 / AUDIT_2026-06-14 #3).
+                # ReasoningTraceRegistry.commit() minted an on-chain id. Gating on
+                # trace_id stops a non-commitment anchor's blocks from masquerading as a
+                # verified temporal binding (#714 / AUDIT_2026-06-14 #3) — and since #714
+                # removed the v1 publishTrace fallback, no such anchor is written here
+                # any more; the gate stays because records persisted before it still are.
                 "commit_tx_hash": commit_tx,
                 "commit_block_number": commit_block,
                 "reveal_tx_hash": reveal_tx,
@@ -2061,7 +2062,14 @@ class StrategyRunner:
         commit_tx: str | None = None,
         commit_block: int | None = None,
     ) -> None:
-        """Build and publish a reasoning trace."""
+        """Build and record a reasoning trace for a NO-TRADE decision.
+
+        Every caller passes an empty trade list — this is the SKIP / error path. The
+        trace is hashed and persisted off-chain only: with no trade there is no tradeId
+        to bind, so neither ``commit()``/``reveal()`` nor the retired v1 ``publishTrace``
+        anchor applies (#714). ``is_verified`` is therefore always False here; a trace
+        that carries an on-chain claim comes from ``_commit_trace``/``_reveal_trace``.
+        """
         trace = ReasoningTrace(
             id=str(uuid.uuid4()),
             vault_address=vault_address,
@@ -2096,16 +2104,16 @@ class StrategyRunner:
         trace.compute_hash()
         logger.info("[tick %s] Trace hash: %s", tick_id, trace.trace_hash[:16])
 
-        if not DRY_RUN:
-            try:
-                arc_tx = await trace_publisher.publish(trace)
-                if arc_tx:
-                    logger.info("[tick %s] Trace anchored on-chain: %s", tick_id, arc_tx[:16])
-            except Exception as e:
-                logger.error("[tick %s] Trace publish FAILED: %s", tick_id, e)
-                arc_tx = None
-        else:
-            arc_tx = None
+        # No-trade decisions are never anchored on-chain (#714). Every caller of this
+        # method passes an empty trade list — it is the SKIP / error path — so there is
+        # no tradeId for ``commit()`` to bind and nothing for ``Vault.executeTrade()``
+        # to consume. Until the #588 redeploy this anchored the hash via the v1
+        # ``publishTrace`` path; that is gone. Synthesising a tradeId to force the
+        # commit-reveal path would write a commitment for a trade that never happens
+        # and pin ``_pendingTrade[vault][tradeId]`` until something clears it — a
+        # fabricated on-chain claim, which is precisely what this issue removes. The
+        # trace is still persisted off-chain below, honestly unverified.
+        logger.info("[tick %s] No-trade decision — recorded off-chain, not anchored", tick_id)
 
         # Persist off-chain to Redis (always, even in dry-run)
         try:
@@ -2123,8 +2131,10 @@ class StrategyRunner:
                 "trades_executed": trace.trades_executed,
                 "strategies_referenced": trace.strategies_referenced,
                 "trace_hash": trace.trace_hash,
-                "arc_tx_hash": arc_tx,
-                "is_verified": arc_tx is not None,
+                # Never anchored (see above): the honest values are a null tx and an
+                # unverified flag, not a v1 publishTrace hash standing in for one.
+                "arc_tx_hash": None,
+                "is_verified": False,
                 # Commit-reveal fields (if available)
                 "commit_tx_hash": commit_tx,
                 "commit_block_number": commit_block,

--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -20,8 +20,10 @@ class TracePublisher:
     """Publishes reasoning trace hashes to on-chain ReasoningTraceRegistry.
 
     Two anchoring paths:
-      - ``publish`` → ``publishTrace`` (v1 anchor-after-the-fact; kept for the
-        legacy SKIP/error path and existing callers).
+      - ``publish`` → ``publishTrace`` (v1 anchor-after-the-fact). No longer used
+        by the agent tick — ``agent_runner`` was migrated off it in #714 — but kept
+        for the operator-driven ``POST /api/traces/publish`` route and any external
+        caller anchoring a trace that has no covered trade.
       - ``commit`` + ``reveal`` (v1.5 temporal binding): the agent commits the
         trace hash BEFORE the trade and reveals the canonical content AFTER it
         settles. The contract recomputes keccak256 on reveal and enforces

--- a/backend/tests/test_agent_runner_commit_reveal.py
+++ b/backend/tests/test_agent_runner_commit_reveal.py
@@ -419,6 +419,9 @@ class TestCommitPhaseUsesTheModernPath:
     """
 
     def test_commit_invokes_commit_never_publish(self, runner_env):
+        # CHARACTERIZATION, not a regression guard (CLAUDE.md § "Before you approve a
+        # merge" rule 3): this passes against the pre-#714 tree too — the old fallback
+        # only ran when supports_commit_reveal() was False, which this test sets True.
         runner, mock_tp = runner_env
         mock_tp.supports_commit_reveal = MagicMock(return_value=True)
         mock_tp.commit = AsyncMock(return_value=(42, "0xCOMMIT", 100, False))
@@ -459,6 +462,10 @@ class TestCommitPhaseUsesTheModernPath:
 
     def test_commit_failure_never_escapes_to_the_tick_loop(self, runner_env, caplog):
         """Error-handling semantics preserved: a publisher raise is logged, not raised."""
+        # CHARACTERIZATION, not a regression guard (CLAUDE.md § "Before you approve a
+        # merge" rule 3): this passes against the pre-#714 tree too — the raise happens
+        # inside commit(), so the except wrapper short-circuits before either tree could
+        # reach the fallback. It documents the preserved contract, it does not pin it.
         runner, mock_tp = runner_env
         mock_tp.supports_commit_reveal = MagicMock(return_value=True)
         mock_tp.commit = AsyncMock(side_effect=RuntimeError("rpc down"))

--- a/backend/tests/test_agent_runner_commit_reveal.py
+++ b/backend/tests/test_agent_runner_commit_reveal.py
@@ -5,8 +5,8 @@ store are all mocked at the boundary (mirrors ``test_agent_runner.py``'s runner 
 
 Covers:
   - the reveal phase uses the real ``trace_publisher.reveal()`` (NOT publishTrace) when a
-    commit-reveal trace_id exists, and gracefully falls back to ``publish()`` when it does
-    not (pre-v1.5 registry, #588 still open);
+    commit-reveal trace_id exists, and anchors NOTHING when it does not — the v1
+    ``publishTrace`` fallback was removed once the #588 redeploy landed (#714);
   - ``temporal_binding_source`` is "chain" ONLY on the real commit-reveal path, and the
     persisted ``temporal_binding_valid`` requires commit < trade <= reveal block ordering;
   - the TraceResponse schema guard can never surface a True binding without a chain source
@@ -83,17 +83,26 @@ class TestRevealWiring:
         mock_tp.reveal.assert_called_once()
         mock_tp.publish.assert_not_called()  # the live path is commit-reveal, never publishTrace
 
-    def test_reveal_falls_back_to_publish_without_trace_id(self, runner_env):
+    def test_reveal_without_trace_id_anchors_nothing(self, runner_env):
+        """#714: no commitment => no anchor at all, never a v1 publishTrace stand-in.
+
+        Before #714 this fell back to ``publish()``. That anchor reveals no
+        commitment, so persisting its tx as ``reveal_tx_hash``/``arc_tx_hash``
+        reported an unbound anchor as a completed reveal and set ``is_verified``.
+        """
         runner, mock_tp = runner_env
         mock_tp.supports_commit_reveal = MagicMock(return_value=True)
         mock_tp.reveal = AsyncMock(return_value=("0xREVEAL", 102))
-        mock_tp.publish = AsyncMock(return_value=None)
+        mock_tp.publish = AsyncMock(return_value="0xLEGACY")
 
-        # trace_id None => pre-v1.5 registry path => graceful publishTrace fallback (#588).
         asyncio.run(runner._reveal_trace(_make_trace(), trace_id=None, tick_id="t1", tx_hashes=["0xtrade"]))
 
-        mock_tp.publish.assert_called_once()
+        mock_tp.publish.assert_not_called()
         mock_tp.reveal.assert_not_called()
+        saved = _saved(runner)
+        assert saved["arc_tx_hash"] is None
+        assert saved["reveal_tx_hash"] is None
+        assert saved["is_verified"] is False
 
 
 class TestTemporalBindingPersistence:
@@ -345,19 +354,183 @@ class TestRevealFailureAfterTradeExecuted:
         assert saved["commit_tx_hash"] == "0xcommit"
         assert saved["commit_block_number"] == 100
 
-    def test_publish_fallback_failure_keeps_the_same_honest_contract(self, runner_env, caplog):
-        """Pre-v1.5 registries (#588): publishTrace raising must degrade
-        identically — loud, unverified, trade visible."""
+    def test_pre_v15_registry_keeps_the_same_honest_contract(self, runner_env, caplog):
+        """A registry with no commit/reveal degrades identically — loud, unverified.
+
+        #714 removed the v1 ``publishTrace`` fallback that used to run here, so the
+        degraded state is now a visible absence: an ERROR naming the reason and a
+        trace persisted unanchored. The executed trade stays visible either way.
+        """
         runner, mock_tp = runner_env
-        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.supports_commit_reveal = MagicMock(return_value=False)
         mock_tp.reveal = AsyncMock(return_value=("0xNEVER", 0))
-        mock_tp.publish = AsyncMock(side_effect=RuntimeError("rpc down"))
+        mock_tp.publish = AsyncMock(return_value="0xLEGACY")
 
         with caplog.at_level("ERROR"):
             asyncio.run(runner._reveal_trace(_make_trace(), trace_id=None, tick_id="t9b", tx_hashes=["0xtrade"]))
 
-        assert "REVEAL publish FAILED" in caplog.text
+        assert "REVEAL SKIPPED" in caplog.text  # the loud, alertable signal
+        mock_tp.publish.assert_not_called()
         saved = _saved(runner)
         assert saved["is_verified"] is False
+        assert saved["arc_tx_hash"] is None
         assert saved["trade_tx_hash"] == "0xtrade"
         assert saved["temporal_binding_valid"] is False
+
+
+# ── #714: the legacy publishTrace call sites are gone from agent_runner ──
+
+
+def _commit_args(**over):
+    """Minimal real-shaped args for ``_commit_trace``.
+
+    Only the fields the method actually reads are set, and they are real values
+    (not MagicMocks) because the trace it builds must survive ``canonical_json()``.
+    """
+    consensus = MagicMock()
+    consensus.label.value = "aligned"
+    consensus.flat_pct = 0.0
+    portfolio = MagicMock()
+    portfolio.total_value_usdc = 1000.0
+    portfolio.holdings = []
+    args = {
+        "vault_address": "0x1234567890abcdef1234567890abcdef12345678",
+        "trades": [],
+        "all_signals": [],
+        "market_regime": "bull",
+        "consensus": consensus,
+        "tick_id": "t714",
+        "reasoning": "commit wiring guard",
+        "portfolio": portfolio,
+        "targets": [],
+        "trade_id": b"\x11" * 32,
+    }
+    args.update(over)
+    return args
+
+
+class TestCommitPhaseUsesTheModernPath:
+    """#714: ``_commit_trace`` anchors via ``commit()`` and never via ``publish()``.
+
+    The representative site for the three legacy ``trace_publisher.publish()`` calls
+    removed from ``agent_runner.py``. Mocked at the publisher boundary (the repo
+    idiom — see the ``runner_env`` fixture), so this pins the call actually made to
+    the chain layer rather than any internal helper.
+    """
+
+    def test_commit_invokes_commit_never_publish(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.commit = AsyncMock(return_value=(42, "0xCOMMIT", 100, False))
+        mock_tp.publish = AsyncMock(return_value="0xLEGACY")
+
+        trace, trace_id, commit_tx, commit_block, claimed, reverted = asyncio.run(
+            runner._commit_trace(**_commit_args())
+        )
+
+        mock_tp.commit.assert_awaited_once()
+        mock_tp.publish.assert_not_called()  # the retired v1 anchor
+        # The tradeId binding reaches the contract call unchanged.
+        assert mock_tp.commit.await_args.args[2] == b"\x11" * 32
+        # ...and the hash committed is the trace's own canonical hash (untouched here).
+        assert mock_tp.commit.await_args.args[0] is trace
+        assert (trace_id, commit_tx, commit_block, reverted) == (42, "0xCOMMIT", 100, False)
+        assert claimed is not None
+
+    def test_pre_v15_registry_anchors_nothing_and_says_so(self, runner_env, caplog):
+        """No commit/reveal on the deployed ABI => a loud absence, not a v1 anchor.
+
+        The removed fallback returned the publishTrace tx as ``commit_tx``, which
+        then persisted as ``commit_tx_hash`` despite binding no trade.
+        """
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=False)
+        mock_tp.commit = AsyncMock(return_value=(42, "0xCOMMIT", 100, False))
+        mock_tp.publish = AsyncMock(return_value="0xLEGACY")
+
+        with caplog.at_level("ERROR"):
+            result = asyncio.run(runner._commit_trace(**_commit_args()))
+
+        mock_tp.publish.assert_not_called()
+        mock_tp.commit.assert_not_called()
+        assert "COMMIT SKIPPED" in caplog.text
+        # (trace, trace_id, commit_tx, commit_block, claimed, reverted) — no anchor.
+        assert result[1:] == (None, None, None, None, False)
+
+    def test_commit_failure_never_escapes_to_the_tick_loop(self, runner_env, caplog):
+        """Error-handling semantics preserved: a publisher raise is logged, not raised."""
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.commit = AsyncMock(side_effect=RuntimeError("rpc down"))
+        mock_tp.publish = AsyncMock(return_value="0xLEGACY")
+
+        with caplog.at_level("ERROR"):
+            result = asyncio.run(runner._commit_trace(**_commit_args()))
+
+        assert "COMMIT FAILED" in caplog.text
+        mock_tp.publish.assert_not_called()  # no silent legacy retry
+        assert result[1:] == (None, None, None, None, False)
+
+
+class TestNoTradeDecisionsAreNeverAnchored:
+    """#714 site 3: ``_publish_trace`` is the SKIP/error path and touches no chain write.
+
+    Every call site passes an empty trade list, so there is no tradeId to bind and
+    nothing for ``Vault.executeTrade()`` to consume — the trace is recorded off-chain,
+    honestly unverified, rather than anchored via the retired v1 path.
+    """
+
+    def test_skip_trace_touches_no_publisher_write_and_is_unverified(self, runner_env):
+        runner, mock_tp = runner_env
+        mock_tp.supports_commit_reveal = MagicMock(return_value=True)
+        mock_tp.publish = AsyncMock(return_value="0xLEGACY")
+        mock_tp.commit = AsyncMock(return_value=(42, "0xCOMMIT", 100, False))
+
+        args = _commit_args()
+        asyncio.run(
+            runner._publish_trace(
+                args["vault_address"],
+                DecisionType.SKIP,
+                "aligned",
+                args["portfolio"],
+                [],
+                [],
+                args["market_regime"],
+                args["consensus"],
+                "t714b",
+                "no drift",
+            )
+        )
+
+        mock_tp.publish.assert_not_called()
+        mock_tp.commit.assert_not_called()
+        saved = _saved(runner)
+        assert saved["arc_tx_hash"] is None
+        assert saved["is_verified"] is False
+        assert saved["decision_type"] == "skip"
+
+
+class TestLegacyPublishCallSitesStayGone:
+    """The #714 anti-goal gate, enforced as a test rather than a one-off grep.
+
+    Acceptance criterion from the issue: ``grep -n "trace_publisher.publish("
+    backend/archimedes/chain/agent_runner.py`` returns 0 matches. Reading the
+    source keeps that durable — a future edit that reintroduces the retired v1
+    anchor on the tick path fails here instead of silently shipping.
+    """
+
+    def test_agent_runner_never_calls_the_v1_publish_anchor(self):
+        from pathlib import Path
+
+        from archimedes.chain import agent_runner
+
+        source = Path(agent_runner.__file__).read_text(encoding="utf-8")
+        offenders = [
+            f"{n}: {line.strip()}"
+            for n, line in enumerate(source.splitlines(), start=1)
+            if "trace_publisher.publish(" in line
+        ]
+        assert offenders == [], (
+            "agent_runner.py must anchor via commit()/reveal() only (#714); "
+            f"found legacy publishTrace call site(s): {offenders}"
+        )

--- a/ui/src/components/Portfolio.jsx
+++ b/ui/src/components/Portfolio.jsx
@@ -741,6 +741,19 @@ export default function Portfolio({
 																<span className="i-lucide-check-circle w-3.5 h-3.5" />{" "}
 																anchored on Arc
 															</span>
+														) : t.decision_type === "skip" ? (
+															// A skip anchors nothing BY DESIGN (#714): with no trade
+															// there is no tradeId for commit() to bind, so the agent
+															// never attempts a registry write for this trace. "anchor
+															// pending" would promise a write that is never coming;
+															// the honest state is a permanent, explained absence.
+															<span
+																className="flex items-center gap-1 text-[var(--text-3)]"
+																title="No trade was made, so there is nothing for an on-chain commitment to bind. The trace is hashed and persisted off-chain; no anchor is attempted or pending."
+															>
+																<span className="i-lucide-skip-forward w-3.5 h-3.5" />{" "}
+																not anchored (no trade to bind)
+															</span>
 														) : (
 															<span
 																className="flex items-center gap-1 text-[var(--text-3)]"

--- a/ui/test/trace-anchor-copy.test.js
+++ b/ui/test/trace-anchor-copy.test.js
@@ -1,0 +1,158 @@
+// Claim-integrity guard for Portfolio's trace anchor-state copy (#714).
+//
+// #714 retired the v1 `publishTrace` fallbacks from the agent tick. The
+// SKIP/error path (`_publish_trace`) now makes no chain call at all and
+// persists `arc_tx_hash: None` / `is_verified: False` permanently, by design:
+// with no trade there is no tradeId for `commit()` to bind, so no registry
+// write is ever attempted for a skip trace.
+//
+// Portfolio.jsx rendered every `is_verified === false` trace as "anchor
+// pending — registry write didn't complete yet — usually transient". For a
+// skip that is now false in both halves: nothing is pending, and nothing is
+// transient. The agent ticks emit skips continuously while pools are thin, so
+// this is the *common* row, not an edge case — the flagship portfolio page
+// would promise an anchor that is never coming.
+//
+// Same idiom as oracle-copy.test.js / roadmap-copy.test.js: a raw source-text
+// scan (readFileSync, no JSX parsing) with anti-vacuity coverage — the
+// predicate is run against the exact pre-#714 branch shape and must reject it,
+// so a pin that stops discriminating fails loudly instead of guarding nothing.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function repoFile(rel) {
+	return new URL(`../${rel}`, import.meta.url);
+}
+
+const portfolio = readFileSync(repoFile("src/components/Portfolio.jsx"), "utf8");
+
+// The anchor-state ternary, sliced from its `is_verified` discriminator up to
+// the "anchor pending" label. Anything the skip case needs in order NOT to
+// reach that label has to live inside this slice — which is what makes the
+// check structural (branch ordering) rather than "the string exists somewhere
+// in a 900-line file".
+function anchorStateSlice(src) {
+	const start = src.indexOf("{t.is_verified ? (");
+	assert.ok(start !== -1, "no is_verified anchor-state branch found in Portfolio.jsx");
+	const end = src.indexOf("anchor pending", start);
+	assert.ok(end !== -1, "no 'anchor pending' label found after the anchor-state branch");
+	return src.slice(start, end);
+}
+
+// True when a skip trace is peeled off BEFORE the pending fallback — i.e. the
+// pending copy is unreachable for `decision_type === "skip"`.
+function skipBranchedBeforePending(src) {
+	return /t\.decision_type === "skip"/.test(anchorStateSlice(src));
+}
+
+//: The exact branch shape Portfolio.jsx carried before #714 (whitespace
+//: normalised — every predicate above is indentation-independent). Every
+//: assertion that passes on the live source is re-run against this to prove it
+//: discriminates; see test_the_pin_rejects_the_pre_714_branch below.
+const PRE_714_ANCHOR_STATE = `{t.is_verified ? (
+	<span className="flex items-center gap-1 text-[var(--positive)]">
+		<span className="i-lucide-check-circle w-3.5 h-3.5" /> anchored on Arc
+	</span>
+) : (
+	<span
+		className="flex items-center gap-1 text-[var(--text-3)]"
+		title="Trace hashed + persisted off-chain; on-chain anchor pending (registry write didn't complete yet — usually transient)."
+	>
+		<span className="i-lucide-clock w-3.5 h-3.5" /> anchor pending
+	</span>
+)}`;
+
+test("a skip trace never falls through to the 'anchor pending' copy", () => {
+	assert.ok(
+		skipBranchedBeforePending(portfolio),
+		"the anchor-state ternary must peel off decision_type === 'skip' before the pending fallback",
+	);
+});
+
+test("the skip branch states the honest reason, not a failure or a pending write", () => {
+	const slice = anchorStateSlice(portfolio);
+	assert.ok(
+		slice.includes("not anchored (no trade to bind)"),
+		"the skip branch must name the real reason: there is no trade for a commitment to bind",
+	);
+	// The reason must survive a hover, not just the label: the title is the only
+	// place with room to say *why* nothing is anchored.
+	assert.ok(
+		/title="No trade was made[^"]*no anchor is attempted or pending\."/.test(slice),
+		"the skip branch's title must say no anchor is attempted or pending",
+	);
+});
+
+test("the skip branch borrows neither the verified affordance nor the pending one", () => {
+	const slice = anchorStateSlice(portfolio);
+	const skipStart = slice.indexOf('t.decision_type === "skip"');
+	assert.ok(skipStart !== -1, "no skip branch to inspect");
+	// Bound the branch at the `) : (` that opens the pending fallback, or the
+	// assertions below would read the fallback's own copy and never fail.
+	const skipEnd = slice.indexOf(") : (", skipStart);
+	assert.ok(skipEnd !== -1, "could not find the end of the skip branch");
+	const skipBranch = slice.slice(skipStart, skipEnd);
+	// The claim under test is the RENDERED copy; the code comments legitimately
+	// quote the pending wording to explain why it is wrong here, so strip them.
+	const rendered = skipBranch.replace(/^\s*\/\/.*$/gm, "");
+
+	// Not a success: no green check / positive styling for a trace with no anchor.
+	assert.ok(
+		!rendered.includes("i-lucide-check-circle"),
+		"the skip branch must not reuse the anchored-on-Arc check icon",
+	);
+	assert.ok(
+		!rendered.includes("--positive"),
+		"the skip branch must not reuse the anchored-on-Arc positive styling",
+	);
+	// Not a failure and not a wait: no clock, and none of the pending branch's
+	// affirmative claims about a write that is still coming.
+	assert.ok(
+		!rendered.includes("i-lucide-clock"),
+		"the skip branch must not reuse the pending clock icon — nothing is being waited on",
+	);
+	assert.ok(
+		!rendered.includes("anchor pending"),
+		"the skip branch must not carry the pending label",
+	);
+	assert.ok(
+		!/registry write didn't complete|\btransient\b|\bfailed\b/i.test(rendered),
+		"the skip branch must not imply an incomplete or failed registry write",
+	);
+});
+
+test("the pending copy survives for the states it is still true of (anti-goal)", () => {
+	// #714 did not make "anchor pending" false everywhere. `is_verified` is
+	// `reveal_tx is not None` (agent_runner._reveal_trace), so a rebalance that
+	// committed but whose reveal has not landed persists unverified with a real
+	// commit_tx_hash — genuinely pending, and #1276's reveal reconciliation
+	// retries it on a later tick. Widening this fix past `decision_type ===
+	// "skip"` would deny an anchor that really is still coming.
+	assert.ok(
+		portfolio.includes("anchor pending"),
+		"the pending copy must remain for non-skip traces that really are awaiting a write",
+	);
+	assert.ok(
+		portfolio.includes("i-lucide-clock w-3.5 h-3.5"),
+		"the pending clock affordance must remain for the states it still describes",
+	);
+});
+
+// ── Anti-vacuity ─────────────────────────────────────────────────────────
+//
+// The pin above is only worth anything if it rejects the code it was written
+// against. Run the same predicate over the pre-#714 branch shape.
+
+test("the pin rejects the pre-#714 branch, where every unverified trace read as pending", () => {
+	assert.equal(
+		skipBranchedBeforePending(PRE_714_ANCHOR_STATE),
+		false,
+		"the pre-#714 branch routed skips straight to 'anchor pending' — the pin must reject it",
+	);
+	assert.ok(
+		!PRE_714_ANCHOR_STATE.includes("not anchored (no trade to bind)"),
+		"the honest skip copy did not exist before #714 — the pin must not match it vacuously",
+	);
+});


### PR DESCRIPTION
The 3 legacy trace_publisher.publish() sites were deliberate pre-#588 fallbacks; their precondition is gone. Now: commit/reveal is the only anchor path, SKIP-path traces (all 11 call sites pass no trades) anchor nothing and say so loudly — no synthetic tradeIds fabricated for trades that never happened. Acceptance met: grep returns 0. Review verdict: merge-ready backend + one UI string it made false — fixed in the same PR (Portfolio.jsx renders 'not anchored (no trade to bind)' instead of implying failure). Adversarial proof independent: 5 guards fail against unfixed code; 2 characterization tests labeled as such. Full suite 3,905 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7