### PR TITLE
[perf] Batch list_traces body reads with MGET instead of one Redis GET per trace

### DIFF
--- a/backend/archimedes/services/redis_state.py
+++ b/backend/archimedes/services/redis_state.py
@@ -37,6 +37,18 @@ KEY_TRACE_PREFIX = "archimedes:trace:"
 KEY_TRACE_INDEX = "archimedes:trace:index"
 KEY_SIWE_NONCE_PREFIX = "archimedes:auth:nonce:"
 
+# How many trace blobs ``list_traces`` fetches per MGET (#1577).
+#
+# The read it batches is deliberately unbounded at the index (the caller's
+# window is applied only after filtering, so the store cannot know how far to
+# read), which rules out a single MGET over everything: Redis executes MGET as
+# one blocking command on its single thread, so an index-sized key list would
+# turn one client's listing into a latency spike for every other client, and
+# the entire reply would land in this process at once. A fixed batch keeps
+# both the per-command cost and the peak buffer flat while still collapsing
+# the round-trip count from O(index) to O(index / 500).
+TRACE_MGET_BATCH = 500
+
 # Reveal-reconciliation durable index (#1353, hardening the #1276 pass).
 #
 # ``list_recent_traces(N)`` bounds its scan at the newest N entries of
@@ -657,25 +669,46 @@ class AgentStateStore:
         # Get all trace hashes sorted by timestamp (newest first)
         all_hashes = await r.zrevrange(KEY_TRACE_INDEX, 0, -1)
 
-        # Load and filter
+        # Load in MGET batches, then filter (#1577). This used to be one
+        # awaited GET per member of the WHOLE index — on a TLS ElastiCache
+        # connection that is one full round trip each, so a 2000-trace index
+        # cost 2001 round trips before the first row was filtered. Batching
+        # makes it ``1 + ceil(len(index) / TRACE_MGET_BATCH)``.
+        #
+        # Chunked rather than one MGET over the whole index because this read
+        # is deliberately unbounded (the window is applied AFTER filtering —
+        # see the docstring), so a single MGET would grow without limit: Redis
+        # is single-threaded and serves a 100k-key MGET as one blocking
+        # command that stalls every other client, and the whole reply would be
+        # materialised in this process at once. The batch bounds both.
         traces: list[dict] = []
-        for h in all_hashes:
-            raw = await r.get(f"{KEY_TRACE_PREFIX}{h}")
-            if not raw:
-                continue
-            data = _safe_json_loads(raw, context="trace:index")
-            if data is None:
-                continue
+        for start in range(0, len(all_hashes), TRACE_MGET_BATCH):
+            batch = all_hashes[start : start + TRACE_MGET_BATCH]
+            # MGET preserves request order, and the batches are walked in
+            # index order, so the newest-first ordering `zrevrange` returned
+            # survives unchanged.
+            raws = await r.mget([f"{KEY_TRACE_PREFIX}{h}" for h in batch])
+            for raw in raws:
+                # Same malformed-row tolerance as the per-key loop: a hash in
+                # the index whose blob is gone (`None`) and a blob that no
+                # longer parses are both skipped, never raised. MGET returns
+                # `None` in the slot of a missing key, which is exactly what
+                # the old `GET` returned for one.
+                if not raw:
+                    continue
+                data = _safe_json_loads(raw, context="trace:index")
+                if data is None:
+                    continue
 
-            # Apply filters
-            if vault_address and data.get("vault_address", "").lower() != vault_address.lower():
-                continue
-            if decision_type and data.get("decision_type") != decision_type:
-                continue
-            if strategy_id and not trace_references_strategy(data, strategy_id):
-                continue
+                # Apply filters
+                if vault_address and data.get("vault_address", "").lower() != vault_address.lower():
+                    continue
+                if decision_type and data.get("decision_type") != decision_type:
+                    continue
+                if strategy_id and not trace_references_strategy(data, strategy_id):
+                    continue
 
