### PR TITLE
[infra] Arm the #1556 trace-visibility floor: PUBLIC_TRACE_VAULTS as a terraform var

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -615,7 +615,15 @@ resource "aws_ecs_task_definition" "backend" {
         # the admin-wallet publish bypass / marketplace publish respectively
         # until Dan supplies real values.
         { name = "PLATFORM_ADMIN_WALLETS", value = var.platform_admin_wallets },
-        { name = "ARCHIMEDES_TREASURY_WALLET", value = var.archimedes_treasury_wallet }
+        { name = "ARCHIMEDES_TREASURY_WALLET", value = var.archimedes_treasury_wallet },
+        # Arms the #1556 trace-visibility floor: ownerless trace rows are served
+        # publicly ONLY for these house vaults; every other ownerless row goes
+        # private. Unset, the floor is unarmed (every ownerless row is presumed
+        # house content — WARNING-logged). Public on-chain addresses, not
+        # secrets — same reasoning as PLATFORM_ADMIN_WALLETS above. Terraform
+        # owns this so a bare apply can never silently revert it (the
+        # infra/README PLATFORM_ADMIN_WALLETS lesson).
+        { name = "PUBLIC_TRACE_VAULTS", value = var.public_trace_vaults }
       ]
 
       # KNOWN GAP #3 (see file header) — RESOLVED (2026-07-08): AURORA_MASTER_PASSWORD

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -211,3 +211,9 @@ variable "dmarc_rua_address" {
   type        = string
   default     = "dmarc-reports@archimedes-arc.com"
 }
+
+variable "public_trace_vaults" {
+  description = "Comma-separated house/demo vault addresses whose ownerless reasoning traces form the public proof surface (backend/archimedes/services/trace_visibility.py, #1556). Public on-chain addresses, not secrets. The default is the five house vaults observed in the live trace store on 2026-08-31; ownerless traces from any other vault go private once this is applied."
+  type        = string
+  default     = "0x88F284e6667947d66949528dB209b2a50bf2f612,0x99120A79f54F83f6729E1E1e2B1f536952BF3574,0x9d4530e874D712d3F0f65c49F9355403bf232e66,0xA3b077e16C208cD794581db46b559FDC9619ada7,0xcdd47c6D16a206f2C69B6D533Ac98b56Db3CeF52"
+}


### PR DESCRIPTION
The #1562 deploy gate, done the durable way. `PUBLIC_TRACE_VAULTS` becomes a terraform variable (`infra/variables.tf`) wired into the backend task env (`infra/ecs.tf`) — the exact `platform_admin_wallets` pattern:

- **Not SSM**: these are public on-chain addresses, not secrets (same reasoning as the sibling var's own description).
- **Not apply.sh / CI**: `deploy.yml` deliberately clones the live task definition and swaps only images, so terraform-owned env survives every CI deploy — and unlike an out-of-band edit, a bare `terraform apply` can never silently revert it (the `PLATFORM_ADMIN_WALLETS` lesson in `infra/README.md`).
- **Default = the five house vaults** observed in the live trace store tonight (distinct `vault_address` values over the last 50 traces — all house content today). Committed in the default because they're public; override via tfvars if the house set changes.

What applying does: arms the floor. Today (unarmed) every *ownerless* trace row is presumed house content and served publicly, WARNING-logged. Armed, an ownerless trace from any vault **not** on this list goes private — closing the legacy-unstamped-row + identity-DB-outage leak documented in #1562. It cannot hide the proof surface (these five are exactly what `/reasoning` renders) and cannot expose an owned trace (ownership layers return before the floor is consulted).

**Post-merge ops (owner, one step):** `terraform apply` from the canonical checkout. The next CI deploy after that carries the var forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7