### PR TITLE
[backend][security] Gate /api/traces/* reads on trace ownership (#1556)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -2036,6 +2036,17 @@ async def _run_fusion_job(job_id: str) -> None:
                     {
                         "id": str(uuid.uuid4()),
                         "vault_address": "",
+                        # #1556: this trace has NO vault, so the vault-owner
+                        # lookup in save_trace cannot resolve it — and its
+                        # `reasoning` is the user's private strategy thesis,
+                        # which was world-readable through GET /api/traces/.
+                        # Stamp the generating account here, the only place
+                        # that knows it. Present-but-None is deliberate for a
+                        # legacy job payload with no owner: it suppresses the
+                        # vault guess and leaves the row visible to nobody,
+                        # which is the correct way to fail on private content.
+                        "owner_user_id": payload.get("owner_user_id"),
+                        "owner_wallet": payload.get("owner_wallet"),
                         "decision_type": "construction",
                         "trigger": "fusion_generation",
                         "timestamp": datetime.now(UTC).isoformat(),

--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -1,4 +1,14 @@
-"""Reasoning trace endpoints — /api/traces/*."""
+"""Reasoning trace endpoints — /api/traces/*.
+
+Every READ route here is ownership-gated (#1556). Before that issue the four
+read routes carried no auth dependency at all and ``vault_address`` was a
+filter, not a gate — omitting it enumerated every trace on the platform, and
+``/canonical`` returned the full hashed body including holdings. The predicate
+lives in ``services.trace_visibility`` and is never re-implemented here; these
+routes only decide the *status code* for a denial, which is uniformly **404**,
+matching the #850 ownership contract in ``strategies_routes``: a caller who may
+not read a trace must not learn that it exists.
+"""
 
 from __future__ import annotations
 
@@ -69,60 +79,133 @@ def _anchored_only_trace(trace_id: str, detail: dict) -> TraceResponse:
     )
 
 
+def _caller_identity(request: Request) -> tuple[str | None, str | None]:
+    """``(user_id, linked_wallet)`` for the caller — both ``None`` if anonymous.
+
+    Anonymous is a normal outcome, not an error: the public proof pages read
+    this API without a session and are entitled to the house-public traces.
+    The wallet lookup is a DB read (``get_linked_wallet_address``) and is
+    wrapped because its failure must degrade the caller to "no wallet" — which
+    can only ever *reduce* what they can see — never 500 a read route.
+    """
+    from archimedes.api.account_auth import get_current_user
+
+    user = get_current_user(request)
+    try:
+        from archimedes.api.auth_siwe import get_verified_wallet
+
+        wallet = get_verified_wallet(request)
+    except Exception:
+        logger.warning("trace read: linked-wallet resolution failed — treating caller as wallet-less", exc_info=True)
+        wallet = None
+    return (user.id if user else None), wallet
+
+
+def _offchain_trace_response(t: dict, fallback_id: str = "") -> TraceResponse:
+    """Project a stored off-chain trace record onto the wire schema."""
+    return TraceResponse(
+        id=t.get("id", fallback_id),
+        vault_address=t.get("vault_address", ""),
+        decision_type=t.get("decision_type", "unknown"),
+        trigger=t.get("trigger", "unknown"),
+        timestamp=t.get("timestamp", ""),
+        reasoning=t.get("reasoning", ""),
+        confidence=t.get("confidence", 0.0),
+        trace_hash=t.get("trace_hash", ""),
+        arc_tx_hash=t.get("arc_tx_hash"),
+        is_verified=t.get("is_verified", False),
+        regime_at_decision=t.get("market_context", {}).get("regime"),
+        trades_executed=t.get("trades_executed", []),
+        strategies_referenced=t.get("strategies_referenced", []),
+        commit_tx_hash=t.get("commit_tx_hash"),
+        commit_block_number=t.get("commit_block_number"),
+        reveal_tx_hash=t.get("reveal_tx_hash"),
+        reveal_block_number=t.get("reveal_block_number"),
+        trade_tx_hash=t.get("trade_tx_hash"),
+        trade_block_number=t.get("trade_block_number"),
+        temporal_binding_valid=t.get("temporal_binding_valid"),
+        temporal_binding_source=t.get("temporal_binding_source", "none"),
+    )
+
+
+def _assert_can_read(trace: dict, request: Request) -> None:
+    """404 unless the caller may read this trace (#1556).
+
+    404 rather than 403 deliberately: a 403 on someone else's trace id
+    confirms the id exists, which is half of the enumeration the gate is here
+    to prevent.
+    """
+    from fastapi import HTTPException
+
+    from archimedes.services.trace_visibility import can_read_trace
+
+    caller_user_id, caller_wallet = _caller_identity(request)
+    if not can_read_trace(trace, caller_wallet, caller_user_id=caller_user_id):
+        raise HTTPException(status_code=404, detail="Trace not found")
+
+
 @traces_router.get("/", response_model=TraceListResponse)
 async def list_traces(
+    request: Request,
     vault_address: str | None = None,
     decision_type: str | None = Query(None, pattern="^(construction|rebalance|rotation|regime_change|skip)$"),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
-    """List reasoning traces -- merges on-chain IDs with off-chain metadata."""
+    """List reasoning traces -- merges on-chain IDs with off-chain metadata.
+
+    Scoped to what the caller may read (#1556): house-public traces for an
+    anonymous caller, plus their own for a signed-in one. ``vault_address``
+    stays a *filter* — it narrows the visible set, it never widens it — so
+    dropping it can no longer enumerate the platform.
+    """
     from archimedes.services.redis_state import AgentStateStore
+    from archimedes.services.trace_visibility import (
+        MAX_TRACE_SCAN,
+        is_trace_visible,
+        safe_resolve_vault_owners,
+        trace_owner_view,
+    )
+
+    caller_user_id, caller_wallet = _caller_identity(request)
 
     state = AgentStateStore()
     try:
         try:
-            off_chain_traces, total = await state.list_traces(
+            # Fetch the whole candidate set and window AFTER filtering. Windowing
+            # first would return short pages whose length leaks how many of
+            # somebody else's traces were skipped.
+            off_chain_traces, _ = await state.list_traces(
                 vault_address=vault_address,
                 decision_type=decision_type,
-                limit=limit,
-                offset=offset,
+                limit=MAX_TRACE_SCAN,
+                offset=0,
             )
         except Exception:
             logger.warning("list_traces: Redis unavailable — falling back to on-chain-only listing", exc_info=True)
-            off_chain_traces, total = [], 0
+            off_chain_traces = []
 
         if off_chain_traces:
-            traces = []
-            for t in off_chain_traces:
-                if t.get("trigger") == "empty_vault":
-                    continue
-                traces.append(
-                    TraceResponse(
-                        id=t.get("id", ""),
-                        vault_address=t.get("vault_address", ""),
-                        decision_type=t.get("decision_type", "unknown"),
-                        trigger=t.get("trigger", "unknown"),
-                        timestamp=t.get("timestamp", ""),
-                        reasoning=t.get("reasoning", ""),
-                        confidence=t.get("confidence", 0.0),
-                        trace_hash=t.get("trace_hash", ""),
-                        arc_tx_hash=t.get("arc_tx_hash"),
-                        is_verified=t.get("is_verified", False),
-                        regime_at_decision=t.get("market_context", {}).get("regime"),
-                        trades_executed=t.get("trades_executed", []),
-                        strategies_referenced=t.get("strategies_referenced", []),
-                        commit_tx_hash=t.get("commit_tx_hash"),
-                        commit_block_number=t.get("commit_block_number"),
-                        reveal_tx_hash=t.get("reveal_tx_hash"),
-                        reveal_block_number=t.get("reveal_block_number"),
-                        trade_tx_hash=t.get("trade_tx_hash"),
-                        trade_block_number=t.get("trade_block_number"),
-                        temporal_binding_valid=t.get("temporal_binding_valid"),
-                        temporal_binding_source=t.get("temporal_binding_source", "none"),
-                    )
-                )
-            return TraceListResponse(traces=traces, total=total)
+            # One batched ownership lookup for the whole page, and only for rows
+            # that lack an on-record stamp — a stamped row needs no DB at all.
+            owners = safe_resolve_vault_owners(
+                {
+                    str(t.get("vault_address") or "")
+                    for t in off_chain_traces
+                    if not (t.get("owner_user_id") or t.get("owner_wallet"))
+                }
+            )
+            visible = [
+                t
+                for t in off_chain_traces
+                if t.get("trigger") != "empty_vault"
+                and is_trace_visible(trace_owner_view(t, owners), caller_wallet, caller_user_id=caller_user_id)
+            ]
+            total = len(visible)
+            return TraceListResponse(
+                traces=[_offchain_trace_response(t) for t in visible[offset : offset + limit]],
+                total=total,
+            )
 
         from archimedes.chain.trace_publisher import trace_publisher
 
@@ -140,6 +223,7 @@ async def list_traces(
             start = max(1, total_count - offset - limit + 1)
             end = max(1, total_count - offset)
 
+            on_chain_details: list[tuple[int, dict]] = []
             for trace_id in range(end, start - 1, -1):
                 detail = await trace_publisher.get_trace_by_id(trace_id)
                 if detail is None:
@@ -148,6 +232,17 @@ async def list_traces(
                 if vault_address and detail["vault"].lower() != vault_address.lower():
                     continue
 
+                on_chain_details.append((trace_id, detail))
+
+            # The registry-only projection carries no reasoning body, but it
+            # still names the vault and the anchor — gate it on exactly the
+            # same predicate so a caller cannot enumerate another user's
+            # vault's trace ids by taking Redis out of the picture.
+            owners = safe_resolve_vault_owners({str(d["vault"]) for _, d in on_chain_details})
+            for trace_id, detail in on_chain_details:
+                view = trace_owner_view({"vault_address": detail["vault"]}, owners)
+                if not is_trace_visible(view, caller_wallet, caller_user_id=caller_user_id):
+                    continue
                 traces.append(_anchored_only_trace(str(trace_id), detail))
         except Exception:
             logger.debug("on-chain trace listing failed", exc_info=True)
@@ -158,8 +253,12 @@ async def list_traces(
 
 
 @traces_router.get("/{trace_id}", response_model=TraceResponse)
-async def get_trace(trace_id: str):
-    """Get a single reasoning trace by ID (on-chain or off-chain hash)."""
+async def get_trace(trace_id: str, request: Request):
+    """Get a single reasoning trace by ID (on-chain or off-chain hash).
+
+    Ownership-gated (#1556): a non-owner gets 404, whether the trace resolves
+    off-chain or only from the registry.
+    """
     from fastapi import HTTPException
 
     from archimedes.chain.trace_publisher import trace_publisher
@@ -173,29 +272,8 @@ async def get_trace(trace_id: str):
             logger.warning("get_trace: Redis unavailable — falling back to on-chain-only lookup", exc_info=True)
             off_chain = None
         if off_chain:
-            return TraceResponse(
-                id=off_chain.get("id", trace_id),
-                vault_address=off_chain.get("vault_address", ""),
-                decision_type=off_chain.get("decision_type", "unknown"),
-                trigger=off_chain.get("trigger", "unknown"),
-                timestamp=off_chain.get("timestamp", ""),
-                reasoning=off_chain.get("reasoning", ""),
-                confidence=off_chain.get("confidence", 0.0),
-                trace_hash=off_chain.get("trace_hash", ""),
-                arc_tx_hash=off_chain.get("arc_tx_hash"),
-                is_verified=off_chain.get("is_verified", False),
-                regime_at_decision=off_chain.get("market_context", {}).get("regime"),
-                trades_executed=off_chain.get("trades_executed", []),
-                strategies_referenced=off_chain.get("strategies_referenced", []),
-                commit_tx_hash=off_chain.get("commit_tx_hash"),
-                commit_block_number=off_chain.get("commit_block_number"),
-                reveal_tx_hash=off_chain.get("reveal_tx_hash"),
-                reveal_block_number=off_chain.get("reveal_block_number"),
-                trade_tx_hash=off_chain.get("trade_tx_hash"),
-                trade_block_number=off_chain.get("trade_block_number"),
-                temporal_binding_valid=off_chain.get("temporal_binding_valid"),
-                temporal_binding_source=off_chain.get("temporal_binding_source", "none"),
-            )
+            _assert_can_read(off_chain, request)
+            return _offchain_trace_response(off_chain, fallback_id=trace_id)
 
         try:
             int_id = int(trace_id)
@@ -206,6 +284,7 @@ async def get_trace(trace_id: str):
         if detail is None:
             raise HTTPException(status_code=404, detail="Trace not found")
 
+        _assert_can_read({"vault_address": detail["vault"]}, request)
         return _anchored_only_trace(trace_id, detail)
     finally:
         await state.close()
@@ -216,6 +295,12 @@ async def publish_trace(req: TracePublishRequest, _: None = Depends(require_inte
     """Publish a reasoning trace: compute hash, anchor on Arc, persist off-chain.
 
     Internal-only: requires X-Internal-Agent-Key header.
+
+    Ownership (#1556) is stamped onto the stored record by
+    ``AgentStateStore.save_trace``, resolved from the vault this trace is for.
+    It is done there rather than here on purpose: this route is one of five
+    trace write paths, and the guarantee that matters is "every persisted trace
+    knows its owner", which only a single choke point can make true.
     """
     import uuid
     from datetime import datetime
@@ -313,8 +398,14 @@ async def publish_trace(req: TracePublishRequest, _: None = Depends(require_inte
 
 @traces_router.get("/{trace_id}/verify", response_model=TraceVerifyResponse)
 @limiter.exempt
-async def verify_trace(trace_id: str, request: Request):  # noqa: ARG001 — slowapi @limiter.exempt inspects param name
-    """Verify a reasoning trace against its on-chain anchor."""
+async def verify_trace(trace_id: str, request: Request):
+    """Verify a reasoning trace against its on-chain anchor.
+
+    Ownership-gated (#1556) on the same predicate as the display routes: the
+    response names the vault, the agent and the anchor timestamp, so an
+    ungated verify is an enumeration oracle even though it carries no
+    reasoning body.
+    """
     from fastapi import HTTPException
 
     from archimedes.chain.trace_publisher import trace_publisher
@@ -347,6 +438,7 @@ async def verify_trace(trace_id: str, request: Request):  # noqa: ARG001 — slo
             if not detail:
                 raise HTTPException(status_code=404, detail="Trace not found")
 
+            _assert_can_read({"vault_address": detail["vault"]}, request)
             return TraceVerifyResponse(
                 trace_id=int_id,
                 trace_hash=detail["trace_hash"],
@@ -357,6 +449,8 @@ async def verify_trace(trace_id: str, request: Request):  # noqa: ARG001 — slo
                 on_chain_timestamp=detail["timestamp"],
                 details="Hash is anchored on-chain — no off-chain trace body was stored, so no hashes were compared",
             )
+
+        _assert_can_read(off_chain, request)
 
         trace_hash = off_chain.get("trace_hash", "")
         is_verified = False
@@ -415,8 +509,14 @@ async def verify_trace(trace_id: str, request: Request):  # noqa: ARG001 — slo
 
 
 @traces_router.get("/{trace_id}/canonical")
-async def get_trace_canonical(trace_id: str):
-    """Get the canonical JSON used to compute the trace hash."""
+async def get_trace_canonical(trace_id: str, request: Request):
+    """Get the canonical JSON used to compute the trace hash.
+
+    The most sensitive of the four reads and the reason #1556 was filed
+    CRITICAL: the canonical body is the FULL hashed record —
+    ``portfolio_before`` / ``portfolio_after`` (holdings) and
+    ``market_context`` — so it is ownership-gated like the rest.
+    """
     from fastapi import HTTPException
     from fastapi.responses import PlainTextResponse
 
@@ -434,6 +534,8 @@ async def get_trace_canonical(trace_id: str):
             raise HTTPException(status_code=503, detail="Trace store temporarily unavailable — retry.") from None
         if not off_chain:
             raise HTTPException(status_code=404, detail="Trace not found")
+
+        _assert_can_read(off_chain, request)
 
         trace = ReasoningTrace(
             id=off_chain["id"],

--- a/backend/archimedes/services/redis_state.py
+++ b/backend/archimedes/services/redis_state.py
@@ -359,6 +359,21 @@ class AgentStateStore:
         """Store off-chain reasoning trace data keyed by trace_hash.
 
         Also maintains secondary index by trace UUID for lookup.
+
+        Stamps ownership on the way in (#1556). This is the single write choke
+        point for traces — ``publish_trace``, the agent runner's three persist
+        sites and the generation-trace writer all land here — so stamping HERE
+        is what makes "every persisted trace knows who owns it" true by
+        construction rather than by five call sites remembering. The read gate
+        (``services.trace_visibility``) then needs no database round-trip for
+        anything published after this change, which is why a Postgres outage
+        cannot downgrade a private trace to a public one.
+
+        A caller that already knows the owner (the generation path, whose trace
+        has no vault at all) sets ``owner_user_id``/``owner_wallet`` itself;
+        the presence of either key suppresses the lookup, including when the
+        value is ``None`` — "this writer resolved the owner and there isn't
+        one" must not be overwritten by a vault guess.
         """
         r = await self._get_redis()
         trace_hash = trace_data.get("trace_hash", "")
@@ -366,6 +381,9 @@ class AgentStateStore:
         if not trace_hash:
             logger.warning("Cannot save trace without trace_hash")
             return
+
+        if "owner_user_id" not in trace_data and "owner_wallet" not in trace_data:
+            trace_data = {**trace_data, **self._resolve_trace_owner(trace_data.get("vault_address", ""))}
 
         # Store full trace data by hash
         key = f"{KEY_TRACE_PREFIX}{trace_hash}"
@@ -389,6 +407,26 @@ class AgentStateStore:
 
         await r.zadd(KEY_TRACE_INDEX, {trace_hash: score})
         logger.debug("Saved trace %s to Redis", trace_hash[:16])
+
+    @staticmethod
+    def _resolve_trace_owner(vault_address: str) -> dict:
+        """``{"owner_user_id": …, "owner_wallet": …}`` for a vault (#1556).
+
+        Fail-soft by design — a trace must still persist when the identity
+        database is unreachable, and an unstamped row is not a leak: the read
+        gate falls back to looking the vault owner up itself, and to the
+        house-vault allowlist below that.
+        """
+        try:
+            from archimedes.services.trace_visibility import resolve_vault_owners
+
+            owner_user_id, owner_wallet = resolve_vault_owners({str(vault_address or "")}).get(
+                str(vault_address or "").strip().lower(), (None, None)
+            )
+        except Exception:
+            logger.warning("save_trace: owner stamp lookup failed — persisting unstamped", exc_info=True)
+            return {}
+        return {"owner_user_id": owner_user_id, "owner_wallet": owner_wallet}
 
     async def get_trace(self, trace_id_or_hash: str) -> dict | None:
         """Get off-chain trace data by hash or UUID."""

--- a/backend/archimedes/services/trace_visibility.py
+++ b/backend/archimedes/services/trace_visibility.py
@@ -1,0 +1,271 @@
+"""Reasoning-trace visibility predicate — issue #1556.
+
+Before this module the four ``/api/traces/*`` READ routes had no auth
+dependency at all. ``vault_address`` was a *filter* query param, not a gate:
+omit it and you enumerated every trace on the platform, and
+``/api/traces/{id}/canonical`` handed back the full hashed body —
+``portfolio_before`` / ``portfolio_after`` (holdings) and ``market_context``.
+That was survivable only for as long as every trace belonged to the house
+agent; ``POST /api/vaults/create`` is user-facing, so the first user-owned
+vault to publish a trace would have published its portfolio and reasoning to
+the internet.
+
+**Ownership resolution is three-layered, most-authoritative first.**
+
+1. **The stamp on the record.** Every trace persisted through
+   ``AgentStateStore.save_trace`` now carries ``owner_user_id`` /
+   ``owner_wallet`` (see that method). This is the layer that matters: it is
+   written once, at publish time, and read back with no database round-trip,
+   so a Postgres outage cannot downgrade a private trace to a public one.
+2. **The vault's owner, looked up now.** Legacy rows persisted before the
+   stamp existed carry no ownership at all, so ownership is recovered from
+   ``vault_metadata`` (``owner_user_id`` / ``creator_address``) and, for a
+   vault created through ``POST /api/vaults/create`` whose owner never wrote
+   metadata, from the ``vault_created`` rows in ``identity_events``. This is
+   the Redis-store equivalent of the data backfill a schema migration would
+   ship with — traces live in Redis, not in a table, so there is no column to
+   add and no Alembic revision to write.
+3. **The house-vault allowlist** (``PUBLIC_TRACE_VAULTS``, falling back to the
+   agent runner's own ``AGENT_VAULT_ADDRESSES``). This is the FLOOR, and it
+   only ever applies to a row whose ownership could not be established by (1)
+   or (2). It cannot make an owned trace public: the ownership branches return
+   before it is consulted.
+
+**Anonymous callers see house-public traces and nothing else.** That is not a
+convenience: ``/reasoning`` and ``/quant-lab`` are the public proof surface and
+render an unfiltered ``GET /api/traces/?limit=50``. Filtering per row (rather
+than the issue's interim "require ``vault_address`` on every read") gets the
+same enumeration guarantee — a row that is not yours is never in the response —
+without blanking the page that the product's central claim rests on.
+
+Deliberately shaped after ``services/strategy_visibility.py``: one predicate,
+never re-implemented at a call site. This codebase's characteristic defect is a
+rule fixed in the one function the current ticket touches while sibling readers
+keep the old behaviour, and a visibility rule that disagrees with itself across
+two routes is an authorization bug.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Comma-separated house/demo vault addresses whose traces are the public proof
+#: surface. ``AGENT_VAULT_ADDRESSES`` (the agent runner's own explicit vault
+#: list) is the fallback because a deployment that pins the runner to specific
+#: vaults has already named its house vaults there.
+_PUBLIC_VAULTS_ENV = "PUBLIC_TRACE_VAULTS"
+_AGENT_VAULTS_ENV = "AGENT_VAULT_ADDRESSES"
+
+#: Upper bound on rows pulled out of the trace index before the visibility
+#: filter runs. The filter must run over the whole candidate set — windowing
+#: first and filtering second returns short pages and lets the page size leak
+#: how many of another user's traces were skipped.
+MAX_TRACE_SCAN = 2000
+
+_warned_unconfigured_allowlist = False
+
+
+def _norm(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def public_trace_vaults() -> frozenset[str]:
+    """Lowercased house-vault allowlist, or an empty set when unconfigured."""
+    raw = os.getenv(_PUBLIC_VAULTS_ENV) or os.getenv(_AGENT_VAULTS_ENV) or ""
+    return frozenset(v.strip().lower() for v in raw.split(",") if v.strip())
+
+
+def is_public_trace_vault(vault_address: object) -> bool:
+    """Is this vault's *unowned* trace part of the public proof surface?
+
+    Only ever reached for a row with no resolvable owner — see
+    ``is_trace_visible``. Two hard edges:
+
+    - **A blank ``vault_address`` is never public.** Generation traces
+      (``trigger="fusion_generation"``) are written with ``vault_address=""``
+      and carry a user's private strategy thesis in ``reasoning``. An ownerless
+      body with no vault behind it is not a house artifact, and defaulting it
+      public is precisely the leak this module exists to close.
+    - **An unconfigured allowlist means "every unowned row is the house
+      agent's"**, which is what the platform actually looks like today and what
+      keeps ``/reasoning`` rendering. It is a *documented* default, not a
+      silent one: the first time it decides a row is public it logs a WARNING
+      naming the env var, so an operator sees that the floor is not armed.
+      Setting ``PUBLIC_TRACE_VAULTS`` arms it and every unowned row outside the
+      list goes private.
+    """
+    addr = _norm(vault_address)
+    if not addr:
+        return False
+
+    allowlist = public_trace_vaults()
+    if allowlist:
+        return addr in allowlist
+
+    global _warned_unconfigured_allowlist
+    if not _warned_unconfigured_allowlist:
+        _warned_unconfigured_allowlist = True
+        logger.warning(
+            "%s is not set — traces with no resolvable owner are served publicly (house-agent default). "
+            "Set %s to the house vault addresses to arm the allowlist floor (#1556).",
+            _PUBLIC_VAULTS_ENV,
+            _PUBLIC_VAULTS_ENV,
+        )
+    return True
+
+
+def is_trace_visible(
+    view: dict[str, Any] | None,
+    caller_wallet: str | None,
+    *,
+    caller_user_id: str | None = None,
+) -> bool:
+    """Can ``caller`` read this trace?
+
+    ``view`` is ``{"vault_address", "owner_user_id", "owner_wallet"}`` as
+    produced by :func:`trace_owner_view`.
+
+    OWNERSHIP IS TWO-TIERED, for the same reason ``is_strategy_visible`` is:
+    canonical identity (Better Auth ``auth_users.id``) arrived after rows
+    already existed.
+
+    - When an ``owner_user_id`` is known, that is the ONLY thing that grants
+      access. A matching wallet must not, or the canonical model is bypassable
+      by anyone who controls a wallet the row happens to name.
+    - When it is not, fall back to the wallet comparison.
+    - When neither is known, the row is unowned and the house-vault floor
+      decides.
+    """
+    if view is None:
+        return False
+
+    owner_user_id = view.get("owner_user_id")
+    if owner_user_id:
+        # Both sides must be non-empty: `None == None` is not ownership.
+        return bool(caller_user_id) and str(owner_user_id) == str(caller_user_id)
+
+    owner_wallet = _norm(view.get("owner_wallet"))
+    if owner_wallet:
+        return bool(caller_wallet) and _norm(caller_wallet) == owner_wallet
+
+    return is_public_trace_vault(view.get("vault_address"))
+
+
+def resolve_vault_owners(vault_addresses: set[str]) -> dict[str, tuple[str | None, str | None]]:
+    """``{lowercased vault → (owner_user_id, owner_wallet)}`` for legacy rows.
+
+    Two sources, in precedence order:
+
+    1. ``vault_metadata`` — written by ``POST /api/vaults/metadata``, which
+       proves the writer is the vault's on-chain owner before it commits.
+    2. ``identity_events`` rows of type ``vault_created`` — emitted by ``POST
+       /api/vaults/create``. This closes the gap where a user deploys a vault
+       and never gets as far as writing metadata: without it that vault reads
+       as unowned and its traces would fall through to the house floor.
+
+    **Fail-soft, and safely so.** A DB outage returns ``{}`` rather than
+    raising, because the read routes must keep serving; the reason that is not
+    a fail-open hole is that every trace written after #1556 carries its owner
+    *on the record*, so this lookup is a backfill for legacy rows only.
+    Callers that care about the distinction should arm ``PUBLIC_TRACE_VAULTS``.
+    """
+    wanted = {_norm(a) for a in vault_addresses if _norm(a)}
+    if not wanted:
+        return {}
+
+    owners: dict[str, tuple[str | None, str | None]] = {}
+    try:
+        from archimedes.db import get_session
+        from archimedes.models.chat import VaultMetadata
+        from archimedes.models.identity import IdentityEvent
+
+        with get_session() as session:
+            rows = session.query(VaultMetadata).filter(VaultMetadata.vault_address.in_(sorted(wanted))).all()
+            for row in rows:
+                owners[_norm(row.vault_address)] = (row.owner_user_id or None, _norm(row.creator_address) or None)
+
+            missing = wanted - set(owners)
+            if missing:
+                # `meta` is JSONB on Postgres and plain JSON on SQLite; there is
+                # no portable containment operator across both, so this filters
+                # on the indexed `event_type` column and matches the address in
+                # Python. Bounded by the number of vaults ever created, which
+                # is the same order as the vault list itself.
+                events = (
+                    session.query(IdentityEvent)
+                    .filter(IdentityEvent.event_type == "vault_created")
+                    .order_by(IdentityEvent.id.desc())
+                    .limit(MAX_TRACE_SCAN)
+                    .all()
+                )
+                for event in events:
+                    addr = _norm((event.meta or {}).get("vault_address"))
+                    if addr in missing and addr not in owners and _norm(event.wallet):
+                        owners[addr] = (None, _norm(event.wallet))
+    except Exception:
+        logger.warning("trace ownership lookup failed — falling back to on-record stamps only", exc_info=True)
+        return owners
+
+    return owners
+
+
+def safe_resolve_vault_owners(vault_addresses: set[str]) -> dict[str, tuple[str | None, str | None]]:
+    """:func:`resolve_vault_owners` that cannot raise into a read route.
+
+    ``resolve_vault_owners`` already swallows database errors, so this exists
+    for the class of failure it cannot anticipate — an import error, a model
+    change, a mocked-out dependency. A read route degrading to "no legacy
+    owners recovered" is safe (unstamped rows fall to the allowlist floor); a
+    read route 500ing because an ownership lookup blew up is not.
+    """
+    try:
+        return resolve_vault_owners(vault_addresses)
+    except Exception:
+        logger.warning("trace ownership lookup raised — continuing with on-record stamps only", exc_info=True)
+        return {}
+
+
+def trace_owner_view(trace: dict[str, Any], owners: dict[str, tuple[str | None, str | None]]) -> dict[str, Any]:
+    """Merge the on-record ownership stamp with the looked-up vault owner.
+
+    The stamp wins. A row that was persisted with ``owner_user_id`` recorded is
+    authoritative about its own owner even if the vault has since been handed
+    to someone else — the reasoning body in that row belonged to the account
+    that produced it.
+    """
+    vault_address = trace.get("vault_address", "")
+    owner_user_id = trace.get("owner_user_id") or None
+    owner_wallet = _norm(trace.get("owner_wallet")) or None
+
+    if owner_user_id is None and owner_wallet is None:
+        looked_up = owners.get(_norm(vault_address))
+        if looked_up is not None:
+            owner_user_id, owner_wallet = looked_up
+
+    return {
+        "vault_address": vault_address,
+        "owner_user_id": owner_user_id,
+        "owner_wallet": owner_wallet,
+    }
+
+
+def can_read_trace(
+    trace: dict[str, Any],
+    caller_wallet: str | None,
+    *,
+    caller_user_id: str | None = None,
+) -> bool:
+    """Single-trace convenience: resolve this trace's owner, then decide.
+
+    Skips the database entirely when the record carries its own stamp — the
+    common case for anything published after #1556.
+    """
+    if trace.get("owner_user_id") or trace.get("owner_wallet"):
+        owners: dict[str, tuple[str | None, str | None]] = {}
+    else:
+        owners = safe_resolve_vault_owners({str(trace.get("vault_address") or "")})
+    return is_trace_visible(trace_owner_view(trace, owners), caller_wallet, caller_user_id=caller_user_id)

--- a/backend/tests/api/test_traces_ownership_gate.py
+++ b/backend/tests/api/test_traces_ownership_gate.py
@@ -1,0 +1,429 @@
+"""Ownership gate on the /api/traces/* READ routes — issue #1556.
+
+The hole: `list_traces`, `get_trace`, `verify_trace` and `get_trace_canonical`
+had NO auth dependency. `vault_address` was a filter query param, not a gate —
+omit it and you enumerated every trace on the platform; `/canonical` returned
+the full hashed body, holdings included.
+
+Every test here is a GUARD test, so each one is paired with proof that it can
+fail. The `neutralized_gate` fixture reproduces the pre-#1556 route exactly:
+those routes ran no predicate at all, so forcing this codebase's predicate to
+`True` puts the app back in the unfixed state. Each `*_leaks_without_the_gate`
+test asserts the leak IS reproducible there — if the gate stopped being
+load-bearing, those tests fail, and a gate test that passes either way is
+worthless coverage (CLAUDE.md § "A test that passes against the unfixed code
+proves nothing").
+
+Hermetic: the trace store is mocked at the `AgentStateStore` boundary and the
+identity DB is a per-test tmp SQLite. No Redis, no Postgres, no .env.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+pytestmark = pytest.mark.anyio
+
+OWNER_USER_ID = "user-owner-1556"
+OTHER_USER_ID = "user-other-1556"
+OWNER_WALLET = "0x1111111111111111111111111111111111111111"
+OTHER_WALLET = "0x2222222222222222222222222222222222222222"
+
+HOUSE_VAULT = "0xaaaa000000000000000000000000000000000aaa"
+USER_VAULT = "0xbbbb000000000000000000000000000000000bbb"
+
+#: Distinctive strings that must never reach an unauthorized reader. Asserting
+#: on the CONTENT, not just the status code, is what makes these tests about
+#: the leak rather than about a number.
+SECRET_REASONING = "PRIVATE-1556 rotate 80% into the user's undisclosed basket"
+SECRET_HOLDING = "SECRETTOKEN1556"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    """Per-test SQLite carrying the identity tables the gate reads."""
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _unset_allowlist(monkeypatch):
+    """Run against the WEAKEST configuration of the floor.
+
+    With `PUBLIC_TRACE_VAULTS` unset, an unowned trace defaults to house-public
+    — so anything these tests prove is hidden is hidden by *ownership*, not by
+    an allowlist that happened to be armed. A guard demonstrated only in its
+    strictest configuration would not be a demonstration of the ownership
+    model at all.
+    """
+    monkeypatch.delenv("PUBLIC_TRACE_VAULTS", raising=False)
+    monkeypatch.delenv("AGENT_VAULT_ADDRESSES", raising=False)
+
+
+def _house_trace() -> dict:
+    return {
+        "id": "house-trace-1",
+        "vault_address": HOUSE_VAULT,
+        "decision_type": "rebalance",
+        "trigger": "drift",
+        "timestamp": "2026-08-30T00:00:00+00:00",
+        "market_context": {"regime": "risk_on"},
+        "portfolio_before": {"USDC": 1},
+        "portfolio_after": {"USDC": 1},
+        "reasoning": "House agent public demo reasoning",
+        "confidence": 0.5,
+        "trades_executed": [],
+        "strategies_referenced": [],
+        "trace_hash": "0xhousehash",
+        "arc_tx_hash": None,
+        "is_verified": False,
+    }
+
+
+def _user_trace(*, stamped: bool) -> dict:
+    """A user-owned private trace.
+
+    ``stamped`` picks which of the two ownership layers is under test: the
+    on-record stamp written by ``save_trace`` (every trace published after
+    #1556), or the legacy row with no stamp whose owner has to be recovered
+    from ``vault_metadata``.
+    """
+    trace = {
+        "id": "user-trace-1",
+        "vault_address": USER_VAULT,
+        "decision_type": "rebalance",
+        "trigger": "drift",
+        "timestamp": "2026-08-30T01:00:00+00:00",
+        "market_context": {"regime": "risk_off"},
+        "portfolio_before": {SECRET_HOLDING: 42},
+        "portfolio_after": {SECRET_HOLDING: 99},
+        "reasoning": SECRET_REASONING,
+        "confidence": 0.9,
+        "trades_executed": [],
+        "strategies_referenced": [],
+        "trace_hash": "0xuserhash",
+        "arc_tx_hash": None,
+        "is_verified": False,
+    }
+    if stamped:
+        trace["owner_user_id"] = OWNER_USER_ID
+        trace["owner_wallet"] = OWNER_WALLET
+    return trace
+
+
+def _seed_vault_owner() -> None:
+    """`vault_metadata` row making USER_VAULT owned by OWNER_USER_ID."""
+    from datetime import UTC, datetime
+
+    from archimedes.db import get_session
+    from archimedes.models.account import AuthUser
+    from archimedes.models.chat import VaultMetadata
+    from archimedes.models.identity import WalletIdentity
+
+    now = datetime.now(UTC)
+    with get_session() as session:
+        for uid, email in ((OWNER_USER_ID, "owner@example.test"), (OTHER_USER_ID, "other@example.test")):
+            session.merge(AuthUser(id=uid, name=uid, email=email, email_verified=True, created_at=now, updated_at=now))
+        for wallet in (OWNER_WALLET, OTHER_WALLET):
+            session.merge(WalletIdentity(wallet_address=wallet.lower(), actor_class="human", first_seen_at=now))
+        session.merge(
+            VaultMetadata(
+                vault_address=USER_VAULT.lower(),
+                name="user vault",
+                symbol="UV",
+                creator_address=OWNER_WALLET.lower(),
+                owner_user_id=OWNER_USER_ID,
+                strategy_ids="[]",
+            )
+        )
+        session.commit()
+
+
+@contextmanager
+def _as(user_id: str | None, wallet: str | None = None):
+    """Run the request as this caller. ``None`` = anonymous.
+
+    Patches the two identity resolvers the routes consult, which is the
+    boundary: `get_current_user` reads the Better Auth session and
+    `get_verified_wallet` reads the linked-wallet table. Nothing about the gate
+    itself is patched.
+    """
+    from archimedes.api.account_auth import CurrentUser
+
+    user = (
+        None
+        if user_id is None
+        else CurrentUser(id=user_id, name=user_id, email=f"{user_id}@example.test", email_verified=True)
+    )
+    with (
+        patch("archimedes.api.account_auth.get_current_user", return_value=user),
+        patch("archimedes.api.auth_siwe.get_verified_wallet", return_value=wallet),
+    ):
+        yield
+
+
+@contextmanager
+def _store(traces: list[dict]):
+    """Mock the trace store at the `AgentStateStore` boundary."""
+    from archimedes.services.redis_state import AgentStateStore
+
+    by_id = {t["id"]: t for t in traces}
+    by_id.update({t["trace_hash"]: t for t in traces})
+
+    async def _list(vault_address=None, decision_type=None, limit=20, offset=0):
+        rows = [
+            t
+            for t in traces
+            if (not vault_address or t["vault_address"].lower() == vault_address.lower())
+            and (not decision_type or t["decision_type"] == decision_type)
+        ]
+        return rows[offset : offset + limit], len(rows)
+
+    with (
+        patch.object(AgentStateStore, "list_traces", AsyncMock(side_effect=_list)),
+        patch.object(AgentStateStore, "get_trace", AsyncMock(side_effect=lambda k: by_id.get(k))),
+        patch.object(AgentStateStore, "close", AsyncMock()),
+    ):
+        yield
+
+
+@contextmanager
+def neutralized_gate():
+    """Put the app back in its pre-#1556 state: no visibility predicate at all.
+
+    The unfixed routes had no gate, so every read was allowed — which is
+    exactly what forcing the predicate to `True` reproduces. Both entry points
+    are patched because `list_traces` calls `is_trace_visible` directly while
+    the three detail routes go through `can_read_trace`.
+    """
+    with (
+        patch("archimedes.services.trace_visibility.is_trace_visible", return_value=True),
+        patch("archimedes.services.trace_visibility.can_read_trace", return_value=True),
+    ):
+        yield
+
+
+async def _get(path: str, **params):
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.get(path, params=params)
+
+
+# ── The gate holds ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("stamped", [True, False], ids=["stamped-record", "legacy-row-via-vault-metadata"])
+async def test_anonymous_list_returns_only_house_traces(stamped):
+    """ACCEPTANCE: anonymous `GET /api/traces/?limit=100` never returns a user's."""
+    _seed_vault_owner()
+    with _store([_house_trace(), _user_trace(stamped=stamped)]), _as(None):
+        resp = await _get("/api/traces/", limit=100)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [t["id"] for t in body["traces"]] == ["house-trace-1"]
+    assert body["total"] == 1  # the private row is not even counted
+    assert SECRET_REASONING not in resp.text
+
+
+@pytest.mark.parametrize("stamped", [True, False], ids=["stamped-record", "legacy-row-via-vault-metadata"])
+async def test_different_user_list_does_not_see_another_users_trace(stamped):
+    _seed_vault_owner()
+    with _store([_house_trace(), _user_trace(stamped=stamped)]), _as(OTHER_USER_ID, OTHER_WALLET):
+        resp = await _get("/api/traces/", limit=100)
+
+    assert [t["id"] for t in resp.json()["traces"]] == ["house-trace-1"]
+    assert SECRET_REASONING not in resp.text
+
+
+@pytest.mark.parametrize("stamped", [True, False], ids=["stamped-record", "legacy-row-via-vault-metadata"])
+async def test_owner_still_sees_their_own_trace(stamped):
+    """The gate must not be a wall: the owner keeps full access."""
+    _seed_vault_owner()
+    with _store([_house_trace(), _user_trace(stamped=stamped)]), _as(OWNER_USER_ID, OWNER_WALLET):
+        listed = await _get("/api/traces/", limit=100)
+        detail = await _get("/api/traces/user-trace-1")
+        canonical = await _get("/api/traces/user-trace-1/canonical")
+
+    assert {t["id"] for t in listed.json()["traces"]} == {"house-trace-1", "user-trace-1"}
+    assert detail.status_code == 200
+    assert detail.json()["reasoning"] == SECRET_REASONING
+    assert canonical.status_code == 200
+    assert SECRET_HOLDING in canonical.text
+
+
+@pytest.mark.parametrize("stamped", [True, False], ids=["stamped-record", "legacy-row-via-vault-metadata"])
+@pytest.mark.parametrize("caller", [None, OTHER_USER_ID], ids=["anonymous", "different-user"])
+async def test_non_owner_cannot_read_trace_by_id(stamped, caller):
+    """ACCEPTANCE: a non-owner cannot read another user's trace by id.
+
+    404, not 403: a 403 on someone else's id confirms the id exists, which is
+    half of the enumeration the gate exists to prevent.
+    """
+    _seed_vault_owner()
+    wallet = OTHER_WALLET if caller else None
+    with _store([_user_trace(stamped=stamped)]), _as(caller, wallet):
+        detail = await _get("/api/traces/user-trace-1")
+        canonical = await _get("/api/traces/user-trace-1/canonical")
+        verify = await _get("/api/traces/user-trace-1/verify")
+
+    assert detail.status_code == 404
+    assert canonical.status_code == 404
+    assert verify.status_code == 404
+    for resp in (detail, canonical, verify):
+        assert SECRET_REASONING not in resp.text
+        assert SECRET_HOLDING not in resp.text
+
+
+async def test_wallet_alone_does_not_grant_access_to_a_user_owned_trace():
+    """Canonical identity is not bypassable by controlling the named wallet.
+
+    Same two-tier rule as `is_strategy_visible`: once a row carries an
+    `owner_user_id`, a matching wallet must NOT grant access, or migrating to
+    canonical identity would have been a security downgrade.
+    """
+    _seed_vault_owner()
+    with _store([_user_trace(stamped=True)]), _as(None, OWNER_WALLET):
+        resp = await _get("/api/traces/user-trace-1")
+    assert resp.status_code == 404
+
+
+async def test_stamped_record_stays_private_when_the_identity_db_is_down():
+    """A Postgres outage must not downgrade a private trace to a public one.
+
+    This is why ownership is stamped on the record at write time rather than
+    looked up on every read.
+    """
+    _seed_vault_owner()
+    with (
+        _store([_user_trace(stamped=True)]),
+        _as(None),
+        patch(
+            "archimedes.services.trace_visibility.resolve_vault_owners",
+            side_effect=RuntimeError("db down"),
+        ),
+    ):
+        listed = await _get("/api/traces/", limit=100)
+        detail = await _get("/api/traces/user-trace-1")
+
+    assert listed.json()["traces"] == []
+    assert detail.status_code == 404
+
+
+async def test_generation_trace_with_no_vault_is_never_public():
+    """`trigger="fusion_generation"` traces carry a user's private thesis.
+
+    They are written with `vault_address=""`, so there is no vault to own them
+    — an ownerless body with no vault must not fall through to the house
+    default.
+    """
+    trace = _user_trace(stamped=False)
+    trace["vault_address"] = ""
+    trace["trigger"] = "fusion_generation"
+
+    with _store([trace]), _as(None):
+        listed = await _get("/api/traces/", limit=100)
+        detail = await _get("/api/traces/user-trace-1")
+
+    assert listed.json()["traces"] == []
+    assert detail.status_code == 404
+
+
+async def test_allowlist_when_armed_restricts_unowned_traces(monkeypatch):
+    """The interim FLOOR: with `PUBLIC_TRACE_VAULTS` set, an unowned trace
+    outside the list is private even though nothing owns it."""
+    monkeypatch.setenv("PUBLIC_TRACE_VAULTS", HOUSE_VAULT)
+
+    stranger = _house_trace()
+    stranger["id"] = "stranger-trace-1"
+    stranger["trace_hash"] = "0xstrangerhash"
+    stranger["vault_address"] = "0xcccc000000000000000000000000000000000ccc"
+
+    with _store([_house_trace(), stranger]), _as(None):
+        resp = await _get("/api/traces/", limit=100)
+
+    assert [t["id"] for t in resp.json()["traces"]] == ["house-trace-1"]
+
+
+async def test_onchain_fallback_listing_is_gated_too():
+    """Taking Redis out of the picture must not reopen enumeration.
+
+    The registry-only projection carries no reasoning body, but it still names
+    the vault and the anchor, so the same predicate applies.
+    """
+    from archimedes.services.redis_state import AgentStateStore
+
+    _seed_vault_owner()
+    details = {
+        1: {"vault": HOUSE_VAULT, "timestamp": 1_700_000_000, "trace_hash": "0xh1"},
+        2: {"vault": USER_VAULT, "timestamp": 1_700_000_100, "trace_hash": "0xh2"},
+    }
+
+    with (
+        patch.object(AgentStateStore, "list_traces", AsyncMock(side_effect=ConnectionError("redis down"))),
+        patch.object(AgentStateStore, "close", AsyncMock()),
+        patch("archimedes.chain.trace_publisher.trace_publisher") as mock_pub,
+        _as(None),
+    ):
+        mock_pub.get_total_trace_count = AsyncMock(return_value=2)
+        mock_pub.get_trace_by_id = AsyncMock(side_effect=lambda tid: details.get(tid))
+        resp = await _get("/api/traces/", limit=10)
+
+    assert [t["vault_address"] for t in resp.json()["traces"]] == [HOUSE_VAULT]
+
+
+# ── The gate is load-bearing (non-tautology proof) ──────────────────────────
+
+
+@pytest.mark.parametrize("stamped", [True, False], ids=["stamped-record", "legacy-row-via-vault-metadata"])
+async def test_anonymous_list_leaks_without_the_gate(stamped):
+    """Same request as `test_anonymous_list_returns_only_house_traces`, run
+    against the unfixed behaviour — it MUST leak, or that test guards nothing."""
+    _seed_vault_owner()
+    with _store([_house_trace(), _user_trace(stamped=stamped)]), _as(None), neutralized_gate():
+        resp = await _get("/api/traces/", limit=100)
+
+    assert "user-trace-1" in [t["id"] for t in resp.json()["traces"]]
+    assert SECRET_REASONING in resp.text
+
+
+async def test_canonical_leaks_holdings_without_the_gate():
+    """The CRITICAL half of #1556: `/canonical` returns the full hashed body,
+    holdings included, to an anonymous caller when the gate is not there."""
+    _seed_vault_owner()
+    with _store([_user_trace(stamped=True)]), _as(None), neutralized_gate():
+        resp = await _get("/api/traces/user-trace-1/canonical")
+
+    assert resp.status_code == 200
+    body = json.loads(resp.text)
+    assert body["portfolio_after"] == {SECRET_HOLDING: 99}
+    assert SECRET_REASONING in resp.text
+
+
+async def test_detail_leaks_without_the_gate():
+    _seed_vault_owner()
+    with _store([_user_trace(stamped=True)]), _as(None), neutralized_gate():
+        resp = await _get("/api/traces/user-trace-1")
+
+    assert resp.status_code == 200
+    assert resp.json()["reasoning"] == SECRET_REASONING
+
+
+async def test_verify_leaks_without_the_gate():
+    _seed_vault_owner()
+    with _store([_user_trace(stamped=True)]), _as(None), neutralized_gate():
+        resp = await _get("/api/traces/user-trace-1/verify")
+
+    assert resp.status_code == 200
+    assert resp.json()["vault"] == USER_VAULT

--- a/backend/tests/services/test_trace_ownership_stamp.py
+++ b/backend/tests/services/test_trace_ownership_stamp.py
@@ -1,0 +1,259 @@
+"""Ownership stamping + the visibility predicate — issue #1556.
+
+``AgentStateStore.save_trace`` is the single write choke point for reasoning
+traces (``publish_trace``, the agent runner's two persist sites, the reveal
+reconciler and the generation-trace writer all land there). Stamping ownership
+*there* is what makes "every persisted trace knows who owns it" true by
+construction, and it is what lets the read gate answer without a database.
+
+The predicate tests below are the unit-level companion to the route-level guard
+tests in ``backend/tests/api/test_traces_ownership_gate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from archimedes.services.redis_state import AgentStateStore
+from archimedes.services.trace_visibility import (
+    is_public_trace_vault,
+    is_trace_visible,
+    resolve_vault_owners,
+    trace_owner_view,
+)
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+OWNER_USER_ID = "user-owner-1556"
+OWNER_WALLET = "0x1111111111111111111111111111111111111111"
+USER_VAULT = "0xbbbb000000000000000000000000000000000bbb"
+
+
+@pytest.fixture
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _unset_allowlist(monkeypatch):
+    monkeypatch.delenv("PUBLIC_TRACE_VAULTS", raising=False)
+    monkeypatch.delenv("AGENT_VAULT_ADDRESSES", raising=False)
+
+
+def _fake_redis() -> MagicMock:
+    r = MagicMock()
+    r.get = AsyncMock(return_value=None)
+    r.set = AsyncMock()
+    r.zadd = AsyncMock()
+    r.aclose = AsyncMock()
+    return r
+
+
+def _store() -> tuple[AgentStateStore, MagicMock]:
+    store = AgentStateStore(url="redis://fake/")
+    fake = _fake_redis()
+    store._redis = fake
+    return store, fake
+
+
+def _written_record(fake: MagicMock) -> dict:
+    """The JSON body save_trace wrote under the trace-hash key."""
+    for call in fake.set.await_args_list:
+        key, value = call.args[0], call.args[1]
+        if not key.startswith("archimedes:trace:id:"):
+            return json.loads(value)
+    raise AssertionError("save_trace never wrote a trace body")
+
+
+def _seed_vault_owner() -> None:
+    from archimedes.db import get_session
+    from archimedes.models.account import AuthUser
+    from archimedes.models.chat import VaultMetadata
+    from archimedes.models.identity import WalletIdentity
+
+    now = datetime.now(UTC)
+    with get_session() as session:
+        session.merge(
+            AuthUser(id=OWNER_USER_ID, name="owner", email="owner@example.test", created_at=now, updated_at=now)
+        )
+        session.merge(WalletIdentity(wallet_address=OWNER_WALLET.lower(), actor_class="human", first_seen_at=now))
+        session.merge(
+            VaultMetadata(
+                vault_address=USER_VAULT.lower(),
+                name="v",
+                symbol="V",
+                creator_address=OWNER_WALLET.lower(),
+                owner_user_id=OWNER_USER_ID,
+                strategy_ids="[]",
+            )
+        )
+        session.commit()
+
+
+def _trace(**over) -> dict:
+    base = {
+        "id": "t1",
+        "vault_address": USER_VAULT,
+        "decision_type": "rebalance",
+        "trigger": "drift",
+        "timestamp": "2026-08-30T00:00:00+00:00",
+        "reasoning": "private",
+        "trace_hash": "0xhash1",
+    }
+    base.update(over)
+    return base
+
+
+async def test_save_trace_stamps_the_vaults_owner(_tmp_db):
+    _seed_vault_owner()
+    store, fake = _store()
+    await store.save_trace(_trace())
+
+    record = _written_record(fake)
+    assert record["owner_user_id"] == OWNER_USER_ID
+    assert record["owner_wallet"] == OWNER_WALLET.lower()
+
+
+async def test_save_trace_does_not_mutate_the_callers_dict(_tmp_db):
+    """The stamp goes on the persisted copy, not on the caller's object.
+
+    The agent runner reuses its ``off_chain_data`` dict after the save; a
+    stamping step that wrote through it would be an invisible side effect.
+    """
+    _seed_vault_owner()
+    store, _ = _store()
+    payload = _trace()
+    await store.save_trace(payload)
+
+    assert "owner_user_id" not in payload
+
+
+async def test_save_trace_respects_an_explicit_owner(_tmp_db):
+    """A writer that already knows the owner wins over the vault lookup."""
+    _seed_vault_owner()
+    store, fake = _store()
+    await store.save_trace(_trace(owner_user_id="someone-else"))
+
+    assert _written_record(fake)["owner_user_id"] == "someone-else"
+
+
+async def test_explicit_none_owner_suppresses_the_vault_guess(_tmp_db):
+    """ "I resolved the owner and there isn't one" must not be overwritten.
+
+    This is the generation-trace shape (``vault_address=""``, owner unknown for
+    a legacy job payload). Guessing an owner from a vault there would be a
+    fabricated ownership claim.
+    """
+    _seed_vault_owner()
+    store, fake = _store()
+    await store.save_trace(_trace(owner_user_id=None, owner_wallet=None))
+
+    record = _written_record(fake)
+    assert record["owner_user_id"] is None
+    assert record["owner_wallet"] is None
+
+
+async def test_save_trace_persists_unstamped_when_ownership_lookup_fails(monkeypatch):
+    """A trace must still persist when the identity DB is unreachable.
+
+    Not a leak: the read gate falls back to resolving the vault owner itself,
+    and to the allowlist floor below that.
+    """
+    monkeypatch.setattr(
+        "archimedes.services.trace_visibility.resolve_vault_owners",
+        MagicMock(side_effect=RuntimeError("db down")),
+    )
+    store, fake = _store()
+    await store.save_trace(_trace())
+
+    record = _written_record(fake)
+    assert record["reasoning"] == "private"
+    assert record.get("owner_user_id") is None
+
+
+def test_resolve_vault_owners_reads_vault_metadata(_tmp_db):
+    _seed_vault_owner()
+    owners = resolve_vault_owners({USER_VAULT.upper()})
+    assert owners[USER_VAULT.lower()] == (OWNER_USER_ID, OWNER_WALLET.lower())
+
+
+def test_resolve_vault_owners_recovers_a_vault_that_never_wrote_metadata(_tmp_db):
+    """`POST /api/vaults/create` emits a `vault_created` identity event but
+    writes no metadata row. Without this second source that vault reads as
+    unowned and its traces fall through to the house floor."""
+    from archimedes.db import get_session
+    from archimedes.models.identity import IdentityEvent, WalletIdentity
+
+    unregistered = "0xdddd000000000000000000000000000000000ddd"
+    with get_session() as session:
+        session.merge(
+            WalletIdentity(wallet_address=OWNER_WALLET.lower(), actor_class="human", first_seen_at=datetime.now(UTC))
+        )
+        session.add(
+            IdentityEvent(
+                wallet=OWNER_WALLET.lower(),
+                event_type="vault_created",
+                actor_class="human",
+                meta={"vault_address": unregistered},
+            )
+        )
+        session.commit()
+
+    assert resolve_vault_owners({unregistered}) == {unregistered: (None, OWNER_WALLET.lower())}
+
+
+# ── The predicate ───────────────────────────────────────────────────────────
+
+
+def test_owner_user_id_is_the_only_key_once_it_exists():
+    """Two-tier ownership, same rule as `is_strategy_visible`: a matching
+    wallet must NOT grant access to a row that carries a canonical owner."""
+    view = {"vault_address": USER_VAULT, "owner_user_id": OWNER_USER_ID, "owner_wallet": OWNER_WALLET}
+
+    assert is_trace_visible(view, None, caller_user_id=OWNER_USER_ID)
+    assert not is_trace_visible(view, OWNER_WALLET, caller_user_id=None)
+    assert not is_trace_visible(view, OWNER_WALLET, caller_user_id="someone-else")
+
+
+def test_legacy_wallet_owner_still_matches_case_insensitively():
+    view = {"vault_address": USER_VAULT, "owner_user_id": None, "owner_wallet": OWNER_WALLET.lower()}
+    assert is_trace_visible(view, OWNER_WALLET.upper(), caller_user_id=None)
+    assert not is_trace_visible(view, "0x9999999999999999999999999999999999999999", caller_user_id=None)
+
+
+def test_anonymous_caller_never_matches_an_owned_row():
+    assert not is_trace_visible(
+        {"vault_address": USER_VAULT, "owner_user_id": OWNER_USER_ID}, None, caller_user_id=None
+    )
+    assert not is_trace_visible({"vault_address": USER_VAULT, "owner_wallet": OWNER_WALLET}, None, caller_user_id=None)
+
+
+def test_a_trace_with_no_vault_is_never_public():
+    assert not is_public_trace_vault("")
+    assert not is_public_trace_vault(None)
+    assert not is_trace_visible({"vault_address": "", "owner_user_id": None}, None, caller_user_id=None)
+
+
+def test_armed_allowlist_excludes_everything_outside_it(monkeypatch):
+    monkeypatch.setenv("PUBLIC_TRACE_VAULTS", f" {USER_VAULT.upper()} , 0xother")
+    assert is_public_trace_vault(USER_VAULT.lower())
+    assert not is_public_trace_vault("0xcccc000000000000000000000000000000000ccc")
+
+
+def test_agent_vault_addresses_is_the_allowlist_fallback(monkeypatch):
+    monkeypatch.setenv("AGENT_VAULT_ADDRESSES", USER_VAULT)
+    assert is_public_trace_vault(USER_VAULT)
+    assert not is_public_trace_vault("0xcccc000000000000000000000000000000000ccc")
+
+
+def test_stamp_wins_over_the_looked_up_vault_owner():
+    """A row records who produced it; a later vault transfer must not hand the
+    old reasoning body to the new vault owner."""
+    view = trace_owner_view(
+        {"vault_address": USER_VAULT, "owner_user_id": "original-author"},
+        {USER_VAULT.lower(): ("new-vault-owner", None)},
+    )
+    assert view["owner_user_id"] == "original-author"


### PR DESCRIPTION
Closes #1556 (CRITICAL, 2026-08-30 red-team). The four `/api/traces/*` READ routes had no auth dependency at all: `vault_address` was a filter, not a gate — omit it and you enumerated every trace on the platform, and `/canonical` returned full `portfolio_before`/`portfolio_after` + `market_context`. Survivable only while every trace is the house agent's; the first user vault to publish a trace would have published its portfolio and reasoning to the internet.

## The fix
New `services/trace_visibility.py` — one predicate, never re-implemented at call sites (the `strategy_visibility` pattern). Ownership resolves three layers deep, most-authoritative first:
1. **The stamp**: every trace persisted through the single `save_trace` choke point (all six call sites route through it) now carries `owner_user_id`/`owner_wallet` — written at publish time, read back with no DB round trip.
2. **Legacy backfill at read time**: rows predating the stamp resolve through `vault_metadata` and `identity_events` `vault_created` rows (traces live in Redis — this is the migration-ships-with-its-data rule with no column to add).
3. **The house-vault allowlist floor** (`PUBLIC_TRACE_VAULTS`, fallback `AGENT_VAULT_ADDRESSES`) — consulted only for rows with no resolvable owner; it can never make an owned trace public. Unarmed = documented house-agent default with a WARNING log naming the env var.

All four read routes gated — `list` (per-row filter, so `/reasoning`'s public proof surface keeps rendering while enumeration dies), `detail`, `verify` (both branches incl. `anchored_only`), `canonical` — **and the on-chain fallback paths inside list/detail**, so a Redis outage does not reopen enumeration. Denials are uniformly **404** (existence-hiding; the reachable-traces UI treats 404 as a clean empty state). Blank `vault_address` (generation traces carrying a user's strategy thesis) is never public.

## Evidence (independent validation + my review)
- Full unit suite **4128 passed, 0 failed**; 34 new gate/stamp tests; 90 pre-existing trace tests unregressed; single alembic head (no migration needed — Redis store).
- **Real neutralization demo**: the pre-#1556 `traces_routes.py` was written back over the fix and the new suite re-run → **13 failed** (exactly the leak guards), 7 passed (the leaks-without-gate controls + owner-access tests). Restored clean.
- **12 independent adversarial probes** by a second validator: filter-widening, case bypass, hash-key detail access, on-chain-only detail, `anchored_only` verify, mixed-case owner match (no over-block), pagination count leak, `decision_type` widening, wallet-vs-canonical-identity, identity-DB-outage fail-open — 10 leaked against unfixed code, **all 12 pass against the fix**.

## Deploy gate (ops, before/at deploy)
Set **`PUBLIC_TRACE_VAULTS`** to the house vault addresses in the task env. Unarmed, a legacy unstamped row + an identity-DB outage can still serve an ownerless trace publicly (pre-fix behavior, WARNING-logged; stamping closes it for all new writes). Note: the T3.2 redeploy runbook tells operators to clear `AGENT_VAULT_ADDRESSES` — which is the fallback — so the primary var must be set explicitly.

## Ordering
`dbrowneup/user-reachable-traces` (which widens the detail response) must land **after** this; its branch is being integrated against this gate.

Known accepted limits (validator minors, tracked): 2000-row scan cap on list/backfill paths; sync DB session inside async `save_trace` (existing codebase style); `GET /api/vaults/{address}` still embeds recent trace ids/hashes (placeholder reasoning only — not the enumeration hole; follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7