### PR TITLE
[chain] Confirm the Circle signer address via GET /wallets/{WALLET_ID} so the #1353 reveal pre-check actually fires in prod

### DIFF
--- a/backend/archimedes/chain/agent_runner.py
+++ b/backend/archimedes/chain/agent_runner.py
@@ -1929,14 +1929,19 @@ class StrategyRunner:
         # that can never change. Checking it here is a cheap, zero-attempt
         # short-circuit straight to terminal instead. Skipped (falls through
         # to the normal path) when the signer can't be CONFIRMED
-        # (``backend_signer_address_confirmed`` returns None — always true on
-        # the Circle path, where the only address available, WALLET_ADDRESS,
-        # is a hand-maintained mirror of the real signer rather than a
-        # cryptographic derivation of it, see executor.py) or the commitment
-        # carries no committer — never guess, only reject a CONFIRMED
-        # mismatch, because terminal here is irreversible and a false
-        # positive would permanently kill a perfectly recoverable reveal.
-        configured_addr = chain_executor.backend_signer_address_confirmed()
+        # (``backend_signer_address_confirmed`` returns None) or the
+        # commitment carries no committer — never guess, only reject a
+        # CONFIRMED mismatch, because terminal here is irreversible and a
+        # false positive would permanently kill a perfectly recoverable
+        # reveal.
+        #
+        # On the Circle path (the only prod signer) that confirmation is a
+        # bounded read of GET /wallets/{WALLET_ID} asking Circle what the
+        # signing wallet's address is (#1412) — NOT the hand-maintained
+        # WALLET_ADDRESS mirror, which could drift stale and read as a
+        # rotation that never happened. If Circle can't answer, the answer is
+        # None and this check simply does not fire.
+        configured_addr = await chain_executor.backend_signer_address_confirmed()
         committer = commitment.get("committer")
         if configured_addr and committer and str(committer).lower() != str(configured_addr).lower():
             await self._reconcile_terminal(

--- a/backend/archimedes/chain/circle_signer.py
+++ b/backend/archimedes/chain/circle_signer.py
@@ -31,6 +31,14 @@ _TERMINAL = {"COMPLETE", "FAILED", "DENIED", "CANCELLED"}
 _POLL_INTERVAL = 2.0  # seconds
 _MAX_POLLS = 60  # 2 minutes max
 
+# Bounded wall-clock ceiling on the wallet-address lookup (#1412). This runs
+# inside the agent tick's reveal-reconciliation pass, so an unbounded read
+# against a hung Circle endpoint would stall the tick. aiohttp's own default is
+# 5 minutes; a lookup that has not answered in 10s is not going to answer
+# usefully, and "no answer" has a correct, safe meaning here (None = could not
+# confirm).
+_WALLET_LOOKUP_TIMEOUT = 10.0  # seconds
+
 
 def _encrypt_entity_secret(entity_secret_hex: str, public_key_pem: str) -> str:
     """Encrypt entity secret with Circle's RSA public key (OAEP/SHA-256)."""
@@ -67,10 +75,87 @@ class CircleSigner:
         self._entity_secret: str = os.getenv("CIRCLE_ENTITY_SECRET", "")
         self._wallet_id: str = os.getenv("WALLET_ID", "")
         self._circle_public_key: str | None = None
+        self._wallet_address: str | None = None
 
     @property
     def is_configured(self) -> bool:
         return bool(self._api_key and self._entity_secret and self._wallet_id)
+
+    async def get_wallet_address(self) -> str | None:
+        """The EVM address WALLET_ID actually signs with, asked of Circle itself.
+
+        ``GET /wallets/{WALLET_ID}`` returns Circle's own record of the wallet
+        this signer submits every transaction through, so the answer is derived
+        from the same identifier that does the signing — not from
+        ``WALLET_ADDRESS``, a separate env var that an operator maintains BY
+        HAND and that nothing re-derives from the wallet (see
+        ``.env.example`` and ``ChainExecutor.backend_signer_address``). That
+        distinction is the whole point of this method: a caller that acts
+        irreversibly on a signer mismatch (#1353's reveal-reconciliation
+        pre-check) can trust this and must not trust the mirror.
+
+        Returns:
+            The wallet's EVM address, or ``None`` when it could not be
+            established — unconfigured credentials, a non-200 from Circle, a
+            payload without an address, a timeout, or any transport error.
+
+        ``None`` means "could not confirm", never "confirmed absent" and never
+        "confirmed unchanged". Callers must treat it as *no information*: the
+        pre-check skips itself and falls through to the ordinary (reversible)
+        retry path rather than terminaling on a guess. Consequently this method
+        must never raise and must never substitute a plausible-looking value
+        for a failed lookup — a fail-soft guess here would permanently kill
+        recoverable dangling reveals (CLAUDE.md § fail-soft).
+
+        The successful answer is cached for the process lifetime, same as
+        ``_get_public_key``: a Circle wallet's address is immutable for a given
+        wallet ID, and re-reading it on every reconciliation pass would add a
+        network round-trip to each agent tick. Failures are deliberately NOT
+        cached, so a transient outage does not pin "unconfirmable" forever.
+        """
+        if self._wallet_address:
+            return self._wallet_address
+        if not self.is_configured:
+            return None
+
+        try:
+            async with (
+                aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=_WALLET_LOOKUP_TIMEOUT)) as session,
+                session.get(
+                    f"{CIRCLE_API_BASE}/wallets/{self._wallet_id}",
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                ) as resp,
+            ):
+                if resp.status != 200:
+                    logger.error(
+                        "Circle wallet address lookup failed for wallet %s: HTTP %d",
+                        self._wallet_id,
+                        resp.status,
+                    )
+                    return None
+                body = await resp.json()
+        except (TimeoutError, aiohttp.ClientError, ValueError) as e:
+            # TimeoutError covers asyncio.TimeoutError (its alias since 3.11) and
+            # so aiohttp's ServerTimeoutError; ValueError covers a non-JSON body.
+            logger.error(
+                "Circle wallet address lookup errored for wallet %s: %r — reporting 'could not confirm'",
+                self._wallet_id,
+                e,
+            )
+            return None
+
+        data = body.get("data") or {} if isinstance(body, dict) else {}
+        wallet = data.get("wallet") or {} if isinstance(data, dict) else {}
+        address = wallet.get("address") if isinstance(wallet, dict) else None
+        if not address:
+            logger.error(
+                "Circle wallet address lookup for wallet %s returned no address field",
+                self._wallet_id,
+            )
+            return None
+
+        self._wallet_address = str(address)
+        return self._wallet_address
 
     async def _get_public_key(self, session: aiohttp.ClientSession) -> str | None:
         """Fetch Circle's RSA public key (cached)."""