-            traces.append(data)
+                traces.append(data)
 
         total = len(traces)
         window = traces[offset : offset + limit]

--- a/backend/tests/services/test_redis_json_guard.py
+++ b/backend/tests/services/test_redis_json_guard.py
@@ -59,7 +59,13 @@ async def test_list_traces_skips_malformed_entry():
     store = AgentStateStore()
     store._redis = AsyncMock()
     store._redis.zrevrange = AsyncMock(return_value=["hash1"])
+    # Both read shapes are stubbed with the same corrupt body: `list_traces`
+    # batches with MGET (#1577), the single-key readers still use GET, and a
+    # bare AsyncMock would answer an unstubbed `mget` with an empty-iterating
+    # MagicMock — passing this test vacuously, without a malformed row ever
+    # reaching the guard.
     store._redis.get = AsyncMock(return_value="{corrupted")
+    store._redis.mget = AsyncMock(return_value=["{corrupted"])
     traces, total = await store.list_traces()
     assert traces == [] and total == 0  # skipped, not a 500
 

--- a/backend/tests/services/test_redis_state.py
+++ b/backend/tests/services/test_redis_state.py
@@ -27,9 +27,11 @@ from archimedes.services.redis_state import (
     KEY_REGIME,
     KEY_SIWE_NONCE_PREFIX,
     KEY_TRACE_INDEX,
+    KEY_TRACE_PREFIX,
     KEY_TRACE_RECONCILE_FIRST_SEEN,
     KEY_TRACE_RECONCILE_PENDING,
     KEY_TRACE_RECONCILE_TERMINAL,
+    TRACE_MGET_BATCH,
     AgentStateStore,
     is_dangling_reveal,
 )
@@ -39,6 +41,7 @@ def _fake_redis() -> MagicMock:
     """Build an AsyncMock-flavored Redis client."""
     r = MagicMock()
     r.get = AsyncMock(return_value=None)
+    r.mget = AsyncMock(return_value=[])
     r.set = AsyncMock()
     r.setex = AsyncMock()
     r.getdel = AsyncMock(return_value=None)
@@ -66,6 +69,33 @@ async def _store_with_fake_redis() -> tuple[AgentStateStore, MagicMock]:
     fake = _fake_redis()
     store._redis = fake  # bypass _get_redis lazy init
     return store, fake
+
+
+def _seed_trace_bodies(fake: MagicMock, bodies: dict[str, str]) -> None:
+    """Back BOTH ``get`` and ``mget`` with one key → raw-JSON map.
+
+    Faithful to the real client on the two points the read paths depend on:
+    ``MGET`` returns one slot per requested key, **in request order**, holding
+    ``None`` where the key is absent — the same value a ``GET`` on that key
+    would have returned.
+
+    Both methods are stubbed even though ``list_traces`` now only calls
+    ``mget``, per CLAUDE.md rule 5's corollary: a double that covers only the
+    branch under test silently drops a sibling's calls (``get_trace`` and
+    ``list_recent_traces`` still read one key at a time). It is also what lets
+    the round-trip regression test below fail on the *round-trip count* rather
+    than on a missing row, since the reverted per-key loop still resolves
+    every body correctly against this same map.
+    """
+
+    async def _get(key: str):
+        return bodies.get(key)
+
+    async def _mget(keys):
+        return [bodies.get(k) for k in keys]
+
+    fake.get = AsyncMock(side_effect=_get)
+    fake.mget = AsyncMock(side_effect=_mget)
 
 
 def _classification(regime: Regime = Regime.RISK_ON, confidence: float = 0.8) -> RegimeClassification:
@@ -317,10 +347,103 @@ class TestTraces:
             {"vault_address": "0xV", "decision_type": "skip"},
             {"vault_address": "0xOTHER", "decision_type": "rebalance"},
         ]
