### PR TITLE
[api] rename_strategy: decide ownership with owns_strategy, not a re-derived copy

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -1722,9 +1722,22 @@ async def rename_strategy(
     display name. The strategy_passports table carries no display-name column,
     so only strategy_store is updated.
 
+    Ownership is decided by ``owns_strategy`` — the single implementation of
+    the two-tier rule (#1557), the same predicate every sibling reader on this
+    router calls. It is NOT re-derived here (#1283): the tiers are (1) a row
+    carrying an ``owner_user_id`` is owned by that account and by nobody else,
+    so a matching ``owner_wallet`` grants nothing, and (2) only a row with NO
+    user stamp falls back to the wallet comparison. Re-implementing that
+    ordering inline is how a mutating route drifts out of agreement with the
+    readers that gate the same row — an authorization bug, not an
+    inconsistency.
+
     Legacy-wallet fallback (#1283): a pre-account row (``owner_user_id`` NULL)
-    matched via the caller's linked wallet is reclaimed onto canonical account
-    ownership in the same transaction as the rename, using the same bulk claim
+    matched via the caller's linked wallet — i.e. tier 2 is what granted
+    ownership, which is exactly ``owns_strategy() and owner_user_id is None``
+    because tier 2 is unreachable when a user stamp exists — is reclaimed onto
+    canonical account ownership in the same transaction as the rename, using
+    the same bulk claim
     (``claim_legacy_wallet_data``) a verified wallet link performs — but
     scoped to the strategy-side tables only (``StrategyRecord`` /
     ``StrategyPassportRecord`` / ``StrategyProposal``), with
@@ -1754,6 +1767,7 @@ async def rename_strategy(
     from archimedes.models.strategy_passport_record import StrategyPassportRecord
     from archimedes.models.strategy_proposal import StrategyProposal
     from archimedes.models.strategy_store import StrategyRecord
+    from archimedes.services.strategy_visibility import owns_strategy
 
     name = payload.get("name")
     if not isinstance(name, str):
@@ -1768,17 +1782,31 @@ async def rename_strategy(
             # Curated examples are not user-owned — same 404 as a missing row.
             raise HTTPException(status_code=404, detail="Strategy not found")
         caller = get_linked_wallet_address(request)
-        is_owner = row.owner_user_id == user.id
-        if not is_owner and row.owner_user_id is None and row.owner_wallet and caller == row.owner_wallet.lower():
-            # Proven via linked-wallet match on a still-unclaimed row: reclaim
-            # every pre-account STRATEGY row tied to this wallet (not just
-            # this one), matching what re-verifying the wallet link would do
-            # for those tables. vault_metadata/user_profiles are excluded —
-            # see the docstring above.
+        # The canonical two-tier match, asked once, from the one place it is
+        # implemented. `owns_strategy` consults `owner_wallet` ONLY when
+        # `owner_user_id` is NULL, so a row stamped with another account's id
+        # is not renamable by whoever happens to control the wallet it names.
+        is_owner = owns_strategy(row, caller, caller_user_id=user.id)
+        if is_owner and row.owner_user_id is None:
+            # Tier 2 is the only tier that can have granted this (tier 1
+            # requires a non-NULL stamp), so the caller is proven via a
+            # linked-wallet match on a still-unclaimed row: reclaim every
+            # pre-account STRATEGY row tied to this wallet (not just this
+            # one), matching what re-verifying the wallet link would do for
+            # those tables. vault_metadata/user_profiles are excluded — see
+            # the docstring above.
+            #
+            # `claim_legacy_wallet_data` filters on an EXACT `owner_wallet ==
+            # address` match, so it is handed the same normalized form
+            # `owns_strategy` compared on. Linked wallets are stored
+            # lower-cased (`issue_wallet_challenge`), so this is not a
+            # live casing fix — it keeps the bulk claim's reach identical to
+            # the reach of the check that authorized it, rather than relying
+            # on the two agreeing by convention.
             claim_legacy_wallet_data(
                 session,
                 user.id,
-                caller,
+                str(caller).strip().lower(),
                 models=(
                     (StrategyRecord, StrategyRecord.owner_wallet),
                     (StrategyPassportRecord, StrategyPassportRecord.owner_wallet),
@@ -1787,7 +1815,6 @@ async def rename_strategy(
                 include_profile=False,
             )
             row.owner_user_id = user.id
-            is_owner = True
         if not is_owner:
             # Hide unpublished rows from non-owners (404); published rows are
             # visible, so an honest 403 is returned instead.

--- a/backend/tests/test_strategy_ownership.py
+++ b/backend/tests/test_strategy_ownership.py
@@ -7,7 +7,10 @@ Hermetic (tmp-sqlite, no .env / network / Redis). Covers:
   * /api/strategies/generated visibility: anon sees only published; owner also
     sees their own unpublished rows
   * GET /api/strategies/{id}: unpublished non-example rows 404 for non-owners
-  * PATCH /api/strategies/{id}: owner-gated rename, non-example rows only
+  * PATCH /api/strategies/{id}: owner-gated rename, non-example rows only —
+    both ownership tiers (canonical owner_user_id; legacy owner_wallet only on
+    an unstamped row, which self-heals onto the account) and the deny matrix,
+    including the canonical-bypass case a wallet-first ordering would open
   * scripts/purge_orphan_generated.py: dry-run (default) vs --execute
 
 DB fixture copies the `_use_tmp_db` pattern from test_live_gate_returns.py.
@@ -591,6 +594,123 @@ async def test_rename_legacy_wallet_fallback_does_not_touch_vault_metadata_or_pr
 
         profile = session.query(UserProfile).filter_by(wallet_address=_W_OWNER.lower()).first()
         assert profile.owner_user_id is None  # untouched — no PII adoption on a non-fresh-signature lookup
+
+
+async def test_rename_canonical_owner_tier_needs_no_wallet_match():
+    """TIER 1 (#1283). A row already stamped with the caller's canonical
+    ``owner_user_id`` is renamable on that stamp ALONE — the wallet on the row
+    is a stranger's and the caller's linked wallet does not match it.
+
+    Every pre-existing rename test builds rows with ``owner_user_id`` NULL, so
+    they all travel the legacy-wallet fallback; nothing covered the canonical
+    tier this issue migrates onto. It also pins the no-op half of the reclaim:
+    an already-claimed row must not be re-stamped or dragged onto the caller's
+    wallet."""
+    sid = "can00000000000001"
+    _mk_strategy(
+        sid,
+        owner=_W_OTHER,  # someone else's wallet on the row
+        owner_user=f"legacy-test:{_W_OWNER.lower()}",  # but MY account owns it
+        published=False,
+        name="Before",
+    )
+
+    from archimedes.main import app
+    from archimedes.models.strategy_store import StrategyRecord
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.patch(f"/api/strategies/{sid}", json={"name": "After"}, cookies=_siwe_cookies(_W_OWNER))
+    assert resp.status_code == 200
+
+    with db.get_session() as session:
+        row = session.query(StrategyRecord).filter_by(id=sid).first()
+        assert row.strategy_name == "After"
+        assert row.owner_user_id == f"legacy-test:{_W_OWNER.lower()}"  # unchanged
+        assert row.owner_wallet == _W_OTHER.lower()  # the reclaim did NOT re-point provenance
+
+
+async def test_rename_matching_wallet_cannot_hijack_row_stamped_to_another_account():
+    """THE canonical-bypass guard (#1283). The row carries ANOTHER account's
+    ``owner_user_id`` and, at the same time, the caller's own linked wallet in
+    ``owner_wallet`` — the exact row shape a wallet-first ordering would hand
+    over. Tier 2 must be unreachable whenever a user stamp exists, or migrating
+    to canonical identity is a security downgrade: anyone controlling a wallet
+    a row happens to name could rename an account-owned strategy.
+
+    Asserted on the wire (403/404) AND in the database, so the test cannot be
+    satisfied by the request merely erroring for some unrelated reason.
+    """
+    victim_user_id = f"legacy-test:{_W_OTHER.lower()}"
+    private_sid = "byp00000000000001"
+    published_sid = "byp00000000000002"
+    # owner_wallet is the ATTACKER's wallet; owner_user_id is the VICTIM's account.
+    _mk_strategy(private_sid, owner=_W_OWNER, owner_user=victim_user_id, published=False, name="Before")
+    _mk_strategy(published_sid, owner=_W_OWNER, owner_user=victim_user_id, published=True, name="Before")
+
+    from archimedes.main import app
+    from archimedes.models.strategy_store import StrategyRecord
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        private = await client.patch(
+            f"/api/strategies/{private_sid}", json={"name": "Hijacked"}, cookies=_siwe_cookies(_W_OWNER)
+        )
+        published = await client.patch(
+            f"/api/strategies/{published_sid}", json={"name": "Hijacked"}, cookies=_siwe_cookies(_W_OWNER)
+        )
+    assert private.status_code == 404  # existence stays hidden for unpublished rows
+    assert published.status_code == 403  # already visible, so an honest refusal
+
+    with db.get_session() as session:
+        for sid in (private_sid, published_sid):
+            row = session.query(StrategyRecord).filter_by(id=sid).first()
+            assert row.strategy_name == "Before"  # no write landed
+            assert row.owner_user_id == victim_user_id  # ownership not reassigned
+
+
+async def test_rename_denied_for_wrong_user_wrong_wallet_and_anonymous():
+    """The deny matrix on ONE row, so a permissive change cannot pass by
+    flipping only the case a narrower test looks at.
+
+    * anonymous              -> 401 (no session at all)
+    * wrong account          -> 404 (row stamped to me, caller is another user)
+    * wrong wallet, no stamp -> 404 (legacy row, caller's wallet isn't its wallet)
+
+    Each case is re-read from the DB: a 4xx that still wrote the name would be
+    the worst possible outcome and the status code alone would hide it."""
+    stamped_sid = "dny00000000000001"
+    legacy_sid = "dny00000000000002"
+    _mk_strategy(stamped_sid, owner=None, owner_user=f"legacy-test:{_W_OWNER.lower()}", published=False, name="Before")
+    _mk_strategy(legacy_sid, owner=_W_OWNER, published=False, name="Before")  # owner_user_id NULL
+
+    from archimedes.main import app
+    from archimedes.models.strategy_store import StrategyRecord
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        anon = await client.patch(f"/api/strategies/{stamped_sid}", json={"name": "After"})
+        wrong_user = await client.patch(
+            f"/api/strategies/{stamped_sid}", json={"name": "After"}, cookies=_siwe_cookies(_W_OTHER)
+        )
+        wrong_wallet = await client.patch(
+            f"/api/strategies/{legacy_sid}", json={"name": "After"}, cookies=_siwe_cookies(_W_OTHER)
+        )
+        # Positive control: the SAME rows rename fine for the real owner, so
+        # the three refusals above are the gate, not a broken route.
+        owner_stamped = await client.patch(
+            f"/api/strategies/{stamped_sid}", json={"name": "Renamed"}, cookies=_siwe_cookies(_W_OWNER)
+        )
+        owner_legacy = await client.patch(
+            f"/api/strategies/{legacy_sid}", json={"name": "Renamed"}, cookies=_siwe_cookies(_W_OWNER)
+        )
+
+    assert anon.status_code == 401
+    assert wrong_user.status_code == 404
+    assert wrong_wallet.status_code == 404
+    assert owner_stamped.status_code == 200  # tier 1
+    assert owner_legacy.status_code == 200  # tier 2
+
+    with db.get_session() as session:
+        for sid in (stamped_sid, legacy_sid):
+            assert session.query(StrategyRecord).filter_by(id=sid).first().strategy_name == "Renamed"
 
 
 async def test_rename_published_non_owner_403():


### PR DESCRIPTION
## What

`rename_strategy` now asks **`owns_strategy`** — the single implementation of the
two-tier ownership rule — instead of re-deriving that rule inline. The legacy-wallet
fallback and its self-healing reclaim are unchanged in effect; only the *decision* moves
to the canonical predicate. Adds the rename-path test coverage that did not exist.

```diff
-        is_owner = row.owner_user_id == user.id
-        if not is_owner and row.owner_user_id is None and row.owner_wallet and caller == row.owner_wallet.lower():
+        is_owner = owns_strategy(row, caller, caller_user_id=user.id)
+        if is_owner and row.owner_user_id is None:
```

## Why

`owns_strategy`'s docstring says it is *the* single implementation and that the rule must
never be re-implemented at a call site — "an ownership rule that disagrees with itself
across two routes is an authorization bug, not an inconsistency." `rename_strategy` was
the remaining re-implementation, and per this issue it is **the one mutating call site on
the relaxed `get_linked_wallet_address` lookup**, so a drifted copy there is a write
authorization bug rather than a read leak.

Two things follow:

* **The reclaim trigger is now derived, not restated.** `owns_strategy` reaches the wallet
  tier only when `owner_user_id` is NULL, so "tier 2 is what granted this" is exactly
  `is_owner and row.owner_user_id is None`. There is no second place where the tier
  ordering is written down and can drift.
* **The bulk claim gets the address the check compared on.** `claim_legacy_wallet_data`
  filters on an exact `owner_wallet == address` match. The old inline condition guaranteed
  a lowercase `caller` as a side effect of its comparison; the delegated predicate
  normalizes internally, so `caller` is now explicitly normalized at the call. **This is
  not a live casing fix** — `LinkedWallet.address` is written lower-cased in
  `issue_wallet_challenge` (`address = payload.address.lower()`, `wallet_routes.py:153`),
  so no production caller is mixed-case. It keeps the claim's reach tied to the reach of
  the check that authorized it rather than to a convention holding two files apart.

**No behaviour change for well-formed data.** Both tiers, the reclaim, the sibling-row
bulk claim, and the `vault_metadata`/`user_profiles` exclusions all keep their existing
semantics; the four pre-existing `test_rename_*` tests pass unmodified.

## Files touched

* `backend/archimedes/api/strategies_routes.py` — `rename_strategy` only (decision +
  docstring)
* `backend/tests/test_strategy_ownership.py` — three new tests + module docstring row

## Tests

Hermetic (tmp-sqlite via `_use_tmp_db`, no `.env`, no network, no Redis/Postgres). Auth
goes through the repo's real signed-cookie fixture (`_siwe_cookies` → the autouse
`_legacy_siwe_test_adapter` in `conftest.py`), not header spoofing.

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_strategy_ownership.py -q
29 passed, 33 warnings in 13.39s
```

Neighbouring ownership/visibility suites (the other `owns_strategy` consumers):

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
    backend/tests/test_strategy_ownership.py backend/tests/test_reasoning_disclosure_gates.py \
    backend/tests/test_brief_on_passport.py backend/tests/test_generate_job_status.py \
    backend/tests/test_user_routes.py -q
87 passed, 79 warnings in 9.52s
```

The exact CI command, from the repo root (CLAUDE.md rule 2):

```
$ python -m pytest -m "not integration" --tb=short -q
FAILED backend/tests/test_health_always_answers.py::TestStalenessFieldsAppearExactlyWhenAProbeTimedOut::test_a_timed_out_probe_serves_the_last_known_value_with_its_age - assert 2.450675208121538 < 2.0
= 1 failed, 4792 passed, 3 skipped, 2 deselected, 327 warnings in 509.44s (0:08:29) =
```

**That failure is a pre-existing wall-clock flake on this machine, not this diff** — and I
checked rather than assumed. It asserts `/health` latency against hard second budgets
(`assert 2.45 < 2.0`). Re-running that file alone while the box was still loaded failed a
*different* pair of tests (`..._chain_client_hangs_forever` at 3.65s,
`..._both_are_dark` at 2.86s); re-running it on an idle box passed 17/17 on **this
branch's** content, and passed 17/17 with both touched files reverted to `origin/main`.
Different tests failing across runs of identical code is the flake signature. This diff
touches only `rename_strategy` and one test file; nothing it changes is reachable from
`/health`.

Lint (the blocking `ruff-gate` job, ruff 0.15.13 matching CI's pin):

```
$ ruff format --check backend/archimedes/api/strategies_routes.py backend/tests/test_strategy_ownership.py
2 files already formatted
$ ruff check --select E9,F63,F7,F40,F82 backend/archimedes/api/strategies_routes.py backend/tests/test_strategy_ownership.py
All checks passed!
```

A full `ruff check` also reports one `SIM105` in `strategies_routes.py:1131` — verified
present unchanged on `origin/main` (checked by ruff-ing `git show
origin/main:backend/archimedes/api/strategies_routes.py`), informational-only in
`lint-report`, and outside this change. Not touched.

## Adversarial demo — the guard rejects the input built to break it

The input that *should* be refused: a caller whose linked wallet **matches**
`owner_wallet`, on a row stamped with **another account's** `owner_user_id`. That is the
exact row shape a wallet-first ordering hands over. Built it, ran it, it is refused —
asserted on the wire *and* in the database, so a 4xx that still wrote the name cannot pass:

```python
victim_user_id = f"legacy-test:{_W_OTHER.lower()}"
# owner_wallet is the ATTACKER's wallet; owner_user_id is the VICTIM's account.
_mk_strategy(private_sid,   owner=_W_OWNER, owner_user=victim_user_id, published=False, name="Before")
_mk_strategy(published_sid, owner=_W_OWNER, owner_user=victim_user_id, published=True,  name="Before")
...
assert private.status_code == 404     # existence stays hidden for unpublished rows
assert published.status_code == 403   # already visible, so an honest refusal
for sid in (private_sid, published_sid):
    row = session.query(StrategyRecord).filter_by(id=sid).first()
    assert row.strategy_name == "Before"          # no write landed
    assert row.owner_user_id == victim_user_id    # ownership not reassigned
```

The deny-matrix test carries a **positive control** — the same two rows rename fine
(`200`) for their real owner in the same request block — so the three refusals are the
gate, not a route that is simply broken.

## Revert demo — the regression test fails with the fix reverted

Reverted the tier ordering at the call site (wallet consulted first) and re-ran. Verbatim:

```python
        # REVERT-DEMO ONLY: tiers swapped (wallet consulted first).
        is_owner = bool(caller) and bool(row.owner_wallet) and caller == str(row.owner_wallet).strip().lower()
        if not is_owner:
            is_owner = owns_strategy(row, caller, caller_user_id=user.id)
```

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_strategy_ownership.py -q -k "rename"
collected 29 items / 20 deselected / 9 selected

backend/tests/test_strategy_ownership.py .....F...                       [100%]

=================================== FAILURES ===================================
___ test_rename_matching_wallet_cannot_hijack_row_stamped_to_another_account ___
backend/tests/test_strategy_ownership.py:660: in test_rename_matching_wallet_cannot_hijack_row_stamped_to_another_account
    assert private.status_code == 404  # existence stays hidden for unpublished rows
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   assert 200 == 404
E    +  where 200 = <Response [200 OK]>.status_code
=========== 1 failed, 8 passed, 20 deselected, 18 warnings in 4.80s ============
```

Two things this establishes, beyond "the test fails":

1. **`200` is the hijack.** The attacker's rename of a row owned by another account
   *succeeded* under the reverted ordering.
2. **`8 passed` is the point.** Every other rename test — including all four pre-existing
   ones and the two other new ones — stays green with the ordering reverted. The old suite
   did not guard this case at all; only the new test does.

Restored, re-ran, `9 passed` (`-k rename`) / `29 passed` (whole file).

## Not done here

* **Deleting the legacy-wallet branch.** That is the issue's other half and it is gated on
  a *data* condition, not a code one: zero rows with `owner_user_id IS NULL AND
  owner_wallet IS NOT NULL` across `strategy_store` / `strategy_passports` /
  `strategy_proposals` / `vault_metadata`, plus a decision on rows whose wallet was never
  linked to any account (those cannot self-heal via a rename or a link). Needs prod DB
  access I do not have. Per @onder-akkaya's 2026-08-28 check and @dbrowneup's 2026-08-30
  refresh, **#1283 should stay open on that residual** — this PR does not close it.
* **The `owner_user_id is not None` vs truthiness divergence.** `owns_strategy` gates tier
  1 on `is not None`; `trace_visibility.is_trace_visible` gates it on truthiness. They
  differ for the empty string, which nothing writes today. Out of scope for a one-logical-change
  PR; flag it if you want it unified.
* **No prod row-count query, no migration, no backfill.** Metadata-decision path only.
* **`vault_metadata` / `user_profiles` reclaim** stays behind the signature-verified
  wallet-link flow, unchanged and still asserted by
  `test_rename_legacy_wallet_fallback_does_not_touch_vault_metadata_or_profile`.

---

Refs #1283 — **deliberately not `Closes #1283`.** This PR lands the code half only. Both
maintainers on the thread ruled that the issue's own stated deliverable (deleting the
legacy path) is gated on a prod row-count check, so an auto-closing keyword here would
close the issue on a deliverable that has not been met. Close it by hand once that
verification and the never-linked-wallet decision are done.