--- a/backend/archimedes/chain/executor.py
+++ b/backend/archimedes/chain/executor.py
@@ -544,28 +544,41 @@ class ChainExecutor:
         account = chain_client.settings.agent_account
         return account.address if account else None
 
-    def backend_signer_address_confirmed(self) -> str | None:
+    async def backend_signer_address_confirmed(self) -> str | None:
         """Like ``backend_signer_address``, but ONLY when the answer is
-        cryptographically certain — never an operator-maintained mirror that
-        can silently drift out of sync with what actually signs (#1403
-        review of #1353's signer pre-check).
+        established from what actually signs — never an operator-maintained
+        mirror that can silently drift out of sync with it (#1403 review of
+        #1353's signer pre-check).
 
         Raw-key path: the address IS the signer, derived straight from
-        ``ARC_AGENT_PRIVATE_KEY`` — always confirmed.
+        ``ARC_AGENT_PRIVATE_KEY`` — always confirmed, no I/O.
 
-        Circle path: signing is keyed on WALLET_ID (circle_signer.py); the
-        EVM address is surfaced separately via a hand-maintained WALLET_ADDRESS
-        env var (.env.example: "WALLET_ID is the Circle wallet UUID,
-        WALLET_ADDRESS is its EVM address") that nothing re-derives from the
-        Circle wallet itself. Returns None here — "can't be confirmed," not
-        "confirmed absent" — because a caller that goes straight to an
-        IRREVERSIBLE terminal state on a mismatch (the reveal reconciliation
-        signer pre-check) must never act on this value: a stale WALLET_ADDRESS
-        while the true signer is unchanged would read as a rotation and
-        permanently terminal a perfectly recoverable dangling reveal.
+        Circle path: signing is keyed on WALLET_ID (circle_signer.py), while
+        the EVM address is *also* surfaced through a hand-maintained
+        WALLET_ADDRESS env var (.env.example: "WALLET_ID is the Circle wallet
+        UUID, WALLET_ADDRESS is its EVM address") that nothing re-derives from
+        the wallet. This method ignores that mirror entirely and asks Circle
+        what WALLET_ID signs with (``CircleSigner.get_wallet_address`` →
+        ``GET /wallets/{WALLET_ID}``), so the answer is bound to the signing
+        identifier rather than to an operator's bookkeeping (#1412).
+
+        Returns None when the answer cannot be established — Circle
+        unreachable, non-200, no address in the payload, or (raw-key path) no
+        configured account. **None means "could not confirm", never
+        "confirmed".** The caller acts IRREVERSIBLY on a mismatch (the reveal
+        reconciliation pre-check goes terminal), so it must skip the check
+        entirely on None rather than treat it as evidence of anything; see
+        CLAUDE.md § fail-soft — a plausible substitute here would permanently
+        kill a recoverable dangling reveal.
+
+        Async because the Circle answer is a bounded network read
+        (``_WALLET_LOOKUP_TIMEOUT``); before #1412 this returned None
+        unconditionally on the Circle path, which made the pre-check a
+        permanent no-op in production (the runner env file refuses to write
+        without Circle credentials, so Circle is the only prod signer).
         """
         if circle_signer.is_configured:
-            return None
+            return await circle_signer.get_wallet_address()
         account = chain_client.settings.agent_account
         return account.address if account else None
 

--- a/backend/tests/chain/test_circle_signer.py
+++ b/backend/tests/chain/test_circle_signer.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from archimedes.chain.circle_signer import CircleSigner, _encrypt_entity_secret
 
@@ -52,6 +53,15 @@ def _resp(status: int, body: dict) -> MagicMock:
     resp = MagicMock(status=status)
     resp.json = AsyncMock(return_value=body)
     return resp
