### PR TITLE
[perf][backend] Memoize trace ownership resolution — the proof surface was loading in 21s (#1573)

### DIFF
--- a/backend/archimedes/api/traces_routes.py
+++ b/backend/archimedes/api/traces_routes.py
@@ -128,19 +128,27 @@ def _offchain_trace_response(t: dict, fallback_id: str = "") -> TraceResponse:
     )
 
 
-def _assert_can_read(trace: dict, request: Request) -> None:
+async def _assert_can_read(trace: dict, request: Request) -> None:
     """404 unless the caller may read this trace (#1556).
 
     404 rather than 403 deliberately: a 403 on someone else's trace id
     confirms the id exists, which is half of the enumeration the gate is here
     to prevent.
+
+    ``can_read_trace`` may open a synchronous SQLAlchemy session (only for an
+    unstamped legacy row — a stamped one is answered from the record), so it
+    runs in a worker thread: a blocking DB call made directly here stalls the
+    whole event loop, every other in-flight request included (#1573).
     """
+    import asyncio
+
     from fastapi import HTTPException
 
     from archimedes.services.trace_visibility import can_read_trace
 
     caller_user_id, caller_wallet = _caller_identity(request)
-    if not can_read_trace(trace, caller_wallet, caller_user_id=caller_user_id):
+    allowed = await asyncio.to_thread(can_read_trace, trace, caller_wallet, caller_user_id=caller_user_id)
+    if not allowed:
         raise HTTPException(status_code=404, detail="Trace not found")
 
 
