### PR TITLE
[infra][ci] Add a path-filtered terraform fmt-check + validate gate — nothing in CI parsed a .tf file

### DIFF
--- a/.github/workflows/infra-gate.yml
+++ b/.github/workflows/infra-gate.yml
@@ -1,0 +1,124 @@
+# Infra gate — the first thing in CI that actually parses a `.tf` file (issue #1483).
+#
+# Before this workflow, `grep -rn "terraform" .github/workflows/*.yml` returned
+# exactly one hit and it was a warning *string* inside deploy.yml, not a step.
+# The one infra-named job — quality-gate.yml's "Infra — user-data size guard" —
+# is a byte-count on `infra/user-data.sh`; it never opens a `.tf` file, yet it is
+# the row a reviewer watches go green on an `infra/**` PR. That is the
+# "a signal was trusted for something it does not actually measure" shape from
+# CLAUDE.md § the green check may not mean what you think.
+#
+# `infra/ecs.tf` is where the money switches live (PAYMENTS_DRY_RUN,
+# GENERATION_PAYMENTS_DRY_RUN, GENERATION_PAYMENT_REQUIRED, GENERATION_PRICE_USD,
+# the daily generation caps). Until now a typo there surfaced for the first time
+# at `terraform apply`, which is also the prod deploy path.
+#
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ DO NOT MARK THIS A REQUIRED STATUS CHECK.                               │
+# │                                                                         │
+# │ This workflow is path-filtered. A required check that is path-filtered  │
+# │ never reports on a PR that misses the filter, and GitHub treats "never  │
+# │ reported" as "pending" forever — every non-infra PR is blocked and      │
+# │ cannot be merged without an admin override. If you want this required,  │
+# │ you must first add an always-running fallback job (no `paths:` filter)  │
+# │ that reports the same check name and passes trivially when the PR       │
+# │ touches no infra. Until that job exists, keep this advisory.            │
+# │                                                                         │
+# │ Same trap boxed at the top of docs-gate.yml and spelled out in          │
+# │ scripts/setup-branch-protection.sh (INCLUDE_CONTRACTS_CHECK). Do not    │
+# │ add "Infra — terraform fmt + validate (...)" to that script's CONTEXTS. │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# WHY fmt + validate AND NOT plan (issue #1483 anti-goals)
+#   `plan` needs AWS credentials and reads remote state. Per CLAUDE.md § git
+#   safety the state backend is a secrets store — the `tls_private_key` resource
+#   puts a private key into state. Granting CI read access to that in order to
+#   catch syntax errors is a bad trade. `validate` is the right depth:
+#     - `fmt -check` needs no init and no network beyond the toolchain.
+#     - `init -backend=false` + `validate` need no AWS credentials and never
+#       contact the S3 backend at infra/main.tf:7-13. They resolve the provider
+#       schemas and type-check the configuration, nothing more.
+#   Verified locally with a scrubbed environment (`env -i`, no AWS_* at all):
+#   both roots return "Success! The configuration is valid." — see PR #1483.
+#
+# TWO TERRAFORM ROOTS, not one. `git ls-files '*.tf'` finds 20 files under
+# `infra/` and one under `company-site/infra/` (a deliberately standalone stack:
+# its own state key, aws provider ~> 6.0 vs the product root's ~> 5.0). They
+# cannot share a `.terraform/` directory, so they are a matrix rather than one
+# job. Covering only `infra/` would leave the workflow's own name a half-truth.
+
+name: infra-gate
+
+on:
+  pull_request:
+    paths:
+      - "infra/**"
+      - "company-site/infra/**"
+      - ".github/workflows/infra-gate.yml"
+
+# Mirrors docs-gate.yml: two runs racing on successive pushes to one branch are
+# wasted minutes, and the later-finishing run may describe the older commit.
+concurrency:
+  group: infra-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege GITHUB_TOKEN — this workflow only reads the repo. Same
+# rationale as contracts-test.yml: satisfies CodeQL
+# actions/missing-workflow-permissions and bounds blast radius if the
+# third-party action below is ever compromised.
+permissions:
+  contents: read
+
+env:
+  # Suppresses terraform's interactive "you may now run plan" epilogue, which is
+  # noise in a log nobody reads until it is red.
+  TF_IN_AUTOMATION: "1"
+
+jobs:
+  infra-gate:
+    name: Infra — terraform fmt + validate (${{ matrix.dir }})
+    runs-on: ubuntu-latest
+    strategy:
+      # Both roots always report, so one broken root cannot mask the other.
+      fail-fast: false
+      matrix:
+        dir:
+          - infra
+          - company-site/infra
+    steps:
+      # No `submodules:` — deliberate. No .tf file references a submodule path,
+      # so cloning them would cost minutes for zero signal.
+      - uses: actions/checkout@v7
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          # Pinned, not "latest": `terraform fmt` is a formatter, and a formatter
+          # that silently changes its mind between releases turns this gate red on
+          # a PR that touched nothing. 1.15.8 is the version the tree was verified
+          # fmt-clean against; bump it deliberately, with a re-run of `terraform
+          # fmt -recursive` in the same PR.
+          terraform_version: "1.15.8"
+          # The action's default wraps the `terraform` binary in a script that
+          # captures stdout/stderr into step outputs. We consume no step outputs
+          # here, and the wrapper is a known source of mangled exit codes in
+          # multi-line runs — turn it off and let the real binary's exit status
+          # be the gate.
+          terraform_wrapper: false
+
+      # Needs no init and no credentials. `-diff` prints exactly what to change,
+      # so a red gate is actionable without re-running anything locally.
+      # Exit codes: 0 = formatted, 3 = would reformat, 2 = the file does not parse.
+      - name: terraform fmt -check (blocking)
+        run: terraform fmt -check -recursive -diff "${{ matrix.dir }}"
+
+      # `-backend=false` skips backend initialisation entirely: no S3 call, no
+      # state read, no credentials. `-upgrade` keeps this from ever becoming a
+      # lockfile argument — .terraform.lock.hcl is gitignored (.gitignore:56,119),
+      # so CI resolves providers fresh every run, and if a lockfile is ever
+      # committed this still will not fail on a stale one (issue #1483 anti-goal).
+      - name: terraform init -backend=false (no credentials, no state)
+        run: terraform -chdir="${{ matrix.dir }}" init -backend=false -input=false -upgrade -no-color
+
+      - name: terraform validate (blocking)
+        run: terraform -chdir="${{ matrix.dir }}" validate -no-color

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ blocks and what does not**:
 | `import-guard.yml` | **YES** | Runs on every PR. Catches imports that resolve locally but not in a clean environment. |
 | `contracts-test.yml` | no | `forge build` + `forge test`. **Path-filtered to `contracts/**`, so it must not be made a required check** until an always-runs fallback job reports the same check name — see the boxed comment in `scripts/setup-branch-protection.sh`. |
 | `docs-gate.yml` | no | Link resolution and index completeness across `docs/` and root markdown; staleness reported but never blocking. **Path-filtered — same constraint as `contracts-test.yml`, and the same warning is boxed at the top of the workflow.** Run it locally with `make docs-check`. |