+
+
+def _raising_cm(exc: BaseException) -> MagicMock:
+    """An async context manager whose __aenter__ raises — how aiohttp surfaces
+    a timeout / transport failure at the `async with session.get(...)` line."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(side_effect=exc)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
 
 
 @pytest.fixture
@@ -97,6 +107,136 @@ class TestGetPublicKey:
         session = _mock_session()
         session.get = MagicMock(return_value=session._cm(_resp(403, {"error": "denied"})))
         assert await configured._get_public_key(session) is None
+
+
+# ── get_wallet_address (#1412) ────────────────────────────────
+
+
+class TestGetWalletAddress:
+    """``get_wallet_address`` asks Circle what WALLET_ID actually signs with.
+
+    This is the value the reveal-reconciliation signer pre-check acts on
+    IRREVERSIBLY (``ChainExecutor.backend_signer_address_confirmed`` →
+    ``agent_runner._reconcile_one_reveal``), so the contract under test is
+    two-sided: a real address when Circle answers, and ``None`` — meaning
+    "could not confirm", never "confirmed" — for every way the lookup can fail.
+    """
+
+    async def test_returns_the_address_circle_reports(self, configured):
+        session = _mock_session()
+        body = {
+            "data": {
+                "wallet": {
+                    "id": "wallet-uuid",
+                    "address": "0xCIRCLE0000000000000000000000000000000001",
+                    "blockchain": "ARC-TESTNET",
+                }
+            }
+        }
+        session.get = MagicMock(return_value=session._cm(_resp(200, body)))
+
+        with patch(
+            "archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)
+        ) as mock_session_cls:
+            addr = await configured.get_wallet_address()
+
+        assert addr == "0xCIRCLE0000000000000000000000000000000001"
+        # The lookup must be keyed on WALLET_ID — the identifier that signs —
+        # not on the WALLET_ADDRESS mirror.
+        assert session.get.call_args.args[0].endswith("/wallets/wallet-uuid")
+        # Bounded (#1412): this runs inside the agent tick, so a hung Circle
+        # endpoint must not stall it. Pinned so a future edit can't silently
+        # drop the ceiling back to aiohttp's 5-minute default.
+        timeout = mock_session_cls.call_args.kwargs["timeout"]
+        assert timeout.total is not None
+        assert 0 < timeout.total <= 30
+
+    async def test_caches_the_successful_answer(self, configured):
+        session = _mock_session()
+        body = {"data": {"wallet": {"address": "0xCIRCLE0000000000000000000000000000000001"}}}
+        session.get = MagicMock(return_value=session._cm(_resp(200, body)))
+
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)):
+            first = await configured.get_wallet_address()
+            session.get.reset_mock()
+            second = await configured.get_wallet_address()
+
+        assert first == second == "0xCIRCLE0000000000000000000000000000000001"
+        session.get.assert_not_called()  # cached, same pattern as _get_public_key
+
+    async def test_unconfigured_returns_none_without_calling_circle(self, monkeypatch):
+        monkeypatch.delenv("CIRCLE_API_KEY", raising=False)
+        monkeypatch.delenv("CIRCLE_ENTITY_SECRET", raising=False)
+        monkeypatch.delenv("WALLET_ID", raising=False)
+        signer = CircleSigner()
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession") as mock_session_cls:
+            assert await signer.get_wallet_address() is None
+        mock_session_cls.assert_not_called()
+
+    async def test_non_200_returns_none_and_is_not_cached(self, configured):
+        """A 401/500 is "could not confirm", not "confirmed absent" — and a
+        transient outage must not pin that state for the process lifetime."""
+        session = _mock_session()
+        session.get = MagicMock(return_value=session._cm(_resp(401, {"message": "unauthorized"})))
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)):
+            assert await configured.get_wallet_address() is None
+
+        # Circle recovers → the next call re-reads rather than serving a
+        # cached failure.
+        ok = _mock_session()
+        ok.get = MagicMock(
+            return_value=ok._cm(
+                _resp(200, {"data": {"wallet": {"address": "0xLATER00000000000000000000000000000000001"}}})
+            )
+        )
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(ok)):
+            assert await configured.get_wallet_address() == "0xLATER00000000000000000000000000000000001"
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("no data key", {"message": "ok"}),
+            ("null data", {"data": None}),
+            ("no wallet key", {"data": {}}),
+            ("null wallet", {"data": {"wallet": None}}),
+            ("no address field", {"data": {"wallet": {"id": "wallet-uuid"}}}),
+            ("empty address", {"data": {"wallet": {"address": ""}}}),
+        ],
+    )
+    async def test_payload_without_a_usable_address_returns_none(self, configured, label, body):
+        session = _mock_session()
+        session.get = MagicMock(return_value=session._cm(_resp(200, body)))
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)):
+            assert await configured.get_wallet_address() is None, label
+
+    @pytest.mark.parametrize(
+        ("label", "exc"),
+        [
+            # TimeoutError IS asyncio.TimeoutError on 3.11+ — this is what the
+            # bounded _WALLET_LOOKUP_TIMEOUT raises when Circle hangs.
+            ("timeout", TimeoutError()),
+            ("connection error", aiohttp.ClientConnectionError("circle unreachable")),
+        ],
+    )
+    async def test_transport_failure_returns_none_and_never_raises(self, configured, label, exc):
+        """The caller runs inside the agent tick and acts irreversibly on a
+        confirmed mismatch — a raised exception here would abort the whole
+        reconciliation pass, and a guessed address would terminal a
+        recoverable reveal. Both are wrong; None is the honest answer."""
+        session = _mock_session()
+        session.get = MagicMock(return_value=_raising_cm(exc))
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)):
+            assert await configured.get_wallet_address() is None, label
+
+    async def test_non_json_body_returns_none(self, configured):
+        """A 200 whose body doesn't parse (proxy error page, truncated
+        response) must not propagate out of the tick."""
+        session = _mock_session()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(side_effect=ValueError("Expecting value"))
+        session.get = MagicMock(return_value=session._cm(resp))
+        with patch("archimedes.chain.circle_signer.aiohttp.ClientSession", return_value=_session_context(session)):
+            assert await configured.get_wallet_address() is None
 
 
 # ── execute_contract ──────────────────────────────────────────

--- a/backend/tests/chain/test_executor_reads.py
+++ b/backend/tests/chain/test_executor_reads.py
@@ -327,10 +327,12 @@ class TestBackendSignerAddressConfirmed:
     """``backend_signer_address`` surfaces WALLET_ADDRESS on the Circle path —
     an operator-maintained mirror of the real signer, not a derivation of it
     (signing itself is keyed on the separate WALLET_ID, circle_signer.py).
