### PR TITLE
[backend][security] Reasoning surfaces gate on ownership, not is_strategy_visible (#1557)

### DIFF
--- a/backend/archimedes/api/paper_routes.py
+++ b/backend/archimedes/api/paper_routes.py
@@ -34,12 +34,32 @@ paper_router = APIRouter(prefix="/api/paper", tags=["paper"])
 
 
 def _spec_for_strategy(session, strategy_id: str, caller_wallet: str | None, caller_user_id: str | None) -> dict:
-    """The spec to snapshot, honoring strategy visibility (#850 rules)."""
+    """The spec to snapshot, gated on OWNERSHIP of the source strategy.
+
+    The validated DSL spec is the strategy's EXECUTABLE LOGIC — the derivation,
+    not the card. Publishing a strategy puts its name, methodology and metrics
+    on a public board; it does not hand over the machine-readable
+    implementation for anyone to snapshot into their own ledger. So this asks
+    ``is_strategy_reasoning_visible``, not ``is_strategy_visible``: curated /
+    ``is_example`` house content stays available to everyone, a user's row is
+    available to its owner, and ``is_published`` alone grants nothing (#1557 —
+    this call site used the card predicate, so any published row's spec was
+    deployable by any signed-in stranger).
+
+    This fails CLOSED on purpose. If a marketplace/licensing flow later makes
+    "paper-trade someone else's published strategy" a deliberate product
+    decision, that flow reopens it explicitly — with whatever attribution or
+    licensing check it decides on — rather than inheriting the permission by
+    accident from a predicate that was never about reasoning.
+
+    404 for both "no such strategy" and "not yours": existence stays private
+    (#850 idiom, same as ``_owned_deployment`` below).
+    """
     from archimedes.models.strategy_store import StrategyRecord
-    from archimedes.services.strategy_visibility import is_strategy_visible
+    from archimedes.services.strategy_visibility import is_strategy_reasoning_visible
 
     row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
-    if row is None or not is_strategy_visible(row, caller_wallet, caller_user_id=caller_user_id):
+    if row is None or not is_strategy_reasoning_visible(row, caller_wallet, caller_user_id=caller_user_id):
         raise HTTPException(status_code=404, detail="Strategy not found")
     spec = (row.to_dict() or {}).get("strategy_spec")
     if not spec:

--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -651,6 +651,31 @@ def _generated_strategy_rigor(strategy_id: str, request: Request, strictness: in
     this caller" so the route 404s either way — existence must never leak to a
     non-owner via a different response shape.
 
+    **This is CARD-level and stays on ``is_strategy_visible`` — a deliberate
+    call, not an oversight (#1557).** #1557 moved the reasoning-disclosure
+    surfaces (debate transcript, full daily-return series, DSL spec) onto
+    ``is_strategy_reasoning_visible``, which ignores ``is_published``. This
+    route is not one of them, for two reasons that were checked rather than
+    assumed:
+
+      1. Every number it returns — ``dsr_p_value``, ``pbo_score``,
+         ``out_of_sample_sharpe``, ``deflated_sharpe_ratio``,
+         ``passes_rigor_gate`` — is ALREADY served anonymously for published
+         rows by ``strategies_routes._public_generated_strategy_responses`` on
+         ``GET /api/leaderboard``. Gating here would close nothing while the
+         identical values stayed public one route over — a guard that rejects
+         nothing real.
+      2. The rigor verdict is the CERTIFICATION of a public claim, not the
+         derivation behind it. A published card asserts "this passed the gate";
+         the product's whole positioning is that a reader can check that
+         assertion. Making the check owner-only would leave the claim standing
+         and the verification private.
+
+    The existing contract test ``test_generated_strategy_published_visible_to_
+    anonymous_caller`` pins this. If a future ticket decides the gate detail IS
+    private, it must also stop the leaderboard from publishing the same
+    numbers, or it changes nothing.
+
     Returns a MISSING-shaped result (mirroring the curated "no backtest data"
     branch above) when the strategy exists, is visible, but has fewer than 10
     persisted daily returns — the honest "Pending Backtest" case, not a 404.

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1407,16 +1407,15 @@ def _owned_generated_strategy_responses(
     Deliberately narrower than ``_generated_strategy_responses`` (published-
     by-anyone ∪ owned-by-caller): here the question is "is this MINE", not
     "am I allowed to see this", so another user's published strategy must
-    NOT appear just because it is public. Reuses ``is_strategy_visible`` (the
-    single #850 predicate — never re-implement ownership matching at a call
-    site) for the two-tier owner_user_id/owner_wallet check, but pins
-    ``is_published`` False in the row_view fed to it so a stranger's
-    published row can never ride that predicate's publish-visibility clause
-    onto this caller's board. Curated (``is_example``) rows have no owner and
-    are never returned here — they are the separate "curated" scope.
+    NOT appear just because it is public. Asks ``owns_strategy`` — the single
+    two-tier owner_user_id/owner_wallet match (#1557 named what this used to
+    express by pinning ``is_published`` False in a hand-built row_view fed to
+    ``is_strategy_visible``; same rule, one implementation, never
+    re-implemented at a call site). Curated (``is_example``) rows have no owner
+    and are never returned here — they are the separate "curated" scope.
     """
     from archimedes.services.passport_loader import list_passports
-    from archimedes.services.strategy_visibility import is_strategy_visible
+    from archimedes.services.strategy_visibility import owns_strategy
 
     if not caller_user_id and not caller_wallet:
         return []
@@ -1425,16 +1424,7 @@ def _owned_generated_strategy_responses(
     if not records:
         return []
 
-    owned = []
-    for r in records:
-        row_view = {
-            "is_example": False,
-            "is_published": False,  # ownership only — publish state is irrelevant to "own"
-            "owner_user_id": r.owner_user_id,
-            "owner_wallet": r.owner_wallet,
-        }
-        if is_strategy_visible(row_view, caller_wallet, caller_user_id=caller_user_id):
-            owned.append(r)
+    owned = [r for r in records if owns_strategy(r, caller_wallet, caller_user_id=caller_user_id)]
     return _passport_responses(owned, session)
 
 
@@ -1445,8 +1435,20 @@ async def get_strategy_returns(strategy_id: str, request: Request):
     Response schema: {strategy_id, source: "persisted_backtest", start, end,
     n, daily_returns: [...]}
 
-    404 when the strategy does not exist (or is private and the caller is not
-    the owner — 404-hides-existence per the #850 ownership gating contract).
+    **The per-day series is REASONING, not card content, and gates on
+    OWNERSHIP (#1557).** Curated / ``is_example`` strategies stay fully public
+    (house demo content; ``/quant`` fetches exactly this for every curated
+    library row with no session). For a generated row the series is 404 unless
+    the caller OWNS it — a published row is NOT enough, because a full
+    day-by-day return series lets a reader reconstruct positions and clone the
+    strategy. The HEADLINE stats derived from it (``sharpe_ratio``, ``cagr``,
+    ``max_drawdown``, the rigor verdict) remain on the public card served by
+    ``GET /api/strategies/{id}`` and the leaderboard — publishing shares the
+    result, not the derivation. See the matrix in
+    ``services/strategy_visibility.py``.
+
+    404 when the strategy does not exist (or the caller is not entitled to its
+    reasoning — 404-hides-existence per the #850 ownership gating contract).
     404 with body ``{"detail": "no persisted returns"}`` when the strategy
     exists but has no BacktestResultRecord row. Never synthesizes data from
     fixture metrics; only real persisted run data is returned (#passport-honesty).
@@ -1456,7 +1458,7 @@ async def get_strategy_returns(strategy_id: str, request: Request):
     """
     from fastapi import HTTPException
 
-    # ── 1. Existence + ownership gate (mirrors get_strategy) ────────────────
+    # ── 1. Existence + OWNERSHIP gate ──────────────────────────────────────
     # Curated strategies (in LocalStrategyProvider) are always public.
     strat = strategy_provider().get_strategy(strategy_id)
     is_curated = strat is not None
@@ -1465,7 +1467,7 @@ async def get_strategy_returns(strategy_id: str, request: Request):
         from archimedes.api.auth_siwe import get_verified_wallet
         from archimedes.db import get_session
         from archimedes.models.strategy_store import StrategyRecord
-        from archimedes.services.strategy_visibility import is_strategy_visible
+        from archimedes.services.strategy_visibility import is_strategy_reasoning_visible
 
         with get_session() as session:
             row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
@@ -1474,7 +1476,7 @@ async def get_strategy_returns(strategy_id: str, request: Request):
             # get_verified_wallet, not get_linked_wallet_address.
             caller = get_verified_wallet(request)
             user = get_current_user(request)
-            if not is_strategy_visible(row, caller, caller_user_id=user.id if user else None):
+            if not is_strategy_reasoning_visible(row, caller, caller_user_id=user.id if user else None):
                 raise HTTPException(status_code=404, detail="Strategy not found")
 
     # ── 2. Load persisted daily returns from backtest_results ────────────────
@@ -1520,36 +1522,48 @@ async def get_strategy_debate(strategy_id: str, request: Request):
     Response shape: ``{strategy_id, generation_id, candidate_id, created_at,
     transcript: [{role, round, verdict, claims}, ...]}``.
 
-    Auth mirrors ``GET /api/strategies/{id}/returns`` and the plain detail
-    route exactly: curated strategies are always public; a generated
-    strategy's transcript is 404 unless the caller owns the row (existence
-    stays hidden either way — never a 403).
+    **This route is PURE REASONING and gates on OWNERSHIP, not on card-level
+    visibility (#1557).** Curated / ``is_example`` strategies are always public
+    (house demo content — in practice they carry no transcript at all, the
+    debate society never ran for them). For a generated row the transcript is
+    404 unless the caller OWNS it — a published row is NOT enough. Existence
+    stays hidden either way: 404, never 403.
+
+    Until #1557 this docstring claimed exactly that contract while the code
+    asked ``is_strategy_visible``, which returns True on ``is_published`` — so
+    an anonymous GET on any published strategy returned its full generation
+    debate. The claim was false; the predicate is now the one that makes it
+    true. Publishing consents to sharing the strategy, not the multi-agent
+    argument that produced it (same reasoning as ``brief_intent`` on the detail
+    route, and ``_redact_owner_wallet`` for the owner's wallet).
 
     404 with ``{"detail": "no debate transcript"}`` when the strategy exists
-    and is visible but no transcript was ever persisted for it — every
-    strategy generated before this table existed, every curated strategy
-    (the debate society never ran for those), and any run whose debate step
-    genuinely produced nothing (no LLM backend reachable). Never fabricates a
-    transcript.
+    and the caller is entitled to its reasoning but no transcript was ever
+    persisted for it — every strategy generated before this table existed,
+    every curated strategy, and any run whose debate step genuinely produced
+    nothing (no LLM backend reachable). Never fabricates a transcript.
     """
     from fastapi import HTTPException
 
     from archimedes.db import get_session
 
-    # ── 1. Existence + ownership gate (mirrors get_strategy / get_strategy_returns) ──
+    # ── 1. Existence + OWNERSHIP gate ─────────────────────────────────────
+    # Deliberately NOT the same gate as `get_strategy` (the card): see the
+    # matrix in services/strategy_visibility.py. The card of a published
+    # strategy is public; its debate transcript is not.
     strat = strategy_provider().get_strategy(strategy_id)
     is_curated = strat is not None
 
     if not is_curated:
         from archimedes.api.auth_siwe import get_verified_wallet
         from archimedes.models.strategy_store import StrategyRecord
-        from archimedes.services.strategy_visibility import is_strategy_visible
+        from archimedes.services.strategy_visibility import is_strategy_reasoning_visible
 
         with get_session() as session:
             row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
             caller = get_verified_wallet(request)
             user = get_current_user(request)
-            if not is_strategy_visible(row, caller, caller_user_id=user.id if user else None):
+            if not is_strategy_reasoning_visible(row, caller, caller_user_id=user.id if user else None):
                 raise HTTPException(status_code=404, detail="Strategy not found")
 
     # ── 2. Load the persisted transcript ──────────────────────────────────
@@ -1576,6 +1590,20 @@ async def get_strategy(strategy_id: str, request: Request):
     Private-until-published: non-public row is 404 unless canonical user owns it,
     with linked-wallet fallback for legacy rows. 404 prevents existence probing.
     Curated strategies (provider path / is_example rows) stay fully public.
+
+    **This route is MIXED and stays CARD-gated (#1557).** Everything the
+    response carries for a generated row is card content — name, papers,
+    methodology writeup, headline metrics, the rigor badge — which is exactly
+    what a published strategy is published FOR, so a published row 200s for
+    anonymous callers and the public detail page keeps working. The one
+    REASONING field on the schema, ``brief_intent``, is stripped for non-owners
+    below rather than 404ing the whole route (the strip-don't-404 rule for
+    mixed routes; the purely-reasoning siblings ``/{id}/debate`` and
+    ``/{id}/returns`` 404 instead). Audited field by field against
+    ``_passport_to_strategy_response``: ``brief_intent`` is the only reasoning
+    field it can populate — ``equity_curve`` is never set on this path, and the
+    rigor/display metrics are aggregates, not derivation. See the matrix in
+    ``services/strategy_visibility.py``.
     """
     from fastapi import HTTPException
 
@@ -1587,7 +1615,7 @@ async def get_strategy(strategy_id: str, request: Request):
     from archimedes.db import get_session
     from archimedes.models.strategy_store import StrategyRecord
     from archimedes.services.passport_loader import get_passport
-    from archimedes.services.strategy_visibility import is_strategy_visible
+    from archimedes.services.strategy_visibility import is_strategy_visible, owns_strategy
 
     with get_session() as session:
         row = session.query(StrategyRecord).filter_by(id=strategy_id).first()
@@ -1615,24 +1643,16 @@ async def get_strategy(strategy_id: str, request: Request):
             # row, but the brief is the user's own words, and publishing a
             # strategy consents to sharing the STRATEGY, not the sentence its
             # owner typed to ask for it (same reasoning as
-            # `_redact_owner_wallet` for owner_wallet). So the same #850
-            # predicate is re-asked in ownership-only form — `is_example` and
-            # `is_published` pinned False in the row_view so neither
-            # public-visibility clause can grant it — which is exactly the
-            # shape `_owned_generated_strategy_responses` uses for the
-            # leaderboard's "own" scope. Never re-implement the owner match
-            # at a call site; ask the one predicate. Non-owners and anonymous
-            # callers keep the schema default (None).
-            if row is not None and is_strategy_visible(
-                {
-                    "is_example": False,
-                    "is_published": False,
-                    "owner_user_id": row.owner_user_id,
-                    "owner_wallet": row.owner_wallet,
-                },
-                caller,
-                caller_user_id=user.id if user else None,
-            ):
+            # `_redact_owner_wallet` for owner_wallet). Non-owners and
+            # anonymous callers keep the schema default (None).
+            #
+            # `owns_strategy` (#1557) is the named form of what this used to
+            # express by calling `is_strategy_visible` with `is_example` and
+            # `is_published` pinned False in a hand-built row_view. Same rule,
+            # same single implementation — but a reader can no longer mistake
+            # the pinned-flags trick for an accident, and the ownership match
+            # is not re-implemented at a call site.
+            if row is not None and owns_strategy(row, caller, caller_user_id=user.id if user else None):
                 resp.brief_intent = row.brief_intent
             return resp
 

--- a/backend/archimedes/services/strategy_visibility.py
+++ b/backend/archimedes/services/strategy_visibility.py
@@ -1,4 +1,76 @@
-"""Strategy visibility predicate implementing #850 privacy rules."""
+"""Strategy visibility predicates implementing #850 privacy rules and the
+#1557 card-vs-reasoning split.
+
+TWO predicates live here, and picking the wrong one is an authorization bug:
+
+    is_strategy_visible          -> may the caller read the CARD?
+    is_strategy_reasoning_visible -> may the caller read the REASONING?
+
+────────────────────────────────────────────────────────────────────────────
+THE VISIBILITY MATRIX (#1557)
+────────────────────────────────────────────────────────────────────────────
+
+                                CARD                    REASONING
+                                (name, papers,          (debate transcript,
+                                 methodology,            full daily-return
+                                 headline metrics,       series, machine-
+                                 rigor badge +           readable DSL spec,
+                                 its gate detail)        the owner's brief)
+  ──────────────────────────────────────────────────────────────────────────
+  curated / is_example row      PUBLIC                  PUBLIC
+  (house demo content)          `is_strategy_visible`   `is_strategy_reasoning_visible`
+
+  user row, is_published=True   PUBLIC                  OWNER ONLY
+  (owner opted in)              `is_strategy_visible`   `is_strategy_reasoning_visible`
+
+  user row, private             OWNER ONLY              OWNER ONLY
+  (the default)                 `is_strategy_visible`   `is_strategy_reasoning_visible`
+
+**Publishing consents to sharing the RESULT, not the DERIVATION.** That is the
+whole rule. A user who publishes a strategy is putting a card on a public
+board — its name, the papers it came from, the methodology writeup, the
+measured metrics, and the rigor verdict that certifies those metrics. They are
+not handing over the multi-agent debate that produced it, the day-by-day
+return series it was graded on, or the executable spec that runs it. Those are
+the derivation, and they stay with the owner.
+
+Why ``is_example`` reasoning stays public: those rows are house-curated demo
+content with no owner to protect, and the product already renders their
+reasoning to anonymous visitors — ``GET /{id}/returns`` and ``GET /{id}/debate``
+both short-circuit BEFORE any row check when
+``strategy_provider().get_strategy(id)`` resolves, and ``/quant`` (QuantLab)
+fetches the full return series for every curated library row with no session at
+all. Gating them would break a live public page while protecting nobody.
+(Verified against ui/src/components/QuantLab.jsx and the ``is_curated``
+short-circuits in ``strategies_routes``, not assumed.)
+
+Where the line was drawn, route by route, and why — the deliberate calls:
+
+  * ``GET /api/strategies/{id}/debate`` — REASONING, and nothing but. The full
+    bull/bear LLM transcript. 404s for a non-owner.
+  * ``GET /api/strategies/{id}/returns`` — REASONING. The per-day series is the
+    raw backtest output; from it a reader can reconstruct positions and clone
+    the strategy. The *headline* stats derived from it (Sharpe, CAGR, max
+    drawdown) stay on the public card. 404s for a non-owner.
+  * ``POST /api/paper/deployments`` (``_spec_for_strategy``) — REASONING. The
+    validated DSL spec is the strategy's executable logic: the thing a
+    marketplace would license, not give away. There is no licensing flow yet,
+    so this fails closed; it can be reopened deliberately when one exists.
+  * ``GET /api/strategies/{id}`` — MIXED. Stays card-public (a 404 here would
+    take the public detail page down for published strategies); the one
+    reasoning field on the response, ``brief_intent``, is stripped for
+    non-owners via ``owns_strategy`` (#1547).
+  * ``GET /api/selection-bias/gate/{id}`` — CARD, deliberately. Every number it
+    returns (``dsr_p_value`` / ``pbo_score`` / ``out_of_sample_sharpe`` /
+    ``deflated_sharpe_ratio`` / ``passes_rigor_gate``) is ALREADY served
+    anonymously for published rows by ``_public_generated_strategy_responses``
+    on ``GET /api/leaderboard``. Gating it would close nothing while the same
+    values stayed public one route over, and would break the public
+    verify-the-claim affordance the product's whole positioning rests on.
+    Pinned by ``test_generated_strategy_published_visible_to_anonymous_caller``.
+  * List surfaces (``/``, ``/generated``, ``/passports``, the leaderboard) —
+    CARD. Unchanged.
+"""
 
 from __future__ import annotations
 
@@ -12,18 +84,23 @@ def _field(row: StrategyRecord | dict, name: str, default: Any = None) -> Any:
     return row.get(name, default) if isinstance(row, dict) else getattr(row, name, default)
 
 
-def is_strategy_visible(
+def owns_strategy(
     row: StrategyRecord | dict | None,
     caller_wallet: str | None,
     *,
     caller_user_id: str | None = None,
 ) -> bool:
-    """Checks if a strategy is visible to the caller per #850 privacy rules.
+    """Does *caller* OWN this row? Publish/example state is irrelevant here.
 
-    A strategy is visible if:
-      1. row is not None AND row.is_example is True, OR
-      2. row.is_published is True, OR
-      3. the caller owns it.
+    THE single implementation of the two-tier ownership match. Both public
+    predicates below delegate to it, and so does every call site that needs
+    "is this MINE" rather than "am I allowed to see this"
+    (``_owned_generated_strategy_responses``, the ``brief_intent`` gate in
+    ``get_strategy``). Never re-implement it at a call site: this codebase's
+    characteristic defect is a rule being fixed in the one function the current
+    ticket touches while sibling readers keep the old behaviour, and an
+    ownership rule that disagrees with itself across two routes is an
+    authorization bug, not an inconsistency.
 
     OWNERSHIP IS TWO-TIERED, because canonical identity was introduced after
     rows already existed (Better Auth ``auth_users.id``):
@@ -34,20 +111,10 @@ def is_strategy_visible(
         which would make the migration to canonical identity a downgrade in
         security rather than an upgrade.
       - If ``owner_user_id`` is NULL, the row predates canonical identity and
-        falls back to the wallet comparison this function has always done.
-
-    This predicate is the single source of truth for that rule. It is
-    deliberately not re-implemented at call sites: this codebase's
-    characteristic defect is a rule being fixed in the one function the current
-    ticket touches while sibling readers keep the old behaviour, and a
-    visibility rule that disagrees with itself across two routes is an
-    authorization bug, not an inconsistency.
+        falls back to the wallet comparison this module has always done.
     """
     if row is None:
         return False
-
-    if _field(row, "is_example", False) or _field(row, "is_published", False):
-        return True
 
     owner_user_id = _field(row, "owner_user_id")
     if owner_user_id is not None:
@@ -61,3 +128,70 @@ def is_strategy_visible(
         return False
 
     return str(owner).strip().lower() == str(caller_wallet).strip().lower()
+
+
+def is_strategy_visible(
+    row: StrategyRecord | dict | None,
+    caller_wallet: str | None,
+    *,
+    caller_user_id: str | None = None,
+) -> bool:
+    """CARD-level visibility: may the caller read this strategy AT ALL?
+
+    A strategy's card is visible if:
+      1. row is not None AND row.is_example is True, OR
+      2. row.is_published is True, OR
+      3. the caller owns it (see ``owns_strategy``).
+
+    **This predicate means "readable by ANYONE", including anonymous callers,
+    the moment ``is_published`` flips.** That is correct for a card and WRONG
+    for reasoning — it was the #1557 hole: five consumers used it to gate
+    reasoning-disclosure surfaces, so publishing a strategy handed its full
+    generation debate to the internet. Reasoning surfaces call
+    ``is_strategy_reasoning_visible`` instead. Read the module docstring's
+    matrix before choosing between them.
+
+    This predicate is the single source of truth for card-level visibility. It
+    is deliberately not re-implemented at call sites: a visibility rule that
+    disagrees with itself across two routes is an authorization bug, not an
+    inconsistency.
+    """
+    if row is None:
+        return False
+
+    if _field(row, "is_example", False) or _field(row, "is_published", False):
+        return True
+
+    return owns_strategy(row, caller_wallet, caller_user_id=caller_user_id)
+
+
+def is_strategy_reasoning_visible(
+    row: StrategyRecord | dict | None,
+    caller_wallet: str | None,
+    *,
+    caller_user_id: str | None = None,
+) -> bool:
+    """REASONING-level visibility: may the caller read HOW this strategy was
+    derived — the debate transcript, the full daily-return series, the
+    executable DSL spec?
+
+    Reasoning is visible if:
+      1. row is not None AND row.is_example is True (house demo content — the
+         product already renders its reasoning to anonymous visitors; see the
+         module docstring for the verification), OR
+      2. the caller owns it.
+
+    ``is_published`` is DELIBERATELY ABSENT from that list, and its absence is
+    the entire point of this function (#1557). Publishing consents to sharing
+    the result, not the derivation. If a future change adds an ``is_published``
+    clause here, it re-opens the hole: an anonymous ``GET
+    /api/strategies/{id}/debate`` on any published row returns that user's full
+    generation transcript.
+    """
+    if row is None:
+        return False
+
+    if _field(row, "is_example", False):
+        return True
+
+    return owns_strategy(row, caller_wallet, caller_user_id=caller_user_id)

--- a/backend/tests/test_reasoning_disclosure_gates.py
+++ b/backend/tests/test_reasoning_disclosure_gates.py
@@ -1,0 +1,494 @@
+"""Reasoning-disclosure gates: publishing shares the RESULT, not the DERIVATION (#1557).
+
+``is_strategy_visible`` returns True on ``is_example OR is_published``, i.e.
+"readable by ANYONE, including anonymous". That is the right rule for a
+strategy's CARD and the wrong rule for its REASONING — and five consumers used
+it for reasoning. The moment anything flips ``is_published=True`` on a user's
+row, an anonymous ``GET /api/strategies/{id}/debate`` returned that user's full
+bull/bear generation transcript. The route's own docstring claimed "404 unless
+the caller owns the row"; it was false.
+
+This file is the guard for the fix. Three things it is built to do:
+
+**1. Fail against the unfixed predicate.** Every route assertion here is made
+on a row that is ``is_published=True`` and owned by someone else — the exact
+input ``is_strategy_visible`` returns True for. Swap
+``is_strategy_reasoning_visible`` back to ``is_strategy_visible`` at any of the
+gated call sites and these tests go red. (Demonstrated by doing it, not
+assumed: see the PR body.)
+
+**2. Not pass for the wrong reason.** A 404 is a weak assertion — the row could
+be missing, the transcript never persisted, the fixture broken. So every leak
+test carries a POSITIVE CONTROL in the same test body: the OWNER gets 200 and
+the sentinel payload back, proving the data really is there and reachable, so
+the anonymous/stranger 404 is the gate rather than absent data. Leak
+assertions are made on the raw response TEXT against a distinctive sentinel,
+not only on a status code, so a refactor that moves the transcript into some
+other key still trips them.
+
+**3. Prove the public surface survives.** The same published row's CARD must
+still 200 for an anonymous caller, and ``is_example`` house content must still
+serve its reasoning publicly — otherwise the fix is a regression on the
+leaderboard/library/detail pages rather than a privacy gate.
+
+Hermetic: tmp-sqlite rebind (the ``_use_tmp_db`` pattern from
+test_strategy_ownership.py / test_selection_bias_generated_gate.py), signed
+SIWE fixture cookies mapped onto canonical Better Auth users by conftest's
+autouse ``_legacy_siwe_test_adapter``. No network, no Redis, no .env.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import archimedes.db as db
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from httpx import ASGITransport, AsyncClient
+
+_W_OWNER = "0xAbC0000000000000000000000000000000000F01"  # mixed case on purpose
+_W_STRANGER = "0x0000000000000000000000000000000000000F02"
+
+# Distinctive strings/values that must never appear in a non-owner's response.
+# Chosen to survive `sanitize_transcript` (no T<n>.<n> / "cutover" / "Phase-"
+# jargon patterns), so a missing sentinel means the GATE fired, never that the
+# sanitizer ate it.
+_BULL_SENTINEL = "SENTINEL-BULL-cross-sectional-momentum-persists-in-small-caps"
+_BEAR_SENTINEL = "SENTINEL-BEAR-the-factor-is-crowded-and-decays-post-publication"
+_SPEC_SENTINEL = "SENTINEL-SPEC-name-that-must-not-escape"
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Point the DB at a FRESH temp sqlite (rebinds db.engine + db.SessionLocal).
+
+    db.engine/SessionLocal are created once at import, so setenv alone doesn't
+    re-point them; rebind both to a per-test engine, then init_db() registers
+    every table (incl. the passport/backtest/debate side-effect imports).
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'reasoning_gates.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _legacy_user_id(wallet: str) -> str:
+    """The canonical user id conftest's ``_legacy_siwe_test_adapter`` mints for
+    a SIWE fixture cookie. Derived, not hard-coded, so it cannot drift from the
+    adapter (which builds ``legacy-test:{wallet}`` from a payload lower-cased
+    at signing time)."""
+    return f"legacy-test:{wallet.lower()}"
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    """A real signed SIWE session cookie, not header spoofing."""
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _mk_strategy(
+    sid: str,
+    *,
+    owner_user: str | None = None,
+    owner_wallet: str | None = None,
+    published: bool = False,
+    example: bool = False,
+    spec: dict | None = None,
+):
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with db.get_session() as session:
+        session.add(
+            StrategyRecord(
+                id=sid,
+                content_hash=("0x" + sid).ljust(66, "0"),
+                generation_method="debate",
+                source_papers="[]",
+                strategy_name="Reasoning Gate Probe",
+                thesis="test thesis",
+                asset_universe='["SPY"]',
+                risk_profile="moderate",
+                status="candidate",
+                is_example=example,
+                is_published=published,
+                owner_user_id=owner_user,
+                owner_wallet=owner_wallet.lower() if owner_wallet else None,
+                strategy_spec=json.dumps(spec) if spec else None,
+            )
+        )
+        session.commit()
+
+
+def _mk_passport(sid: str):
+    """The strategy_passports mirror the CARD route reads (``get_passport``)."""
+    from archimedes.models.strategy_passport_record import PassportPaperRef, StrategyPassportRecord
+
+    with db.get_session() as session:
+        record = StrategyPassportRecord(
+            id=sid,
+            content_hash=("0y" + sid).ljust(66, "0"),
+            generation_method="debate",
+            methodology_summary="Public methodology writeup",
+            asset_universe='["SPY"]',
+        )
+        record.paper_refs = [PassportPaperRef(passport_id=sid, arxiv_id="2401.00001", title="Paper")]
+        session.add(record)
+        session.commit()
+
+
+def _mk_debate_transcript(sid: str):
+    from archimedes.models.debate_transcript import record_debate_transcript
+
+    with db.get_session() as session:
+        record_debate_transcript(
+            session,
+            strategy_id=sid,
+            generation_id="job-reasoning-gate",
+            candidate_id="cand_probe",
+            transcript=[
+                {"role": "bull", "round": 1, "verdict": "act", "claims": [_BULL_SENTINEL]},
+                {"role": "bear", "round": 1, "verdict": "decline", "claims": [_BEAR_SENTINEL]},
+            ],
+        )
+        session.commit()
+
+
+# A short, deliberately odd series: each value is distinctive enough that its
+# string form appearing in a response body is proof the series leaked.
+_RETURNS = [0.0137911, -0.0091733, 0.0245177, -0.0033099, 0.0188421]
+
+
+def _mk_backtest(sid: str, returns: list[float] | None = None):
+    from archimedes.models.backtest_store import BacktestResultRecord
+
+    series = _RETURNS if returns is None else returns
+    with db.get_session() as session:
+        session.add(
+            BacktestResultRecord(
+                strategy_id=sid,
+                content_hash=f"bt_{sid}",
+                artifact_json=json.dumps({"results": [{"metrics": {"daily_returns": series}}]}),
+                source_pipeline="test",
+            )
+        )
+        session.commit()
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 1. The predicate itself — the divergence #1557 introduces
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_the_two_predicates_diverge_on_a_published_row():
+    """The whole bug in one assertion.
+
+    A published row owned by someone else is CARD-visible to an anonymous
+    caller and must NOT be REASONING-visible. If this ever reports the same
+    answer for both, the split has collapsed and every route gate below is
+    decorative.
+    """
+    from archimedes.services.strategy_visibility import is_strategy_reasoning_visible, is_strategy_visible
+
+    published = {
+        "is_example": False,
+        "is_published": True,
+        "owner_user_id": "user_someone_else",
+        "owner_wallet": None,
+    }
+
+    assert is_strategy_visible(published, None, caller_user_id=None) is True
+    assert is_strategy_reasoning_visible(published, None, caller_user_id=None) is False
+    # …and for a DIFFERENT signed-in user, not only anonymous.
+    assert is_strategy_visible(published, None, caller_user_id="user_stranger") is True
+    assert is_strategy_reasoning_visible(published, None, caller_user_id="user_stranger") is False
+
+
+def test_reasoning_predicate_grants_example_rows_to_everyone():
+    """House-curated demo content: reasoning IS the demo. Anonymous callers
+    already get exactly this on /quant for every curated library row."""
+    from archimedes.services.strategy_visibility import is_strategy_reasoning_visible
+
+    example = {"is_example": True, "is_published": False, "owner_user_id": None, "owner_wallet": None}
+    assert is_strategy_reasoning_visible(example, None, caller_user_id=None) is True
+
+
+def test_reasoning_predicate_grants_owners_on_both_ownership_tiers():
+    from archimedes.services.strategy_visibility import is_strategy_reasoning_visible
+
+    canonical = {"is_example": False, "is_published": True, "owner_user_id": "user_a", "owner_wallet": "0xabc"}
+    assert is_strategy_reasoning_visible(canonical, None, caller_user_id="user_a") is True
+    # Canonical ownership is exclusive: a matching WALLET must not grant a row
+    # that carries an owner_user_id (else canonical identity is bypassable).
+    assert is_strategy_reasoning_visible(canonical, "0xabc", caller_user_id=None) is False
+
+    legacy = {"is_example": False, "is_published": True, "owner_user_id": None, "owner_wallet": "0xABC"}
+    assert is_strategy_reasoning_visible(legacy, "  0xabc ", caller_user_id=None) is True
+    assert is_strategy_reasoning_visible(legacy, "0xdef", caller_user_id=None) is False
+    assert is_strategy_reasoning_visible(legacy, None, caller_user_id=None) is False
+
+
+def test_reasoning_predicate_denies_none_row():
+    from archimedes.services.strategy_visibility import is_strategy_reasoning_visible
+
+    assert is_strategy_reasoning_visible(None, "0xabc", caller_user_id="user_a") is False
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 2. GET /{id}/debate — the transcript leak named in #1557
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("caller", [None, _W_STRANGER], ids=["anonymous", "different-user"])
+async def test_published_debate_transcript_never_reaches_a_non_owner(caller):
+    """THE #1557 ACCEPTANCE TEST.
+
+    The row is PUBLISHED — the exact state that made ``is_strategy_visible``
+    return True for everybody. An anonymous visitor and a signed-in stranger
+    must both get 404 and must never see a word of the transcript.
+    """
+    sid = "rsn00000000000001"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=True)
+    _mk_passport(sid)
+    _mk_debate_transcript(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/api/strategies/{sid}/debate",
+            cookies=_siwe_cookies(caller) if caller else None,
+        )
+
+    assert resp.status_code == 404, "a published row's debate transcript must 404 for a non-owner"
+    # Asserted on the raw text, not just the field: a refactor that free-forms
+    # the transcript into another key still trips this.
+    assert _BULL_SENTINEL not in resp.text
+    assert _BEAR_SENTINEL not in resp.text
+
+
+async def test_published_debate_transcript_still_reaches_its_owner():
+    """POSITIVE CONTROL for the test above — and the reason its 404s mean
+    something. Same fixture, same published row: the owner gets 200 and both
+    sentinels back, so the transcript demonstrably exists and is reachable.
+    Without this, the 404s could be a missing row or a broken fixture."""
+    sid = "rsn00000000000002"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=True)
+    _mk_passport(sid)
+    _mk_debate_transcript(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}/debate", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    assert resp.json()["strategy_id"] == sid
+    assert _BULL_SENTINEL in resp.text
+    assert _BEAR_SENTINEL in resp.text
+
+
+async def test_example_row_debate_transcript_stays_public():
+    """House content is not user reasoning: an ``is_example`` row's transcript
+    stays anonymously readable, matching the ``is_curated`` short-circuit the
+    provider-backed path has always had."""
+    sid = "rsn00000000000003"
+    _mk_strategy(sid, example=True)
+    _mk_debate_transcript(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}/debate")
+
+    assert resp.status_code == 200
+    assert _BULL_SENTINEL in resp.text
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 3. GET /{id}/returns — the full daily-return series
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("caller", [None, _W_STRANGER], ids=["anonymous", "different-user"])
+async def test_published_returns_series_never_reaches_a_non_owner(caller):
+    """The per-day series is the raw backtest output — enough to reconstruct
+    positions and clone the strategy. Headline stats stay on the public card;
+    the series does not."""
+    sid = "rsn00000000000004"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=True)
+    _mk_passport(sid)
+    _mk_backtest(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/api/strategies/{sid}/returns",
+            cookies=_siwe_cookies(caller) if caller else None,
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Strategy not found", (
+        "must be the existence-hiding 404, not 'no persisted returns' — the "
+        "latter would confirm the strategy exists to a non-owner"
+    )
+    for value in _RETURNS:
+        assert str(value) not in resp.text
+
+
+async def test_published_returns_series_still_reaches_its_owner():
+    """POSITIVE CONTROL: the series exists and the owner gets all of it."""
+    sid = "rsn00000000000005"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=True)
+    _mk_passport(sid)
+    _mk_backtest(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}/returns", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["n"] == len(_RETURNS)
+    assert body["daily_returns"] == pytest.approx(_RETURNS, rel=1e-9)
+
+
+async def test_example_row_returns_series_stays_public():
+    """/quant fetches exactly this, anonymously, for every curated library row.
+    Gating ``is_example`` here would break a live public page."""
+    sid = "rsn00000000000006"
+    _mk_strategy(sid, example=True)
+    _mk_backtest(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}/returns")
+
+    assert resp.status_code == 200
+    assert resp.json()["daily_returns"] == pytest.approx(_RETURNS, rel=1e-9)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 4. The CARD must survive — this is a reasoning gate, not a takedown
+# ══════════════════════════════════════════════════════════════════════════
+
+
+async def test_published_card_stays_public_for_anonymous_callers():
+    """The anti-regression half of the matrix, and the anchor that makes every
+    404 above meaningful: the SAME published row whose reasoning is now
+    owner-only still serves its card — name, papers, methodology, metrics — to
+    an anonymous visitor. If this ever 404s, the fix has broken the
+    leaderboard/library/detail pages instead of protecting reasoning."""
+    sid = "rsn00000000000007"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=True)
+    _mk_passport(sid)
+    _mk_debate_transcript(sid)
+    _mk_backtest(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == sid
+    assert body["methodology_summary"] == "Public methodology writeup"
+    # …but no reasoning rides along on the card.
+    assert body["brief_intent"] is None
+    assert _BULL_SENTINEL not in resp.text
+
+
+async def test_private_row_card_still_404s_for_non_owners():
+    """Unchanged #850 behaviour — pinned here so a future edit to the shared
+    predicate cannot loosen the card gate while everyone watches the reasoning
+    gate."""
+    sid = "rsn00000000000008"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=False)
+    _mk_passport(sid)
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = await client.get(f"/api/strategies/{sid}")
+        stranger = await client.get(f"/api/strategies/{sid}", cookies=_siwe_cookies(_W_STRANGER))
+        owner = await client.get(f"/api/strategies/{sid}", cookies=_siwe_cookies(_W_OWNER))
+
+    assert anon.status_code == 404
+    assert stranger.status_code == 404
+    assert owner.status_code == 200
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 5. paper_routes._spec_for_strategy — the executable DSL spec
+# ══════════════════════════════════════════════════════════════════════════
+#
+# Tested at the helper rather than through POST /api/paper/deployments: the
+# gate under test is this function, and the route around it drags in real
+# market-data advancement that has nothing to do with the authorization
+# question.
+
+
+def _spec_call(sid: str, *, caller_wallet: str | None, caller_user_id: str | None):
+    from archimedes.api import paper_routes
+
+    with db.get_session() as session:
+        return paper_routes._spec_for_strategy(session, sid, caller_wallet, caller_user_id)
+
+
+_SPEC = {
+    "name": _SPEC_SENTINEL,
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "daily",
+    "entry": {"gt": ["momentum_20", 0]},
+    "exit": {"lt": ["momentum_20", -0.99]},
+}
+
+
+@pytest.mark.parametrize(
+    ("caller_wallet", "caller_user_id"),
+    [(None, None), (None, "legacy-test:0x0000000000000000000000000000000000000f02")],
+    ids=["anonymous", "different-user"],
+)
+def test_published_strategy_spec_is_not_snapshottable_by_a_non_owner(caller_wallet, caller_user_id):
+    """A published card is not a licence to snapshot the executable logic into
+    someone else's paper ledger. Fails closed until a marketplace/licensing
+    flow opens it deliberately."""
+    from fastapi import HTTPException
+
+    sid = "rsn00000000000009"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=True, spec=_SPEC)
+
+    with pytest.raises(HTTPException) as exc:
+        _spec_call(sid, caller_wallet=caller_wallet, caller_user_id=caller_user_id)
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Strategy not found"
+
+
+def test_published_strategy_spec_still_snapshottable_by_its_owner():
+    """POSITIVE CONTROL: the spec is really stored and really returned — so the
+    404s above are the gate, not a missing/undecodable spec column (which would
+    raise a 422 'no_strategy_spec' instead and is a different failure)."""
+    sid = "rsn00000000000010"
+    _mk_strategy(sid, owner_user=_legacy_user_id(_W_OWNER), published=True, spec=_SPEC)
+
+    spec = _spec_call(sid, caller_wallet=None, caller_user_id=_legacy_user_id(_W_OWNER))
+    assert spec["name"] == _SPEC_SENTINEL
+
+
+def test_example_strategy_spec_stays_snapshottable_by_anyone():
+    """House demo content stays paper-tradeable by any signed-in user — the
+    quickstart journey depends on it."""
+    sid = "rsn00000000000011"
+    _mk_strategy(sid, example=True, spec=_SPEC)
+
+    spec = _spec_call(sid, caller_wallet=None, caller_user_id="legacy-test:0xsomeone")
+    assert spec["name"] == _SPEC_SENTINEL

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -409,17 +409,37 @@ async def test_debate_unpublished_404_unless_owner():
     assert [t["role"] for t in body["transcript"]] == ["bull", "bear"]
 
 
-async def test_debate_published_is_public():
+async def test_debate_published_is_still_owner_only():
+    """#1557 INVERTS the old ``test_debate_published_is_public`` contract.
+
+    Publishing a strategy shares the strategy, not the multi-agent argument
+    that produced it. The transcript is REASONING and gates on ownership, so
+    ``is_published`` grants nothing here — while the card (``GET
+    /api/strategies/{id}``) stays public for exactly the same row, which is
+    asserted alongside so this cannot pass by the row simply being invisible.
+    """
     sid = "dbt00000000000002"
     _mk_strategy(sid, owner=_W_OWNER, published=True)
+    _mk_passport(sid)
     _mk_debate_transcript(sid)
 
     from archimedes.main import app
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get(f"/api/strategies/{sid}/debate")
-    assert resp.status_code == 200
-    assert resp.json()["strategy_id"] == sid
+        anon = await client.get(f"/api/strategies/{sid}/debate")
+        other = await client.get(f"/api/strategies/{sid}/debate", cookies=_siwe_cookies(_W_OTHER))
+        owner = await client.get(f"/api/strategies/{sid}/debate", cookies=_siwe_cookies(_W_OWNER))
+        card = await client.get(f"/api/strategies/{sid}")
+
+    assert anon.status_code == 404
+    assert other.status_code == 404  # 404, not 403 — existence stays hidden
+    # Positive control: the transcript really is persisted and reachable, so
+    # the two 404s above are the GATE, not missing data.
+    assert owner.status_code == 200
+    assert owner.json()["strategy_id"] == sid
+    # The card of the very same published row stays public — this is a
+    # reasoning gate, not a re-privatisation of published strategies.
+    assert card.status_code == 200
 
 
 async def test_debate_404_when_strategy_exists_but_no_transcript_was_persisted():


### PR DESCRIPTION
Closes #1557 (CRITICAL, 2026-08-30 red-team). `is_strategy_visible` returns True on `is_example OR is_published` — "readable by ANYONE" — and five consumers used it to gate **reasoning**. The moment anything flips `is_published` on a user's strategy, an anonymous `GET /{id}/debate` would return the full bull/bear transcript. The debate route's docstring claimed owner-only; that was false.

## The fix — a card-vs-reasoning split
`strategy_visibility.py` now holds three predicates, each rule implemented once:
- **`owns_strategy`** — the two-tier owner match (canonical `owner_user_id`, wallet fallback), extracted as THE single implementation; the #1547 brief gate and the leaderboard "own" scope now delegate to it.
- **`is_strategy_visible`** — unchanged, documented as CARD-only.
- **`is_strategy_reasoning_visible`** — `is_example OR owner`; **no publish clause**.

**Matrix** (documented at every gate): example rows = card public / reasoning public (house demo content, verified live-rendered to anon). User published = card public / **reasoning owner-only** (was public — the bug). User private = owner-only both. *Publishing consents to sharing the RESULT, not the DERIVATION.*

Gated onto reasoning: `/{id}/debate` (pure reasoning → 404), `/{id}/returns` (per-day series is raw backtest output; headline stats stay on the card), `POST /api/paper/deployments` spec snapshot (executable logic; fails closed until a licensing flow exists). `GET /{id}` stays card-public with `brief_intent` stripped for non-owners (strip-don't-404, audited field-by-field). False `/debate` docstring fixed and the old lie called out in place.

**Deliberate deviation, flagged for the owner:** `GET /api/selection-bias/gate/{id}` stays card-gated — every number it returns is already served anonymously for published rows by the leaderboard, and the public verify-the-claim affordance is the product's positioning. Gating it would close nothing while the leaderboard serves the same values one route over. Rationale in the route docstring; pinned by `test_generated_strategy_published_visible_to_anonymous_caller`. Say the word and it's a 1-line change + one inverted test.

## Evidence (repo review rules 3 & 4)
- Full unit suite: `pytest -m "not integration"` → **4112 passed, 0 failed**.
- New guard file `test_reasoning_disclosure_gates.py` (18 tests): leak assertions run on **raw response text against sentinels**, each with an owner positive control proving the payload exists — a 404 cannot pass for missing data.
- **Guard shown to reject something:** with `is_strategy_reasoning_visible` temporarily reverted to delegate to the old predicate (the exact unfixed boundary), the suite goes **9 failed / 35 passed** — precisely the leak guards go red, every public-still-works test stays green. A throwaway cookie-less probe on the unfixed code returned HTTP 200 with both sentinel claims; fix restored, re-ran clean.
- `ruff format --check` clean; the single `ruff check` hit (SIM105, `strategies_routes.py:1087`) is pre-existing on main (verified) and outside the blocking gate.
- No `ui/` changes — verified, not assumed: nothing fetches `/debate`; `/returns` is fetched only by QuantLab over curated ids (which short-circuit before the row check); the published card still 200s; no UI call site POSTs `/api/paper/deployments`.

## Known limits / follow-ups (not new work — named doors)
- `is_published` is dormant today (nothing flips it) — this is fail-closed **ahead of** the publish flow; re-verify against a real published row when that flow lands.
- `GET /api/strategies/generated` still serves `strategy_spec` via `to_dict()` for other users' published rows — same disclosure class through an auth-gated door; latent while `is_published` is dormant. Tracked as the remaining hole in this wall.
- Paper-spec gate is tested at the `_spec_for_strategy` helper (the helper IS the gate); an end-to-end route test drags in live market-data advancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7