-        fake.get = AsyncMock(side_effect=[json.dumps(t) for t in traces])
+        _seed_trace_bodies(fake, {f"{KEY_TRACE_PREFIX}h{i + 1}": json.dumps(t) for i, t in enumerate(traces)})
         window, total = await store.list_traces(vault_address="0xV", decision_type="rebalance")
         assert total == 1
         assert window[0]["decision_type"] == "rebalance"
+
+    @pytest.mark.asyncio
+    async def test_list_traces_batches_body_reads_into_one_mget(self) -> None:
+        """#1577: the body reads are ONE batched round trip, not one per trace.
+
+        The pre-#1577 loop awaited a separate ``GET`` per member of the whole
+        index — on the TLS ElastiCache connection that is a full round trip
+        each, and the index is read unwindowed, so the cost scaled with all of
+        history rather than with the page.
+
+        The body map is shared by ``get`` and ``mget`` (see
+        ``_seed_trace_bodies``) precisely so the reverted implementation still
+        returns all 50 rows: the only thing that changes when the fix is
+        reverted is the round-trip count asserted here.
+        """
+        store, fake = await _store_with_fake_redis()
+        n = 50
+        fake.zrevrange.return_value = [f"h{i}" for i in range(n)]
+        _seed_trace_bodies(
+            fake,
+            {f"{KEY_TRACE_PREFIX}h{i}": json.dumps({"id": f"t{i}", "vault_address": "0xV"}) for i in range(n)},
+        )
+
+        window, total = await store.list_traces(limit=n)
+
+        # Every row really was read and parsed — the batching is not "cheap"
+        # because it quietly dropped work.
+        assert total == n
+        assert [t["id"] for t in window] == [f"t{i}" for i in range(n)]
+        # ONE batched call for 50 bodies, and zero single-key reads.
+        assert fake.mget.await_count == 1, "the body reads were not batched"
+        assert fake.get.await_count == 0, f"{fake.get.await_count} sequential GETs — one per trace is the bug"
+
+    @pytest.mark.asyncio
+    async def test_list_traces_mget_is_chunked_and_preserves_index_order(self) -> None:
+        """Batches are bounded at ``TRACE_MGET_BATCH`` and walked in order.
+
+        The chunking is why the claim is ``1 + ceil(N / TRACE_MGET_BATCH)``
+        round trips rather than exactly one: this read is unbounded at the
+        index, and a single index-sized MGET would block Redis' one thread for
+        every other client. Ordering is load-bearing — the newest-first
+        contract callers page against comes from ``zrevrange``, and it must
+        survive being cut into batches.
+        """
+        store, fake = await _store_with_fake_redis()
+        n = TRACE_MGET_BATCH * 2 + 7
+        fake.zrevrange.return_value = [f"h{i}" for i in range(n)]
+        _seed_trace_bodies(
+            fake,
+            {f"{KEY_TRACE_PREFIX}h{i}": json.dumps({"id": f"t{i}", "vault_address": "0xV"}) for i in range(n)},
+        )
+
+        window, total = await store.list_traces(limit=n)
+
+        assert total == n
+        assert [t["id"] for t in window] == [f"t{i}" for i in range(n)]  # newest-first order intact
+        assert fake.mget.await_count == 3  # ceil(1007 / 500), not 1007 and not 1
+        # No batch exceeds the bound.
+        assert all(len(call.args[0]) <= TRACE_MGET_BATCH for call in fake.mget.await_args_list)
+
+    @pytest.mark.asyncio
+    async def test_list_traces_empty_index_issues_no_body_read(self) -> None:
+        """An empty index must not send ``MGET`` with zero keys — real Redis
+        answers that with ``ERR wrong number of arguments``, which would turn
+        the quietest case (no traces yet) into a 500."""
+        store, fake = await _store_with_fake_redis()
+        fake.zrevrange.return_value = []
+
+        window, total = await store.list_traces()
+
+        assert (window, total) == ([], 0)
+        assert fake.mget.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_list_traces_tolerates_missing_and_malformed_rows(self) -> None:
+        """A hash whose blob is gone (``None`` in the MGET slot) and a blob
+        that no longer parses are both skipped, exactly as the per-key loop
+        skipped them — a corrupt row never breaks the listing."""
+        store, fake = await _store_with_fake_redis()
+        fake.zrevrange.return_value = ["h1", "h2", "h3"]
+        _seed_trace_bodies(
+            fake,
+            {
+                # h1 absent entirely → MGET returns None in its slot
+                f"{KEY_TRACE_PREFIX}h2": "{not json",
+                f"{KEY_TRACE_PREFIX}h3": json.dumps({"id": "t3", "vault_address": "0xV"}),
+            },
+        )
+
+        window, total = await store.list_traces()
+
+        assert [t["id"] for t in window] == ["t3"]
+        assert total == 1
 
     @pytest.mark.asyncio
     async def test_list_recent_traces_bounds_the_range_at_the_index(self) -> None:
@@ -350,7 +473,7 @@ class TestTraces:
     async def test_get_last_trace_returns_first(self) -> None:
         store, fake = await _store_with_fake_redis()
         fake.zrevrange.return_value = ["h1"]
-        fake.get = AsyncMock(side_effect=[json.dumps({"vault_address": "0xV", "id": "t1"})])
+        _seed_trace_bodies(fake, {f"{KEY_TRACE_PREFIX}h1": json.dumps({"vault_address": "0xV", "id": "t1"})})
         result = await store.get_last_trace("0xV")
         assert result["id"] == "t1"
 

--- a/backend/tests/test_traces_strategy_scope.py
+++ b/backend/tests/test_traces_strategy_scope.py
@@ -356,6 +356,12 @@ def _fake_redis(traces: list[dict]):
         async def get(self, key):
             return bodies.get(key)
 
+        async def mget(self, keys):
+            # `list_traces` batches the body reads (#1577). Mirrors the real
+            # contract: one slot per requested key, in request order, `None`
+            # where the key is absent. `get` stays for the single-key readers.
+            return [bodies.get(k) for k in keys]
+
     return _R()
 
 


### PR DESCRIPTION
## What

`AgentStateStore.list_traces` loaded trace bodies with **one awaited Redis `GET` per member of the whole index**. It now reads them in `MGET` batches of `TRACE_MGET_BATCH` (500).

Round trips go from `1 + N` to `1 + ceil(N / 500)`. At the documented `MAX_TRACE_SCAN = 2000` the route passes, that is **5 round trips instead of 2001**.

## Why

Found while fixing #1573 (PR #1576). The index read is `zrevrange(KEY_TRACE_INDEX, 0, -1)` — deliberately unwindowed, because the caller's `offset`/`limit` is applied *after* filtering (windowing first would return short pages whose length leaks how many of somebody else's traces were skipped, #1556). So the per-trace `GET` loop scaled with **all of history**, not with the page, and on the TLS ElastiCache connection each `GET` is a full round trip.

`list_recent_traces` got an index-level bound in #1276; `list_traces` never did.

### Why chunked, and not one `MGET` over the whole index

The issue's acceptance wording is "O(1) Redis round trips". I did not ship a literal single call, and the honest number is `1 + ceil(N/500)`. Reason: this read has **no index bound**, and Redis executes `MGET` as one blocking command on its single thread — an index-sized key list would turn one client's listing into a latency spike for every other client, and the entire reply would be materialised in this process at once. The fixed batch keeps both the per-command cost and the peak buffer flat while still removing ~99.8% of the round trips. Both properties are pinned by tests below.

## Preserved exactly

