### PR TITLE
[deps][frontend] Clear the permanently-red ui dev-only npm-audit row: brace-expansion 5.0.8 -> 5.0.9

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2413,9 +2413,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

One line of dependency resolution: `brace-expansion` `5.0.8` → `5.0.9` in `ui/package-lock.json`. Produced by `cd ui && npm audit fix` — no `--force`, no `.npmrc`, no `--audit-level`, no ignore list, and no new `overrides` entry. (To be exact: `ui/package.json` already carries one pre-existing override, `"ws": ">=8.21.0"`, from earlier work. This PR does not add to it, remove it, or touch it — `ui/package.json` is byte-identical to `origin/main`. Nothing in this change suppresses an advisory.)

```
 ui/package-lock.json | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

## Why

The `npm audit (ui, dev-only)` row in the supply-chain table has been red on every PR. It was one advisory, reached through lint tooling only:

```
ui@0.0.0
`-- eslint@10.8.1
  `-- minimatch@10.2.5
    `-- brace-expansion@5.0.8
```

`GHSA-rgw5-rvv9-x895` — high, DoS via unbounded intermediate arrays. It does not reach the browser bundle: `npm audit --omit=dev` was already `0`, and the CI dev row is computed as `full − prod`, so this single advisory *was* the whole red row.

The issue's anti-goals are all respected. Diffing the lockfile package-by-package, **exactly one entry changes**:

```
$ python -c "<compare packages{} in both lockfiles>"
packages whose version changed: ['node_modules/brace-expansion']
  node_modules/eslint: 10.9.1 -> 10.9.1
  node_modules/minimatch: 10.2.5 -> 10.2.5
  node_modules/vite: 8.2.2 -> 8.2.2
  node_modules/brace-expansion: 5.0.8 -> 5.0.9
total package entries: 485 -> 485
```

No eslint major. `ui/package.json` is byte-identical — `git diff --name-only` returns only `ui/package-lock.json`. `wallet-setup/` untouched.

## Test evidence

All commands run from the branch worktree with `node v26.2.0` / `npm 11.13.0` (the `archimedes` conda env).

```
$ cd ui && rm -rf node_modules && npm ci
added 407 packages, and audited 408 packages in 6s

118 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

$ npm audit
found 0 vulnerabilities

$ npm audit --omit=dev
found 0 vulnerabilities
```

`npm ci` leaves the lockfile unmodified (`git status --short` still shows only the one staged file), so the lockfile is internally consistent — not a hand-edit that `npm ci` would reject or rewrite.

```
$ npm run lint

> ui@0.0.0 lint
> eslint .

(exit 0, no output)

$ npm run build
dist/assets/index-BYJkZfTK.js                     271.81 kB │ gzip:  82.82 kB
dist/assets/api-BhrXNLIq.js                       769.65 kB │ gzip: 230.28 kB
✓ built in 2.06s
(the >500 kB chunk warning is pre-existing and unrelated)

$ npm test
ℹ tests 614
ℹ suites 0
ℹ pass 614
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 848.963291
```

No Python files are touched, so `ruff format` / `ruff check` have nothing in scope. No docs changes, so no `make docs-check` / index row is due.

## Adversarial demo 1 — revert the fix and the red row comes back

There is no bespoke unit test here; the regression guard for this change **is** the audit invocation CI already runs. So the "must fail with the fix reverted" demonstration is done against that gate directly. Two scratch trees, identical `ui/package.json`, differing only in which lockfile they carry — the worktree is never mutated:

```
$ cp $W/ui/package.json /tmp/1496-demo/prefix/
$ git -C $W show HEAD:ui/package-lock.json > /tmp/1496-demo/prefix/package-lock.json   # pre-fix
$ cp $W/ui/package.json $W/ui/package-lock.json /tmp/1496-demo/postfix/                # post-fix
prefix brace-expansion:  5.0.8
postfix brace-expansion: 5.0.9
```

**Reverted** (the lockfile as it stands on `origin/main`) — the false-red reproduces:

```
$ cd /tmp/1496-demo/prefix && npm audit
# npm audit report

brace-expansion  4.0.0 - 5.0.8
Severity: high
brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation - https://github.com/advisories/GHSA-rgw5-rvv9-x895
fix available via `npm audit fix`
node_modules/brace-expansion

1 high severity vulnerability

To address all issues, run:
  npm audit fix

$ npm audit --omit=dev
found 0 vulnerabilities
```

`full = 1`, `prod = 0` → dev-only delta `1` → **not passed**. That is the red row, reproduced locally.

