### PR TITLE
[frontend] Split the leaderboard into a research board and a live paper board !minor

### DIFF
--- a/backend/archimedes/api/leaderboard_routes.py
+++ b/backend/archimedes/api/leaderboard_routes.py
@@ -25,19 +25,29 @@ passed rigor (#850 privacy principle — publish is the consent signal). A
 generated strategy earns a spot the same way a curated one does: real,
 rigor-gated backtest numbers score it via ``compute_conviction`` — a strategy
 missing a metric scores 0 on that axis and sinks honestly, never fabricated.
+
+TWO SURFACES (Lane 3.4). Everything above is the RESEARCH board: conviction is
+100% backtest-era, so its rows now carry ``performance_basis="backtest_research"``
+plus the backtest window they were measured over. The forward story lives at
+``GET /api/leaderboard/live-paper`` — rows only for deployments that are
+actually running and have produced ledger observations, ranked on realised
+return. Nothing joins the two: there is no blended score anywhere in this
+module, and the anti-fabrication rule for the forward board (no row without
+ledger data) is enforced in exactly one place, ``build_live_paper_leaderboard``.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 
 from fastapi import APIRouter, Query, Request
 
 from archimedes.api._route_helpers import strategy_provider
 from archimedes.api.account_auth import get_current_user
-from archimedes.api.leaderboard_schemas import LeaderboardResponse
+from archimedes.api.leaderboard_schemas import LeaderboardResponse, LivePaperLeaderboardResponse
 from archimedes.api.wallet_routes import get_linked_wallet_address
-from archimedes.services.leaderboard import build_leaderboard
+from archimedes.services.leaderboard import LivePaperLedger, build_leaderboard, build_live_paper_leaderboard
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +225,134 @@ async def get_leaderboard(
         min_rigor=min_rigor,
         limit=limit,
         scope=effective_scope,
+        degraded=degraded,
+        degraded_reason=degraded_reason,
+    )
+
+
+# ── Live paper board — /api/leaderboard/live-paper (Lane 3.4) ────────────────
+#
+# A SECOND endpoint rather than a ?mode= on the one above, deliberately: the
+# two boards share neither a row shape (no conviction score, no rigor gate, no
+# regime here; no inception date, no days-live there) nor a sort domain, so a
+# mode param would have to make most of LeaderboardEntry optional and push a
+# discriminated union into every existing consumer. The existing route,
+# response model and the UI table that renders it are untouched by this file's
+# addition — that is what "less invasive" means here.
+
+
+def _display_names(session, strategy_ids: set[str]) -> dict[str, str]:
+    """Best-effort human labels for the deployed strategies. Missing rows just
+    fall through to the deployed spec's own name at the call site — a label is
+    cosmetic, and a lookup failure must never drop a real ledger row."""
+    if not strategy_ids:
+        return {}
+    try:
+        from archimedes.models.strategy_store import StrategyRecord
+
+        rows = session.query(StrategyRecord.id, StrategyRecord.strategy_name).filter(
+            StrategyRecord.id.in_(strategy_ids)
+        )
+        return {rid: name for rid, name in rows if name}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("live-paper board: strategy name lookup unavailable: %s", exc)
+        return {}
+
+
+def _spec_name(spec_json: str | None) -> str:
+    try:
+        return str(json.loads(spec_json or "{}").get("name") or "")
+    except (TypeError, ValueError):
+        return ""
+
+
+def _live_paper_ledgers(user_id: str) -> tuple[list[LivePaperLedger], bool, str]:
+    """Load the caller's ACTIVE paper deployments and their forward ledgers.
+
+    Ownership is ``owner_user_id`` only — the same predicate paper_routes uses.
+    A paper track record is private (#850): this board never shows another
+    user's deployment, published strategy or not, so there is no 'curated' or
+    global cohort here to fall back to.
+
+    Deployments with an EMPTY ledger are returned as-is (empty ``returns``) and
+    dropped by ``build_live_paper_leaderboard``, which counts them — filtering
+    them out here instead would hide the count and put the anti-fabrication
+    rule in two places.
+    """
+    from archimedes.db import get_session, init_db
+    from archimedes.models.paper_store import STATUS_ACTIVE, PaperDailyReturn, PaperDeployment
+
+    try:
+        init_db()
+        with get_session() as session:
+            deps = (
+                session.query(PaperDeployment)
+                .filter(
+                    PaperDeployment.owner_user_id == user_id,
+                    PaperDeployment.status == STATUS_ACTIVE,
+                )
+                .all()
+            )
+            if not deps:
+                return [], False, ""
+
+            dep_ids = [d.id for d in deps]
+            observations: dict[str, list[tuple]] = {}
+            last_appended: dict[str, object] = {}
+            for row in session.query(PaperDailyReturn).filter(PaperDailyReturn.deployment_id.in_(dep_ids)):
+                observations.setdefault(row.deployment_id, []).append((row.date, row.daily_return))
+                prev = last_appended.get(row.deployment_id)
+                if row.appended_at is not None and (prev is None or row.appended_at > prev):
+                    last_appended[row.deployment_id] = row.appended_at
+
+            names = _display_names(session, {d.strategy_id for d in deps})
+            return (
+                [
+                    LivePaperLedger(
+                        deployment_id=d.id,
+                        strategy_id=d.strategy_id,
+                        name=names.get(d.strategy_id) or _spec_name(d.spec_json) or d.strategy_id,
+                        inception=d.deployed_at,
+                        returns=observations.get(d.id, []),
+                        last_appended_at=last_appended.get(d.id),
+                        drift_detected=d.drift_detected_at is not None,
+                    )
+                    for d in deps
+                ],
+                False,
+                "",
+            )
+    except Exception as exc:  # pragma: no cover - defensive
+        # Same convention as the conviction board: the detail is logged
+        # server-side only, the wire gets a fixed category string.
+        logger.warning("live-paper board: paper deployments unavailable: %s", exc)
+        return [], True, "paper deployments unavailable"
+
+
+@leaderboard_router.get("/live-paper", response_model=LivePaperLeaderboardResponse)
+async def get_live_paper_leaderboard(
+    request: Request,
+    limit: int = Query(50, ge=1, le=200),
+) -> LivePaperLeaderboardResponse:
+    """Forward board: the caller's own active paper deployments, ranked by the
+    return they have ACTUALLY realised since inception.
+
+    Public and never 401 — same contract as the conviction board. An anonymous
+    caller has no paper deployments to show, so they get an empty board tagged
+    ``scope='anonymous'``; that is an honest empty state, distinct from
+    ``degraded`` (something broke) and from ``scope='own'`` with zero entries
+    (signed in, nothing deployed yet). The UI needs all three to say three
+    different true things.
+    """
+    user = get_current_user(request)
+    if user is None:
+        return build_live_paper_leaderboard([], scope="anonymous", limit=limit)
+
+    ledgers, degraded, degraded_reason = _live_paper_ledgers(user.id)
+    return build_live_paper_leaderboard(
+        ledgers,
+        scope="own",
+        limit=limit,
         degraded=degraded,
         degraded_reason=degraded_reason,
     )

--- a/backend/archimedes/api/leaderboard_schemas.py
+++ b/backend/archimedes/api/leaderboard_schemas.py
@@ -12,6 +12,18 @@ explicit and echoed in the response; and the StockBench / live-P&L axis carries 
 flows — the UI omits the axis rather than rendering it (#1365). (A prior
 marketplace surface was removed for "hardcoded fees + invented math", #381 — we
 do not repeat that.)
+
+TWO BOARDS, NEVER BLENDED (Lane 3.4). The conviction board above is entirely
+BACKTEST-ERA: gate, DSR, OOS and PBO are all measured on history the strategy
+was fitted and graded against. A separate surface — ``LivePaperLeaderboard
+Response``, served from /api/leaderboard/live-paper — ranks only what is
+actually running forward, computed from the append-only paper ledger
+(``paper_daily_returns``). They are deliberately NOT combined into one score:
+a blended number would let a strong backtest carry a strategy that has traded
+forward for four days, which is the precise claim this product exists to
+refuse. Instead every row on both boards carries ``performance_basis`` —
+``"backtest_research"`` or ``"live_paper"`` — so a number can never be read
+off either board without its provenance attached.
 """
 
 from __future__ import annotations
@@ -19,6 +31,11 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 from archimedes.api.schemas import PaperRefResponse
+
+#: Provenance tags for a displayed number. These are the ONLY two bases the
+#: product measures on, and every row on every board carries exactly one.
+BASIS_BACKTEST = "backtest_research"
+BASIS_LIVE_PAPER = "live_paper"
 
 
 class LeaderboardScoreComponents(BaseModel):
@@ -108,6 +125,24 @@ class LeaderboardEntry(BaseModel):
     # Forward axis (paired, honest-pending).
     forward: LeaderboardForwardAxis
 
+    # ── Provenance of the numbers in this row (Lane 3.4) ────────────────────
+    # Every metric above — conviction score, Sharpe, CAGR, DSR, PBO, OOS — is
+    # measured on the BACKTEST window named by backtest_start/backtest_end,
+    # not on anything the strategy has done forward. The constant below is not
+    # decoration: it is what lets a reader (or another surface) tell a row on
+    # this board apart from a row on the live-paper board, which carries
+    # ``live_paper`` and an inception date instead.
+    performance_basis: str = Field(
+        BASIS_BACKTEST,
+        description="Always 'backtest_research' on this board — the numbers are backtest-era, not forward.",
+    )
+    # The window the metrics were computed over (ISO dates, threaded from the
+    # passport's backtest_start/backtest_end). None where the source row
+    # predates the field or was never evaluated — rendered as an explicit
+    # "window unknown", never as a silently absent qualifier.
+    backtest_start: str | None = None
+    backtest_end: str | None = None
+
     # Provenance + context.
     regime_tag: str = "regime_neutral"
     return_source: str = "noise"
@@ -146,6 +181,13 @@ class LeaderboardScoringEngine(BaseModel):
 class LeaderboardResponse(BaseModel):
     entries: list[LeaderboardEntry]
     total: int
+    # Board-level restatement of every row's basis, so a consumer can label the
+    # whole surface without inspecting rows (and so an empty board still says
+    # what it would have been showing).
+    performance_basis: str = Field(
+        BASIS_BACKTEST,
+        description="'backtest_research' — this board ranks backtest-era metrics only. Never blended with live paper.",
+    )
     sort_by: str
     order: str
     scope: str = Field(
@@ -166,5 +208,82 @@ class LeaderboardResponse(BaseModel):
     # build). `degraded_reason` names which. The UI must never render "No
     # strategies match these filters yet." while this is True — that is a
     # different, false claim.
+    degraded: bool = False
+    degraded_reason: str = ""
+
+
+# ── Live paper board — the forward surface (Lane 3.4) ────────────────────────
+
+
+class LivePaperEntry(BaseModel):
+    """One ACTIVE paper deployment with a non-empty forward ledger.
+
+    Hard construction rule, enforced in ``build_live_paper_leaderboard`` and
+    pinned by test: a deployment with zero ``paper_daily_returns`` rows NEVER
+    becomes an entry. There is no zero-filled row, no "0.0% since inception",
+    no placeholder — a deployment that has not produced a single observation
+    has no forward performance to display, and rendering one would fabricate
+    the exact thing this board exists to prove. Withheld deployments are
+    counted on the response (``withheld_no_ledger``) so the omission is a
+    loud absence rather than a silence.
+    """
+
+    rank: int
+    deployment_id: str
+    strategy_id: str
+    name: str = Field(..., description="Human label — the strategy's name, else the deployed spec's name, else its id")
+
+    performance_basis: str = Field(
+        BASIS_LIVE_PAPER,
+        description="Always 'live_paper' — every number in this row is compounded from the append-only forward ledger.",
+    )
+    # Compounded product of the ledger's daily returns, minus 1. Never
+    # annualised, never extrapolated: over a handful of days an annualised
+    # figure is a fiction, and this board's whole point is that four days of
+    # forward data must look like four days.
+    cumulative_return: float = Field(..., description="∏(1 + daily_return) − 1 over the whole ledger, since inception")
+    days_live: int = Field(..., ge=1, description="Count of ledger observations — always ≥ 1 by construction")
+    inception_date: str = Field(..., description="ISO date the deployment opened (paper_deployments.deployed_at)")
+    as_of: str = Field(..., description="ISO date of the LAST ledger observation — what the return actually reflects")
+    last_updated: str | None = Field(
+        None, description="ISO timestamp the last ledger row was appended (paper_daily_returns.appended_at)"
+    )
+    # The ledger is append-only by law; a replay that disagrees with already
+    # written rows stamps the deployment instead of rewriting it. Surfaced so
+    # a drifted track record is visibly drifted on the board too.
+    drift_detected: bool = False
+
+
+class LivePaperLeaderboardResponse(BaseModel):
+    """The forward board. Deliberately carries NO conviction score and no
+    backtest metric: the two bases never share a row, never share a sort, and
+    are never averaged into one number."""
+
+    entries: list[LivePaperEntry]
+    total: int = Field(..., description="Qualifying rows BEFORE `limit` — deployments with ledger data, nothing else")
+    performance_basis: str = Field(
+        BASIS_LIVE_PAPER, description="'live_paper' — forward, paper/simulated, compounded from the ledger"
+    )
+    scope: str = Field(
+        "own",
+        description=(
+            "'own' — the signed-in caller's own paper deployments (a paper "
+            "track record is private, #850). 'anonymous' — no session, so "
+            "there is no cohort to show; entries is empty and that is an "
+            "honest empty state, not a degradation."
+        ),
+    )
+    sort_by: str = Field("cumulative_return", description="Fixed — the only forward number this board has")
+    order: str = "desc"
+    #: Latest ledger date across all entries; None on an empty board.
+    as_of: str | None = None
+    #: Active deployments dropped for having no ledger rows yet. Counted, not
+    #: hidden — see LivePaperEntry's docstring.
+    withheld_no_ledger: int = 0
+    methodology: str = Field(
+        ...,
+        description="One-line, plain statement of exactly how the displayed number was computed.",
+    )
+    disclaimer: str
     degraded: bool = False
     degraded_reason: str = ""

--- a/backend/archimedes/services/leaderboard.py
+++ b/backend/archimedes/services/leaderboard.py
@@ -11,18 +11,35 @@ Two axes, honestly separated:
     as honest "pending" until that data flows, so the engine visibly *pairs*
     them with validation (per Dan's call) without inventing values.
 
-This module is pure: it takes ``StrategyResponse`` objects and returns schema
+TWO BOARDS (Lane 3.4). ``build_leaderboard`` ranks by conviction, which is
+100% backtest-era; ``build_live_paper_leaderboard`` ranks ONLY what is running
+forward, compounded from the append-only paper ledger. They are separate
+functions returning separate response types on purpose — there is no blended
+score and no code path that produces one, because a blend would let a strong
+backtest carry a strategy that has traded forward for four days. Every row
+either function emits carries ``performance_basis`` naming which of the two it
+is.
+
+This module is pure: it takes ``StrategyResponse`` objects (or, for the
+forward board, already-loaded ``LivePaperLedger`` values) and returns schema
 objects. No DB, no network — trivially unit-testable.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
 from archimedes.api.leaderboard_schemas import (
+    BASIS_BACKTEST,
+    BASIS_LIVE_PAPER,
     LeaderboardEntry,
     LeaderboardForwardAxis,
     LeaderboardResponse,
     LeaderboardScoreComponents,
     LeaderboardScoringEngine,
+    LivePaperEntry,
+    LivePaperLeaderboardResponse,
     StockBenchGlobalContext,
 )
 from archimedes.api.schemas import StrategyResponse
@@ -158,6 +175,15 @@ def _entry(resp: StrategyResponse) -> LeaderboardEntry:
         cost_model_id=resp.cost_model_id,
         metrics_source=resp.metrics_source,
         forward=LeaderboardForwardAxis(),
+        # Provenance (Lane 3.4): this board's numbers are backtest-era, and the
+        # window they were measured over travels with them. Both fields already
+        # existed on StrategyResponse and simply stopped here — the same defect
+        # shape as backtest_engine/cost_model_id before #1187: the information
+        # existed all the way to the response builder and was dropped at the one
+        # surface that puts rows side by side.
+        performance_basis=BASIS_BACKTEST,
+        backtest_start=resp.backtest_start,
+        backtest_end=resp.backtest_end,
         regime_tag=resp.regime_tag,
         return_source=resp.return_source,
         status=resp.status,
@@ -241,10 +267,127 @@ def build_leaderboard(
     return LeaderboardResponse(
         entries=ranked,
         total=total,
+        performance_basis=BASIS_BACKTEST,
         sort_by=sort_by,
         order=order,
         scope=scope,
         scoring_engine=engine,
+        degraded=degraded,
+        degraded_reason=degraded_reason,
+    )
+
+
+# ── Live paper board — the forward surface (Lane 3.4) ────────────────────────
+
+LIVE_PAPER_METHODOLOGY = (
+    "cumulative_return = ∏(1 + daily_return) − 1 over every observation the "
+    "append-only paper ledger holds for this deployment, from its inception "
+    "date to `as_of`. Not annualised, not extrapolated, not blended with any "
+    "backtest number."
+)
+
+LIVE_PAPER_DISCLAIMER = (
+    "Testnet — paper/simulated forward performance. These rows are ranked ONLY "
+    "on what each deployment has actually done since it went live; a few days "
+    "of forward data is a few days of forward data, and is not evidence the "
+    "edge is real. The research board's conviction score is a separate, "
+    "backtest-era claim and the two are never combined."
+)
+
+
+@dataclass(frozen=True)
+class LivePaperLedger:
+    """One active paper deployment plus the forward ledger already loaded for it.
+
+    The DTO boundary that keeps this module pure: the route layer does the DB
+    work (``paper_deployments`` ⋈ ``paper_daily_returns``) and hands the result
+    over as plain values, so the ranking itself stays trivially testable.
+
+    ``returns`` may legitimately be EMPTY — a deployment opened today, before
+    its first advance, has no observations. That case is the reason this type
+    exists rather than a pre-filtered list: the builder must be the thing that
+    drops it, so the drop is one auditable place with one test on it.
+    """
+
+    deployment_id: str
+    strategy_id: str
+    name: str
+    inception: date
+    returns: list[tuple[date, float]] = field(default_factory=list)
+    last_appended_at: datetime | None = None
+    drift_detected: bool = False
+
+
+def _cumulative_return(returns: list[tuple[date, float]]) -> float:
+    equity = 1.0
+    for _, r in returns:
+        equity *= 1.0 + r
+    return equity - 1.0
+
+
+def build_live_paper_leaderboard(
+    ledgers: list[LivePaperLedger],
+    *,
+    scope: str = "own",
+    limit: int = 50,
+    degraded: bool = False,
+    degraded_reason: str = "",
+) -> LivePaperLeaderboardResponse:
+    """Rank ACTIVE paper deployments by realised forward return. Pure — no I/O.
+
+    The one hard rule, and the only interesting logic in here: **a deployment
+    with an empty ledger is dropped, never rendered.** Not as a 0.0% row, not
+    as an em-dash row, not as a "pending" row that still occupies a rank. A
+    forward board that shows a strategy with no forward observations is making
+    a claim about performance out of nothing, which is precisely the failure
+    (#381's "invented math", the fixture-column leaderboard in
+    architectural-principles.md § fail-soft) this surface was split out to
+    stop. The drop is COUNTED into ``withheld_no_ledger`` so it reads as a
+    visible absence rather than a silence.
+
+    Ranking is by ``cumulative_return`` descending only. There is no
+    configurable sort and no secondary score: this board has exactly one
+    honest number.
+    """
+    graded = [led for led in ledgers if led.returns]
+    withheld = len(ledgers) - len(graded)
+
+    rows: list[LivePaperEntry] = []
+    for led in graded:
+        observations = sorted(led.returns, key=lambda item: item[0])
+        rows.append(
+            LivePaperEntry(
+                rank=0,  # assigned after sort
+                deployment_id=led.deployment_id,
+                strategy_id=led.strategy_id,
+                name=led.name,
+                performance_basis=BASIS_LIVE_PAPER,
+                cumulative_return=_cumulative_return(observations),
+                days_live=len(observations),
+                inception_date=led.inception.isoformat(),
+                as_of=observations[-1][0].isoformat(),
+                last_updated=led.last_appended_at.isoformat() if led.last_appended_at else None,
+                drift_detected=led.drift_detected,
+            )
+        )
+
+    rows.sort(key=lambda e: e.cumulative_return, reverse=True)
+    for i, entry in enumerate(rows, start=1):
+        entry.rank = i
+
+    total = len(rows)
+    board_as_of = max((e.as_of for e in rows), default=None)
+    return LivePaperLeaderboardResponse(
+        entries=rows[:limit],
+        total=total,
+        performance_basis=BASIS_LIVE_PAPER,
+        scope=scope,
+        sort_by="cumulative_return",
+        order="desc",
+        as_of=board_as_of,
+        withheld_no_ledger=withheld,
+        methodology=LIVE_PAPER_METHODOLOGY,
+        disclaimer=LIVE_PAPER_DISCLAIMER,
         degraded=degraded,
         degraded_reason=degraded_reason,
     )

--- a/backend/archimedes/services/leaderboard.py
+++ b/backend/archimedes/services/leaderboard.py
@@ -376,7 +376,9 @@ def build_live_paper_leaderboard(
         entry.rank = i
 
     total = len(rows)
-    board_as_of = max((e.as_of for e in rows), default=None)
+    # as_of must describe the rows actually SERVED: with a truncating limit,
+    # max() over the full set can postdate every visible row's ledger.
+    board_as_of = max((e.as_of for e in rows[:limit]), default=None)
     return LivePaperLeaderboardResponse(
         entries=rows[:limit],
         total=total,

--- a/backend/tests/test_leaderboard_live_paper.py
+++ b/backend/tests/test_leaderboard_live_paper.py
@@ -1,0 +1,415 @@
+"""The leaderboard split — research (backtest) vs live paper (Lane 3.4).
+
+Two surfaces, and the whole point of splitting them is that a number can never
+be read off either one without its basis attached. This file pins both halves:
+
+  1. ANTI-FABRICATION (the load-bearing guard): an ACTIVE paper deployment with
+     zero ``paper_daily_returns`` rows never becomes an entry — not as a 0.0%
+     row, not as a placeholder holding a rank. It is dropped and COUNTED into
+     ``withheld_no_ledger``, so the omission is a visible absence.
+  2. Rows that DO have ledger data carry real, recomputable numbers:
+     cumulative_return is the compounded product of the ledger, days_live is
+     the observation count, as_of is the last observation's date, and
+     inception_date is the deployment's own deploy date.
+  3. Ordering is realised forward return, descending — never conviction, never
+     a blend.
+  4. Ownership: the forward board is ``owner_user_id``-scoped (#850 — a paper
+     track record is private). User A never sees user B's deployment even when
+     B's is the better-performing one.
+  5. Stopped deployments are excluded (the board claims "live", so it must be).
+  6. Anonymous callers get an honest empty board (scope='anonymous'), never a
+     401 and never someone else's rows.
+  7. The RESEARCH board keeps its conviction math untouched but now states its
+     basis: every row carries performance_basis='backtest_research' plus the
+     backtest window it was measured over.
+  8. No blended score exists: the forward response has no conviction field and
+     the research response has no live-paper field.
+
+Hermetic: tmp sqlite via ``redirect_to_tmp_sqlite``; Better Auth's session
+fetch is monkeypatched at its boundary; the httpx ASGITransport idiom from
+test_leaderboard_single_user_scope.py / test_risk_routes.py.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import httpx
+import pytest
+from archimedes.api import account_auth
+from archimedes.api.leaderboard_schemas import BASIS_BACKTEST, BASIS_LIVE_PAPER
+from archimedes.main import app
+from archimedes.services.leaderboard import LivePaperLedger, build_live_paper_leaderboard
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+LIVE_PAPER_URL = "/api/leaderboard/live-paper"
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+def _deploy(
+    deployment_id: str,
+    *,
+    owner_user_id: str,
+    strategy_id: str = "strat-1",
+    deployed_at: date = date(2026, 8, 1),
+    status: str = "active",
+    returns: list[float] | None = None,
+    drift: bool = False,
+) -> None:
+    """One paper deployment plus ``returns`` consecutive ledger observations.
+
+    ``returns=None`` means an EMPTY ledger — a deployment that opened but has
+    not produced a single observation yet. That is the shape the anti-
+    fabrication guard is about, so it is the default, not a special case.
+    """
+    import archimedes.db as db
+    from archimedes.models.paper_store import PaperDailyReturn, PaperDeployment
+
+    with db.get_session() as session:
+        session.add(
+            PaperDeployment(
+                id=deployment_id,
+                strategy_id=strategy_id,
+                owner_user_id=owner_user_id,
+                owner_wallet=None,
+                spec_json='{"name": "Deployed Spec Name"}',
+                deployed_at=deployed_at,
+                status=status,
+                drift_detected_at=datetime.now(UTC) if drift else None,
+            )
+        )
+        for offset, daily in enumerate(returns or []):
+            session.add(
+                PaperDailyReturn(
+                    deployment_id=deployment_id,
+                    date=deployed_at + timedelta(days=offset),
+                    daily_return=daily,
+                    appended_at=datetime(2026, 8, 20, 12, 0, offset, tzinfo=UTC),
+                )
+            )
+        session.commit()
+
+
+def _named_strategy(strategy_id: str, name: str) -> None:
+    import archimedes.db as db
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with db.get_session() as session:
+        session.add(
+            StrategyRecord(
+                id=strategy_id,
+                content_hash=("0x" + strategy_id).ljust(66, "0"),
+                generation_method="fusion",
+                source_papers="[]",
+                strategy_name=name,
+                thesis="t",
+                asset_universe="[]",
+                risk_profile="moderate",
+                status="live",
+                is_example=False,
+            )
+        )
+        session.commit()
+
+
+def _session_for(user_id: str):
+    async def fetch(_request):
+        return {
+            "user": {"id": user_id, "name": user_id, "email": f"{user_id}@example.com", "emailVerified": True},
+            "session": {"id": f"s-{user_id}", "expiresAt": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+        }
+
+    return fetch
+
+
+def _sign_in(monkeypatch, user_id: str) -> None:
+    monkeypatch.setattr(account_auth, "_fetch_session", _session_for(user_id))
+
+
+def _client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"cookie": "better-auth.session_token=opaque", "host": "test"},
+    )
+
+
+# ── 1. Anti-fabrication: no ledger data ⇒ no row, and the drop is counted ───
+
+
+@pytest.mark.asyncio
+async def test_active_deployment_with_empty_ledger_is_never_rendered(monkeypatch):
+    """THE guard. A deployment that is active but has produced zero
+    observations has no forward performance, so it must not appear at all —
+    and the count of what was withheld must be on the wire."""
+    _deploy("dep-empty", owner_user_id="user-a", strategy_id="s-empty", returns=None)
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        resp = await client.get(LIVE_PAPER_URL)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["entries"] == [], "an active deployment with an empty ledger must not produce a row"
+    assert body["total"] == 0
+    assert body["withheld_no_ledger"] == 1, "the withheld deployment must be counted, not silently dropped"
+    assert body["degraded"] is False, "an honestly-empty board is not a degraded board"
+    assert body["as_of"] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_ledger_row_is_dropped_even_beside_a_real_one(monkeypatch):
+    """The mixed case: the drop must be per-row, not an all-or-nothing bail.
+    A real row still renders; the ledger-less one is still withheld."""
+    _deploy("dep-real", owner_user_id="user-a", strategy_id="s-real", returns=[0.01, 0.02])
+    _deploy("dep-empty", owner_user_id="user-a", strategy_id="s-empty", returns=None)
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get(LIVE_PAPER_URL)).json()
+
+    assert [e["deployment_id"] for e in body["entries"]] == ["dep-real"]
+    assert body["total"] == 1
+    assert body["withheld_no_ledger"] == 1
+
+
+def test_builder_drops_empty_ledgers_without_any_io():
+    """Same rule at the pure layer — the builder is the single place the rule
+    lives, so it is asserted directly and not only through the route."""
+    board = build_live_paper_leaderboard(
+        [
+            LivePaperLedger(
+                deployment_id="d1",
+                strategy_id="s1",
+                name="Has data",
+                inception=date(2026, 8, 1),
+                returns=[(date(2026, 8, 1), 0.01)],
+            ),
+            LivePaperLedger(
+                deployment_id="d2",
+                strategy_id="s2",
+                name="No data",
+                inception=date(2026, 8, 1),
+                returns=[],
+            ),
+        ]
+    )
+    assert [e.deployment_id for e in board.entries] == ["d1"]
+    assert board.withheld_no_ledger == 1
+    # No entry may ever carry days_live == 0 — the schema floor plus the drop.
+    assert all(e.days_live >= 1 for e in board.entries)
+
+
+# ── 2. Real rows carry real, recomputable numbers ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_live_row_numbers_are_computed_from_the_ledger(monkeypatch):
+    _named_strategy("s-real", "Cross-Sectional Momentum")
+    _deploy(
+        "dep-real",
+        owner_user_id="user-a",
+        strategy_id="s-real",
+        deployed_at=date(2026, 8, 3),
+        returns=[0.01, -0.005, 0.02],
+    )
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get(LIVE_PAPER_URL)).json()
+
+    (row,) = body["entries"]
+    expected = 1.01 * 0.995 * 1.02 - 1.0
+    assert row["cumulative_return"] == pytest.approx(expected)
+    assert row["days_live"] == 3
+    assert row["inception_date"] == "2026-08-03"
+    assert row["as_of"] == "2026-08-05", "as_of is the LAST observation's date, not today"
+    assert row["last_updated"] is not None
+    assert row["name"] == "Cross-Sectional Momentum"
+    assert row["performance_basis"] == BASIS_LIVE_PAPER
+    assert body["performance_basis"] == BASIS_LIVE_PAPER
+    assert body["as_of"] == "2026-08-05"
+    assert body["methodology"], "the forward board must state how its one number is computed"
+
+
+@pytest.mark.asyncio
+async def test_drift_is_surfaced_on_the_row(monkeypatch):
+    """The ledger is append-only; a disagreeing replay stamps the deployment
+    instead of rewriting it. A drifted track record must read as drifted."""
+    _deploy("dep-drift", owner_user_id="user-a", strategy_id="s-d", returns=[0.01], drift=True)
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get(LIVE_PAPER_URL)).json()
+
+    assert body["entries"][0]["drift_detected"] is True
+
+
+# ── 3. Ranking is realised forward return, descending ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rows_sort_by_realised_return_descending(monkeypatch):
+    _deploy("dep-low", owner_user_id="user-a", strategy_id="s-low", returns=[-0.05])
+    _deploy("dep-high", owner_user_id="user-a", strategy_id="s-high", returns=[0.04])
+    _deploy("dep-mid", owner_user_id="user-a", strategy_id="s-mid", returns=[0.01])
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get(LIVE_PAPER_URL)).json()
+
+    assert [e["deployment_id"] for e in body["entries"]] == ["dep-high", "dep-mid", "dep-low"]
+    assert [e["rank"] for e in body["entries"]] == [1, 2, 3]
+    assert body["sort_by"] == "cumulative_return"
+
+
+# ── 4 & 5. Ownership and liveness are both real filters ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_forward_board_never_leaks_another_users_deployment(monkeypatch):
+    """Poison test, same shape as the conviction board's: B's deployment is
+    the better performer, so a broken ownership filter would leak it straight
+    to rank 1."""
+    _deploy("dep-a", owner_user_id="user-a", strategy_id="s-a", returns=[0.01])
+    _deploy("dep-b", owner_user_id="user-b", strategy_id="s-b", returns=[0.50])
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get(LIVE_PAPER_URL)).json()
+
+    assert [e["deployment_id"] for e in body["entries"]] == ["dep-a"]
+    assert body["scope"] == "own"
+
+
+@pytest.mark.asyncio
+async def test_stopped_deployment_is_excluded(monkeypatch):
+    """The board says "live paper trading". A stopped deployment is not live,
+    ledger rows or not."""
+    _deploy("dep-stopped", owner_user_id="user-a", strategy_id="s-s", status="stopped", returns=[0.30])
+    _deploy("dep-active", owner_user_id="user-a", strategy_id="s-a", status="active", returns=[0.01])
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get(LIVE_PAPER_URL)).json()
+
+    assert [e["deployment_id"] for e in body["entries"]] == ["dep-active"]
+    # A stopped deployment is not "withheld for lack of data" either — it is
+    # out of cohort entirely, so it must not inflate that count.
+    assert body["withheld_no_ledger"] == 0
+
+
+# ── 6. Anonymous: honest empty board, never a 401, never a leak ────────────
+
+
+@pytest.mark.asyncio
+async def test_anonymous_gets_empty_board_not_an_error_and_not_a_leak():
+    _deploy("dep-private", owner_user_id="user-a", strategy_id="s-p", returns=[0.42])
+
+    async with _client() as client:
+        client.headers.pop("cookie", None)
+        resp = await client.get(LIVE_PAPER_URL)
+
+    assert resp.status_code == 200, "public endpoint — never 401, same contract as the conviction board"
+    body = resp.json()
+    assert body["entries"] == []
+    assert body["scope"] == "anonymous"
+    assert body["degraded"] is False
+
+
+# ── 7. The research board states its basis and its window ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_research_board_rows_carry_backtest_basis_and_window(monkeypatch):
+    from archimedes.api import leaderboard_routes
+    from archimedes.api.schemas import StrategyResponse
+
+    resp = StrategyResponse(
+        id="r-1",
+        methodology_summary="m",
+        asset_universe=["SPY"],
+        position_sizing="equal_weight",
+        rebalance_frequency="daily",
+        status="live",
+        paper_title="A Research Row",
+        sharpe_ratio=1.2,
+        dsr_p_value=0.9,
+        out_of_sample_sharpe=1.1,
+        pbo_score=0.1,
+        passes_rigor_gate=True,
+        backtest_start="2015-01-01",
+        backtest_end="2024-12-31",
+    )
+    monkeypatch.setattr(leaderboard_routes, "_own_cohort_responses", lambda *_a, **_k: ([resp], False, ""))
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get("/api/leaderboard?scope=own")).json()
+
+    (row,) = body["entries"]
+    assert row["performance_basis"] == BASIS_BACKTEST
+    assert row["backtest_start"] == "2015-01-01"
+    assert row["backtest_end"] == "2024-12-31"
+    assert body["performance_basis"] == BASIS_BACKTEST
+    # Conviction math is untouched: 100 × (0.35·1 + 0.25·0.9 + 0.25·1.0 + 0.15·0.9) = 96.0
+    # (OOS 1.1 clamps to 1.0 against OOS_TARGET; overfit-resistance = 1 − PBO.)
+    assert row["conviction_score"] == pytest.approx(96.0)
+
+
+@pytest.mark.asyncio
+async def test_research_row_without_a_window_says_so_rather_than_inventing_one(monkeypatch):
+    from archimedes.api import leaderboard_routes
+    from archimedes.api.schemas import StrategyResponse
+
+    resp = StrategyResponse(
+        id="r-2",
+        methodology_summary="m",
+        asset_universe=["SPY"],
+        position_sizing="equal_weight",
+        rebalance_frequency="daily",
+        status="candidate",
+    )
+    monkeypatch.setattr(leaderboard_routes, "_own_cohort_responses", lambda *_a, **_k: ([resp], False, ""))
+
+    _sign_in(monkeypatch, "user-a")
+    async with _client() as client:
+        body = (await client.get("/api/leaderboard?scope=own")).json()
+
+    (row,) = body["entries"]
+    assert row["backtest_start"] is None and row["backtest_end"] is None
+    assert row["performance_basis"] == BASIS_BACKTEST
+
+
+# ── 8. The two bases are never blended ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_neither_board_carries_the_other_boards_numbers(monkeypatch):
+    """Anti-goal pin: no blended score. The forward response must expose no
+    conviction/rigor field, and the research response must expose no
+    live-paper field — a future 'combined score' cannot land without
+    breaking this test."""
+    _deploy("dep-a", owner_user_id="user-a", strategy_id="s-a", returns=[0.01])
+    _sign_in(monkeypatch, "user-a")
+
+    async with _client() as client:
+        forward = (await client.get(LIVE_PAPER_URL)).json()
+        research = (await client.get("/api/leaderboard?scope=own")).json()
+
+    forbidden_on_forward = {"conviction_score", "score_components", "passes_rigor_gate", "deflated_sharpe_ratio"}
+    for row in forward["entries"]:
+        assert not (forbidden_on_forward & set(row)), f"forward row leaked backtest fields: {set(row)}"
+    assert "scoring_engine" not in forward
+
+    forbidden_on_research = {"cumulative_return", "days_live", "inception_date"}
+    for row in research["entries"]:
+        assert not (forbidden_on_research & set(row)), f"research row leaked live-paper fields: {set(row)}"