-    ``backend_signer_address_confirmed`` must return None whenever the answer
-    isn't cryptographically certain, so a stale mirror can never be mistaken
-    for a confirmed signer identity by a caller that acts irreversibly on it
-    (the reveal-reconciliation signer pre-check, agent_runner.py)."""
+    ``backend_signer_address_confirmed`` must never return that mirror: on the
+    Circle path it asks Circle what WALLET_ID signs with (#1412), and returns
+    None whenever the answer cannot be established — so a stale mirror can
+    never be mistaken for a confirmed signer identity by a caller that acts
+    irreversibly on it (the reveal-reconciliation signer pre-check,
+    agent_runner.py)."""
 
     def test_raw_key_path_is_confirmed(self, executor):
         account = MagicMock()
@@ -339,7 +341,7 @@ class TestBackendSignerAddressConfirmed:
         with patch("archimedes.chain.executor.circle_signer") as signer:
             signer.is_configured = False
             addr = executor.backend_signer_address()
-            confirmed = executor.backend_signer_address_confirmed()
+            confirmed = asyncio.run(executor.backend_signer_address_confirmed())
         assert addr == account.address
         assert confirmed == account.address  # raw key IS the signer — always confirmed
 
@@ -348,25 +350,57 @@ class TestBackendSignerAddressConfirmed:
         with patch("archimedes.chain.executor.circle_signer") as signer:
             signer.is_configured = False
             assert executor.backend_signer_address() is None
-            assert executor.backend_signer_address_confirmed() is None
+            assert asyncio.run(executor.backend_signer_address_confirmed()) is None
 
-    def test_circle_path_confirmed_is_none_even_though_the_mirror_has_a_value(self, executor, monkeypatch):
-        """The exact drift the review flagged: WALLET_ADDRESS is set (and
-        would be returned by ``backend_signer_address``) but signing on the
-        Circle path is keyed on WALLET_ID, a separate env var — so the
-        confirmed variant must refuse to vouch for it."""
+    def test_circle_path_confirmed_comes_from_circle_not_the_mirror(self, executor, monkeypatch):
+        """#1412: the confirmed answer is what Circle says WALLET_ID signs
+        with. WALLET_ADDRESS is set to something else entirely here; the
+        confirmed variant must ignore it completely."""
         monkeypatch.setenv("WALLET_ADDRESS", "0xPOSSIBLYSTALE00000000000000000000000000")
         with patch("archimedes.chain.executor.circle_signer") as signer:
             signer.is_configured = True
-            assert executor.backend_signer_address() == "0xPOSSIBLYSTALE00000000000000000000000000"
-            assert executor.backend_signer_address_confirmed() is None
+            signer.get_wallet_address = AsyncMock(return_value="0xCIRCLETRUTH000000000000000000000000000a")
+            addr = executor.backend_signer_address()
+            confirmed = asyncio.run(executor.backend_signer_address_confirmed())
+        assert addr == "0xPOSSIBLYSTALE00000000000000000000000000"  # the mirror, unchanged
+        assert confirmed == "0xCIRCLETRUTH000000000000000000000000000a"
+        assert confirmed != addr  # the two are genuinely different sources
 
-    def test_circle_path_confirmed_is_none_even_when_the_mirror_is_unset(self, executor, monkeypatch):
+    def test_circle_path_confirmed_works_when_the_mirror_is_unset(self, executor, monkeypatch):
+        """WALLET_ADDRESS is optional to the confirmed path — it is never read
+        there. With the mirror entirely absent the confirmation still lands."""
         monkeypatch.delenv("WALLET_ADDRESS", raising=False)
         with patch("archimedes.chain.executor.circle_signer") as signer:
             signer.is_configured = True