@@ -159,6 +167,8 @@ async def list_traces(
     stays a *filter* — it narrows the visible set, it never widens it — so
     dropping it can no longer enumerate the platform.
     """
+    import asyncio
+
     from archimedes.services.redis_state import AgentStateStore
     from archimedes.services.trace_visibility import (
         MAX_TRACE_SCAN,
@@ -188,12 +198,18 @@ async def list_traces(
         if off_chain_traces:
             # One batched ownership lookup for the whole page, and only for rows
             # that lack an on-record stamp — a stamped row needs no DB at all.
-            owners = safe_resolve_vault_owners(
+            # `safe_resolve_vault_owners` memoizes per vault, so the handful of
+            # distinct vaults behind a 2000-row candidate set costs at most one
+            # lookup each per TTL rather than one per request; `to_thread` keeps
+            # the synchronous session it may still open off the event loop,
+            # where it was blocking every other in-flight request (#1573).
+            owners = await asyncio.to_thread(
+                safe_resolve_vault_owners,
                 {
                     str(t.get("vault_address") or "")
                     for t in off_chain_traces
                     if not (t.get("owner_user_id") or t.get("owner_wallet"))
-                }
+                },
             )
             visible = [
                 t
@@ -238,7 +254,7 @@ async def list_traces(
             # still names the vault and the anchor — gate it on exactly the
             # same predicate so a caller cannot enumerate another user's
             # vault's trace ids by taking Redis out of the picture.
-            owners = safe_resolve_vault_owners({str(d["vault"]) for _, d in on_chain_details})
+            owners = await asyncio.to_thread(safe_resolve_vault_owners, {str(d["vault"]) for _, d in on_chain_details})
             for trace_id, detail in on_chain_details:
                 view = trace_owner_view({"vault_address": detail["vault"]}, owners)
                 if not is_trace_visible(view, caller_wallet, caller_user_id=caller_user_id):
@@ -272,7 +288,7 @@ async def get_trace(trace_id: str, request: Request):
             logger.warning("get_trace: Redis unavailable — falling back to on-chain-only lookup", exc_info=True)
             off_chain = None
         if off_chain:
-            _assert_can_read(off_chain, request)
+            await _assert_can_read(off_chain, request)
             return _offchain_trace_response(off_chain, fallback_id=trace_id)
 
         try:
@@ -284,7 +300,7 @@ async def get_trace(trace_id: str, request: Request):
         if detail is None:
             raise HTTPException(status_code=404, detail="Trace not found")
 
-        _assert_can_read({"vault_address": detail["vault"]}, request)
+        await _assert_can_read({"vault_address": detail["vault"]}, request)
         return _anchored_only_trace(trace_id, detail)
     finally:
         await state.close()
@@ -438,7 +454,7 @@ async def verify_trace(trace_id: str, request: Request):
             if not detail:
                 raise HTTPException(status_code=404, detail="Trace not found")
 
-            _assert_can_read({"vault_address": detail["vault"]}, request)
+            await _assert_can_read({"vault_address": detail["vault"]}, request)
             return TraceVerifyResponse(
                 trace_id=int_id,
                 trace_hash=detail["trace_hash"],
@@ -450,7 +466,7 @@ async def verify_trace(trace_id: str, request: Request):
                 details="Hash is anchored on-chain — no off-chain trace body was stored, so no hashes were compared",
             )
 
-        _assert_can_read(off_chain, request)
+        await _assert_can_read(off_chain, request)
 
         trace_hash = off_chain.get("trace_hash", "")
         is_verified = False
@@ -535,7 +551,7 @@ async def get_trace_canonical(trace_id: str, request: Request):
         if not off_chain:
             raise HTTPException(status_code=404, detail="Trace not found")
 
-        _assert_can_read(off_chain, request)
+        await _assert_can_read(off_chain, request)
 
         trace = ReasoningTrace(
             id=off_chain["id"],

--- a/backend/archimedes/api/vaults_routes.py
+++ b/backend/archimedes/api/vaults_routes.py
@@ -389,6 +389,14 @@ async def create_vault(
         meta={"vault_address": vault_address, "strategy_ids": req.strategy_ids},
     )
 
+    # This event is one of the two things that make a vault OWNED, and the trace
+    # read gate memoizes vault ownership (#1573). Drop the memo now so a
+    # "this vault is unowned" answer cached moments ago cannot outlive the fact
+    # — an unowned legacy trace falls to the house-public floor.
+    from archimedes.services.trace_visibility import invalidate_vault_owner
+
+    invalidate_vault_owner(vault_address)
+
     return VaultCreateResponse(vault_address=vault_address, strategy_ids=req.strategy_ids)
 
 
@@ -488,6 +496,14 @@ async def store_vault_metadata(
         meta.set_strategy_ids(req.strategy_ids)
         session.commit()
         session.refresh(meta)
+
+        # The other ownership-establishing write — same reason as in
+        # `create_vault`: the trace read gate memoizes vault ownership (#1573)
+        # and a stale "unowned" memo would keep this vault's legacy traces on
+        # the house-public floor for the rest of the TTL.
+        from archimedes.services.trace_visibility import invalidate_vault_owner
+
+        invalidate_vault_owner(vault_address)
 
         # Fire-and-forget on-chain strategy anchoring (best-effort, non-fatal)
         if req.strategy_ids:

--- a/backend/archimedes/services/trace_visibility.py
+++ b/backend/archimedes/services/trace_visibility.py
@@ -24,7 +24,12 @@ the internet.
    metadata, from the ``vault_created`` rows in ``identity_events``. This is
    the Redis-store equivalent of the data backfill a schema migration would
    ship with — traces live in Redis, not in a table, so there is no column to
-   add and no Alembic revision to write.
+   add and no Alembic revision to write. On the READ path this lookup is
+   **memoized per vault** (:func:`safe_resolve_vault_owners`) and run off the
+   event loop by its callers — re-running it per request cost the anonymous
+   ``/reasoning`` page 21.2s (#1573). The write-path resolver
+   (:func:`resolve_vault_owners`, which produces the permanent stamp) stays
+   uncached.
 3. **The house-vault allowlist** (``PUBLIC_TRACE_VAULTS``, falling back to the
    agent runner's own ``AGENT_VAULT_ADDRESSES``). This is the FLOOR, and it
    only ever applies to a row whose ownership could not be established by (1)
@@ -49,6 +54,8 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
+import time
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -66,7 +73,63 @@ _AGENT_VAULTS_ENV = "AGENT_VAULT_ADDRESSES"
 #: how many of another user's traces were skipped.
 MAX_TRACE_SCAN = 2000
 
+#: How long a resolved ``vault → (owner_user_id, owner_wallet)`` pair stays
+#: memoized on the READ path, in seconds (#1573).
+#:
+#: **Why a cache is safe here, and why 300s is the right number.** The mapping
+#: is write-once in practice: a vault gets its owner when it is deployed
+#: (``POST /api/vaults/create`` → a ``vault_created`` identity event) or when
+#: its on-chain owner first writes metadata, and it does not change again.
+#: Both of those writers call :func:`invalidate_vault_owner`, so the in-process
+#: entry for a vault that *does* acquire an owner is dropped at the moment it
+#: acquires one — the TTL is the backstop for a write that happened in another
+#: process (a second Fargate task), not the primary mechanism.
+#:
+#: **The cache cannot flip a private row public**, which is the only direction
+#: that would be a gate regression:
+#:
+#: - A trace persisted after #1556 carries its owner ON THE RECORD, and a
+#:   stamped row never consults this resolver at all (see
+#:   :func:`can_read_trace` and the listing route's set comprehension). Every
+#:   row written from here on is therefore outside the cache's blast radius.
+#: - For a legacy unstamped row, a stale *positive* entry keeps the row private
+#:   — to the previous owner rather than the new one. Private-to-someone, never
+#:   public.
+#: - A stale *negative* entry (vault looked unowned, then acquired an owner) is
+#:   the only widening direction. It is bounded by this TTL, closed immediately
+#:   in-process by :func:`invalidate_vault_owner`, and floored by
+#:   ``PUBLIC_TRACE_VAULTS``: with the allowlist armed an unowned row outside
+#:   the list is private, so the armed configuration fails CLOSED.
+VAULT_OWNER_CACHE_TTL_SECONDS = 300
+
+#: Hard bound on cached entries so a pathological caller cannot grow the cache
+#: without limit. One entry is two short strings; 4096 is far above the number
+#: of vaults that exist, and blowing past it clears rather than evicts (the
+#: cost of a cleared cache is one extra lookup, so cleverness buys nothing).
+VAULT_OWNER_CACHE_MAX_ENTRIES = 4096
+
+#: ``{lowercased vault → (expires_at_monotonic, owner_pair_or_None)}``.
+#: A stored ``None`` is a NEGATIVE result — "this vault has no recoverable
+#: owner" — and caching it is the point: the unresolvable case is the expensive
+#: one, because it is what triggers the ``identity_events`` scan below.
+_vault_owner_cache: dict[str, tuple[float, tuple[str | None, str | None] | None]] = {}
+_vault_owner_cache_lock = threading.Lock()
+
 _warned_unconfigured_allowlist = False
+
+
+class TraceOwnerLookupIncomplete(Exception):
+    """The ownership lookup did not finish; ``partial`` is what it did get.
+
+    Exists to keep "this vault has no owner" distinguishable from "the database
+    did not answer". Only the former may be negative-cached — caching a DB
+    outage as a confirmed absence would let the outage outlive itself by a full
+    TTL.
+    """
+
+    def __init__(self, partial: dict[str, tuple[str | None, str | None]]) -> None:
+        super().__init__("trace ownership lookup did not complete")
+        self.partial = partial
 
 
 def _norm(value: object) -> str:
@@ -155,6 +218,54 @@ def is_trace_visible(
     return is_public_trace_vault(view.get("vault_address"))
 
 
+def _resolve_vault_owners_uncached(wanted: frozenset[str]) -> dict[str, tuple[str | None, str | None]]:
+    """The database half of :func:`resolve_vault_owners`. Always hits the DB.
+
+    ``wanted`` is already normalized and non-empty. Raises
+    :class:`TraceOwnerLookupIncomplete` (carrying whatever it managed to read)
+    when the round trip fails, so callers can tell "no owner" from "no answer".
+    """
+    owners: dict[str, tuple[str | None, str | None]] = {}
+    try:
+        from archimedes.db import get_session
+        from archimedes.models.chat import VaultMetadata
+        from archimedes.models.identity import IdentityEvent
+
+        with get_session() as session:
+            rows = session.query(VaultMetadata).filter(VaultMetadata.vault_address.in_(sorted(wanted))).all()
+            for row in rows:
+                owners[_norm(row.vault_address)] = (row.owner_user_id or None, _norm(row.creator_address) or None)
+
+            missing = set(wanted) - set(owners)
+            if missing:
+                # `meta` is JSONB on Postgres and plain JSON on SQLite; there is
+                # no portable containment operator across both, so this filters
+                # on the indexed `event_type` column and matches the address in
+                # Python. Bounded by the number of vaults ever created, which
+                # is the same order as the vault list itself.
+                #
+                # This is the expensive branch — up to MAX_TRACE_SCAN rows
+                # materialized as ORM objects — and it fires precisely when a
+                # vault CANNOT be resolved, which is why the negative result is
+                # cached alongside the positive one (#1573).
+                events = (
+                    session.query(IdentityEvent)
+                    .filter(IdentityEvent.event_type == "vault_created")
+                    .order_by(IdentityEvent.id.desc())
+                    .limit(MAX_TRACE_SCAN)
+                    .all()
+                )
+                for event in events:
+                    addr = _norm((event.meta or {}).get("vault_address"))
+                    if addr in missing and addr not in owners and _norm(event.wallet):
+                        owners[addr] = (None, _norm(event.wallet))
+    except Exception as exc:
+        logger.warning("trace ownership lookup failed — falling back to on-record stamps only", exc_info=True)
+        raise TraceOwnerLookupIncomplete(owners) from exc
+
+    return owners
+
+
 def resolve_vault_owners(vault_addresses: set[str]) -> dict[str, tuple[str | None, str | None]]:
     """``{lowercased vault → (owner_user_id, owner_wallet)}`` for legacy rows.
 
@@ -167,63 +278,129 @@ def resolve_vault_owners(vault_addresses: set[str]) -> dict[str, tuple[str | Non
        and never gets as far as writing metadata: without it that vault reads
        as unowned and its traces would fall through to the house floor.
 
-    **Fail-soft, and safely so.** A DB outage returns ``{}`` rather than
+    **Fail-soft, and safely so.** A DB outage returns what it has rather than
     raising, because the read routes must keep serving; the reason that is not
     a fail-open hole is that every trace written after #1556 carries its owner
     *on the record*, so this lookup is a backfill for legacy rows only.
     Callers that care about the distinction should arm ``PUBLIC_TRACE_VAULTS``.
+
+    **Deliberately uncached.** This is the WRITE-path resolver: ``save_trace``
+    stamps a trace with what this returns, and that stamp is permanent, so it
+    must never be answered from a memo that predates the vault's owner
+    (#1573). Read paths use :func:`safe_resolve_vault_owners`, which is
+    memoized precisely because its answer is re-derived on every request.
     """
-    wanted = {_norm(a) for a in vault_addresses if _norm(a)}
+    wanted = frozenset(_norm(a) for a in vault_addresses if _norm(a))
     if not wanted:
         return {}
-
-    owners: dict[str, tuple[str | None, str | None]] = {}
     try:
-        from archimedes.db import get_session
-        from archimedes.models.chat import VaultMetadata
-        from archimedes.models.identity import IdentityEvent
+        return _resolve_vault_owners_uncached(wanted)
+    except TraceOwnerLookupIncomplete as exc:
+        return exc.partial
 
-        with get_session() as session:
-            rows = session.query(VaultMetadata).filter(VaultMetadata.vault_address.in_(sorted(wanted))).all()
-            for row in rows:
-                owners[_norm(row.vault_address)] = (row.owner_user_id or None, _norm(row.creator_address) or None)
 
-            missing = wanted - set(owners)
-            if missing:
-                # `meta` is JSONB on Postgres and plain JSON on SQLite; there is
-                # no portable containment operator across both, so this filters
-                # on the indexed `event_type` column and matches the address in
-                # Python. Bounded by the number of vaults ever created, which
-                # is the same order as the vault list itself.
-                events = (
-                    session.query(IdentityEvent)
-                    .filter(IdentityEvent.event_type == "vault_created")
-                    .order_by(IdentityEvent.id.desc())
-                    .limit(MAX_TRACE_SCAN)
-                    .all()
-                )
-                for event in events:
-                    addr = _norm((event.meta or {}).get("vault_address"))
-                    if addr in missing and addr not in owners and _norm(event.wallet):
-                        owners[addr] = (None, _norm(event.wallet))
-    except Exception:
-        logger.warning("trace ownership lookup failed — falling back to on-record stamps only", exc_info=True)
-        return owners
+def invalidate_vault_owner(vault_address: object) -> None:
+    """Drop one vault's memoized owner (#1573).
 
-    return owners
+    Called from the two writes that can *create* ownership — the
+    ``vault_created`` identity event in ``POST /api/vaults/create`` and the
+    ``vault_metadata`` commit in ``POST /api/vaults/metadata``. Without this, a
+    vault whose "unowned" answer was cached moments before it acquired an owner
+    would keep reading as unowned for the rest of the TTL, and an unowned
+    legacy row falls to the house-vault floor. This makes the cache correct at
+    the instant of the write in this process; the TTL covers the same write
+    arriving in a sibling process.
+    """
+    addr = _norm(vault_address)
+    if not addr:
+        return
+    with _vault_owner_cache_lock:
+        _vault_owner_cache.pop(addr, None)
+
+
+def clear_vault_owner_cache() -> None:
+    """Forget every memoized vault owner. For tests and operational reset."""
+    with _vault_owner_cache_lock:
+        _vault_owner_cache.clear()
 
 
 def safe_resolve_vault_owners(vault_addresses: set[str]) -> dict[str, tuple[str | None, str | None]]:
-    """:func:`resolve_vault_owners` that cannot raise into a read route.
+    """Memoized, non-raising ownership lookup for the READ routes (#1573).
 
-    ``resolve_vault_owners`` already swallows database errors, so this exists
-    for the class of failure it cannot anticipate — an import error, a model
-    change, a mocked-out dependency. A read route degrading to "no legacy
-    owners recovered" is safe (unstamped rows fall to the allowlist floor); a
-    read route 500ing because an ownership lookup blew up is not.
+    Two jobs, both of which the read routes need and the write path does not:
+
+    **1. It cannot raise into a read route.** ``_resolve_vault_owners_uncached``
+    already converts database errors into a partial result, so this covers the
+    class of failure it cannot anticipate — an import error, a model change, a
+    mocked-out dependency. A read route degrading to "no legacy owners
+    recovered" is safe (unstamped rows fall to the allowlist floor); a read
+    route 500ing because an ownership lookup blew up is not.
+
+    **2. It memoizes, per vault, for ``VAULT_OWNER_CACHE_TTL_SECONDS``.** Before
+    this, ``GET /api/traces/?limit=50`` re-ran the whole lookup on every
+    request — a synchronous ``vault_metadata`` query plus, for any vault it
+    could not resolve, a ``MAX_TRACE_SCAN``-row ``identity_events`` scan —
+    inside the async event loop, on the anonymous page that ``/reasoning`` and
+    ``/quant-lab`` render. Measured live at 21.2s (#1573). The listing covers
+    only a handful of distinct vaults, so almost all of that work was the same
+    answer computed again.
+
+    Only the vaults that MISS reach the database; a request whose vaults are
+    all cached does no database work at all. Negative results are cached too,
+    and they are the ones that matter: an unresolvable vault is what triggers
+    the ``identity_events`` scan. A result is negative-cached only when the
+    lookup actually completed — see :class:`TraceOwnerLookupIncomplete`.
+
+    Gate semantics are unchanged: this returns the same mapping the uncached
+    resolver would, so every row gets the same verdict. See
+    :data:`VAULT_OWNER_CACHE_TTL_SECONDS` for why the staleness window cannot
+    turn a private trace public.
     """
     try:
-        return resolve_vault_owners(vault_addresses)
+        wanted = frozenset(_norm(a) for a in vault_addresses if _norm(a))
+        if not wanted:
+            return {}
+
+        now = time.monotonic()
+        resolved: dict[str, tuple[str | None, str | None]] = {}
+        missing: set[str] = set()
+        with _vault_owner_cache_lock:
+            for addr in wanted:
+                entry = _vault_owner_cache.get(addr)
+                if entry is None or entry[0] <= now:
+                    missing.add(addr)
+                elif entry[1] is not None:
+                    resolved[addr] = entry[1]
+                # A live negative entry contributes nothing to the mapping —
+                # "absent" is exactly how the uncached resolver reports an
+                # unowned vault, so the verdict is identical either way.
+
+        if not missing:
+            return resolved
+
+        complete = True
+        try:
+            looked_up = _resolve_vault_owners_uncached(frozenset(missing))
+        except TraceOwnerLookupIncomplete as exc:
+            looked_up, complete = exc.partial, False
+
+        resolved.update(looked_up)
+        expires_at = time.monotonic() + VAULT_OWNER_CACHE_TTL_SECONDS
+        with _vault_owner_cache_lock:
+            for addr in missing:
+                value = looked_up.get(addr)
+                if value is None and not complete:
+                    # "The database did not answer" is not "this vault has no
+                    # owner". Leaving it uncached costs one lookup; caching it
+                    # would extend an outage's effect past the outage.
+                    continue
+                _vault_owner_cache[addr] = (expires_at, value)
+            if len(_vault_owner_cache) > VAULT_OWNER_CACHE_MAX_ENTRIES:
+                for stale in [k for k, (exp, _) in _vault_owner_cache.items() if exp <= now]:
+                    del _vault_owner_cache[stale]
+                if len(_vault_owner_cache) > VAULT_OWNER_CACHE_MAX_ENTRIES:
+                    _vault_owner_cache.clear()
+        return resolved
     except Exception:
         logger.warning("trace ownership lookup raised — continuing with on-record stamps only", exc_info=True)
         return {}

--- a/backend/tests/api/test_traces_ownership_gate.py
+++ b/backend/tests/api/test_traces_ownership_gate.py
@@ -309,8 +309,16 @@ async def test_stamped_record_stays_private_when_the_identity_db_is_down():
     with (
         _store([_user_trace(stamped=True)]),
         _as(None),
+        # Both resolvers: `resolve_vault_owners` is the write-path entry point,
+        # `_resolve_vault_owners_uncached` the one the memoized read path calls
+        # (#1573). Patching only the former would leave the read path talking to
+        # a live database and quietly stop simulating the outage.
         patch(
             "archimedes.services.trace_visibility.resolve_vault_owners",
+            side_effect=RuntimeError("db down"),
+        ),
+        patch(
+            "archimedes.services.trace_visibility._resolve_vault_owners_uncached",
             side_effect=RuntimeError("db down"),
         ),
     ):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -140,3 +140,22 @@ def _clear_rigor_cache():
     rigor_cache.clear()
     yield
     rigor_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_vault_owner_cache():
+    """Reset the trace-ownership memo (services/trace_visibility.py) — #1573.
+
+    Same hazard as ``_clear_rigor_cache`` above, one layer down: the vault →
+    owner memo is a module-global dict keyed on the vault address, and several
+    test files reuse the SAME vault addresses against DIFFERENT per-test
+    SQLite databases. Without this reset, "vault X is owned by user Y" (or,
+    worse, "vault X is unowned") learned in one test would be served to a
+    later test whose database says otherwise, making an ownership *verdict*
+    depend on suite order. Cleared before and after, like its sibling.
+    """
+    from archimedes.services.trace_visibility import clear_vault_owner_cache
+
+    clear_vault_owner_cache()
+    yield
+    clear_vault_owner_cache()

--- a/backend/tests/services/test_trace_owner_cache.py
+++ b/backend/tests/services/test_trace_owner_cache.py
@@ -1,0 +1,429 @@
+"""Memoized trace-ownership resolution — issue #1573.
+
+``GET /api/traces/?limit=50`` was measured at **21.2s** on the live public
+proof surface right after #1562 deployed. The listing runs the ownership
+predicate over up to ``MAX_TRACE_SCAN`` candidate rows, and every request
+re-derived the vault → owner mapping from scratch: a synchronous
+``vault_metadata`` query plus — for any vault it could not resolve — a
+``MAX_TRACE_SCAN``-row ``identity_events`` scan, executed inside the async
+event loop. The rows cover a handful of distinct vaults, so nearly all of that
+work was the same answer computed again.
+
+**Every test here is a GUARD test.** Each one either fails outright against
+pre-#1573 ``trace_visibility.py`` or is paired with an explicit proof that the
+property it asserts is not free. The demonstration is recorded in the PR body:
+with ``safe_resolve_vault_owners``'s memo removed, the "once per distinct
+vault" tests report one database round trip *per request* instead of one in
+total.
+
+The non-goal is as load-bearing as the goal: **no verdict may change.** The
+last group below re-runs the gate's own questions against a warm cache and
+asserts the answers are byte-identical to the cold ones, including for the
+private legacy row that must never appear on an anonymous listing.
+
+Hermetic: per-test tmp SQLite, ``AgentStateStore`` mocked at its boundary. No
+Redis, no Postgres, no ``.env``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from archimedes.services import trace_visibility
+from archimedes.services.trace_visibility import (
+    TraceOwnerLookupIncomplete,
+    can_read_trace,
+    clear_vault_owner_cache,
+    invalidate_vault_owner,
+    is_trace_visible,
+    safe_resolve_vault_owners,
+    trace_owner_view,
+)
+from httpx import ASGITransport, AsyncClient
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+OWNER_USER_ID = "user-owner-1573"
+OWNER_WALLET = "0x1111111111111111111111111111111111111111"
+
+HOUSE_VAULT = "0xaaaa000000000000000000000000000000000aaa"
+#: Five distinct user vaults — the live shape the issue measured: 50 listed
+#: rows spread over a handful of addresses.
+USER_VAULTS = [f"0x{str(i) * 40}" for i in range(1, 6)]
+
+SECRET_REASONING = "PRIVATE-1573 the user's undisclosed rotation thesis"
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _unset_allowlist(monkeypatch):
+    """Run against the WEAKEST floor, exactly as the #1556 gate tests do.
+
+    With ``PUBLIC_TRACE_VAULTS`` unset an unowned trace defaults to
+    house-public, so anything shown hidden here is hidden by *ownership* — the
+    thing the cache could in principle corrupt — and not by an allowlist that
+    happened to be armed.
+    """
+    monkeypatch.delenv("PUBLIC_TRACE_VAULTS", raising=False)
+    monkeypatch.delenv("AGENT_VAULT_ADDRESSES", raising=False)
+
+
+def _seed_owner(vault: str, *, user_id: str = OWNER_USER_ID) -> None:
+    """A ``vault_metadata`` row making ``vault`` owned by ``user_id``."""
+    from archimedes.db import get_session
+    from archimedes.models.account import AuthUser
+    from archimedes.models.chat import VaultMetadata
+    from archimedes.models.identity import WalletIdentity
+
+    now = datetime.now(UTC)
+    with get_session() as session:
+        session.merge(
+            AuthUser(id=user_id, name=user_id, email=f"{user_id}@example.test", created_at=now, updated_at=now)
+        )
+        session.merge(WalletIdentity(wallet_address=OWNER_WALLET.lower(), actor_class="human", first_seen_at=now))
+        session.merge(
+            VaultMetadata(
+                vault_address=vault.lower(),
+                name="v",
+                symbol="V",
+                creator_address=OWNER_WALLET.lower(),
+                owner_user_id=user_id,
+                strategy_ids="[]",
+            )
+        )
+        session.commit()
+
+
+@contextmanager
+def _count_db_lookups():
+    """Spy on the one function that actually opens a database session.
+
+    Yields a list of the address sets it was asked to resolve, so a test can
+    assert both HOW MANY round trips happened and WHICH vaults each one
+    covered. Delegates to the real implementation — this counts the database
+    path, it does not replace it.
+    """
+    calls: list[frozenset[str]] = []
+    real = trace_visibility._resolve_vault_owners_uncached
+
+    def _spy(wanted):
+        calls.append(frozenset(wanted))
+        return real(wanted)
+
+    with patch.object(trace_visibility, "_resolve_vault_owners_uncached", _spy):
+        yield calls
+
+
+def _trace(vault: str, idx: int, *, stamped: bool = False) -> dict:
+    trace = {
+        "id": f"trace-{idx}",
+        "vault_address": vault,
+        "decision_type": "rebalance",
+        "trigger": "drift",
+        "timestamp": f"2026-08-30T00:00:{idx:02d}+00:00",
+        "reasoning": SECRET_REASONING,
+        "confidence": 0.5,
+        "trades_executed": [],
+        "strategies_referenced": [],
+        "trace_hash": f"0xhash{idx}",
+        "market_context": {},
+        "is_verified": False,
+    }
+    if stamped:
+        trace["owner_user_id"] = OWNER_USER_ID
+        trace["owner_wallet"] = OWNER_WALLET.lower()
+    return trace
+
+
+def _fifty_rows(*, stamped: bool = False) -> list[dict]:
+    """50 rows over 5 distinct vaults — the listing the issue measured."""
+    return [_trace(USER_VAULTS[i % len(USER_VAULTS)], i, stamped=stamped) for i in range(50)]
+
+
+@contextmanager
+def _store(traces: list[dict]):
+    from archimedes.services.redis_state import AgentStateStore
+
+    by_id = {t["id"]: t for t in traces}
+    by_id.update({t["trace_hash"]: t for t in traces})
+
+    async def _list(vault_address=None, decision_type=None, limit=20, offset=0):
+        rows = [t for t in traces if not vault_address or t["vault_address"].lower() == vault_address.lower()]
+        return rows[offset : offset + limit], len(rows)
+
+    with (
+        patch.object(AgentStateStore, "list_traces", AsyncMock(side_effect=_list)),
+        patch.object(AgentStateStore, "get_trace", AsyncMock(side_effect=lambda k: by_id.get(k))),
+        patch.object(AgentStateStore, "close", AsyncMock()),
+    ):
+        yield
+
+
+@contextmanager
+def _anonymous():
+    with (
+        patch("archimedes.api.account_auth.get_current_user", return_value=None),
+        patch("archimedes.api.auth_siwe.get_verified_wallet", return_value=None),
+    ):
+        yield
+
+
+async def _get(path: str, **params):
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.get(path, params=params)
+
+
+# ── The resolver runs once per distinct vault, not once per row/request ─────
+
+
+async def test_a_fifty_row_listing_resolves_each_distinct_vault_once():
+    """ACCEPTANCE (#1573): 50 rows over 5 vaults, three requests → 5 vaults
+    resolved, ONE database round trip.
+
+    Pre-#1573 this was one full round trip *per request* — the batching inside
+    a single request was already there, but nothing survived the request
+    boundary, so the anonymous proof surface paid the ``vault_metadata`` query
+    plus the ``identity_events`` scan on every single page load. Reverting the
+    memo makes this assert 3 round trips and fail.
+    """
+    for vault in USER_VAULTS:
+        _seed_owner(vault)
+
+    with _store(_fifty_rows()), _anonymous(), _count_db_lookups() as calls:
+        for _ in range(3):
+            resp = await _get("/api/traces/", limit=50)
+            assert resp.status_code == 200
+
+    assert len(calls) == 1, f"expected one database round trip across three listings, got {len(calls)}"
+    assert calls[0] == frozenset(v.lower() for v in USER_VAULTS)
+
+
+async def test_repeated_detail_reads_of_a_legacy_row_resolve_its_vault_once():
+    """The detail routes were the genuinely per-call path: ``can_read_trace``
+    opened a session for every unstamped trace read. Ten reads → one lookup."""
+    _seed_owner(USER_VAULTS[0])
+    row = _trace(USER_VAULTS[0], 0)
+
+    with _store([row]), _anonymous(), _count_db_lookups() as calls:
+        for _ in range(10):
+            assert (await _get("/api/traces/trace-0")).status_code == 404
+
+    assert len(calls) == 1, f"expected one database round trip across ten detail reads, got {len(calls)}"
+
+
+def test_the_unresolvable_vault_is_negative_cached():
+    """The MISS is the expensive case, so the miss is what must be cached.
+
+    A vault with no ``vault_metadata`` row is what triggers the
+    ``MAX_TRACE_SCAN``-row ``identity_events`` scan. Caching only successes
+    would leave exactly the slow path uncached.
+    """
+    unknown = "0xdead" + "0" * 36
+
+    with _count_db_lookups() as calls:
+        assert safe_resolve_vault_owners({unknown}) == {}
+        assert safe_resolve_vault_owners({unknown}) == {}
+        assert safe_resolve_vault_owners({unknown.upper()}) == {}
+
+    assert len(calls) == 1, f"the negative result was not cached: {len(calls)} round trips"
+
+
+def test_only_the_uncached_vaults_reach_the_database():
+    """A partially warm request must not re-resolve what it already knows."""
+    for vault in USER_VAULTS:
+        _seed_owner(vault)
+
+    with _count_db_lookups() as calls:
+        safe_resolve_vault_owners(set(USER_VAULTS[:3]))
+        safe_resolve_vault_owners(set(USER_VAULTS))
+
+    assert len(calls) == 2
+    assert calls[0] == frozenset(v.lower() for v in USER_VAULTS[:3])
+    assert calls[1] == frozenset(v.lower() for v in USER_VAULTS[3:]), "warm vaults were re-resolved"
+
+
+# ── A stamped row never consults the resolver ───────────────────────────────
+
+
+async def test_a_stamped_listing_never_touches_the_resolver():
+    """The on-record stamp is the layer that matters (#1556): 50 stamped rows
+    must produce ZERO database work, cache or no cache."""
+    with _store(_fifty_rows(stamped=True)), _anonymous(), _count_db_lookups() as calls:
+        resp = await _get("/api/traces/", limit=50)
+
+    assert resp.status_code == 200
+    assert resp.json()["traces"] == []  # private, and privately: no leak
+    assert calls == [], "a stamped row consulted the ownership resolver"
+
+
+def test_can_read_trace_skips_the_resolver_for_a_stamped_row():
+    """Unit-level companion: the short-circuit is in the predicate itself, so a
+    Postgres outage cannot downgrade a stamped private trace."""
+    stamped = _trace(USER_VAULTS[0], 0, stamped=True)
+
+    with _count_db_lookups() as calls:
+        assert can_read_trace(stamped, None, caller_user_id=OWNER_USER_ID)
+        assert not can_read_trace(stamped, None, caller_user_id="someone-else")
+
+    assert calls == []
+
+
+# ── Zero gate-semantics change ──────────────────────────────────────────────
+
+
+def test_a_cache_hit_returns_the_same_verdict_as_a_cold_resolve():
+    """ACCEPTANCE (#1573): warm answers are identical to cold ones.
+
+    Cold verdicts are computed with the cache empty; the resolver's database
+    path is then made to raise, so a second pass can ONLY be answered from the
+    memo — and every verdict must match, for owner, non-owner and anonymous
+    alike.
+    """
+    for vault in USER_VAULTS:
+        _seed_owner(vault)
+    callers = [(None, None), (OWNER_USER_ID, OWNER_WALLET), ("someone-else", "0x9" + "9" * 39)]
+    rows = _fifty_rows()
+
+    def _verdicts() -> list[bool]:
+        owners = safe_resolve_vault_owners({r["vault_address"] for r in rows})
+        return [
+            is_trace_visible(trace_owner_view(r, owners), wallet, caller_user_id=uid)
+            for r in rows
+            for uid, wallet in callers
+        ]
+
+    clear_vault_owner_cache()
+    cold = _verdicts()
+
+    def _explode(_wanted):
+        raise AssertionError("the warm pass must not reach the database")
+
+    with patch.object(trace_visibility, "_resolve_vault_owners_uncached", _explode):
+        warm = _verdicts()
+
+    assert warm == cold
+    assert any(cold), "sanity: some caller must be able to read something"
+    assert not all(cold), "sanity: some caller must be denied, or this proves nothing"
+
+
+async def test_a_private_legacy_row_stays_private_on_the_warmed_listing():
+    """The verdict that matters, at the route: an anonymous caller sees the
+    house trace and never the user's, on the cold request and every warm one
+    after it."""
+    for vault in USER_VAULTS:
+        _seed_owner(vault)
+    rows = [*_fifty_rows(), _trace(HOUSE_VAULT, 99)]
+    rows[-1]["reasoning"] = "house demo reasoning"
+
+    with _store(rows), _anonymous():
+        for _ in range(3):
+            resp = await _get("/api/traces/", limit=100)
+            assert [t["id"] for t in resp.json()["traces"]] == ["trace-99"]
+            assert SECRET_REASONING not in resp.text
+
+
+def test_a_failed_lookup_is_never_negative_cached():
+    """ "The database did not answer" is not "this vault has no owner".
+
+    Caching an outage as a confirmed absence would let the outage outlive
+    itself by a full TTL — and an unowned legacy row falls to the house-public
+    floor, so that is the one direction in which a cache could widen the gate.
+    """
+    _seed_owner(USER_VAULTS[0])
+
+    def _down(_wanted):
+        raise TraceOwnerLookupIncomplete({})
+
+    with patch.object(trace_visibility, "_resolve_vault_owners_uncached", _down):
+        assert safe_resolve_vault_owners({USER_VAULTS[0]}) == {}
+
+    # DB back: the owner must be found, i.e. the outage was not memoized.
+    assert safe_resolve_vault_owners({USER_VAULTS[0]}) == {
+        USER_VAULTS[0].lower(): (OWNER_USER_ID, OWNER_WALLET.lower())
+    }
+
+
+def test_becoming_owned_invalidates_the_memo():
+    """The only staleness direction that could widen the gate — a vault that
+    looked unowned and then acquires an owner — is closed at the write, not
+    left to the TTL. ``POST /api/vaults/create`` and ``POST
+    /api/vaults/metadata`` both call ``invalidate_vault_owner``.
+    """
+    vault = USER_VAULTS[0]
+    assert safe_resolve_vault_owners({vault}) == {}  # negative, and now memoized
+
+    _seed_owner(vault)
+    assert safe_resolve_vault_owners({vault}) == {}, "sanity: the memo is real, or the next line proves nothing"
+
+    invalidate_vault_owner(vault.upper())
+    assert safe_resolve_vault_owners({vault}) == {vault.lower(): (OWNER_USER_ID, OWNER_WALLET.lower())}
+
+
+def test_the_memo_expires(monkeypatch):
+    """The TTL is a real bound, not a decorative constant."""
+    monkeypatch.setattr(trace_visibility, "VAULT_OWNER_CACHE_TTL_SECONDS", 0)
+    vault = USER_VAULTS[0]
+
+    with _count_db_lookups() as calls:
+        safe_resolve_vault_owners({vault})
+        safe_resolve_vault_owners({vault})
+
+    assert len(calls) == 2, "an entry written with a zero TTL was still served"
+
+
+def test_the_cache_is_bounded(monkeypatch):
+    """A pathological caller cannot grow the memo without limit."""
+    monkeypatch.setattr(trace_visibility, "VAULT_OWNER_CACHE_MAX_ENTRIES", 8)
+    for i in range(40):
+        safe_resolve_vault_owners({f"0x{i:040x}"})
+
+    assert len(trace_visibility._vault_owner_cache) <= 8
+
+
+# ── The write-path stamp is never served from the memo ──────────────────────
+
+
+async def test_save_trace_resolves_ownership_uncached():
+    """``save_trace``'s stamp is PERMANENT, so it must never be answered from a
+    memo that predates the vault's owner.
+
+    The write path deliberately calls the uncached ``resolve_vault_owners``:
+    a stale negative here would not expire in 300s, it would be written into
+    the record and make that trace house-public forever.
+    """
+    from unittest.mock import MagicMock
+
+    from archimedes.services.redis_state import AgentStateStore
+
+    vault = USER_VAULTS[0]
+    assert safe_resolve_vault_owners({vault}) == {}  # poison the memo with a negative
+    _seed_owner(vault)
+
+    store = AgentStateStore(url="redis://fake/")
+    fake = MagicMock()
+    fake.get = AsyncMock(return_value=None)
+    fake.set = AsyncMock()
+    fake.zadd = AsyncMock()
+    fake.srem = AsyncMock()
+    fake.hdel = AsyncMock()
+    store._redis = fake
+
+    await store.save_trace(_trace(vault, 0))
+
+    import json
+
+    written = next(
+        json.loads(call.args[1])
+        for call in fake.set.await_args_list
+        if not call.args[0].startswith("archimedes:trace:id:")
+    )
+    assert written["owner_user_id"] == OWNER_USER_ID, "the permanent stamp was served from the read-path memo"


### PR DESCRIPTION
Closes #1573.

## Evidence

`GET /api/traces/?limit=50` measured live at **21.2s** right after #1562 deployed (health: 2.8s), over only **5 distinct vault addresses**. `/reasoning` and `/quant-lab` render that listing **anonymously**, so the public proof surface — the page the product's central claim rests on — loaded in ~21s.

The read gate re-derived the vault → owner mapping on **every request**: a synchronous `vault_metadata` query plus, for any vault it could not resolve, a `MAX_TRACE_SCAN` (2000) row `identity_events` scan materialized as ORM objects — executed **inside the async event loop**, where it stalls every other in-flight request. The listing batched within a request but nothing survived the request boundary; the three detail routes were worse, opening a session per unstamped read (`can_read_trace`).

Local timing, tmp SQLite seeded with 2000 `vault_created` events and 5 unresolvable vaults (the expensive branch), throwaway script, not committed:

```
uncached avg :    23.04 ms   <- pre-#1573: paid on every request, on the event loop
warm avg     :   0.0025 ms   <- post-#1573: cache hit
```

SQLite understates it by a lot — on Aurora the same call is a network round trip plus `pool_pre_ping`, and it was serialized against the event loop rather than a worker thread.

## What changed

| | |
| --- | --- |
| `safe_resolve_vault_owners` (**read** path) | memoized per lowercased vault for `VAULT_OWNER_CACHE_TTL_SECONDS = 300`. Only vaults that MISS reach the database. |
| Negative results | cached too — an unresolvable vault is what triggers the `identity_events` scan, so caching only successes would leave exactly the slow path uncached. |
| `resolve_vault_owners` (**write** path) | deliberately **left uncached**. It backs `save_trace`'s ownership stamp, which is permanent: a stale answer there is written into the record rather than expiring. |
| `TraceOwnerLookupIncomplete` | keeps "this vault has no owner" distinguishable from "the database did not answer", so a DB outage is never negative-cached and cannot outlive itself by a TTL. |
| `asyncio.to_thread` | wraps the resolution in both `list_traces` branches and in `_assert_can_read`, so the synchronous session no longer blocks the loop. |
| `invalidate_vault_owner` | called from the two writes that CREATE ownership — `POST /api/vaults/create`'s `vault_created` event and `POST /api/vaults/metadata`'s commit. |

## Why the TTL cannot weaken the gate

Same verdict for every row — the memo returns the mapping the uncached resolver would return. The staleness analysis, by direction:

- **A stamped row never consults the resolver at all.** Every trace written since #1556 carries its owner on the record, so the entire population written from here on is outside the cache's blast radius. Guarded by `test_a_stamped_listing_never_touches_the_resolver` and `test_can_read_trace_skips_the_resolver_for_a_stamped_row`.
- **Stale positive** (owner A → owner B): the row stays private, to A rather than B. Private-to-someone, never public. Owner changes are essentially write-once anyway — a vault gets its owner at deploy and does not change.
- **Stale negative** (unowned → owned) is the only widening direction, and it is the one closed at the write: `invalidate_vault_owner` drops the entry the moment either ownership-establishing write commits. The TTL is the backstop for that write landing in a sibling Fargate task, not the primary mechanism. With `PUBLIC_TRACE_VAULTS` armed the floor makes even that window fail **closed** (an unowned row outside the list is private).

## Guards — demonstrated to fail

Per CLAUDE.md § "A test that passes against the unfixed code proves nothing". 13 new tests in `backend/tests/services/test_trace_owner_cache.py`. Neutralizing **only** the memo (`VAULT_OWNER_CACHE_TTL_SECONDS = 0`, i.e. exactly the pre-#1573 behaviour: always re-resolve) and re-running:

```
6 failed, 7 passed
FAILED test_a_fifty_row_listing_resolves_each_distinct_vault_once
       - AssertionError: expected one database round trip across three listings, got 3
FAILED test_repeated_detail_reads_of_a_legacy_row_resolve_its_vault_once
       - AssertionError: expected one database round trip across ten detail reads, got 10
FAILED test_the_unresolvable_vault_is_negative_cached
       - AssertionError: the negative result was not cached: 3 round trips
FAILED test_only_the_uncached_vaults_reach_the_database
       - AssertionError: warm vaults were re-resolved
FAILED test_a_cache_hit_returns_the_same_verdict_as_a_cold_resolve
FAILED test_becoming_owned_invalidates_the_memo
       - AssertionError: sanity: the memo is real, or the next line proves nothing
```

With the memo restored: **13 passed.** The spy (`_count_db_lookups`) wraps the one function that actually opens a session and delegates to the real implementation, so it counts the database path rather than replacing it. `test_a_cache_hit_returns_the_same_verdict_as_a_cold_resolve` computes every verdict cold, then makes the DB path raise so the second pass can only be answered from the memo, and asserts the two verdict vectors are identical for owner / non-owner / anonymous — with `assert any(cold)` and `assert not all(cold)` so a degenerate all-same vector cannot pass it.

`_clear_vault_owner_cache` was added as an autouse fixture in `backend/tests/conftest.py`, mirroring the existing `_clear_rigor_cache`: several test files reuse the same vault addresses against different per-test SQLite databases, and without the reset an ownership *verdict* would depend on suite order.

`test_stamped_record_stays_private_when_the_identity_db_is_down` now patches `_resolve_vault_owners_uncached` as well — patching only `resolve_vault_owners` would have left the read path talking to a live database and quietly stopped simulating the outage.

## Tests

- `backend/tests/services/test_trace_owner_cache.py` → **13 passed** (new)
- `backend/tests/api/test_traces_ownership_gate.py` → **20 passed** (the #1556 gate, unchanged verdicts)
- Full unit suite, `pytest -m "not integration" -q` → **4350 passed, 2 skipped, 5 failed**

The 5 failures are **pre-existing on `origin/main`** and untouched by this branch — `test_trace_ownership_stamp.py`'s five `save_trace` cases fail with `TypeError: object MagicMock can't be used in 'await' expression` (its fake Redis lacks the `srem`/`hdel` the #1353 reconcile-index maintenance awaits). Verified by running that file on a clean checkout of `origin/main`: same 5 failures. Fixed by #1565 (`dbrowneup/stamp-test-union-fix`), which is not on `main` yet. The new tests here are deliberately independent of that file.

## Not fixed here — the other term in the 21.2s

Flagging honestly rather than claiming the page is now fast: `AgentStateStore.list_traces` (`services/redis_state.py`) does `zrevrange(index, 0, -1)` and then **one sequential `GET` per trace hash in the whole index**, windowing only afterwards. That is O(index size) awaited Redis round trips against TLS ElastiCache on every listing, and it predates #1562 (`list_recent_traces` was given an index-level bound for exactly this reason in #1276, but `list_traces` was not). Depending on how many traces are in the index it is plausibly the larger share of the 21.2s. Worth a follow-up issue and a live re-measurement after this deploys, which will separate the two terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