+| `infra-gate.yml` | no | `terraform fmt -check -recursive` + `init -backend=false` + `validate`, as a matrix over the two Terraform roots (`infra/`, `company-site/infra/`). No credentials, no `plan`, never reads S3 state. **Path-filtered — same constraint as `contracts-test.yml`/`docs-gate.yml`, same boxed warning at the top of the workflow.** Note that quality-gate's "Infra — user-data size guard" row is a byte-count on `infra/user-data.sh` and parses no `.tf` file; this is the row that does. |
 | `deploy.yml` · `release-tag.yml` | n/a | Build → ECR → roll Fargate (superseded runs auto-cancel); semver tag per merged PR. |
 | `deploy-runners.yml` | n/a | `workflow_dispatch` only — the `push` trigger is deliberately commented out. Oracle + agent EC2 and the KB scheduled Fargate task. |
 

--- a/backend/tests/test_infra_gate_workflow.py
+++ b/backend/tests/test_infra_gate_workflow.py
@@ -1,0 +1,209 @@
+"""Guard for ``.github/workflows/infra-gate.yml`` (issue #1483).
+
+Issue #1483: nothing in CI parsed a ``.tf`` file, so a syntax error in
+``infra/ecs.tf`` — the file holding ``PAYMENTS_DRY_RUN`` and the generation
+price/caps — first surfaced at ``terraform apply``, which is also the prod
+deploy path. ``infra-gate.yml`` closes that. The gate itself is only worth
+anything while its ``on.pull_request.paths`` filter still selects the ``.tf``
+files it claims to cover: delete ``infra/**`` from that list and the workflow
+stays present, stays green-by-never-running, and the tree goes unchecked again.
+That silent-downgrade is exactly the CLAUDE.md § "the green check may not mean
+what you think" failure mode, so it gets a test rather than a convention.
+
+**Stdlib only, on purpose.** PyYAML is not in ``backend/requirements.txt`` and
+is not imported anywhere in ``backend/``; the CI unit job installs only from
+that file (``quality-gate.yml`` line 135), so ``import yaml`` here would pass
+locally and ``ImportError`` in CI — the exact "works on my machine" split the
+testing conventions exist to prevent. ``_pull_request_paths`` is a small
+indentation scanner instead, and it is fail-loud: if it stops understanding the
+file it returns nothing and every assertion below fails. Its output was
+cross-checked against ``yaml.safe_load`` when written (both return the same
+three patterns; note ``safe_load`` parses the ``on:`` key as the boolean
+``True`` under YAML 1.1, which is why a naive ``doc["on"]`` would have been
+wrong anyway).
+
+Hermetic: reads two files off disk, no env, no network, no services.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "infra-gate.yml"
+_BRANCH_PROTECTION = _REPO_ROOT / "scripts" / "setup-branch-protection.sh"
+
+# Directories that are not ours to lint: submodule checkouts, vendored JS, and
+# terraform's own provider cache (gitignored, but present after a local init).
+_SKIP_DIRS = {".git", ".terraform", "node_modules", "submodules"}
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _block_body(lines: list[str], start: int, outer_indent: int) -> list[str]:
+    """Lines belonging to the block opened at ``start``, i.e. everything more
+    indented than ``outer_indent`` until the first line that is not."""
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if not line.strip():
+            body.append(line)
+            continue
+        if _indent(line) <= outer_indent:
+            break
+        body.append(line)
+    return body
+
+
+def _find_key(lines: list[str], key: str) -> int | None:
+    """Index of the shallowest ``<key>:`` line, or None."""
+    for i, line in enumerate(lines):
+        if line.strip() in (f"{key}:", key):
+            return i
+    return None
+
+
+def _pull_request_paths(text: str) -> list[str]:
+    """``on.pull_request.paths`` from a workflow file, stdlib only.
+
+    Returns ``[]`` rather than raising when the shape is not what we expect —
+    the callers assert on the contents, so an unparseable file fails loudly
+    instead of vacuously passing.
+    """
+    lines = text.splitlines()
+
+    on_idx = next(
+        (i for i, ln in enumerate(lines) if _indent(ln) == 0 and ln.strip() == "on:"),
+        None,
+    )
+    if on_idx is None:
+        return []
+    on_body = _block_body(lines, on_idx, 0)
+
+    pr_idx = _find_key(on_body, "pull_request")
+    if pr_idx is None:
+        return []
+    pr_body = _block_body(on_body, pr_idx, _indent(on_body[pr_idx]))
+
+    paths_idx = _find_key(pr_body, "paths")
+    if paths_idx is None:
+        return []
+    paths_body = _block_body(pr_body, paths_idx, _indent(pr_body[paths_idx]))
+
+    out: list[str] = []
+    for line in paths_body:
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        out.append(stripped[2:].strip().strip("\"'"))
+    return out
+
+
+def _pattern_to_regex(pattern: str) -> re.Pattern[str]:
+    """GitHub path-filter glob → regex.
+
+    Per GitHub's filter-pattern cheat sheet: ``**`` crosses ``/``, ``*`` does
+    not, ``?`` is a single non-``/`` character. Anchored at both ends.
+    """
+    out = ["^"]
+    i = 0
+    while i < len(pattern):
+        char = pattern[i]
+        if char == "*":
+            if pattern[i : i + 2] == "**":
+                out.append(".*")
+                i += 2
+                continue
+            out.append("[^/]*")
+        elif char == "?":
+            out.append("[^/]")
+        else:
+            out.append(re.escape(char))
+        i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+def _matches_any(patterns: list[str], path: str) -> bool:
+    return any(_pattern_to_regex(p).match(path) for p in patterns)
+
+
+def _tf_files() -> list[str]:
+    return sorted(
+        p.relative_to(_REPO_ROOT).as_posix() for p in _REPO_ROOT.rglob("*.tf") if not _SKIP_DIRS & set(p.parts)
+    )
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    assert _WORKFLOW.exists(), f"{_WORKFLOW} is missing — issue #1483 is not done"
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def paths(workflow_text: str) -> list[str]:
+    parsed = _pull_request_paths(workflow_text)
+    assert parsed, "could not read on.pull_request.paths out of infra-gate.yml"
+    return parsed
+
+
+def test_path_filter_lists_the_infra_tree(paths: list[str]) -> None:
+    """The literal the issue asks for. ``infra/**`` is what makes an edit to
+    ``infra/ecs.tf`` trigger the gate at all."""
+    assert "infra/**" in paths, f"on.pull_request.paths lost 'infra/**': {paths}"
+
+
+def test_path_filter_selects_every_tf_file_in_the_tree(paths: list[str]) -> None:
+    """The claim the workflow's name makes, checked against the tree rather
+    than against a hard-coded list — a ``.tf`` file added in a directory nobody
+    thought about must either be covered or turn this red."""
+    tf_files = _tf_files()
+    assert tf_files, "no .tf files found — the walker is broken, not the repo"
+    uncovered = [f for f in tf_files if not _matches_any(paths, f)]
+    assert not uncovered, (
+        f"{len(uncovered)} .tf file(s) would not trigger infra-gate.yml: "
+        f"{uncovered}. Either add a pattern to on.pull_request.paths or add the "
+        f"directory to the job matrix."
+    )
+
+
+def test_the_workflow_actually_runs_fmt_and_validate(workflow_text: str) -> None:
+    """A path filter that triggers a job doing nothing is not a gate."""
+    assert "terraform fmt -check -recursive" in workflow_text
+    assert "terraform validate" in workflow_text or "validate -no-color" in workflow_text
+    assert "-backend=false" in workflow_text, (
+        "init must use -backend=false: no credentials, no S3 state read (#1483 anti-goal)"
+    )
+
+
+def test_the_workflow_never_runs_plan(workflow_text: str) -> None:
+    """#1483 anti-goal. ``plan`` needs credentials and reads remote state, and
+    state holds a ``tls_private_key`` — CLAUDE.md § git safety treats the
+    backend as a secrets store."""
+    run_lines = [
+        ln.strip() for ln in workflow_text.splitlines() if "terraform " in ln and not ln.strip().startswith("#")
+    ]
+    offenders = [ln for ln in run_lines if re.search(r"\bterraform\b.*\bplan\b", ln)]
+    assert not offenders, f"infra-gate must not run terraform plan: {offenders}"
+
+
+def test_the_workflow_carries_the_do_not_require_warning(workflow_text: str) -> None:
+    """Path-filtered + required = every non-infra PR permanently unmergeable.
+    docs-gate.yml boxes this warning; so must this one, or the next person
+    reading the CI table will add it to branch protection."""
+    header = workflow_text.split("name: infra-gate")[0]
+    assert "DO NOT MARK THIS A REQUIRED STATUS CHECK." in header
+    assert "fallback" in header
+
+
+def test_the_workflow_is_not_a_required_status_check() -> None:
+    """Acceptance criterion 4: it must not appear in the required-check list."""
+    script = _BRANCH_PROTECTION.read_text(encoding="utf-8")
+    contexts_line = next((ln for ln in script.splitlines() if ln.startswith("CONTEXTS=")), None)
+    assert contexts_line, "CONTEXTS= line vanished from setup-branch-protection.sh"
+    assert "infra-gate" not in contexts_line.lower()
+    assert "terraform" not in contexts_line.lower()


### PR DESCRIPTION
## What

A new path-filtered workflow, `.github/workflows/infra-gate.yml`, that runs `terraform fmt -check -recursive`, `terraform init -backend=false`, and `terraform validate` over the repo's Terraform roots — plus `backend/tests/test_infra_gate_workflow.py`, a stdlib-only guard on the workflow's own path filter, and one row in the CLAUDE.md CI table.

```yaml
- run: terraform fmt -check -recursive -diff "${{ matrix.dir }}"
- run: terraform -chdir="${{ matrix.dir }}" init -backend=false -input=false -upgrade -no-color
- run: terraform -chdir="${{ matrix.dir }}" validate -no-color
```

## Why

`grep -rn "terraform" .github/workflows/*.yml` returned exactly one hit before this, and it was a warning *string* inside `deploy.yml:760` — not a step. The one infra-named job, quality-gate's **"Infra — user-data size guard"**, is a byte-count on `infra/user-data.sh`; it never opens a `.tf` file, yet it is the row a reviewer watches go green on an `infra/**` PR. That is the "a signal was trusted for something it does not actually measure" shape from CLAUDE.md § *the green check may not mean what you think*.

`infra/ecs.tf` holds `PAYMENTS_DRY_RUN`, `GENERATION_PAYMENTS_DRY_RUN`, `GENERATION_PAYMENT_REQUIRED`, `GENERATION_PRICE_USD` and the daily generation caps. Until now a typo there surfaced for the first time at `terraform apply`, which is also the prod deploy path.

### One deliberate deviation from the issue: the matrix covers two roots, not one

The issue scopes to `infra/`. `git ls-files '*.tf'` finds **21** files: 20 under `infra/` and one under `company-site/infra/` — a deliberately standalone stack with its own state key and `aws ~> 6.0` (vs the product root's `~> 5.0`). They cannot share a `.terraform/` directory, so they are a matrix rather than one job. Covering only `infra/` would leave the workflow's own name a half-truth. Both roots are fmt-clean and validate today (evidence below). **If you'd rather keep this scoped to `infra/` exactly as specced, deleting one matrix entry and one path pattern is the whole change.**

## `terraform` was available locally after all

The task brief said this box has OpenTofu only. It does not — `/opt/homebrew/bin/terraform` is **Terraform v1.15.8**, and `tofu` is not installed (`command -v tofu` → not found). So the three `.tf` steps were **executed for real locally**, not just reasoned about, and the workflow YAML was additionally parsed with `yaml.safe_load`.

**The workflow itself has now also run for real** — it is in its own `paths:` list, so it self-triggered on this PR ([run 33400730459](https://github.com/a-apin/archimedes/actions/runs/33400730459)). Both matrix legs are green:

```
Infra — terraform fmt + validate (infra)              | terraform fmt -check (blocking)
  Run terraform fmt -check -recursive -diff "infra"
  env: TF_IN_AUTOMATION: 1
Infra — terraform fmt + validate (infra)              | terraform init -backend=false (...)
  - Installing hashicorp/tls v4.3.0...
  - Installing hashicorp/local v2.9.0...
  - Installing hashicorp/aws v5.100.0...
  Terraform has been successfully initialized!
Infra — terraform fmt + validate (infra)              | terraform validate (blocking)
  Success! The configuration is valid.

Infra — terraform fmt + validate (company-site/infra)
  Run terraform fmt -check -recursive -diff "company-site/infra"
  - Installing hashicorp/aws v6.62.0...
  Terraform has been successfully initialized!
  Success! The configuration is valid.
```

Both legs completed in well under a minute. `hashicorp/setup-terraform@v3` with `terraform_wrapper: false` behaved as expected and no AWS credentials were present in the job.

## Test evidence

### Acceptance criterion 1 — the workflow exists and runs validate

```
$ grep -c "terraform validate" .github/workflows/infra-gate.yml
1
```

That single hit is the step *name*; the executed line is `terraform -chdir="${{ matrix.dir }}" validate -no-color` (line 124), which the literal `grep` in the acceptance criterion does not match because of the `-chdir` between the two words. `test_the_workflow_actually_runs_fmt_and_validate` asserts the executed form, not the step name.

### Acceptance criterion 3 — `fmt -check` passes on the tree as-is

No separate reformatting commit was needed.

```
$ terraform fmt -check -recursive infra/
EXIT=0
$ terraform fmt -check -recursive -diff company-site/infra/
EXIT=0
```

### `init -backend=false` + `validate` need no AWS credentials and never touch state

Run with a scrubbed environment (`env -i` — no `AWS_*`, no `.env`, nothing inherited):

```
$ env -i HOME="$HOME" PATH="/opt/homebrew/bin:/usr/bin:/bin" TF_IN_AUTOMATION=1 \
    terraform -chdir=company-site/infra validate -no-color
COMPANY_SITE_VALIDATE_EXIT=0
Success! The configuration is valid.

=== infra root, scrubbed env (no AWS_*) ===
INFRA_VALIDATE_EXIT=0
Success! The configuration is valid.
```

`init` resolved `hashicorp/aws v5.100.0`, `hashicorp/tls v4.3.0`, `hashicorp/local v2.9.0` for `infra/` and `hashicorp/aws v6.62.0` for `company-site/infra/`; the S3 backend at `main.tf:7-13` was never contacted.

### The guard test

```
$ /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest backend/tests/test_infra_gate_workflow.py -q
6 passed, 1 warning in 2.08s
```

Hermetic gate (CLAUDE.md § testing conventions):

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
    /opt/.../envs/archimedes/bin/python -m pytest backend/tests/test_infra_gate_workflow.py -q
6 passed, 1 warning in 1.23s
```

Full CI command, from the repo root (CLAUDE.md § *verify the merged result*):

```
$ /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest -m "not integration" --tb=short -q
=== 4796 passed, 3 skipped, 2 deselected, 320 warnings in 582.38s (0:09:42) ====
```

And the same suite in CI on this PR — which is the load-bearing check for the stdlib-only decision, since PyYAML is not installed in that job:

```
Backend — unit tests | Test | collected 4801 items / 2 deselected / 4799 selected
Backend — unit tests | Test | backend/tests/test_infra_gate_workflow.py ......      [ 65%]
Backend — unit tests | Test | === 4796 passed, 3 skipped, 2 deselected, 319 warnings in 551.26s (0:09:11) ====
```

Lint on the touched Python file:

```
$ ruff format --check backend/tests/test_infra_gate_workflow.py   # ruff 0.15.13
1 file already formatted
FORMAT_EXIT=0
$ ruff check backend/tests/test_infra_gate_workflow.py
All checks passed!
CHECK_EXIT=0
```

CLAUDE.md is root markdown, so it is in `docs-gate.yml`'s `paths:`:

```
$ make docs-check
links: scanned 1385 in 164 markdown files; broken 0 (0.0%)
index: 159 docs under docs/; 159 indexed, 0 orphaned.
staleness: 0 of 63 `current` docs older than 60 days; 2 missing an `updated` date. Informational.
```

(No `docs/README.md` row: the index rule covers `docs/**/*.md`, and this PR adds no doc there.)

---

## Adversarial demonstrations

Per CLAUDE.md § *a guard must be shown to reject something* and the issue's acceptance criterion 2. All four were run before pushing; the tree was restored and re-verified clean after each.

### 1. The issue's exact scenario — a syntax error in `infra/ecs.tf`

An unclosed `resource` block appended to the end of `infra/ecs.tf`:

```
=== injected an unclosed block at the end of infra/ecs.tf (the issue's exact scenario) ===
}

