### PR TITLE
[rigor] Use the equicorrelated E[max] in the DSR, not an effective trial count

### DIFF
--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -279,30 +279,40 @@ def _dsr_from_stats(
         E_max_N = 0.0
     else:
         # Correlated trials are not independent tests: a parameter sweep whose
-        # variants move together carries fewer effective trials than its nominal
-        # count. Convert N to an effective count under an equicorrelation model
-        # with average pairwise correlation ρ:
-        #     N_eff = N / (1 + (N − 1)·ρ)
-        # the standard "effective number of independent tests" (Cheverud 2001;
-        # Nyholt 2004 — the equicorrelated effective sample size). ρ=0 → N_eff=N
-        # (full multiple-testing penalty); ρ=1 → N_eff=1 (all variants collapse
-        # to a single test, so there is no selection bias to deflate). This
-        # replaces a previous ad-hoc E[max]·sqrt(1 − ρ) factor that had no
-        # published source and let deflation vanish without a principled basis.
+        # variants move together offers fewer distinct chances to get lucky, so
+        # the expected best-of-N null is lower. Under equicorrelation with
+        # average pairwise correlation ρ ≥ 0, the one-factor representation
+        #     X_i = √ρ·Z + √(1−ρ)·ε_i      (Z, ε_i iid standard normal)
+        # gives every X_i unit variance and pairwise correlation ρ, and since Z
+        # is common to all of them it factors straight out of the maximum:
+        #     max_i X_i = √ρ·Z + √(1−ρ)·max_i ε_i
+        #     E[max_i X_i] = √(1−ρ)·E[max of N iid]
+        # so the correlated E[max] is exactly the iid one scaled by √(1−ρ). This
+        # is Bailey-LdP's own √(V[{SR_n}]) term specialised to equicorrelation:
+        # the cross-sectional variance of N equicorrelated null Sharpes has
+        # expectation (1−ρ), which is the same factor under the square root.
+        # Because SR_zero below substitutes the closed-form null variance
+        # 1/(T−1) for the paper's empirical V[{SR_n}], that shrinkage is not
+        # carried implicitly and has to be applied here.
+        #
+        # ρ=0 → the full independent-trial penalty; ρ=1 → all variants are one
+        # test and there is no selection bias to deflate. Negative ρ is clamped
+        # away: equicorrelation is only positive-semidefinite for ρ > −1/(N−1),
+        # and the identity above needs ρ ≥ 0 for √ρ to be real.
+        #
+        # #1558: this REPLACES an effective-trial-count form
+        # N_eff = N/(1 + (N−1)ρ) fed through the quantile approximation. That is
+        # the Kish design effect (effective sample size for a mean), not an
+        # expectation-of-maximum, and it under-deflated by 2×–10× across
+        # ρ ∈ [0.3, 0.9] — at N=16, ρ=0.7 the null gate admitted noise 28.9% of
+        # the time against a nominal 10%. It was also wrong in shape, not just
+        # scale: N_eff → 1/ρ as N grows, so deflation saturated and a
+        # 10,000-variant sweep drew the same penalty as a 64-variant one.
         rho = max(0.0, min(1.0, average_correlation))
-        n_eff = N / (1.0 + (N - 1) * rho) if rho > 0.0 else float(N)
-
-        # The Bailey-LdP two-quantile E[max] approximation is only well-behaved
-        # for ≥ 2 trials (norm.ppf(1 − 1/N) → −∞ as N → 1). Evaluate it at
-        # max(2, N_eff) and linearly taper the result to 0 across the effective
-        # range [1, 2], so a fully correlated grid (N_eff → 1) carries no penalty
-        # without the ppf blow-up a literal non-integer N_eff < 2 would cause.
-        n_for_emax = max(2.0, n_eff)
-        phi_inv_1 = float(norm.ppf(1.0 - 1.0 / n_for_emax))
-        phi_inv_2 = float(norm.ppf(1.0 - 1.0 / (n_for_emax * math.e)))
+        phi_inv_1 = float(norm.ppf(1.0 - 1.0 / N))
+        phi_inv_2 = float(norm.ppf(1.0 - 1.0 / (N * math.e)))
         e_max_full = (1.0 - _EULER_MASCHERONI) * phi_inv_1 + _EULER_MASCHERONI * phi_inv_2
-        taper = min(1.0, max(0.0, n_eff - 1.0))
-        E_max_N = e_max_full * taper
+        E_max_N = e_max_full * math.sqrt(1.0 - rho)
 
     # SR_zero: expected best-of-N under the null, scaled to per-bar variance
     # (under iid normal returns, per-bar SR has variance 1/(T-1))

--- a/backend/tests/test_rigor_evaluator.py
+++ b/backend/tests/test_rigor_evaluator.py
@@ -27,6 +27,7 @@ import math
 import numpy as np
 import pytest
 from archimedes.services._rigor_helpers import (
+    _RF_DAILY,
     _dsr_from_stats,
     _sharpe_per_col,
     benjamini_hochberg_fdr,
@@ -1683,10 +1684,11 @@ class TestDsrCorrelationRelaxesPenalty:
         )
 
     def test_full_correlation_collapses_to_single_effective_trial(self):
-        # ρ=1 under the effective-N model means N_eff = 1: all trials are the
-        # same test, so there is no selection bias to deflate. The DSR must
-        # equal the N=1 (no-penalty) result — not vanish via an undocumented
-        # sqrt(1−ρ) factor.
+        # ρ=1 means every trial is the same test, so there is no selection
+        # bias to deflate and the DSR must equal the N=1 (no-penalty) result.
+        # Note this endpoint does NOT discriminate between formulas: √(1−ρ) and
+        # the old N_eff form both vanish here, which is part of why #1558 went
+        # unnoticed. The interior is pinned in TestEquicorrelatedExpectedMax.
         rng = np.random.default_rng(9)
         rets = list(rng.normal(0.0012, 0.01, 600))
         fully_correlated = compute_dsr(rets, num_trials=25, average_correlation=1.0)
@@ -1715,6 +1717,147 @@ class TestDsrCorrelationRelaxesPenalty:
 
 
 # ─── CPCV wiring into run_rigor_gate ─────────────────────────────────
+
+
+class TestEquicorrelatedExpectedMax:
+    """#1558: the correlated-trials E[max] must be the equicorrelated one.
+
+    For N standard normals with equicorrelation ρ ≥ 0, the one-factor form
+    ``X_i = √ρ·Z + √(1−ρ)·ε_i`` makes the common term factor out of the maximum:
+
+        E[max_i X_i] = √(1−ρ) · E[max of N iid]
+
+    The prior implementation instead converted N to an effective count
+    ``N_eff = N/(1 + (N−1)ρ)`` (the Kish design effect) and pushed that through
+    the quantile approximation, which under-deflated by 2×–10× over
+    ρ ∈ [0.3, 0.9] and let the null gate admit noise at up to 29%.
+
+    Every test in this class FAILS against that prior implementation. The three
+    tests in ``TestDsrCorrelationRelaxesPenalty`` do not: they pin the ρ=0 and
+    ρ=1 endpoints (where the two formulas agree exactly) and monotonicity in
+    between (which both satisfy), so the whole file passed against either one.
+    """
+
+    ANNUALIZATION = 252
+    EULER = 0.5772156649
+
+    @classmethod
+    def _a_n(cls, n: int) -> float:
+        """Bailey-LdP two-quantile E[max of n iid standard normals]."""
+        from scipy.stats import norm
+
+        return float((1.0 - cls.EULER) * norm.ppf(1.0 - 1.0 / n) + cls.EULER * norm.ppf(1.0 - 1.0 / (n * math.e)))
+
+    @classmethod
+    def _recover_e_max(cls, sr_hat: float, t: int, n: int, rho: float) -> float:
+        """Back E_max_N out of the returned deflated Sharpe.
+
+        ``dsr = (SR_hat − SR_zero)·√252`` and ``SR_zero = √(1/(T−1))·E_max_N``,
+        so E_max_N is recoverable exactly from the public return value. Reading
+        it this way keeps the test on the observable output rather than on a
+        private intermediate, so it still bites if the block is refactored.
+        """
+        dsr, _ = _dsr_from_stats(sr_hat, t, 0.0, 3.0, n, rho)
+        assert dsr is not None
+        return (sr_hat - dsr / math.sqrt(cls.ANNUALIZATION)) * math.sqrt(t - 1)
+
+    @pytest.mark.parametrize("n", [4, 8, 16])
+    @pytest.mark.parametrize("rho", [0.0, 0.3, 0.5, 0.7, 0.9])
+    def test_expected_max_matches_the_equicorrelated_closed_form(self, n: int, rho: float) -> None:
+        """The interior, pinned by value — this is what the old tests left free."""
+        recovered = self._recover_e_max(0.03, 756, n, rho)
+        expected = math.sqrt(1.0 - rho) * self._a_n(n)
+        assert recovered == pytest.approx(expected, abs=1e-3), (
+            f"N={n}, rho={rho}: E[max] is {recovered:.4f}, equicorrelated closed form is "
+            f"{expected:.4f} (ratio {recovered / expected:.2f}x)"
+        )
+
+    @pytest.mark.parametrize(("n", "rho"), [(4, 0.5), (8, 0.7), (16, 0.5), (16, 0.9)])
+    def test_correlation_shrinkage_factor_matches_monte_carlo(self, n: int, rho: float) -> None:
+        """Independent of the closed form: simulate the maximum directly.
+
+        Draws from a Cholesky factor of Σ = (1−ρ)I + ρ·11ᵀ rather than the
+        one-factor construction, so the simulation does not assume the identity
+        under test. Seeded, so it cannot go flaky.
+
+        Compares the RATIO E[max](ρ)/E[max](0) on both sides rather than the
+        levels. The two-quantile approximation to E[max of N iid] is itself
+        ~2–3% high (at ρ=0 as much as anywhere), and that bias is common to
+        numerator and denominator, so taking the ratio cancels it and leaves
+        exactly the correlation factor this test is about. Comparing levels
+        would fold a pre-existing approximation error into a correlation test.
+        """
+        rng = np.random.default_rng(1558)
+        cov = np.full((n, n), rho) + np.eye(n) * (1.0 - rho)
+        chol = np.linalg.cholesky(cov).T
+        correlated = float((rng.standard_normal((200_000, n)) @ chol).max(axis=1).mean())
+        independent = float(rng.standard_normal((200_000, n)).max(axis=1).mean())
+        simulated_factor = correlated / independent
+
+        recovered_factor = self._recover_e_max(0.03, 756, n, rho) / self._recover_e_max(0.03, 756, n, 0.0)
+        assert recovered_factor == pytest.approx(simulated_factor, abs=0.01), (
+            f"N={n}, rho={rho}: correlation shrinks E[max] by {recovered_factor:.4f}, "
+            f"simulation says {simulated_factor:.4f} (closed form: {math.sqrt(1 - rho):.4f})"
+        )
+
+    def test_correlated_deflation_keeps_growing_with_trial_count(self) -> None:
+        """Shape in N, not just scale.
+
+        ``N_eff = N/(1 + (N−1)ρ)`` tends to 1/ρ, so the old form's penalty
+        SATURATED: at ρ=0.7 it was 0.203 at N=16 and 0.222 at N=1000, a 9% rise
+        across a 60-fold larger search. The true term grows like √(1−ρ)·√(2 ln N).
+        A large correlated sweep must be charged more than a small one.
+        """
+        small = self._recover_e_max(0.03, 756, 16, 0.7)
+        large = self._recover_e_max(0.03, 756, 1000, 0.7)
+        assert large > 1.5 * small, (
+            f"E[max] barely moved from N=16 ({small:.4f}) to N=1000 ({large:.4f}) — "
+            "the multiple-testing penalty is saturating in N"
+        )
+
+    @pytest.mark.parametrize("n", [2, 4, 16, 100])
+    def test_independent_trial_deflation_is_unchanged(self, n: int) -> None:
+        """Regression guard on the ρ=0 path, which #1558 must not move.
+
+        ρ=0 was already correct and is the only case ``test_dsr_parity`` can
+        reach (the analytics-engine mirror takes no correlation argument), so
+        pin it against the closed form directly.
+        """
+        assert self._recover_e_max(0.03, 756, n, 0.0) == pytest.approx(self._a_n(n), abs=1e-3)
+
+    def test_null_gate_does_not_admit_noise_above_the_nominal_rate(self) -> None:
+        """Calibration, which is the reason any of this matters.
+
+        Every trial is drifted at exactly ``_RF_DAILY`` so its true EXCESS Sharpe
+        is zero, matching the excess convention ``compute_dsr`` grades on (#547).
+        Getting this wrong hides the defect: drifting at zero instead makes every
+        trial underperform cash by 5%/yr, a far harsher null under which even the
+        broken form scores a respectable 10.3%.
+
+        The winner is then picked by in-sample Sharpe, which is precisely the
+        selection event the DSR exists to correct, so a gate at ``dsr_p >= 0.90``
+        should admit about 10%. The pre-#1558 form admitted 25.5% here.
+
+        Seeded and bounded at 600 runs to stay fast. Binomial noise on a 10% rate
+        at n=600 is ~1.2pp, so the 0.16 threshold sits ~5σ above the true rate and
+        ~8σ below the broken one: it cannot flake in either direction.
+        """
+        rng = np.random.default_rng(1558)
+        n, rho, t, runs = 16, 0.5, 756, 600
+        cov = np.full((n, n), rho) + np.eye(n) * (1.0 - rho)
+        chol = np.linalg.cholesky(cov).T
+        false_passes = 0
+        for _ in range(runs):
+            paths = (rng.standard_normal((t, n)) @ chol) * 0.01 + _RF_DAILY
+            in_sample = (paths.mean(axis=0) - _RF_DAILY) / paths.std(axis=0, ddof=1)
+            best = paths[:, int(np.argmax(in_sample))]
+            _, p_value = compute_dsr(best.tolist(), num_trials=n, average_correlation=rho)
+            false_passes += p_value is not None and p_value >= 0.90
+        rate = false_passes / runs
+        assert rate < 0.16, (
+            f"the gate admitted {rate:.1%} of pure-noise winners at N={n}, rho={rho}; "
+            "a calibrated gate at dsr_p >= 0.90 admits about 10%"
+        )
 
 
 class TestRunRigorGateCpcvWiring:


### PR DESCRIPTION
Closes #1558.

## What was wrong

`_dsr_from_stats` corrected the DSR's expected best-of-N null for correlated
trials by converting N into an effective trial count `N_eff = N/(1 + (N−1)ρ)` and
running that through the Bailey-LdP quantile approximation. That is the wrong
functional form for an expectation of a maximum.

For N equicorrelated standard normals, `X_i = √ρ·Z + √(1−ρ)·ε_i` gives every
`X_i` unit variance and pairwise correlation ρ, and the common factor `Z` comes
straight out of the maximum:

```
max_i X_i = √ρ·Z + √(1−ρ)·max_i ε_i    ⟹    E[max_i X_i] = √(1−ρ)·E[max of N iid]
```

I introduced the `N_eff` form in `dca3eb05` and the reasoning was wrong on three
counts, all recorded in the commit body. The short version: `√(1−ρ)` is Bailey-LdP's
own variance-of-trials term specialised to equicorrelation rather than an
unsourced factor; `N/(1 + (N−1)ρ)` is the Kish design effect and not the
Cheverud/Nyholt statistic it cited; and the justification rested on an endpoint
property that both candidates share, so it could not have selected between them.

## The change

```python
rho = max(0.0, min(1.0, average_correlation))
phi_inv_1 = float(norm.ppf(1.0 - 1.0 / N))
phi_inv_2 = float(norm.ppf(1.0 - 1.0 / (N * math.e)))
e_max_full = (1.0 - _EULER_MASCHERONI) * phi_inv_1 + _EULER_MASCHERONI * phi_inv_2
E_max_N = e_max_full * math.sqrt(1.0 - rho)
```

The `max(2.0, N_eff)` clamp and the linear taper both go. They existed only to
keep a non-integer `N_eff < 2` out of `norm.ppf`; with N used directly (integer,
≥ 2 in this branch) neither has anything to do. ρ=0 is byte-identical, so
independent-trial deflation does not move.

## The guard rejects something (rule 4)

Reverting the implementation to the `N_eff` + taper form and re-running the new
class:

```
18 failed, 7 passed
```

The 7 that pass are the ρ=0 cases, which this PR does not change. Sample failures:

```
test_expected_max_matches_the_equicorrelated_closed_form[0.7-16]
  N=16, rho=0.7: E[max] is 0.2034, equicorrelated closed form is 0.9673 (0.21x)
test_correlation_shrinkage_factor_matches_monte_carlo[8-0.7]
  N=8, rho=0.7: correlation shrinks E[max] by 0.1268, simulation says 0.5470
test_correlated_deflation_keeps_growing_with_trial_count
  E[max] barely moved from N=16 (0.2034) to N=1000 (0.2224) — the multiple-testing
  penalty is saturating in N
test_null_gate_does_not_admit_noise_above_the_nominal_rate
  the gate admitted 25.5% of pure-noise winners at N=16, rho=0.5
```

This is the check the original change failed. Its three tests pin the ρ=0
endpoint, the ρ=1 endpoint and monotonicity between them. `√(1−ρ)` satisfies all
three, so swapping the formula left `test_rigor_evaluator.py` at **203 passed** —
the file could not tell apart two formulas differing by 10×. `test_dsr_parity.py`
could not have caught it either: the analytics-engine mirror takes no correlation
argument, so parity only ever runs at ρ=0.

Two things I got wrong while building the tests, both fixed here rather than
papered over:

- The first Monte-Carlo test compared E[max] **levels** and failed by ~2.5% on
  the correct implementation. That gap is the two-quantile approximation to
  `E[max of N iid]`, which is present at ρ=0 as well and is not what this PR
  touches. It now compares the **ratio** `E[max](ρ)/E[max](0)`, where the common
  bias cancels and only the correlation factor remains. Loosening the tolerance
  instead would have hidden a real approximation inside a correlation test.
- The calibration test first drifted the null at zero. Since `compute_dsr` grades
  on excess return (#547), that makes every trial underperform cash by 5%/yr — a
  much harsher null, under which even the broken form scores a respectable 10.3%
  and the test passed against the bug. It now drifts at `_RF_DAILY`, so true
  excess Sharpe is exactly 0, and the broken form scores 25.5%.

## Calibration

Null simulation, T=756, 3000 runs per cell, every trial drifted at `_RF_DAILY` so
true excess Sharpe is 0, winner picked by in-sample Sharpe. A gate at
`dsr_p ≥ 0.90` should fire about 10%:

| N | ρ | before | after |
|---|---|---|---|
| 8 | 0.3 | 14.6% | 4.4% |
| 8 | 0.5 | 20.9% | 6.1% |
| 8 | 0.7 | 22.3% | 8.0% |
| 16 | 0.3 | 19.6% | 3.8% |
| 16 | 0.5 | 26.2% | 5.5% |
| 16 | 0.7 | 27.7% | 7.9% |
| 16 | 0.9 | 20.7% | 8.8% |

The corrected form is conservative at low ρ and approaches the nominal rate as
ρ→1, which is the right limit: ρ=1 is a single test, so no deflation and the
nominal level.

## Blast radius

Live carrier is `fusion_evaluator.py:724`, which passes correlation
**positionally** (`compute_dsr(daily_returns, effective_trials, avg_correlation)`),
so a `grep average_correlation=` does not find it. Reached from the live
generation path via `debate_engine._critic_rigor` → `evaluate_fusion_spec` →
`apply_rigor_gate`, and it fires whenever a spec carries `parameter_variants` —
the proposer prompt's canonical example ships a 5-value grid, so that is the
ordinary case. Variants are the same strategy over the same assets, so ρ sits at
the top of the range.

Unaffected, because all three run `num_trials=1` and short-circuit to
`E_max_N = 0` before the correlation branch: the curated library badge,
`GET /api/selection-bias/gate`, and `rigor_verify_routes`.

**Generated-strategy verdicts will move, and that is the point.** Anything that
was passing on a 20–28% false-positive rate should stop. I have not touched a
threshold to absorb it.

## Tests

```
pytest backend/tests/test_rigor_evaluator.py backend/tests/test_dsr_hac.py \
       backend/tests/test_dsr_parity.py backend/tests/test_num_trials_correlation_guard.py
  → 258 passed

pytest -m "not integration"     # the command quality-gate.yml runs, from the repo root
  → 4089 passed, 10 failed
```

The 10 are `test_alembic_migrations.py`, all `FileNotFoundError: 'alembic'`. They
fail identically on unmodified `main` in my environment (verified by stashing the
diff and re-running), because that file shells out to a bare `alembic` which is
not on my PATH. Unrelated to this change and green in CI, which has it installed.
Worth its own issue — the file's docstring claims hermeticity while depending on
ambient PATH — but not this PR.

Rebased onto `491853dc` immediately before opening, so the checks describe
current `main`.

## Review note

This corrects my own commit, so it has had no reviewer other than its author.
The math is worth a second pair of eyes: the identity is two lines and either
holds or does not, and the reproduction in #1558 runs standalone in a few seconds.