+            signer.get_wallet_address = AsyncMock(return_value="0xCIRCLETRUTH000000000000000000000000000a")
             assert executor.backend_signer_address() is None
-            assert executor.backend_signer_address_confirmed() is None
+            assert asyncio.run(executor.backend_signer_address_confirmed()) == (
+                "0xCIRCLETRUTH000000000000000000000000000a"
+            )
+
+    def test_circle_path_returns_the_mismatching_address_not_none(self, executor, monkeypatch):
+        """When Circle reports an address that differs from the committer the
+        caller is comparing against, the MISMATCHING address must come back —
+        None would silently disarm the pre-check, and the reconciler needs the
+        actual value to log which key it is now signing with."""
+        monkeypatch.setenv("WALLET_ADDRESS", "0xOLDKEY000000000000000000000000000000000")
+        with patch("archimedes.chain.executor.circle_signer") as signer:
+            signer.is_configured = True
+            signer.get_wallet_address = AsyncMock(return_value="0xROTATEDKEY0000000000000000000000000000b")
+            confirmed = asyncio.run(executor.backend_signer_address_confirmed())
+        assert confirmed == "0xROTATEDKEY0000000000000000000000000000b"
+
+    def test_circle_path_lookup_failure_is_none_never_a_guess(self, executor, monkeypatch):
+        """Anti-goal guard (#1412): when the Circle lookup itself fails,
+        ``get_wallet_address`` returns None and the confirmed answer must stay
+        None — NOT fall back to the WALLET_ADDRESS mirror, which is set here
+        precisely so a fallback would be visible."""
+        monkeypatch.setenv("WALLET_ADDRESS", "0xPOSSIBLYSTALE00000000000000000000000000")
+        with patch("archimedes.chain.executor.circle_signer") as signer:
+            signer.is_configured = True
+            signer.get_wallet_address = AsyncMock(return_value=None)
+            confirmed = asyncio.run(executor.backend_signer_address_confirmed())
+        assert confirmed is None
 
 
 # ── helpers: token symbol / decimals / value / parse ──────────

--- a/backend/tests/test_agent_runner_reveal_reconciliation.py
+++ b/backend/tests/test_agent_runner_reveal_reconciliation.py
@@ -82,8 +82,10 @@ def runner_env():
         mock_tp.publish = AsyncMock(return_value=None)
         # Signer pre-check (#1353) default: "can't be determined" — the check
         # is skipped rather than guessed, matching every existing test's
-        # commitment fixtures (none carry a "committer" key).
-        mock_executor.backend_signer_address_confirmed = MagicMock(return_value=None)
+        # commitment fixtures (none carry a "committer" key). AsyncMock since
+        # #1412: on the Circle path confirming the signer is a bounded network
+        # read of GET /wallets/{WALLET_ID}, so the executor method is async.
+        mock_executor.backend_signer_address_confirmed = AsyncMock(return_value=None)
         yield runner, mock_tp
 
 
@@ -611,7 +613,7 @@ class TestSignerPreCheck:
         mock_tp.reveal = AsyncMock(return_value=("0xSHOULDNOTHAPPEN", 999))
 
         with patch("archimedes.chain.agent_runner.chain_executor") as mock_executor:
-            mock_executor.backend_signer_address_confirmed = MagicMock(
+            mock_executor.backend_signer_address_confirmed = AsyncMock(
                 return_value="0xNEWKEY000000000000000000000000000000000"
             )
             _run_pass(runner, [record])
@@ -642,7 +644,7 @@ class TestSignerPreCheck:
         mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 150))
 
         with patch("archimedes.chain.agent_runner.chain_executor") as mock_executor:
-            mock_executor.backend_signer_address_confirmed = MagicMock(
+            mock_executor.backend_signer_address_confirmed = AsyncMock(
                 return_value="0xaaaabbbbccccddddeeeeffff000000000000aaaa"
             )
             _run_pass(runner, [record])
@@ -669,29 +671,79 @@ class TestSignerPreCheck:
         mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 150))
 
         with patch("archimedes.chain.agent_runner.chain_executor") as mock_executor:
-            mock_executor.backend_signer_address_confirmed = MagicMock(return_value=None)
+            mock_executor.backend_signer_address_confirmed = AsyncMock(return_value=None)
             _run_pass(runner, [record])
 
         mock_tp.reveal.assert_awaited_once()
         saved = _saved(runner)
         assert saved["reveal_reconcile_state"] == "reconciled"
 