--- a/docs/api/leaderboard-and-metrics.md
+++ b/docs/api/leaderboard-and-metrics.md
@@ -2,7 +2,7 @@
 
 > **status:** current
 > **owner:** Dan Browne
-> **updated:** 2026-08-20
+> **updated:** 2026-08-30
 
 Two surfaces bundled together because they answer the same question — "how
 is the platform doing?" — at two different scopes: `/api/leaderboard` ranks
@@ -24,6 +24,18 @@ completeness but the detail lives there.
 
 ## Leaderboard
 
+**Two boards, never blended.** `GET /api/leaderboard` is the RESEARCH board:
+its conviction score is built entirely from backtest-era passport fields
+(rigor gate, DSR, OOS, PBO), so every row now carries
+`performance_basis: "backtest_research"` plus the `backtest_start` /
+`backtest_end` window the metrics were measured over.
+`GET /api/leaderboard/live-paper` is the FORWARD board: rows only for active
+paper deployments that have actually produced ledger observations, ranked on
+realised return, each carrying `performance_basis: "live_paper"` and an
+inception date. **No endpoint returns a combined score**, and the forward
+board never renders a deployment with an empty ledger — see its section
+below.
+
 ### GET /api/leaderboard
 Rank strategies by a transparent, real-data-only conviction score. |
 **Auth**: anonymous — never 401s; scope is resolved from whether a session