- Newest-first `zrevrange` ordering (`MGET` returns request order; batches are walked in index order).
- `vault_address` / `decision_type` / `strategy_id`-via-`trace_references_strategy` filters, all still applied **before** windowing, so `total` still counts the filtered universe.
- `offset`/`limit` windowing after filtering.
- Malformed-row tolerance: `MGET` returns `None` in the slot of a missing key — exactly what `GET` returned for one — so a hash whose blob is gone and a blob that no longer parses are both skipped, never raised.
- The `list_traces` **signature is unchanged**, so the `_assert_mirrors` precedent in `test_trace_owner_cache.py` stays green (verified below).

## Test commands + tail output

Touched files plus the security-sensitive trace surface the issue names — **all pass unchanged, none weakened**:

```
$ pytest backend/tests/services/test_redis_state.py \
         backend/tests/services/test_redis_json_guard.py \
         backend/tests/test_traces_strategy_scope.py -q
======================= 105 passed, 19 warnings in 8.75s =======================

$ pytest backend/tests/services/test_trace_owner_cache.py \
         backend/tests/api/test_traces_ownership_gate.py \
         backend/tests/services/test_trace_ownership_stamp.py \
         backend/tests/test_paper_trace_pipeline.py \
         backend/tests/test_api_routes.py \
         backend/tests/api/test_traces_routes.py \
         backend/tests/test_traces_display_anchored_only.py -q -p no:randomly
SKIPPED [1] backend/tests/test_paper_trace_pipeline.py:411: trace_references_strategy lands with #1569 (dbrowneup/user-reachable-traces)
================= 119 passed, 1 skipped, 3 warnings in 15.45s ==================
```

That one skip is pre-existing on `origin/main` and is in a file this PR does not touch.

Full CI-shaped suite from the repo root:

```
$ pytest -m "not integration" -q
=== 4794 passed, 3 skipped, 2 deselected, 320 warnings in 555.87s (0:09:15) ====
```

Hermetic gate on the touched unit file:

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/services/test_redis_state.py -q
======================== 66 passed, 1 warning in 2.03s =========================
```

Lint on touched files:

```
$ ruff format <4 touched files> && ruff check <4 touched files>
4 files left unchanged
All checks passed!
```

## Revert demo (CLAUDE.md rule 3) — the regression test FAILS on the unfixed code

The fix was reverted in place to the pre-#1577 sequential-`GET` loop (`TRACE_MGET_BATCH` left defined, so the failure is the round-trip claim and not an `ImportError`), and the file re-run verbatim:

```
$ pytest backend/tests/services/test_redis_state.py -q -p no:randomly -k list_traces
=================================== FAILURES ===================================
    assert fake.mget.await_count == 1, "the body reads were not batched"
E   AssertionError: the body reads were not batched
E   assert 0 == 1
    assert fake.mget.await_count == 3  # ceil(1007 / 500), not 1007 and not 1
E   AssertionError: assert 0 == 3
FAILED backend/tests/services/test_redis_state.py::TestTraces::test_list_traces_batches_body_reads_into_one_mget - AssertionError: the body reads were not batched
FAILED backend/tests/services/test_redis_state.py::TestTraces::test_list_traces_mget_is_chunked_and_preserves_index_order - AssertionError: assert 0 == 3

$ pytest backend/tests/services/test_redis_state.py -q -p no:randomly   # whole file, still reverted
=================== 2 failed, 64 passed, 1 warning in 2.49s ====================
```

**Exactly the two round-trip tests fail and nothing else.** That is deliberate: `_seed_trace_bodies` backs *both* `get` and `mget` from one key→body map, so the reverted per-key loop still returns all 50 rows correctly. The guard therefore fails on the round-trip count itself, not on a missing row — the trap CLAUDE.md rule 3 describes (a test that would have passed either way, or failed for the wrong reason) does not apply here.

After restoring the fix: `66 passed`.

## Adversarial demo (CLAUDE.md rule 4) — the guard is shown to reject bad input

The guard this change introduces is the batching contract. A **strict** fake was written that rejects what a real Redis server rejects (zero-key `MGET` → `ERR wrong number of arguments`; over-bound `MGET` → refused), the **shipped** `list_traces` was run against it unmodified, and deliberately-broken reimplementations were run against the same fake:

```
== (a) EMPTY INDEX — a zero-key MGET is an ERR on a real server ==
  ACCEPTED : SHIPPED list_traces over an empty index -> ([], 0), 0 MGETs
  REJECTED : unguarded 'MGET everything' over an empty index
             -> ERR wrong number of arguments for 'mget' command