-    def test_circle_path_never_terminals_on_a_stale_operator_mirror(self, runner_env):
-        """PR #1403 review finding: on the Circle path the only address
-        available is WALLET_ADDRESS, an operator-maintained env var kept in
-        sync BY HAND with the wallet's true EVM address — signing itself is
-        keyed on the separate WALLET_ID (circle_signer.py), so WALLET_ADDRESS
-        can drift stale while the real signer is unchanged. Before the fix,
-        ``chain_executor.backend_signer_address()`` returned that mirror
-        directly and a stale value would read as a confirmed key rotation,
-        permanently terminaling a perfectly recoverable dangling reveal with
-        zero attempts and zero diagnostics. ``backend_signer_address_confirmed``
-        must return None on the Circle path — unconditionally, regardless of
-        what WALLET_ADDRESS says — so this always falls through to the normal
-        (reversible) retry path instead."""
+    def test_circle_path_key_rotation_goes_terminal_via_the_real_executor(self, runner_env, monkeypatch):
+        """#1412 acceptance: a GENUINE key rotation on the Circle path — the
+        only signer production uses — now short-circuits to terminal.
+
+        This wires the REAL ``ChainExecutor.backend_signer_address_confirmed``
+        into the runner and mocks only the Circle boundary underneath it, so
+        it exercises the actual prod path (executor → circle_signer →
+        ``GET /wallets/{WALLET_ID}``) rather than restating the runner's own
+        `if`. Before #1412 the executor returned None unconditionally here and
+        this pre-check was a permanent no-op in prod: the runner fell through
+        and burned every REVEAL_RECONCILE_MAX_ATTEMPTS on 'Not committer'
+        reverts.
+
+        WALLET_ADDRESS is deliberately set to the OLD committer: if the
+        confirmed path ever regressed to reading that operator-maintained
+        mirror instead of asking Circle, it would read as a match and this
+        test would stop terminaling."""
+        from archimedes.chain.executor import ChainExecutor
+
+        monkeypatch.setenv("WALLET_ADDRESS", "0xOLDKEY000000000000000000000000000000000")
         runner, mock_tp = runner_env
         record = _dangling_record(runner, mock_tp)
-        # The REAL committer that actually signed via WALLET_ID.
+        # The commitment was signed by the OLD Circle wallet key.
+        mock_tp.get_commitment = AsyncMock(
+            return_value={
+                "revealed": False,
+                "reveal_block": None,
+                "claimed_execution_time": 0,
+                "storage_pointer": "",
+                "committer": "0xOLDKEY000000000000000000000000000000000",
+            }
+        )
+        mock_tp.reveal = AsyncMock(return_value=("0xSHOULDNOTHAPPEN", 999))
+
+        real_executor = ChainExecutor(loader=MagicMock())
+        with (
+            patch("archimedes.chain.executor.circle_signer") as mock_signer,
+            patch("archimedes.chain.agent_runner.chain_executor") as mock_executor,
+        ):
+            mock_signer.is_configured = True  # the prod signer path
+            # Circle now reports a DIFFERENT wallet address than the committer.
+            mock_signer.get_wallet_address = AsyncMock(return_value="0xNEWKEY000000000000000000000000000000000")
+            mock_executor.backend_signer_address_confirmed = real_executor.backend_signer_address_confirmed
+            _run_pass(runner, [record])
+
+        mock_tp.reveal.assert_not_awaited()  # zero gas burned on a doomed revert
+        saved = _saved(runner)
+        assert saved["reveal_reconcile_state"] == "terminal"
+        assert "signer mismatch" in saved["reveal_reconcile_terminal_reason"]
+        # The mismatching address is logged, not swallowed — the operator needs
+        # to see which key the backend is signing with now.
+        assert "0xNEWKEY000000000000000000000000000000000" in saved["reveal_reconcile_terminal_reason"]
+        assert saved.get("reveal_reconcile_attempts", 0) == 0
+
+    def test_circle_path_unconfirmable_still_never_terminals(self, runner_env):
+        """Anti-goal guard (#1412, and the standing #1403 review finding): when
+        the Circle lookup itself fails, ``backend_signer_address_confirmed``
+        returns None and the pre-check must NOT fire. None means "could not
+        confirm", never "confirmed" — terminal here is irreversible, so an
+        unreachable Circle must leave the reveal on the ordinary retry path.
+
+        Same real-executor wiring as above; only the Circle answer changes."""
+        from archimedes.chain.executor import ChainExecutor
+
+        runner, mock_tp = runner_env
+        record = _dangling_record(runner, mock_tp)
         mock_tp.get_commitment = AsyncMock(
             return_value={
                 "revealed": False,
@@ -703,10 +755,14 @@ class TestSignerPreCheck:
         )
         mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 150))
 