@@ -36,7 +48,7 @@ reports what was actually served, which may differ from what was asked for),
 `sort_by: "conviction_score"|"sharpe_ratio"|"cagr"|"sortino_ratio"|"calmar_ratio"|"deflated_sharpe_ratio"|"dsr_p_value"|"out_of_sample_sharpe"|"pbo_score" = "conviction_score"`,
 `order: "asc"|"desc" = "desc"`, `regime_tag: "bull"|"bear"|"regime_neutral"|null`,
 `min_rigor: bool = false`, `limit: int(1..200) = 50`.
-Response (`LeaderboardResponse`): `{entries: [LeaderboardEntry], total: int, sort_by: str, order: str, scope: str, scoring_engine: LeaderboardScoringEngine, degraded: bool=false, degraded_reason: str=""}` — see [Response shape](#response-shape) below. `degraded` is `true` when the underlying strategy provider raised, or the curated cohort came back empty for a reason other than a legitimate filter (e.g. `"strategy corpus not found in build"`, `"curated strategy cohort is empty"`) — the UI must never render "No strategies match these filters yet." while `degraded` is `true` (#1356).
+Response (`LeaderboardResponse`): `{entries: [LeaderboardEntry], total: int, performance_basis: "backtest_research", sort_by: str, order: str, scope: str, scoring_engine: LeaderboardScoringEngine, degraded: bool=false, degraded_reason: str=""}` — see [Response shape](#response-shape) below. `degraded` is `true` when the underlying strategy provider raised, or the curated cohort came back empty for a reason other than a legitimate filter (e.g. `"strategy corpus not found in build"`, `"curated strategy cohort is empty"`) — the UI must never render "No strategies match these filters yet." while `degraded` is `true` (#1356).
 Errors: none — a data-source failure degrades to an empty board with the
 scoring-engine metadata intact, never a 5xx (module docstring: "the page must
 never hard-fail, for either scope").
@@ -76,8 +88,13 @@ better — despite the legacy "p_value" name**), `pbo_score,
 out_of_sample_sharpe, passes_rigor_gate: bool, is_backtest_placeholder: bool,
 forward: {stockbench_status: "pending", stockbench_sortino: float|null,
 live_pnl_status: "pending", live_pnl_pct: float|null}` (per-strategy
-StockBench and live paper-P&L are not wired yet — always `"pending"`, shown
-honestly rather than hidden or fabricated), `regime_tag, return_source,
+StockBench and live paper-P&L are not scored INTO this board — always
+`"pending"` here; realised forward performance has its own endpoint, see
+[live-paper](#get-apileaderboardlive-paper)), `performance_basis:
+"backtest_research"`, `backtest_start: str|null, backtest_end: str|null`
+(the ISO window these metrics were computed over — `null` on rows that were
+never stamped with one, which the UI renders as "window not recorded" rather
+than leaving the numbers unqualified), `regime_tag, return_source,
 status, papers: [PaperRef]`.
 
 `scoring_engine`: `{weights: dict[str,float], oos_target: float, methodology:
@@ -91,6 +108,43 @@ about any individual entry.
 **The response's `scope` field is authoritative, not the request's `?scope=`
 param** — always read it back rather than assuming the server honored what
 was asked for.
+
+### GET /api/leaderboard/live-paper
+The FORWARD board: the caller's own active paper deployments, ranked by the
+return each has actually realised since it went live. | **Auth**: anonymous —
+never 401s, same contract as the conviction board
+
+Request: query `limit: int(1..200) = 50`.
+Response (`LivePaperLeaderboardResponse`): `{entries: [LivePaperEntry], total: int, performance_basis: "live_paper", scope: "own"|"anonymous", sort_by: "cumulative_return", order: "desc", as_of: str|null, withheld_no_ledger: int, methodology: str, disclaimer: str, degraded: bool=false, degraded_reason: str=""}`.
+`LivePaperEntry`: `{rank, deployment_id, strategy_id, name, performance_basis: "live_paper", cumulative_return: float, days_live: int(≥1), inception_date: str, as_of: str, last_updated: str|null, drift_detected: bool}`.
+Errors: none — a DB failure degrades to an empty board with
+`degraded_reason: "paper deployments unavailable"`, never a 5xx.
+
+```bash
+curl -s --cookie "better-auth.session_token=…" \
+  "https://archimedes-arc.com/api/leaderboard/live-paper?limit=50"
+```
+
+Four contract points that are load-bearing rather than incidental:
+
+- **A deployment with an empty ledger is never an entry.** Not as a `0.0%`
+  row, not as a placeholder holding a rank — it is dropped and counted into
+  `withheld_no_ledger`, so the omission is a visible absence rather than a
+  silence. `days_live` therefore has a floor of 1 by construction.
+- **`cumulative_return` is `∏(1 + daily_return) − 1` over the whole ledger.**
+  Never annualised and never extrapolated: over a handful of days an
+  annualised figure is a fiction. `as_of` is the LAST ledger observation's
+  date — what the number actually reflects — not today.
+- **Ownership is `owner_user_id` only** (#850 — a paper track record is
+  private). There is no curated or cross-user cohort here; an anonymous
+  caller gets `scope: "anonymous"` with `entries: []`, which is an honest
+  empty state and distinct from both `degraded` and a signed-in caller with
+  nothing deployed.
+- **`drift_detected`** mirrors `paper_deployments.drift_detected_at`: a
+  replay that disagreed with already-written rows stamps the deployment
+  rather than rewriting the append-only ledger, and a drifted track record
+  reads as drifted on the board too. See
+  [`paper-trading.md`](paper-trading.md).
 
 ## Metrics (public, PII-free)
 

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -8,11 +8,37 @@ import { apiGet } from '../api'
 // transparent conviction score (real rigor gate + backtest). Signed out (or
 // explicitly toggled): shows the curated seed library as an honestly-labeled
 // REFERENCE set, never framed as competition. Nothing here is fabricated:
-// validation metrics are real passport fields; the forward axis (per-strategy
-// StockBench + live paper-P&L) is not scored yet and is called out as
-// "pending" in its own section, not rendered per row. Never auth-gated — public browse stays;
+// validation metrics are real passport fields. Never auth-gated — public browse stays;
 // see backend's `scope` field (own|curated), which reports what was actually
 // served, not just what was requested.
+//
+// TWO BOARDS, NEVER BLENDED (Lane 3.4). The conviction board is entirely
+// BACKTEST-ERA — gate, DSR, OOS and PBO are all measured on history the
+// strategy was fitted and graded against — so it lives behind the "Research"
+// tab and every one of its rows states the window it was measured over. The
+// "Live paper trading" tab is a genuinely different surface fed by a
+// different endpoint (/api/leaderboard/live-paper): rows only for deployments
+// that are actually running forward, ranked on realised return compounded
+// from the append-only paper ledger. There is no combined score and no code
+// path here that makes one — a blend would let a strong backtest carry a
+// strategy that has traded forward for a handful of days.
+//
+// The load-bearing UI rule, guarded in ui/test/leaderboard-boards.test.js:
+// the live tab renders ONLY from `liveData.entries`. It must never fall back
+// to the research payload, and it must never synthesise a row for a
+// deployment with no ledger data — the backend already withholds those, and
+// the empty state below says so plainly instead of showing a zeroed row.
+
+const RESEARCH_BOARD = 'research'
+const LIVE_BOARD = 'live'
+
+const BOARDS = [
+  { id: RESEARCH_BOARD, label: 'Research (backtest conviction)' },
+  { id: LIVE_BOARD, label: 'Live paper trading' },
+]
+
+// The one honest thing to say when the forward ledger is thin or empty.
+const LIVE_EMPTY_MESSAGE = 'No strategies are live paper trading yet'
 
 const SORT_OPTIONS = [
   { id: 'conviction_score', label: 'Conviction' },
@@ -37,6 +63,68 @@ function fmt(v, d = 2) {
 }
 function fmtPct(v, d = 1) {
   return v != null ? `${(v * 100).toFixed(d)}%` : '—'
+}
+// Signed, so a forward return never reads as a bare magnitude.
+function fmtSignedPct(v, d = 2) {
+  if (v == null) return '—'
+  const pct = v * 100
+  return `${pct >= 0 ? '+' : '−'}${Math.abs(pct).toFixed(d)}%`
+}
+
+// ── Provenance labelling ────────────────────────────────────────────────────
+// Every number this page displays carries the basis it was measured on. The
+// two bases are the ONLY two the product measures, they mean different things,
+// and a reader who sees a figure without one has been told less than the truth.
+// Copy is keyed off the backend's `performance_basis` string so the label can
+// never drift from what the API actually said.
+const BASIS_COPY = {
+  backtest_research: {
+    short: 'Backtest',
+    title: 'Backtest research: measured on historical data the strategy was fitted and graded against — not forward performance.',
+    color: 'var(--text-3)',
+  },
+  live_paper: {
+    short: 'Live paper',
+    title: 'Live paper trading: compounded from the append-only forward ledger since this deployment went live. Simulated — no funds move.',
+    color: 'var(--accent)',
+  },
+}
+
+function BasisBadge({ basis }) {
+  const copy = BASIS_COPY[basis]
+  if (!copy) return null
+  return (
+    <span
+      title={copy.title}
+      style={{
+        fontSize: 10,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+        padding: '1px 5px',
+        borderRadius: 3,
+        border: `1px solid ${copy.color}`,
+        color: copy.color,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {copy.short}
+    </span>
+  )
+}
+
+// The backtest window a research row's numbers were measured over. Missing
+// dates say so explicitly — an unlabelled number would read as if it applied
+// to now, which is the misreading this whole split exists to prevent.
+function WindowLabel({ start, end }) {
+  const known = start && end
+  return (
+    <span
+      style={{ fontSize: 11, color: 'var(--text-3)' }}
+      title={known ? 'The historical window these metrics were computed over' : 'This row is not stamped with a backtest window'}
+    >
+      {known ? `${start} → ${end}` : 'window not recorded'}
+    </span>
+  )
 }
 
 function rigorBadge(entry) {
@@ -70,9 +158,17 @@ function ScoreBar({ components, weights }) {
 
 export default function Leaderboard() {
   const { user } = useAuth()
+  const [board, setBoard] = useState(RESEARCH_BOARD)
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  // The forward board is a SEPARATE payload from a separate endpoint. Kept in
+  // its own state deliberately: there is no shape in which a research entry
+  // could stand in for a live row, so there must be no variable either one
+  // could be read out of by accident.
+  const [liveData, setLiveData] = useState(null)
+  const [liveLoading, setLiveLoading] = useState(false)
+  const [liveError, setLiveError] = useState(null)
   const [sortBy, setSortBy] = useState('conviction_score')
   const [order, setOrder] = useState('desc')
   const [minRigor, setMinRigor] = useState(false)
@@ -101,6 +197,21 @@ export default function Leaderboard() {
 
   useEffect(() => { load() }, [load])
 
+  const loadLive = useCallback(() => {
+    setLiveLoading(true)
+    apiGet('/api/leaderboard/live-paper?limit=100')
+      .then(d => { setLiveData(d); setLiveError(null) })
+      .catch(e => setLiveError(e.message || 'Failed to load the live paper board'))
+      .finally(() => setLiveLoading(false))
+  }, [])
+
+  // Fetched only when the forward tab is actually opened, and re-fetched when
+  // the session changes (the board is owner-scoped, so signing in/out changes
+  // what it legitimately contains).
+  useEffect(() => {
+    if (board === LIVE_BOARD) loadLive()
+  }, [board, loadLive, user?.id])
+
   const engine = data?.scoring_engine
   const sb = engine?.stockbench_global
   // The scope actually served (may differ from scopeParam — an anonymous
@@ -124,27 +235,66 @@ export default function Leaderboard() {
   const evaluatedCount = gradedEntries ? gradedEntries.length : null
   const passingCount = gradedEntries ? gradedEntries.filter((e) => e.passes_rigor_gate).length : null
 
+  const isResearch = board === RESEARCH_BOARD
+  const isLive = board === LIVE_BOARD
+  // The forward board's rows, read ONLY out of its own payload. Nothing below
+  // may derive a live row from `data` — see the header comment.
+  const liveEntries = liveData?.entries ?? []
+
   return (
     <div className="leaderboard-page" style={{ maxWidth: 1100 }}>
       <div style={{ marginBottom: 18 }}>
         <h2 className="serif" style={{ fontSize: '2rem', marginBottom: 8 }}>
           {isOwn ? 'Your Strategy Leaderboard' : 'Strategy Leaderboard'}
         </h2>
-        <p className="body" style={{ maxWidth: 760 }}>
-          {isOwn
-            ? <>Your strategies, ranked against each other by a transparent <strong>conviction score</strong> built
-                from real rigor-gate and backtest results — the ugly numbers included. Build your track record now;
-                it carries to mainnet.</>
-            : <>The curated seed library, ranked by a transparent <strong>conviction score</strong> built from real
-                rigor-gate and backtest results — the ugly numbers included. A reference set, not a competition.</>}
-        </p>
+
+        {/* Board switch. Two surfaces, two bases, never averaged — the labels
+            say which is which before a single number is read. */}
+        <div role="tablist" aria-label="Leaderboard board" style={{ display: 'flex', gap: 6, margin: '10px 0 12px' }}>
+          {BOARDS.map(b => (
+            <button
+              key={b.id}
+              type="button"
+              role="tab"
+              aria-selected={board === b.id}
+              onClick={() => setBoard(b.id)}
+              className={`tag-tab ${board === b.id ? 'tag-accent' : 'tag-muted'}`}
+              style={{ cursor: 'pointer', border: 'none', borderRadius: 14, fontSize: 12 }}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+
+        {isResearch && (
+          <p className="body" style={{ maxWidth: 760 }}>
+            {isOwn
+              ? <>Your strategies, ranked against each other by a transparent <strong>conviction score</strong> built
+                  from real rigor-gate and backtest results — the ugly numbers included. Build your track record now;
+                  it carries to mainnet.</>
+              : <>The curated seed library, ranked by a transparent <strong>conviction score</strong> built from real
+                  rigor-gate and backtest results — the ugly numbers included. A reference set, not a competition.</>}
+            {' '}
+            <strong>Every figure on this tab is backtest-era</strong> — measured on history the strategy was fitted
+            and graded against, over the window stamped on each row. Nothing here is forward performance.
+          </p>
+        )}
+
+        {isLive && (
+          <p className="body" style={{ maxWidth: 760 }}>
+            Strategies you have <strong>actually deployed to paper trading</strong>, ranked by the return each one has
+            realised since it went live — compounded from its append-only forward ledger, never annualised and never
+            mixed with a backtest number. A deployment that has not produced an observation yet is withheld rather
+            than shown at zero.
+          </p>
+        )}
 
         {/* Headline selectivity aggregate — see the derivation comment above
             (evaluatedCount / passingCount). Guarded identically to the
             table's non-empty state further down so a zero-over-zero claim
             never renders while loading, on error, degraded, or before any
             strategies exist. */}
-        {!loading && !error && data && !data.degraded && evaluatedCount > 0 && (
+        {isResearch && !loading && !error && data && !data.degraded && evaluatedCount > 0 && (
           <div
             role="status"
             style={{
@@ -189,9 +339,19 @@ export default function Leaderboard() {
             }}
           >
             <span>
-              <strong style={{ color: 'var(--accent)' }}>Sign in to rank your strategies.</strong>{' '}
-              What you're seeing below is the curated library — reference rows, not strategies you're
-              competing against.
+              {isLive ? (
+                <>
+                  <strong style={{ color: 'var(--accent)' }}>Sign in to see your live paper trades.</strong>{' '}
+                  A paper track record is private to the account that deployed it, so there is nothing to show
+                  here while signed out — this board never displays someone else's deployments.
+                </>
+              ) : (
+                <>
+                  <strong style={{ color: 'var(--accent)' }}>Sign in to rank your strategies.</strong>{' '}
+                  What you're seeing below is the curated library — reference rows, not strategies you're
+                  competing against.
+                </>
+              )}
             </span>
             <a
               className="btn-primary"
@@ -203,7 +363,7 @@ export default function Leaderboard() {
           </div>
         )}
 
-        {user && (
+        {isResearch && user && (
           <div style={{ marginTop: 10, display: 'flex', gap: 6, alignItems: 'center' }}>
             <button type="button" onClick={() => setScopeParam('own')}
               className={`tag-tab ${isOwn ? 'tag-accent' : 'tag-muted'}`}
@@ -236,7 +396,7 @@ export default function Leaderboard() {
             false and is retired) — hence the single-caveat banner below,
             scoped to the own view; curated rows are reference-only backtests,
             all verified fresh. */}
-        {isOwn && (
+        {isResearch && isOwn && (
           <div
             role="status"
             style={{
@@ -256,25 +416,43 @@ export default function Leaderboard() {
             current engine.
           </div>
         )}
-        {engine?.disclaimer && (
+        {isResearch && engine?.disclaimer && (
           <div style={{ marginTop: 10, padding: '8px 12px', borderLeft: '3px solid var(--accent)', background: 'var(--accent-muted)', borderRadius: 4, fontSize: 13, color: 'var(--text-2)' }}>
             <strong style={{ color: 'var(--accent)' }}>Testnet — paper/simulated.</strong> {engine.disclaimer}
           </div>
         )}
+
+        {isLive && liveData?.disclaimer && (
+          <div style={{ marginTop: 10, padding: '8px 12px', borderLeft: '3px solid var(--accent)', background: 'var(--accent-muted)', borderRadius: 4, fontSize: 13, color: 'var(--text-2)' }}>
+            <strong style={{ color: 'var(--accent)' }}>Testnet — paper/simulated.</strong> {liveData.disclaimer}
+          </div>
+        )}
       </div>
 
-      {/* Scoring engine: weights + methodology + the one real StockBench datum, as honest context */}
+      {/* RESEARCH-BOARD:BEGIN — everything between these sentinels renders the
+          BACKTEST board and reads from `data` only. The guard in
+          ui/test/leaderboard-boards.test.js slices on them. */}
+      {isResearch && (
+      <>
+      {/* Scoring engine: weights + the one-line methodology sentence + the one
+          real StockBench datum, as honest context. The methodology line is the
+          board's own statement of how conviction is computed — it comes from
+          the API's engine metadata, never restated by hand here, so it cannot
+          drift from the formula the backend actually ran. */}
       {engine && (
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginBottom: 18, padding: 14, background: 'var(--surface-2)', borderRadius: 8, border: '1px solid var(--glass-border)' }}>
           <div style={{ flex: '1 1 320px' }}>
-            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--text-3)', marginBottom: 6 }}>Scoring engine · validation axis (live)</div>
+            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--text-3)', marginBottom: 6, display: 'flex', alignItems: 'center', gap: 6 }}>
+              How this board is scored <BasisBadge basis={data?.performance_basis} />
+            </div>
             <div style={{ fontSize: 13, color: 'var(--text-2)' }}>{engine.methodology}</div>
           </div>
           <div style={{ flex: '1 1 260px' }}>
-            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--text-3)', marginBottom: 6 }}>Forward axis (pending)</div>
+            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--text-3)', marginBottom: 6 }}>Benchmark context</div>
             <div style={{ fontSize: 13, color: 'var(--text-2)' }}>
-              Per-strategy <strong>StockBench</strong> + <strong>live paper-P&L</strong> pair into this engine next.
-              StockBench today is a single whole-pipeline run (honest, not per-strategy):{' '}
+              Realised forward results now have their own tab — see <strong>Live paper trading</strong>; they are never
+              folded into the score above. <strong>StockBench</strong> today is a single whole-pipeline run (honest, not
+              per-strategy):{' '}
               {sb && <span title={`${sb.window} · ${sb.source}`}>Sortino {fmt(sb.sortino)}, return {sb.return_pct}%, rank {sb.rank}</span>}.
             </div>
           </div>
@@ -381,6 +559,14 @@ export default function Leaderboard() {
                         : (e.creator === 'Archimedes' ? 'Archimedes (curated)' : `by ${e.creator.slice(0, 6)}…${e.creator.slice(-4)}`)}
                       {e.regime_tag && e.regime_tag !== 'regime_neutral' ? ` · ${e.regime_tag}` : ''}
                     </div>
+                    {/* Per-row basis + measurement window. Every number in this
+                        row was produced over exactly this span of history; a
+                        row that never recorded one says so rather than
+                        implying the numbers are current. */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
+                      <BasisBadge basis={e.performance_basis} />
+                      <WindowLabel start={e.backtest_start} end={e.backtest_end} />
+                    </div>
                   </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     <div style={{ fontWeight: 600, color: 'var(--accent)' }}>{fmt(e.conviction_score, 1)}</div>
@@ -412,6 +598,132 @@ export default function Leaderboard() {
           </table>
         </div>
       )}
+      </>
+      )}
+      {/* RESEARCH-BOARD:END */}
+
+      {/* LIVE-BOARD:BEGIN — the FORWARD board. Everything between these
+          sentinels reads from `liveData` and nothing else. Two rules the
+          guard enforces by slicing on these markers:
+            1. no reference to `data` (the research payload) — a research
+               entry must never be able to stand in for a live row;
+            2. no row may be rendered without ledger-derived fields, and the
+               table only renders when liveEntries.length > 0 — the backend
+               already withholds ledger-less deployments, and this block must
+               not re-add them from any other source. */}
+      {isLive && (
+      <>
+      {liveData && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginBottom: 18, padding: 14, background: 'var(--surface-2)', borderRadius: 8, border: '1px solid var(--glass-border)' }}>
+          <div style={{ flex: '1 1 380px' }}>
+            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--text-3)', marginBottom: 6, display: 'flex', alignItems: 'center', gap: 6 }}>
+              How this board is measured <BasisBadge basis={liveData.performance_basis} />
+            </div>
+            <div style={{ fontSize: 13, color: 'var(--text-2)' }}>{liveData.methodology}</div>
+          </div>
+          <div style={{ flex: '1 1 200px' }}>
+            <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: 'var(--text-3)', marginBottom: 6 }}>Ledger as of</div>
+            <div style={{ fontSize: 13, color: 'var(--text-2)' }}>
+              {liveData.as_of || 'no observations recorded yet'}
+              {liveData.withheld_no_ledger > 0 && (
+                <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 4 }}>
+                  Deployments awaiting their first observation and therefore not shown:{' '}
+                  <strong>{liveData.withheld_no_ledger}</strong>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {liveLoading && <div className="body" style={{ color: 'var(--text-3)' }}>Loading the live paper board…</div>}
+      {liveError && (
+        <div className="tag-warning" style={{ display: 'inline-block', padding: '6px 10px' }}>
+          Couldn’t load the live paper board: {liveError}
+        </div>
+      )}
+
+      {!liveLoading && !liveError && liveData?.degraded && (
+        <div role="status" className="tag-warning" style={{ display: 'block', padding: '10px 14px', marginBottom: 14, borderRadius: 4 }}>
+          <strong>Forward board data is degraded.</strong>{' '}
+          {liveData.degraded_reason || 'The paper ledger could not be read.'}{' '}
+          <button type="button" className="btn btn-sm btn-outline" onClick={loadLive} style={{ marginLeft: 4 }}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* The honest empty state. A thin or empty ledger is not an error and
+          not a degradation — it is the true statement that nothing has traded
+          forward yet. It must never be replaced by a zeroed row, and it is
+          pre-empted by the degraded banner above, which is a different claim. */}
+      {!liveLoading && !liveError && liveData && !liveData.degraded && liveEntries.length === 0 && (
+        <div className="body" style={{ color: 'var(--text-3)', padding: 20, textAlign: 'center', border: '1px dashed var(--glass-border)', borderRadius: 8 }}>
+          {LIVE_EMPTY_MESSAGE}.
+          {liveData.scope === 'own' && (
+            <>
+              {' '}Deploy one to paper trading from its strategy page, and its forward track record starts here the
+              day it produces its first observation.
+            </>
+          )}
+        </div>
+      )}
+
+      {!liveLoading && !liveError && liveEntries.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{ textAlign: 'left', color: 'var(--text-3)', fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                <th style={{ padding: '8px 10px' }}>#</th>
+                <th style={{ padding: '8px 10px' }}>Strategy</th>
+                <th style={{ padding: '8px 10px' }} title="Compounded from every observation in the deployment's forward ledger">Return since inception</th>
+                <th style={{ padding: '8px 10px' }}>Days live</th>
+                <th style={{ padding: '8px 10px' }}>Inception</th>
+                <th style={{ padding: '8px 10px' }} title="The date of the last ledger observation — what the return reflects">As of</th>
+                <th style={{ padding: '8px 10px' }}>Ledger</th>
+              </tr>
+            </thead>
+            <tbody>
+              {liveEntries.map(row => (
+                <tr key={row.deployment_id} style={{ borderTop: '1px solid var(--glass-border)' }}>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap', fontWeight: 600 }}>{row.rank}</td>
+                  <td style={{ padding: '10px', maxWidth: 280 }}>
+                    <div style={{ color: 'var(--text-1)', fontWeight: 500 }}>{row.name}</div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
+                      <BasisBadge basis={row.performance_basis} />
+                      <span style={{ fontSize: 11, color: 'var(--text-3)' }}>
+                        since {row.inception_date}
+                      </span>
+                    </div>
+                  </td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    <div style={{ fontWeight: 600, color: row.cumulative_return >= 0 ? 'var(--accent)' : 'var(--negative)' }}>
+                      {fmtSignedPct(row.cumulative_return)}
+                    </div>
+                    <div style={{ fontSize: 11, color: 'var(--text-3)' }}>realised, not annualised</div>
+                  </td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{row.days_live}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{row.inception_date}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{row.as_of}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    {row.drift_detected
+                      ? <span className="tag-warning" title="A fresh replay disagreed with rows already written. The ledger is append-only and was NOT rewritten — the discrepancy is surfaced, not hidden.">Drift flagged</span>
+                      : <span className="tag-muted" title="Append-only forward ledger; no replay disagreement recorded">Append-only</span>}
+                    {row.last_updated && (
+                      <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }} title="When the last ledger row was appended">
+                        updated {String(row.last_updated).slice(0, 10)}
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      </>
+      )}
+      {/* LIVE-BOARD:END */}
     </div>
   )
 }

--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -659,11 +659,17 @@ export default function Leaderboard() {
           pre-empted by the degraded banner above, which is a different claim. */}
       {!liveLoading && !liveError && liveData && !liveData.degraded && liveEntries.length === 0 && (
         <div className="body" style={{ color: 'var(--text-3)', padding: 20, textAlign: 'center', border: '1px dashed var(--glass-border)', borderRadius: 8 }}>
-          {LIVE_EMPTY_MESSAGE}.
-          {liveData.scope === 'own' && (
+          {liveData.scope === 'anonymous' ? (
+            <>This board ranks your own live paper deployments — sign in to see yours.</>
+          ) : (
             <>
-              {' '}Deploy one to paper trading from its strategy page, and its forward track record starts here the
-              day it produces its first observation.
+              {LIVE_EMPTY_MESSAGE}.
+              {liveData.scope === 'own' && (
+                <>
+                  {' '}Deploy one to paper trading from its strategy page, and its forward track record starts here the
+                  day it produces its first observation.
+                </>
+              )}
             </>
           )}
         </div>
@@ -677,7 +683,7 @@ export default function Leaderboard() {
                 <th style={{ padding: '8px 10px' }}>#</th>
                 <th style={{ padding: '8px 10px' }}>Strategy</th>
                 <th style={{ padding: '8px 10px' }} title="Compounded from every observation in the deployment's forward ledger">Return since inception</th>
-                <th style={{ padding: '8px 10px' }}>Days live</th>
+                <th style={{ padding: '8px 10px' }} title="Ledger observations appended so far — not calendar days since inception">Observations</th>
                 <th style={{ padding: '8px 10px' }}>Inception</th>
                 <th style={{ padding: '8px 10px' }} title="The date of the last ledger observation — what the return reflects">As of</th>
                 <th style={{ padding: '8px 10px' }}>Ledger</th>

--- a/ui/test/app-visuals.test.js
+++ b/ui/test/app-visuals.test.js
@@ -161,8 +161,13 @@ test("leaderboard caveat banner is own-scope-gated (#1306; the refresh-residual 
 	// the curated view, whose freshness was verified against prod.
 	assert.doesNotMatch(leaderboard, /known to be incorrect/);
 	// The remaining banner renders ONLY under isOwn — the gate expression must
-	// immediately precede the banner's status div.
-	assert.match(leaderboard, /\{isOwn && \(\s*<div\s*\n?\s*role="status"/);
+	// immediately precede the banner's status div. Since the Lane 3.4 board
+	// split the gate also carries `isResearch`: the caveat is about
+	// backtest-era numbers being fixed at generation time, which is a claim
+	// about the RESEARCH board only — repeating it over the live paper board,
+	// whose numbers come from the forward ledger, would be false. Pinning both
+	// halves keeps the banner from drifting onto the wrong surface.
+	assert.match(leaderboard, /\{isResearch && isOwn && \(\s*<div\s*\n?\s*role="status"/);
 	// The one remaining residual: pre-correction rows are fixed at generation
 	// time (never refreshed) — see the dedicated test below (#1365).
 	assert.match(leaderboard, /before the August engine corrections/);

--- a/ui/test/leaderboard-boards.test.js
+++ b/ui/test/leaderboard-boards.test.js
@@ -1,0 +1,216 @@
+// Claim-integrity guards for the leaderboard's two-board split (Lane 3.4).
+//
+// The page now shows two surfaces whose numbers mean entirely different
+// things: a RESEARCH tab whose every figure is backtest-era, and a LIVE PAPER
+// tab whose every figure is compounded from the append-only forward ledger.
+// The whole value of the split is destroyed by exactly two regressions, and
+// both are source-checkable:
+//
+//   1. A LIVE ROW RENDERED WITHOUT LEDGER DATA. The backend already withholds
+//      deployments with an empty ledger, so the only way one can appear on
+//      screen is if this component invents it — most plausibly by falling
+//      back to the research payload (`data.entries`) when `liveData` is empty
+//      or absent. That is the "fabricated statistics on the flagship public
+//      page" defect named in docs/architectural-principles.md § fail-soft,
+//      and the test below slices the live block out by sentinel comments and
+//      proves it contains no reference to the research payload at all.
+//
+//   2. A NUMBER RENDERED WITHOUT ITS BASIS. A Sharpe with no "measured over
+//      2015–2024" beside it reads as a claim about now.
+//
+// Same shape as leaderboard-selectivity.test.js / roadmap-copy.test.js: a raw
+// source-text scan (readFileSync, no JSX parsing), every pattern proved
+// non-vacuous against its own canonical bad example, and a positive assertion
+// that the honest code path exists — so no guard here can pass merely because
+// the feature was deleted.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src')
+const LEADERBOARD_FILE = 'components/Leaderboard.jsx'
+
+const source = readFileSync(join(SRC, LEADERBOARD_FILE), 'utf8')
+
+// The sentinels the component brackets each board's JSX with. They are the
+// contract this file slices on: renaming or dropping one must fail loudly
+// here rather than silently widen what the live-block scan looks at.
+const LIVE_BEGIN = 'LIVE-BOARD:BEGIN'
+const LIVE_END = 'LIVE-BOARD:END'
+const RESEARCH_BEGIN = 'RESEARCH-BOARD:BEGIN'
+const RESEARCH_END = 'RESEARCH-BOARD:END'
+
+// The research payload's row array. If this identifier appears inside the
+// live block, a research entry can reach the live table.
+const RESEARCH_PAYLOAD_ROWS = /\bdata\.entries\b/
+// The exact empty-state sentence the product owes a user with a thin ledger.
+const HONEST_EMPTY_STATE = 'No strategies are live paper trading yet'
+
+function sliceBetween(text, begin, end) {
+  const from = text.indexOf(begin)
+  const to = text.indexOf(end)
+  assert.ok(from !== -1, `sentinel "${begin}" is missing from ${LEADERBOARD_FILE} — this guard cannot slice`)
+  assert.ok(to !== -1, `sentinel "${end}" is missing from ${LEADERBOARD_FILE} — this guard cannot slice`)
+  assert.ok(to > from, `sentinel "${end}" precedes "${begin}" in ${LEADERBOARD_FILE}`)
+  return text.slice(from, to)
+}
+
+// ── the scan cannot silently shrink ─────────────────────────────────────────
+
+test('both board sentinels exist and bracket non-trivial blocks', () => {
+  const live = sliceBetween(source, LIVE_BEGIN, LIVE_END)
+  const research = sliceBetween(source, RESEARCH_BEGIN, RESEARCH_END)
+  // A degenerate (near-empty) slice would make every scan below vacuously
+  // pass. Both blocks render a whole table; a few hundred characters is a
+  // floor no real implementation can fall under.
+  assert.ok(live.length > 500, 'the live-board block is suspiciously small — did the tab get gutted?')
+  assert.ok(research.length > 500, 'the research-board block is suspiciously small — did the tab get gutted?')
+})
+
+test('the two tabs are labelled for what they actually measure', () => {
+  assert.match(source, /Research \(backtest conviction\)/, 'expected the research tab label from the spec')
+  assert.match(source, /Live paper trading/, 'expected the live paper tab label from the spec')
+})
+
+// ── 1. the live tab may never render a row without ledger data ──────────────
+
+test('RESEARCH_PAYLOAD_ROWS rejects its own canonical bad example (guard is not vacuous)', () => {
+  assert.match(
+    '{data.entries.map(e => (',
+    RESEARCH_PAYLOAD_ROWS,
+    'RESEARCH_PAYLOAD_ROWS no longer matches a data.entries render — it is guarding nothing',
+  )
+  assert.match(
+    'const rows = liveData?.entries ?? data.entries',
+    RESEARCH_PAYLOAD_ROWS,
+    'RESEARCH_PAYLOAD_ROWS must catch a fallback from the live payload to the research one',
+  )
+})
+
+test('the live board never reads the research payload — no fallback row source exists', () => {
+  const live = sliceBetween(source, LIVE_BEGIN, LIVE_END)
+  assert.doesNotMatch(
+    live,
+    RESEARCH_PAYLOAD_ROWS,
+    'the live paper block references data.entries (the RESEARCH payload). A backtest row must never be able to ' +
+      'reach the live table — the backend withholds deployments with no ledger data, and a fallback here would ' +
+      'put back exactly the fabricated rows the split exists to prevent.',
+  )
+  // Positive: the live table's rows come from the forward payload, and that
+  // payload is fetched from the forward endpoint.
+  assert.match(live, /liveEntries\.map\(/, 'expected the live table to map over liveEntries')
+  assert.match(source, /const liveEntries = liveData\?\.entries \?\? \[\]/, 'liveEntries must derive from liveData only')
+  assert.match(source, /\/api\/leaderboard\/live-paper/, 'expected the forward board to be fetched from its own endpoint')
+})
+
+test('the live table only renders when the forward payload actually has rows', () => {
+  const live = sliceBetween(source, LIVE_BEGIN, LIVE_END)
+  assert.match(
+    live,
+    /liveEntries\.length > 0 && \(/,
+    'the live table must be gated on liveEntries.length > 0 — never rendered off a null/empty payload',
+  )
+  // ...and the complementary branch says the honest thing rather than
+  // rendering a zeroed row.
+  assert.match(
+    live,
+    /liveEntries\.length === 0 && \(/,
+    'expected an explicit empty branch for a thin ledger, not an implicitly-blank table',
+  )
+})
+
+test('the honest empty state is the exact sentence, and it is not an error state', () => {
+  assert.match(
+    source,
+    new RegExp(HONEST_EMPTY_STATE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    `expected the live tab's empty state to read "${HONEST_EMPTY_STATE}"`,
+  )
+  const live = sliceBetween(source, LIVE_BEGIN, LIVE_END)
+  // An empty ledger is a true statement, not a failure: the empty branch must
+  // be gated on NOT loading, NOT errored and NOT degraded, so it can never
+  // claim "nothing is live" when the real answer is "we could not tell".
+  assert.match(
+    live,
+    /!liveLoading && !liveError && liveData && !liveData\.degraded && liveEntries\.length === 0/,
+    'the empty state must be pre-empted by the loading, error and degraded states — otherwise it asserts ' +
+      '"nothing is paper trading" when the truth is "the ledger could not be read"',
+  )
+  assert.match(live, /degraded_reason/, 'a degraded forward board must say so rather than render as empty')
+})
+
+test('live rows display the ledger-derived fields, not a bare number', () => {
+  const live = sliceBetween(source, LIVE_BEGIN, LIVE_END)
+  for (const field of ['cumulative_return', 'days_live', 'inception_date', 'as_of']) {
+    assert.match(live, new RegExp(`row\\.${field}\\b`), `expected the live row to render ${field} from the payload`)
+  }
+  // The return is realised-to-date and must not be dressed up as a rate.
+  assert.match(live, /realised, not annualised/, 'the forward return must be labelled as realised, not annualised')
+})
+
+// ── 2. every displayed number carries its basis ─────────────────────────────
+
+test('the shared basis badge exists and is keyed off the API field, not hard-coded copy', () => {
+  assert.match(source, /function BasisBadge\(/, 'expected a shared provenance badge component')
+  assert.match(source, /const BASIS_COPY = \{/, 'expected badge copy to be a lookup keyed by the API basis value')
+  assert.match(source, /backtest_research:/, 'expected the backtest basis key from the API')
+  assert.match(source, /live_paper:/, 'expected the live-paper basis key from the API')
+})
+
+test('rows on both boards carry a basis badge sourced from the payload', () => {
+  const live = sliceBetween(source, LIVE_BEGIN, LIVE_END)
+  const research = sliceBetween(source, RESEARCH_BEGIN, RESEARCH_END)
+  assert.match(
+    research,
+    /<BasisBadge basis=\{e\.performance_basis\} \/>/,
+    'each research row must carry the basis the API stamped on it (never a literal)',
+  )
+  assert.match(
+    live,
+    /<BasisBadge basis=\{row\.performance_basis\} \/>/,
+    'each live row must carry the basis the API stamped on it (never a literal)',
+  )
+})
+
+test('research rows label the window their numbers were measured over', () => {
+  const research = sliceBetween(source, RESEARCH_BEGIN, RESEARCH_END)
+  assert.match(
+    research,
+    /<WindowLabel start=\{e\.backtest_start\} end=\{e\.backtest_end\} \/>/,
+    'each research row must show the backtest window its metrics came from',
+  )
+  // A row with no recorded window must SAY so — an omitted qualifier reads as
+  // "these numbers apply now", which is the misreading the split prevents.
+  assert.match(source, /window not recorded/, 'a row without a window must say so rather than render unqualified')
+})
+
+test('the research tab shows the methodology sentence from engine metadata, not restated by hand', () => {
+  const research = sliceBetween(source, RESEARCH_BEGIN, RESEARCH_END)
+  assert.match(
+    research,
+    /\{engine\.methodology\}/,
+    'the conviction methodology line must come from the API engine metadata so it cannot drift from the formula run',
+  )
+})
+
+// ── 3. anti-goal: no blended score anywhere in this component ───────────────
+
+test('no blended cross-basis score is computed in the component', () => {
+  // The anti-goal, source-checked: the page must not combine a conviction
+  // score with a forward return into one figure. Any arithmetic mixing the
+  // two payloads' fields is the smell.
+  const BLEND = /conviction_score[^\n]*cumulative_return|cumulative_return[^\n]*conviction_score/
+  assert.match(
+    'const blended = e.conviction_score * 0.5 + row.cumulative_return * 0.5',
+    BLEND,
+    'BLEND no longer matches its own canonical bad example — it is guarding nothing',
+  )
+  assert.doesNotMatch(
+    source,
+    BLEND,
+    'Leaderboard.jsx appears to combine a backtest conviction score with a live-paper return into one number. ' +
+      'The two bases are never blended — a strong backtest must not be able to carry a strategy that has ' +
+      'traded forward for a handful of days.',
+  )
+})


### PR DESCRIPTION
Backtest metrics were rendering on a surface a reader would take as live performance. This splits them into two boards that share no row shape, no sort domain, and no code path that can produce a blended number.

- `GET /api/leaderboard` is now explicitly the **research board**: every row carries `performance_basis: "backtest_research"` plus the `backtest_start`/`backtest_end` window it was measured over (rows without a stamped window render "window not recorded" rather than an unqualified number).
- New `GET /api/leaderboard/live-paper`: ranks only the caller's **own active paper deployments** by return actually compounded from the append-only forward ledger — never annualised, never blended. Anonymous callers get an honest `scope: "anonymous"` empty board, distinct from `degraded` (something broke) and from `own`-with-zero-entries (nothing deployed yet); the UI renders all three as different true statements.

**The load-bearing rule:** a deployment with an empty ledger is dropped, never rendered as 0.0%, and the drop is counted in `withheld_no_ledger`.

## Evidence
- Proven non-vacuous by mutation: an unguarded builder that zero-fills empty ledgers fails 4 tests **and** trips the `days_live >= 1` schema floor; removing the owner or status predicate fails poison tests where the leaked row would rank #1; four UI source mutations (research-payload fallback, dropped-row gate, un-pre-empted empty state, softened copy) all caught.
- Static scan: the live-board JSX block has 12 references to `liveData` and **zero** references to the research payload.
- 3911+ backend tests, 432+ UI tests, ruff + eslint clean; merges clean against main (`git merge-tree` exit 0).

Final polish commit (validator minors): anonymous empty-state no longer implies nothing is live anywhere; the "Days live" column is relabeled **Observations** (it counts ledger observations, not calendar days); board `as_of` is computed over the rows actually served so a truncating limit can't show a date newer than every visible row.

Known accepted (follow-ups, non-blocking): no automated test for the degraded path (manually verified; UI has the dedicated banner + retry); `performance_basis` is a plain str rather than a `Literal` (unfalsifiable by test today); guard-comment scope in `leaderboard-boards.test.js` slightly overclaims its scan width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7