### PR TITLE
[test] Stub save_trace's full Redis surface in the ownership-stamp double

### DIFF
--- a/backend/tests/services/test_trace_ownership_stamp.py
+++ b/backend/tests/services/test_trace_ownership_stamp.py
@@ -44,11 +44,16 @@ def _unset_allowlist(monkeypatch):
 
 
 def _fake_redis() -> MagicMock:
+    # save_trace is a single write choke point shared by two features: the
+    # ownership stamp under test here (#1556) and the reveal-reconciliation
+    # index maintenance (#1353), which awaits sadd/srem/hsetnx/hdel on the same
+    # client. Stub the choke point's full surface — a double that only knows
+    # one feature's calls breaks the moment the other feature touches the
+    # shared writer (this exact union broke on 2026-08-31).
     r = MagicMock()
+    for method in ("get", "set", "zadd", "sadd", "srem", "hsetnx", "hdel", "aclose"):
+        setattr(r, method, AsyncMock(return_value=None))
     r.get = AsyncMock(return_value=None)
-    r.set = AsyncMock()
-    r.zadd = AsyncMock()
-    r.aclose = AsyncMock()
     return r
 
 


### PR DESCRIPTION
Fix-forward for the one union break from tonight's nine-PR train — the verify-the-merged-result rule's exact failure shape.

**What broke:** `test_trace_ownership_stamp.py` (5 tests) failed on merged main with `TypeError: object MagicMock can't be used in 'await' expression` at `redis_state.py:519` (`await r.srem(...)`). #1562's tests stubbed only the Redis methods `save_trace` used on *its* base (`get/set/zadd/aclose`); #1403 added durable reveal-index maintenance (`sadd/srem/hsetnx/hdel`) to the same single-write choke point. Both PRs were green alone; the union was not. Caught by the CI-exact suite re-run on merged main immediately after the train.

**The fix:** the double now stubs the choke point's full call surface, with a comment naming both features and why a one-feature double breaks on a shared writer. Test-only — production is unaffected (the real client is async for all of these).

**Evidence:** `test_trace_ownership_stamp.py` 14 passed (was 5F/9P on main); `test_agent_runner_reveal_reconciliation.py` 46 passed; `test_traces_ownership_gate.py` green; ruff format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7