-        with patch("archimedes.chain.agent_runner.chain_executor") as mock_executor:
-            # backend_signer_address_confirmed() is None on the Circle path —
-            # even though a (stale) WALLET_ADDRESS mirror would disagree.
-            mock_executor.backend_signer_address_confirmed = MagicMock(return_value=None)
+        real_executor = ChainExecutor(loader=MagicMock())
+        with (
+            patch("archimedes.chain.executor.circle_signer") as mock_signer,
+            patch("archimedes.chain.agent_runner.chain_executor") as mock_executor,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.get_wallet_address = AsyncMock(return_value=None)  # Circle unreachable / non-200
+            mock_executor.backend_signer_address_confirmed = real_executor.backend_signer_address_confirmed
             _run_pass(runner, [record])
 
         mock_tp.reveal.assert_awaited_once()  # the retry actually ran — not short-circuited
@@ -724,7 +780,7 @@ class TestSignerPreCheck:
         mock_tp.reveal = AsyncMock(return_value=("0xRETRYREVEAL", 150))
 
         with patch("archimedes.chain.agent_runner.chain_executor") as mock_executor:
-            mock_executor.backend_signer_address_confirmed = MagicMock(
+            mock_executor.backend_signer_address_confirmed = AsyncMock(
                 return_value="0xANYADDRESS0000000000000000000000000000"
             )
             _run_pass(runner, [record])


### PR DESCRIPTION
## What

`ChainExecutor.backend_signer_address_confirmed()` returned `None` unconditionally whenever
`circle_signer.is_configured` — i.e. on every production tick, since
`infra/runner-user-data.sh` refuses to write the runner env file at all (`exit 4`) without
`CIRCLE_API_KEY` / `CIRCLE_ENTITY_SECRET` / `WALLET_ID`. That made #1353's reveal-reconciliation
signer pre-check (acceptance item 3: "compare `getCommitment().committer` to the configured agent
address … and go terminal immediately") a **permanent no-op on the only signer path prod uses**.

This PR makes the address confirmable on the Circle path:

- **`CircleSigner.get_wallet_address()`** (new) — `GET {CIRCLE_API_BASE}/wallets/{WALLET_ID}`
  through the existing aiohttp seam, bounded by `_WALLET_LOOKUP_TIMEOUT = 10.0s`
  (aiohttp's own default is 5 minutes, and this runs inside the agent tick). The successful
  answer is cached for the process lifetime, same pattern as `_get_public_key`; **failures are
  deliberately not cached**, so a transient Circle outage can't pin "unconfirmable" forever.
- **`backend_signer_address_confirmed()`** returns that address on the Circle path instead of
  `None`. It becomes `async` — the answer is now a network read — and its sole production caller
  (`agent_runner._reconcile_one_reveal`) awaits it. The raw-key path is behaviourally untouched:
  still the address derived from `ARC_AGENT_PRIVATE_KEY`, still no I/O.

## Why the `None` semantics are load-bearing

`None` means **"could not confirm"** — never "confirmed", never "confirmed unchanged". The caller
goes straight to an **irreversible** terminal state on a mismatch, so a fail-soft guess here would
permanently kill a perfectly recoverable dangling reveal (CLAUDE.md § "Fail-soft is correct for
optional configuration and wrong for anything a claim depends on"). Concretely:

- The lookup never reads `WALLET_ADDRESS`. That env var is a **hand-maintained mirror** —
  signing is keyed on the separate `WALLET_ID` — and nothing re-derives it from the wallet. A
  stale mirror would read as a key rotation that never happened. This is the exact hazard the
  #1403 round-2 review guarded against by returning `None`; asking Circle removes the hazard
  rather than working around it.
- Every failure mode (unconfigured, non-200, no `address` in the payload, timeout, transport
  error, non-JSON body) returns `None`, and `get_wallet_address()` never raises — a raised
  exception would abort the whole reconciliation pass.

Anti-goals from the issue, both honoured: the Circle-path fallback on API failure still returns
`None` (guard-demoed below), and the raw-key path is not touched.

## Files touched

| File | Change |
| --- | --- |
| `backend/archimedes/chain/circle_signer.py` | `get_wallet_address()` + `_WALLET_LOOKUP_TIMEOUT` + `_wallet_address` cache slot |
| `backend/archimedes/chain/executor.py` | `backend_signer_address_confirmed()` → `async`, Circle branch delegates to the signer |
| `backend/archimedes/chain/agent_runner.py` | `await` the pre-check; comment block updated (it asserted the no-op as intended behaviour) |
| `backend/tests/chain/test_circle_signer.py` | new `TestGetWalletAddress` (13 cases) |
| `backend/tests/chain/test_executor_reads.py` | `TestBackendSignerAddressConfirmed` Circle cases rewritten + 2 new |
| `backend/tests/test_agent_runner_reveal_reconciliation.py` | `AsyncMock` for the now-async pre-check; Circle-path terminal + unconfirmable cases |

All tests are hermetic: the aiohttp boundary is mocked with the file's existing
`_mock_session` / `_session_context` / `_resp` idiom. No `.env`, no network, no DB, no Redis,
**no live Circle call**.

## Test evidence

### Touched test files

```
$ /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest \
    backend/tests/chain/test_circle_signer.py \
    backend/tests/chain/test_executor_reads.py \
    backend/tests/test_agent_runner_reveal_reconciliation.py -q

112 passed, 1 warning in 3.73s
```

### Hermetic gate (CLAUDE.md § Testing conventions)

```
$ env -i HOME="$HOME" PATH="$PATH" PYTHONPATH=backend \
    /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest \
    backend/tests/chain/test_circle_signer.py \
    backend/tests/chain/test_executor_reads.py \
    backend/tests/test_agent_runner_reveal_reconciliation.py -q

112 passed, 1 warning in 5.80s
```

### Full unit suite — the exact command CI runs, from the repo root

```
$ /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest -m "not integration" -q

4806 passed, 3 skipped, 2 deselected, 320 warnings in 509.42s (0:08:29)
```

### Lint

```
$ ruff format <6 touched files>   → 2 files reformatted, 4 files left unchanged
$ ruff check  <6 touched files>   → All checks passed!
```

No `docs/` changes in this PR, so no `make docs-check` / index row applies.

## Adversarial demonstrations

### 1. Revert demo — the mismatch regression test fails against pre-fix code

Reverted the executor's Circle branch to its pre-#1412 body:

```python
        if circle_signer.is_configured:
            return None  # REVERTED to pre-#1412 behaviour
```

```
$ pytest "backend/tests/test_agent_runner_reveal_reconciliation.py::TestSignerPreCheck::test_circle_path_key_rotation_goes_terminal_via_the_real_executor" -q

=================================== FAILURES ===================================
_ TestSignerPreCheck.test_circle_path_key_rotation_goes_terminal_via_the_real_executor _
backend/tests/test_agent_runner_reveal_reconciliation.py:726: in test_circle_path_key_rotation_goes_terminal_via_the_real_executor
    mock_tp.reveal.assert_not_awaited()  # zero gas burned on a doomed revert
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/lib/python3.12/unittest/mock.py:2429: in assert_not_awaited
    raise AssertionError(msg)
E   AssertionError: Expected reveal to not have been awaited. Awaited 1 times.
=========================== short test summary info ============================
FAILED backend/tests/test_agent_runner_reveal_reconciliation.py::TestSignerPreCheck::test_circle_path_key_rotation_goes_terminal_via_the_real_executor - AssertionError: Expected reveal to not have been awaited. Awaited 1 times.
========================= 1 failed, 1 warning in 4.57s =========================
```

That is precisely the shipped bug: pre-fix, `reveal()` is called anyway on a genuine key
rotation. Restored, and the test passes.

Worth noting *why* this test can fail: it wires the **real**
`ChainExecutor.backend_signer_address_confirmed` into the runner and mocks only the Circle
boundary underneath it, so it exercises executor → circle_signer → HTTP rather than restating the
runner's own `if` against a hand-set mock (CLAUDE.md rule 3: "a test that passes against the
unfixed code proves nothing").

### 2. Guard demo — the honest-`None` guard rejects a fail-soft substitution

Built the input that *should* be rejected: a `get_wallet_address()` that falls back to the
hand-maintained mirror when Circle can't answer.

```python
                    return os.getenv("WALLET_ADDRESS", "").strip() or None  # BAD: fail-soft guess
```

```
$ WALLET_ADDRESS=0xSTALEMIRROR000000000000000000000000000 pytest \
    "backend/tests/chain/test_circle_signer.py::TestGetWalletAddress::test_non_200_returns_none_and_is_not_cached" -q

    assert await configured.get_wallet_address() is None
E   AssertionError: assert '0xSTALEMIRROR000000000000000000000000000' is None
ERROR    archimedes.chain.circle_signer:circle_signer.py:130 Circle wallet address lookup failed for wallet wallet-uuid: HTTP 401
FAILED backend/tests/chain/test_circle_signer.py::TestGetWalletAddress::test_non_200_returns_none_and_is_not_cached - AssertionError: assert '0xSTALEMIRROR000000000000000000000000000' is None
========================= 1 failed, 1 warning in 2.65s =========================
```

The guard rejects it. `test_circle_path_lookup_failure_is_none_never_a_guess` (executor level)
and `test_circle_path_unconfirmable_still_never_terminals` (runner level) pin the same property
one and two layers up — each sets `WALLET_ADDRESS` deliberately so a fallback would be visible.

### 3. Guard demo — the bounded-timeout pin rejects an unbounded session

Dropped the timeout, leaving aiohttp's 5-minute default:

```python
                aiohttp.ClientSession() as session,  # BAD: unbounded (aiohttp default 5 min)
```

```
$ pytest "backend/tests/chain/test_circle_signer.py::TestGetWalletAddress::test_returns_the_address_circle_reports" -q

    timeout = mock_session_cls.call_args.kwargs["timeout"]
FAILED backend/tests/chain/test_circle_signer.py::TestGetWalletAddress::test_returns_the_address_circle_reports - KeyError: 'timeout'
========================= 1 failed, 1 warning in 1.72s =========================
```

Both injections were reverted; `git status` is clean of them and the 112 tests above were re-run
green afterwards.

## Not done here

- **Live-prod confirmation of the actual wallet address is an operator step**, run separately by
  the session owner. No live Circle call was made from this branch. Until someone reads the real
  `GET /wallets/{WALLET_ID}` response in prod, this PR claims only that *the plumbing is correct
  and honest under every mocked outcome* — not that the prod wallet's address matches any
  particular committer on chain. **Recommended operator check before/after merge:** confirm
  `GET /wallets/{WALLET_ID}` returns `data.wallet.address`, and confirm it equals the
  `WALLET_ADDRESS` currently in the runner env. If those two disagree, that is a real finding
  about prod state and should get its own issue — this PR will have surfaced it, not caused it.
- **`WALLET_ADDRESS` is not removed or deprecated.** `backend_signer_address()` (the defensive
  owner≠agent `==` check on the vault-creation path) still reads it, unchanged. Retiring the
  mirror entirely — now that its one safety-critical consumer no longer needs it — is a
  separate call and a separate PR.
- **No caching TTL / invalidation.** A Circle wallet's address is immutable for a given wallet
  ID, so a process-lifetime cache is correct; if `WALLET_ID` itself is ever rotated in the
  runner env, the process restarts anyway.
- **Not wired into any other confirmation surface** — `/health`, the contract census, and the
  Circle integration-status endpoint are untouched. One logical change.

Closes #1412