== (b) 1007-TRACE INDEX — batch bound is 500 ==
  ACCEPTED : SHIPPED list_traces -> total=1007, MGET sizes=[500, 500, 7], order_ok=True
  REJECTED : single MGET over the whole index
             -> REJECTED: MGET with 1007 keys exceeds the 500 batch bound

== (c) ORDERING — batches walked backwards ==
  batch-reversed impl first 3 ids: ['t1000', 't1001', 't1002'] (expected ['t0', 't1', 't2'])
  -> newest-first ordering LOST: True
  (the shipped impl's order_ok=True above is what the ordering assertion pins)
```

All three bite. (a) is why `test_list_traces_empty_index_issues_no_body_read` exists — an unguarded `MGET` would turn the quietest case, no traces yet, into a 500. (b) and (c) are pinned by `test_list_traces_mget_is_chunked_and_preserves_index_order`.

## Test-double hygiene (CLAUDE.md rule 5 corollary)

Three Redis doubles feed the real `list_traces` and needed `mget` on their surface. In **all three**, `get` is kept alongside `mget` rather than replaced — a double that covers only the branch under test silently drops a sibling's calls, and `get_trace` / `list_recent_traces` still read one key at a time:

- `backend/tests/services/test_redis_state.py` — `_fake_redis()` gains `mget`; new `_seed_trace_bodies()` backs both methods from one map, mirroring the real contract (one slot per requested key, in request order, `None` where absent).
- `backend/tests/services/test_redis_json_guard.py` — `test_list_traces_skips_malformed_entry` now stubs `mget` explicitly. **This one mattered:** `store._redis` is a bare `AsyncMock`, whose unstubbed `mget` would have returned an empty-iterating `MagicMock`. The test would have stayed green while no malformed row ever reached the guard — a vacuous pass, exactly the "signal trusted for something it does not measure" shape.
- `backend/tests/test_traces_strategy_scope.py` — the hand-rolled `_R` double gains `mget`.

No fake store's `list_traces` signature changed, because the real one didn't.

## Not done here (honest scope list)

- **The index read is still unbounded.** The issue also asks to bound the `zrevrange` at `MAX_TRACE_SCAN` (the #1276 pattern). I deliberately did not, and it is the larger open question: `MAX_TRACE_SCAN` lives in `trace_visibility`, not the store, and capping the store's read would silently cap `total` for every caller — a paginator that under-reports its universe is the failure mode #1356 was filed about. It is a semantics change with an owner decision in it, not a mechanical follow-on to this batching fix. **It is also no longer the round-trip problem:** `zrevrange` is one round trip whatever the index size, so what remains unbounded after this PR is parse cost and peak memory, not latency-per-round-trip. Worth a follow-up issue; say the word and I will file it.
- **No live re-measurement.** The issue asks to re-measure `GET /api/traces/` after #1576 deploys to attribute the 21.2s split. That needs prod and is not in this PR; the numbers above are round-trip counts from tests, not wall-clock from the live system. I have not claimed a latency figure.
- `list_dangling_reveal_traces` has the same one-`GET`-per-member shape and its own `SSCAN` + `MGET` follow-up already noted in its docstring. Left alone — different call site, different bound question, out of scope for one logical change.
- `TRACE_MGET_BATCH = 500` is a judgement call, not a measured optimum. Nothing was benchmarked to choose it.

Closes #1577