resource "aws_s3_bucket" "zz_syntax" {
  bucket = "x"
=== terraform fmt -check -recursive infra/ ===
FMT_EXIT=2
╷
│ Error: Unclosed configuration block
│
│   on infra/ecs.tf line 943, in resource "aws_s3_bucket" "zz_syntax":
│  943: resource "aws_s3_bucket" "zz_syntax" {
│
│ There is no closing brace for this block before the end of the file. This
│ may be caused by incorrect brace nesting elsewhere in this file.
╵
=== terraform -chdir=infra validate ===
VALIDATE_EXIT=1

Error: Unclosed configuration block

  on ecs.tf line 943, in resource "aws_s3_bucket" "zz_syntax":
 943: resource "aws_s3_bucket" "zz_syntax" {

There is no closing brace for this block before the end of the file. This may
be caused by incorrect brace nesting elsewhere in this file.
=== restored ===
FMT_EXIT_RESTORED=0
```

`git status --porcelain infra/` after the restore printed nothing.

### 2. `fmt -check` rejects a merely misformatted (but parseable) file

```
=== BAD FMT INPUT ===
locals {
  scratch_bad_fmt =   "misaligned"
     extra        = 1
}
=== terraform fmt -check -recursive -diff infra/ ===
FMT_EXIT=3
infra/zz_scratch_fmt.tf
--- old/infra/zz_scratch_fmt.tf
+++ new/infra/zz_scratch_fmt.tf
@@ -1,4 +1,4 @@
 locals {
-  scratch_bad_fmt =   "misaligned"
-     extra        = 1
+  scratch_bad_fmt = "misaligned"
+  extra           = 1
 }
=== after removing scratch file ===
FMT_EXIT_CLEAN=0
```

### 3. `validate` rejects a semantic error `fmt` cannot see

```
=== BAD VALIDATE INPUT ===
resource "aws_s3_bucket" "zz_scratch_bad" {
  bucket              = var.does_not_exist_anywhere
  bogus_argument_name = true
}
=== terraform -chdir=infra validate ===
VALIDATE_EXIT=1

Error: Reference to undeclared input variable

  on zz_scratch_validate.tf line 2, in resource "aws_s3_bucket" "zz_scratch_bad":
   2:   bucket              = var.does_not_exist_anywhere

An input variable with the name "does_not_exist_anywhere" has not been
declared. This variable can be declared with a variable
"does_not_exist_anywhere" {} block.
=== after removing scratch file ===
Success! The configuration is valid.
VALIDATE_EXIT_CLEAN=0
```

Note this file is fmt-clean (I ran `terraform fmt` on it first) — it demonstrates the layer `fmt` alone would have missed.

### 4. The pytest guard rejects a downgraded path filter

This is the guard the issue asked for. A workflow whose `paths:` list loses `infra/**` stays present and stays green **by never running** — a silent downgrade with no red anywhere.

**Delete `- "infra/**"` from `on.pull_request.paths`:**

```
on:
  pull_request:
    paths:
      - "company-site/infra/**"
      - ".github/workflows/infra-gate.yml"
```

```
$ pytest backend/tests/test_infra_gate_workflow.py -q
backend/tests/test_infra_gate_workflow.py FF....

E   AssertionError: on.pull_request.paths lost 'infra/**': ['company-site/infra/**', '.github/workflows/infra-gate.yml']
    assert 'infra/**' in ['company-site/infra/**', '.github/workflows/infra-gate.yml']

E   AssertionError: 20 .tf file(s) would not trigger infra-gate.yml: ['infra/alb.tf',
    'infra/asg.tf', 'infra/aurora.tf', 'infra/cloudfront.tf', 'infra/cloudwatch.tf',
    'infra/dns_email.tf', 'infra/ec2_iam.tf', 'infra/ecr.tf', 'infra/ecs.tf',
    'infra/ecs_migrate.tf', 'infra/efs.tf', 'infra/elasticache.tf', 'infra/kb_runner.tf',
    'infra/main.tf', 'infra/outputs.tf', 'infra/runner_ec2.tf', 'infra/ses_inbound.tf',
    'infra/variables.tf', 'infra/vpc.tf', 'infra/waf.tf']. Either add a pattern to
    on.pull_request.paths or add the directory to the job matrix.
```

Restored → `6 passed`.

**A new `.tf` lands in a directory no pattern covers** (the coverage check is derived from the tree, not from a hard-coded list — so a third Terraform root added later cannot slip in silently):

```
$ echo 'locals { demo = 1 }' > ops/terraform/demo.tf
$ pytest backend/tests/test_infra_gate_workflow.py::test_path_filter_selects_every_tf_file_in_the_tree -q
E   AssertionError: 1 .tf file(s) would not trigger infra-gate.yml: ['ops/terraform/demo.tf'].
    Either add a pattern to on.pull_request.paths or add the directory to the job matrix.
1 failed, 1 warning in 2.82s
```

**A `terraform plan` step is added** (the issue's headline anti-goal — `plan` needs credentials and reads state, and state holds a `tls_private_key`):

```
$ pytest backend/tests/test_infra_gate_workflow.py::test_the_workflow_never_runs_plan -q
E   AssertionError: infra-gate must not run terraform plan:
    ['run: terraform -chdir="${{ matrix.dir }}" plan -no-color']
1 failed, 1 warning in 1.36s
```

Restored → `6 passed`. Working tree after all demos: only the two new files, nothing else modified.

---

## The path-filtered / required-check constraint

Acceptance criterion 4 and the CLAUDE.md CI table. Handled three ways:

1. The boxed `DO NOT MARK THIS A REQUIRED STATUS CHECK` warning from `docs-gate.yml` is reproduced verbatim in the header, extended with a pointer to `scripts/setup-branch-protection.sh`'s `INCLUDE_CONTRACTS_CHECK` comment and a named instruction not to add `"Infra — terraform fmt + validate (...)"` to `CONTEXTS`.
2. `scripts/setup-branch-protection.sh` is **not touched** by this PR — the job is not in the required list.
3. `test_the_workflow_is_not_a_required_status_check` reads that script's `CONTEXTS=` line and asserts it names neither `infra-gate` nor `terraform`, so a future edit adding it turns the suite red.

## Choices worth a second's review

- **`terraform_wrapper: false`** on `hashicorp/setup-terraform@v3`. The action's default wraps the binary in a script that captures stdout/stderr into step outputs. We consume no step outputs, and the wrapper is a known source of mangled exit codes on multi-line runs — with it off, the real binary's exit status is the gate.
- **`terraform_version: "1.15.8"` pinned, not `latest`.** `fmt` is a formatter; one that changes its mind between releases turns this gate red on a PR that touched nothing. 1.15.8 is the version the tree was verified fmt-clean against.
- **`-upgrade` on init, no committed lockfile.** `.terraform.lock.hcl` is gitignored (`.gitignore:56,119`), so CI resolves fresh each run; `-upgrade` means this can never fail on a stale lockfile if one is ever committed. Per the issue's "don't add a lockfile fight" — the pinned-provider guarantee is available if you want it, but it is a maintenance commitment, so it's your call, not mine.
- **`fail-fast: false`** on the matrix, so a broken root cannot mask the other one.
- **The guard test is stdlib-only.** PyYAML is not in `backend/requirements.txt` and is imported nowhere in `backend/`; the CI unit job installs only from that file (`quality-gate.yml:135`), so `import yaml` would pass locally and `ImportError` in CI — the exact split the testing conventions exist to prevent. The scanner's output was cross-checked against `yaml.safe_load` when written:

  ```
  stdlib scanner : ['infra/**', 'company-site/infra/**', '.github/workflows/infra-gate.yml']
  yaml.safe_load : ['infra/**', 'company-site/infra/**', '.github/workflows/infra-gate.yml']
  AGREE          : True
  ```

  (`safe_load` parses the `on:` key as the boolean `True` under YAML 1.1, so a naive `doc["on"]` would have been wrong regardless.)

## Not done here

- **`fmt -check` blocks rather than reports.** The issue lists this as your call. It is blocking (a red X on the PR), because the fix is one `terraform fmt` invocation. Flipping to `continue-on-error: true` is a one-line change if you'd rather it only informed. It is **not** a required status check either way, so nothing is unmergeable.
- **The provider lockfile is still not pinned.** No `.terraform.lock.hcl` is committed; `~> 5.0` / `~> 6.0` can resolve to a new patch in CI and locally. That is the status quo, not a regression — but it means the gate is not reproducible across time. Pinning is a maintenance commitment; your call.
- **No `tflint` / `checkov` / `tfsec`.** `validate` type-checks; it says nothing about security posture (public S3, open security groups). Deliberately out of scope.
- **`terraform plan` is not run and should not be.** See anti-goals.
- **The always-runs fallback job does not exist**, so this cannot be made required. Building it is the follow-up that would also unblock `contracts-test.yml` and `docs-gate.yml` — one shared pattern, three workflows. Worth its own issue.
- **The first real execution of the workflow is this PR's own CI run.** Terraform's three commands were executed locally against real Terraform 1.15.8; `hashicorp/setup-terraform@v3`'s install step and GitHub's path-filter evaluation have not. If the action's version pin or the runner's network to `releases.hashicorp.com` misbehaves, it shows up here first.
- **`infra/scripts/`, `infra/iam/`, `infra/*.sh`, `infra/spike-1411/` are untouched by this gate** — `fmt`/`validate` only read `.tf` and `.tfvars`. The user-data size guard in `quality-gate.yml` remains the only check on `infra/user-data.sh`.

Closes #1483