**Fixed** (this branch's lockfile):

```
$ cd /tmp/1496-demo/postfix && npm audit
found 0 vulnerabilities

$ npm audit --omit=dev
found 0 vulnerabilities
```

## Adversarial demo 2 — the same invocation still reports a real advisory

Green is only worth anything if the check can still go red. Because the fix could in principle have been faked by suppression, here is the *same* audit invocation run against a deliberately vulnerable dev tree — a real package with a real, currently-live advisory, unrelated to `brace-expansion` so the demo isn't circular:

```
$ cat /tmp/1496-demo/injected/package.json
{
  "name": "injected-vuln-dev-tree",
  "private": true,
  "version": "0.0.0",
  "devDependencies": {
    "minimist": "1.2.0"
  }
}

$ npm install --package-lock-only --no-audit --no-fund && npm audit
# npm audit report

minimist  1.0.0 - 1.2.5
Severity: critical
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
fix available via `npm audit fix --force`
Will install minimist@1.2.8, which is outside the stated dependency range
node_modules/minimist

1 critical severity vulnerability

To address all issues, run:
  npm audit fix --force

$ npm audit --omit=dev
found 0 vulnerabilities
```

The guard rejects the bad input. Nothing about the invocation was weakened.

## Adversarial demo 3 — the CI row itself flips

Demos 1 and 2 exercise `npm audit`, which necessarily talks to the registry. The half that decides the *table row* is pure JSON → row and is fully hermetic: no network, no npm, no filesystem beyond the two saved report files. The script below is transcribed verbatim from the `npm audit (ui, prod)` and `npm audit (ui, dev)` steps in `.github/workflows/quality-gate.yml`, including the `#1198` missing-`metadata` and error-propagation branches:

```python
def row(full_path, prod_path):
    # --- step: npm audit (ui, prod) ---
    try:
        data = json.load(open(prod_path))
    except Exception:
        data = {}
    if "metadata" not in data:
        prod_result, prod_count_raw = "error", str(data.get("error", {}).get("code", "unknown"))
    else:
        c = data["metadata"].get("vulnerabilities", {}).get("total", 0)
        prod_result, prod_count_raw = ("passed" if c == 0 else "not passed"), str(c)
    # --- step: npm audit (ui, dev) ---
    try:
        full = json.load(open(full_path))
    except Exception:
        full = {}
    if "metadata" not in full:
        return prod_result, prod_count_raw, "error", str(full.get("error", {}).get("code", "unknown"))
    if prod_result == "error":
        return prod_result, prod_count_raw, "error", f"prod-audit-{prod_count_raw or 'unknown'}"
    full_count = full["metadata"].get("vulnerabilities", {}).get("total", 0)
    prod_count = int(prod_count_raw or "0")
    count = max(full_count - prod_count, 0)
    return prod_result, prod_count_raw, ("passed" if count == 0 else "not passed"), str(count)
```

Fed the three `npm audit --json` / `npm audit --omit=dev --json` report pairs captured above:

```
$ python /tmp/1496-demo/ci_row.py
REVERTED (origin/main lockfile)    | npm audit (ui, prod-only): passed       0 | npm audit (ui, dev-only): not passed   1
FIXED    (this branch)             | npm audit (ui, prod-only): passed       0 | npm audit (ui, dev-only): passed       0
INJECTED (minimist@1.2.0 dev)      | npm audit (ui, prod-only): passed       0 | npm audit (ui, dev-only): not passed   1
```

Row 1 is today's red. Row 2 is what this PR produces. Row 3 is the proof that row 2 is honest green and not a silenced check.

## Not done here

- **No new unit test.** The regression guard is the existing `npm audit (ui, dev-only)` CI row, demonstrated above by reverting the lockfile. I considered a `ui/test/` assertion pinning `brace-expansion >= 5.0.9`, and rejected it: it would restate what `npm audit` already checks, and would need a manual bump on every future advisory — churn that guards nothing new.
- **The delta parser is still duplicated in YAML.** Demo 3 had to transcribe the CI logic into a throwaway script because it lives only inside a heredoc in `quality-gate.yml` and is therefore untestable in place. Lifting it into a real `scripts/` module with its own tests would be a genuine improvement, and is out of scope for a lockfile bump — worth its own issue.
- **`eslint`/`minimatch` are unchanged**, deliberately (issue anti-goal). `minimatch@10.2.5` still declares `brace-expansion: ^5.0.5`, so a future `npm install` resolves to the highest satisfying version — `5.0.9` today. Nothing pins it below the fix, but nothing pins it *at* the fix either; the lockfile is what holds it, which is the normal shape for a transitive resolution.
- **`wallet-setup/` untouched**, per the issue.
- **The forward-looking risk this doesn't address:** the dev-only row goes green today, but the same "nobody owns it" failure mode returns the next time a dev advisory lands. Whether the dev-only row should ever *block* (it is `continue-on-error: true` today) is an owner call, not something to decide inside this PR.

Closes #1496

