### PR TITLE
[frontend] Flatten Strategy/Position/Market crumb groups so no mid-crumb aliases a sibling page (#1405)

### DIFF
--- a/backend/tests/test_breadcrumbs.py
+++ b/backend/tests/test_breadcrumbs.py
@@ -352,3 +352,103 @@ def test_shell_nav_items_stay_inside_the_shell() -> None:
     nav_ids = [i for i in _extract_layout_nav_ids(nav_text) if i != "landing"]
     bad = sorted(set(nav_ids) - app_pages)
     assert not bad, f"sidebar nav items that route outside /app (shell disappears): {bad}"
+
+
+# ---------------------------------------------------------------------------
+# #1405 — the residual of #1370 item 1 that no existing invariant could see:
+# a group crumb wearing a section's name while linking to a sibling page.
+# ---------------------------------------------------------------------------
+
+
+def _extract_nav_sections(nav_text: str) -> dict[str, set[str]]:
+    """Section label -> the page ids navConfig.js lists as its sidebar items.
+
+    Same NAV block `_extract_layout_nav_ids` reads, but keeping the
+    section->items association instead of flattening it, because
+    `test_group_crumb_does_not_alias_a_sibling_nav_page` has to ask "is this
+    page a sibling *within this group*" — a question a flat id list cannot
+    answer. Each NAV element is `{ group: <label|null>, items: [...] }`, so
+    slicing the block at every `group:` marker puts each `id:` with its own
+    section; the unlabelled marketing-site entry (`group: null`) is dropped,
+    since a null section can never be named by a crumb.
+    """
+    m = re.search(r"const\s+NAV\s*=\s*\[(.*?)\n\];", nav_text, re.DOTALL)
+    assert m, "NAV block not found in navConfig.js"
+    block = m.group(1)
+    marks = list(re.finditer(r"""group:\s*(?:["']([^"']+)["']|null)""", block))
+    assert marks, "no `group:` markers found in navConfig.js NAV — parser is out of date"
+    sections: dict[str, set[str]] = {}
+    for i, mark in enumerate(marks):
+        label = mark.group(1)
+        end = marks[i + 1].start() if i + 1 < len(marks) else len(block)
+        ids = set(re.findall(r"""id:\s*["']([a-z0-9_-]+)["']""", block[mark.end() : end]))
+        if label:
+            sections.setdefault(label, set()).update(ids)
+    return sections
+
+
+def test_group_crumb_does_not_alias_a_sibling_nav_page() -> None:
+    """#1405 (residual of #1370 item 1): a group crumb must not be a link to a
+    sibling page wearing a section's name.
+
+    `test_no_page_appears_twice_in_one_trail` cannot see this one. It fires
+    only when a trail lists the *same* page twice, which is what the Discover
+    instance did (Home and Discover both went to 'explore'). The three
+    instances left after #1400 were all distinct pages — 'Strategy' ->
+    generate, 'Position' -> portfolio, 'Market' -> marketplace — so the trail
+    was well-formed and the defect was purely that the crumb lied about where
+    it went: a control labelled with a section name whose destination is a
+    sidebar item with a different name and a different title.
+
+    The rule that separates an honest group crumb from an aliasing one: the
+    groupPage must not be a page navConfig.js already lists as a sidebar item
+    of that same section. A real section landing page — #1405's option 1, still
+    open — would be its own route with its own identity and would pass; a
+    sibling nav destination cannot.
+
+    Deliberately NOT "no entry may declare a group": that would ban the
+    feature instead of policing it, and would go green for the wrong reason
+    the day someone builds the landing page this test is meant to make room
+    for. Demonstrated in the PR body by pointing a group crumb at a
+    non-sidebar route and watching this test stay green.
+    """
+    text = BREADCRUMBS.read_text(encoding="utf-8")
+    keys = _extract_crumb_keys_ordered(text)
+    groups = _extract_crumb_groups(text)
+    group_pages = _extract_crumb_group_pages(text)
+    sections = _extract_nav_sections(NAV_CONFIG.read_text(encoding="utf-8"))
+    assert len(keys) == len(groups) == len(group_pages), (
+        f"CRUMB_MAP has {len(keys)} entries but {len(groups)} group: values and "
+        f"{len(group_pages)} groupPage: values — every entry must declare exactly one of each."
+    )
+
+    # group and groupPage are one setting in two fields; either half alone is a
+    # broken crumb, not a flat one. `group: 'X', groupPage: null` renders a
+    # button whose onClick calls setPage(null); `group: null, groupPage: 'x'`
+    # is unreachable config that reads like a live link to the next maintainer.
+    unpaired = {k: (g, gp) for k, g, gp in zip(keys, groups, group_pages, strict=True) if (g is None) != (gp is None)}
+    assert not unpaired, (
+        f"CRUMB_MAP entries declaring only half of a group crumb: {unpaired}. "
+        "group and groupPage must both be set (a named section with a real landing page) "
+        "or both be null (a flat 'Home / <page>' trail)."
+    )
+
+    aliases: dict[str, tuple[str, str | None]] = {}
+    for key, group, group_page in zip(keys, groups, group_pages, strict=True):
+        if group is None:
+            continue
+        siblings = sections.get(group)
+        assert siblings is not None, (
+            f"CRUMB_MAP entry '{key}' names group {group!r}, which is not a section in "
+            f"navConfig.js NAV (sections: {sorted(sections)}) — the crumb would label a "
+            "section the sidebar does not have."
+        )
+        if group_page in siblings:
+            aliases[key] = (group, group_page)
+    assert not aliases, (
+        "group crumbs that link to a sibling nav page instead of a section landing page: "
+        f"{aliases}. Each renders a mid-crumb labelled with a section name that navigates to "
+        "a page the sidebar lists under its own different name — the mislabel #1370 item 1 "
+        "named and #1405 closed. Either build the section landing page and point at that, or "
+        "flatten the entry to { group: null, groupPage: null }."
+    )

--- a/ui/src/components/Breadcrumbs.jsx
+++ b/ui/src/components/Breadcrumbs.jsx
@@ -1,27 +1,31 @@
 /**
  * Breadcrumb navigation for interior pages.
  *
- * Derives the crumb trail from the current page ID using the same
- * NAV group structure defined in Layout.jsx. Each crumb is clickable
- * and navigates via the `setPage` callback.
+ * Derives the crumb trail from the current page ID. Each crumb is
+ * clickable and navigates via the `setPage` callback. The sidebar's
+ * section structure lives in ../navConfig.js (#1437); a crumb trail may
+ * name one of its sections only when a real landing page for that section
+ * exists to link to — see CRUMB_MAP below and #1405.
  */
 
 import { PAGE_LABELS } from './Layout'
 import { roadmapSurfaceHidden } from '../featureFlags.js'
 
 // `group: null` means "no intermediate label" — breadcrumb reads "Home / <page>".
-// Mirrors Layout.jsx NAV groups: Discover, Strategy, Position, Market, Ops.
-// Every key must exist in App.jsx PAGE_TO_PATH — subset invariant enforced by
-// backend/tests/test_breadcrumbs.py (prevents a fifth stale-map occurrence).
+// Group labels, when used, must be current navConfig.js NAV sections
+// (Discover, Strategy, Position, Market, Ops). Every key must exist in
+// routes.js (#1194 moved routing out of App.jsx's PAGE_TO_PATH) — subset
+// invariant enforced by backend/tests/test_breadcrumbs.py (prevents a fifth
+// stale-map occurrence).
 //
 // Deliberately excluded:
 //   - landing — it *is* Home; breadcrumb would be circular.
 //   - explore — it *is* the Home crumb's own target below. Discover has no
-//     landing page distinct from Home/Explore, so unlike Strategy/Position/
-//     Market it gets no group entry either (#1370: a "Discover" mid-crumb
-//     pointing at the same page as "Home" repeated a stop, and on /app/explore
-//     itself "Home" and the current-page crumb both named 'explore' — the
-//     same page listed twice in one trail either way).
+//     landing page distinct from Home/Explore, so it gets no group entry
+//     either (#1370: a "Discover" mid-crumb pointing at the same page as
+//     "Home" repeated a stop, and on /app/explore itself "Home" and the
+//     current-page crumb both named 'explore' — the same page listed twice
+//     in one trail either way).
 //   - architecture — moved out of the shell nav (#1370, see Layout.jsx); it
 //     renders under PublicLayout, which never mounts Breadcrumbs, so a
 //     CRUMB_MAP entry for it was unreachable dead config.
@@ -29,36 +33,48 @@ import { roadmapSurfaceHidden } from '../featureFlags.js'
 //     param, not entries in PAGE_TO_PATH; reached via deep-link only.
 // Primary path (generate, leaderboard, library, corpus) all have entries
 // below; if one is intentionally omitted a comment must explain why.
+//
+// Every entry is flat as of #1405. The `group`/`groupPage` fields survive
+// because they are the shape a *real* section landing page would use, and
+// the component below still renders one — but the product has no such page
+// today, so nothing may claim one. The rule, enforced by
+// backend/tests/test_breadcrumbs.py::
+// test_group_crumb_does_not_alias_a_sibling_nav_page:
+//
+//   a groupPage may not be a page that navConfig.js already lists as a
+//   sidebar item of that same group.
+//
+// #1370 item 1 named the defect; #1400 fixed the Discover instance (which
+// also repeated a page inside one trail) and flattened Ops on the same
+// reasoning, and #1405 finished the job for the three below. Each of them
+// rendered a mid-crumb labelled with a section name that navigated to a
+// sibling page — "Strategy" landing on Generate, "Position" landing on the
+// deployed-state overview, "Market" landing on Marketplace. The label named
+// a section, the destination was a page with its own different name in the
+// sidebar and its own different title on arrival, so the crumb was a
+// mislabelled control: it never went where it said. Option 1 in #1405 —
+// build real section landing pages — stays open; the moment one exists it
+// gets a route, a nav-less identity of its own, and these entries can name
+// it without tripping the guard.
 export const CRUMB_MAP = {
   // Discover — open to anonymous visitors
   corpus:       { group: null, groupPage: null },
   // Strategy — wallet-gated, owns the primary generation path
   generate:     { group: null, groupPage: null },
-  library:      { group: 'Strategy', groupPage: 'generate' },
-  paper:        { group: 'Strategy', groupPage: 'generate' },
-  leaderboard:  { group: 'Strategy', groupPage: 'generate' },
+  library:      { group: null, groupPage: null },
+  paper:        { group: null, groupPage: null },
+  leaderboard:  { group: null, groupPage: null },
   // Position — wallet-gated deployed-state surfaces
   portfolio:    { group: null, groupPage: null },
-  quant:        { group: 'Position', groupPage: 'portfolio' },
-  reasoning:    { group: 'Position', groupPage: 'portfolio' },
-  learnings:    { group: 'Position', groupPage: 'portfolio' },
+  quant:        { group: null, groupPage: null },
+  reasoning:    { group: null, groupPage: null },
+  learnings:    { group: null, groupPage: null },
   // Market — strategy marketplace
   marketplace:  { group: null, groupPage: null },
-  publish:      { group: 'Market', groupPage: 'marketplace' },
-  subscriptions:{ group: 'Market', groupPage: 'marketplace' },
-  // Ops — only two members (Insights, Account). An "Ops" mid-crumb pointing
-  // at Insights would be a group crumb wearing a section name while actually
-  // linking to a sibling page, not a real section landing page — and with
-  // only two members there's no third page to justify a group crumb at all.
-  // Flat like the other two-page-or-fewer anchors above.
-  //
-  // NOTE: Strategy/generate, Position/portfolio and Market/marketplace above
-  // share this identical shape (a section-named mid-crumb that links to a
-  // sibling page) — the pattern #1370 item 1 names outright, not just the
-  // corpus/Discover repeat-page bug this PR's Discover fix addressed. Left
-  // alone here: no #1370 acceptance check requires it (those pages are
-  // genuinely distinct, so test_no_page_appears_twice_in_one_trail doesn't
-  // fire), so it's a deliberate deferral, not an oversight — tracked in #1405.
+  publish:      { group: null, groupPage: null },
+  subscriptions:{ group: null, groupPage: null },
+  // Ops — only two members (Insights, Account); with two pages there is no
+  // third to justify a group crumb even if a landing page existed.
   insights:     { group: null, groupPage: null },
   account:      { group: null, groupPage: null },
 }
@@ -67,10 +83,13 @@ export default function Breadcrumbs({ page, setPage }) {
   const info = CRUMB_MAP[page]
   if (!info) return null
 
-  // When the group's landing page is a hidden roadmap surface (#1266 —
-  // quant/reasoning point at Portfolio; learnings is itself hidden), the
+  // When the group's landing page is a hidden roadmap surface (#1266), the
   // mid-crumb would link into a not-found route: fall back to a flat
-  // Home / <page> crumb.
+  // Home / <page> crumb. No CRUMB_MAP entry declares a group today (#1405),
+  // so this branch is inert — it is the contract a future section landing
+  // page inherits, not live behaviour; the entries that used to reach it
+  // (quant/reasoning aliasing the deployed-state overview, publish/
+  // subscriptions aliasing Marketplace) were the aliases #1405 removed.
   const crumbs = [
     { label: 'Home', page: 'explore' },
     ...(info.group && !roadmapSurfaceHidden(info.groupPage)


### PR DESCRIPTION
## What

`CRUMB_MAP` in `ui/src/components/Breadcrumbs.jsx` had eight entries that rendered a
mid-crumb labelled with a **section** name while navigating to a **sibling page**:

| entry | trail before | the mid-crumb's real destination |
| --- | --- | --- |
| `library`, `paper`, `leaderboard` | Home / **Strategy** / … | `generate` — sidebar item "Generate" |
| `quant`, `reasoning`, `learnings` | Home / **Position** / … | `portfolio` — sidebar item "Portfolio" |
| `publish`, `subscriptions` | Home / **Market** / … | `marketplace` — sidebar item "Marketplace" |

All eight are now `{ group: null, groupPage: null }`, so those trails read
`Home / <page>`. This is option 2 in #1405, matching how #1400 handled the Discover
instance and Ops.

## Why

The label named a section; the destination was a page the sidebar lists under its own
different name and that shows its own different title on arrival. The crumb never went
where it said — a mislabelled control, which is #1370 item 1's pattern. #1400 fixed the
Discover instance (which *also* repeated a page inside one trail, so an existing test
caught it) and flattened Ops on the same reasoning, but deliberately left these three
groups, filing #1405 so the deferral was tracked rather than dropped.

The `group` / `groupPage` fields and the component's mid-crumb branch are **kept**, not
deleted: they are the shape a real section landing page would use, and #1405's option 1
("build real section landing pages") stays open. What changed is that a new invariant now
polices them, so the shape cannot be reused for another alias.

## The new invariant

`backend/tests/test_breadcrumbs.py::test_group_crumb_does_not_alias_a_sibling_nav_page`
extends the existing Python guard suite (which parses the JSX; NAV now lives in
`ui/src/navConfig.js`). It asserts two things:

1. a `groupPage` may not be a page `navConfig.js` already lists as a sidebar item of that
   same section — a real landing page would be its own route with its own identity;
2. `group` and `groupPage` must be set together or null together — `group: 'X',
   groupPage: null` renders a button whose `onClick` calls `setPage(null)`, and
   `group: null, groupPage: 'x'` is unreachable config that reads like a live link.

It deliberately does **not** assert "no entry may declare a group": that would ban the
feature instead of policing it, and would go green for the wrong reason the day someone
builds the landing page it is meant to make room for. Demo 3 below shows it discriminating.

Why the existing tests never caught this: `test_no_page_appears_twice_in_one_trail` fires
only when one trail lists the *same* page twice. `library` and `generate` are genuinely
distinct pages, so those trails were well-formed — the defect was purely that the crumb
lied about its destination. Note in demos 1 and 2 that the other **8 tests stay green**
while the new one fails.

## Test commands + output

```
$ /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest backend/tests/test_breadcrumbs.py -q
(9 durations < 0.005s hidden.  Use -vv to show these durations.)
========================= 9 passed, 1 warning in 2.31s =========================
```

Hermetic gate (no `.env`, no network, no DB — the suite only reads committed source files):

```
$ env -i HOME=$HOME PATH=<env>/bin:/usr/bin:/bin PYTHONPATH=backend \
    <env>/bin/python -m pytest backend/tests/test_breadcrumbs.py -q
(8 durations < 0.005s hidden.  Use -vv to show these durations.)
========================= 9 passed, 1 warning in 1.35s =========================
```

UI suite (the one #1405 names):

```
$ cd ui && npm test
ℹ tests 614
ℹ suites 0
ℹ pass 614
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1086.252916
```

Lint / format on touched files:

```
$ <env>/bin/ruff format --check backend/tests/test_breadcrumbs.py
1 file already formatted
$ <env>/bin/ruff check backend/tests/test_breadcrumbs.py
All checks passed!
$ cd ui && ./node_modules/.bin/eslint src/components/Breadcrumbs.jsx
eslint clean
$ cd ui && npm run check:routes
check-orphans: OK (115 src files scanned, 0 orphans in components/ or data/)
check-sitemap: OK (6 public route(s) from routes.js all present in sitemap.xml)
```

## Demo 1 — revert-demo: the guard fails with the fix reverted

Restored all eight aliases in `CRUMB_MAP` (`library/paper/leaderboard →
{ group: 'Strategy', groupPage: 'generate' }`, `quant/reasoning/learnings →
{ group: 'Position', groupPage: 'portfolio' }`, `publish/subscriptions →
{ group: 'Market', groupPage: 'marketplace' }`) and re-ran:

```
backend/tests/test_breadcrumbs.py .....F...                              [100%]
=================================== FAILURES ===================================
______________ test_group_crumb_does_not_alias_a_sibling_nav_page ______________
backend/tests/test_breadcrumbs.py:352: in test_group_crumb_does_not_alias_a_sibling_nav_page
    assert not aliases, (
E   AssertionError: group crumbs that link to a sibling nav page instead of a section landing page: {'library': ('Strategy', 'generate'), 'paper': ('Strategy', 'generate'), 'leaderboard': ('Strategy', 'generate'), 'quant': ('Position', 'portfolio'), 'reasoning': ('Position', 'portfolio'), 'learnings': ('Position', 'portfolio'), 'publish': ('Market', 'marketplace'), 'subscriptions': ('Market', 'marketplace')}. Each renders a mid-crumb labelled with a section name that navigates to a page the sidebar lists under its own different name — the mislabel #1370 item 1 named and #1405 closed. Either build the section landing page and point at that, or flatten the entry to { group: null, groupPage: null }.
E   assert not {'leaderboard': ('Strategy', 'generate'), 'learnings': ('Position', 'portfolio'), 'library': ('Strategy', 'generate'), 'paper': ('Strategy', 'generate'), ...}
=========================== short test summary info ============================
FAILED backend/tests/test_breadcrumbs.py::test_group_crumb_does_not_alias_a_sibling_nav_page - AssertionError: group crumbs that link to a sibling nav page instead of a s...
==================== 1 failed, 8 passed, 1 warning in 1.54s ====================
```

The other 8 tests pass on the unfixed code — that is the point of adding this one.

## Demo 2 — adversarial: the guard rejects a half-declared group crumb

Bad input built on purpose: `library: { group: 'Strategy', groupPage: null }` — a mid-crumb
whose button would call `setPage(null)`.

```
E   AssertionError: CRUMB_MAP entries declaring only half of a group crumb: {'library': ('Strategy', None)}. group and groupPage must both be set (a named section with a real landing page) or both be null (a flat 'Home / <page>' trail).
E   assert not {'library': ('Strategy', None)}
FAILED backend/tests/test_breadcrumbs.py::test_group_crumb_does_not_alias_a_sibling_nav_page - AssertionError: CRUMB_MAP entries declaring only half of a group crumb: {'l...
==================== 1 failed, 8 passed, 1 warning in 1.51s ====================
```

## Demo 3 — the guard discriminates, it does not just ban groups

An honest group crumb — one pointing at a route that is **not** a sidebar item of that
section — must still pass, otherwise the guard would block #1405's option 1 forever.
Stand-in: `library: { group: 'Strategy', groupPage: 'strategy' }` (`strategy` is a
`deepRoutes` page in `routes.js` with no `navConfig.js` NAV entry):

```
========================= 9 passed, 1 warning in 2.37s =========================
```

Tree restored to the committed state after each demo (`git status` clean before commit).

## Not done here

- **#1405 option 1 — real Strategy / Position / Market landing pages — is not built.**
  This PR takes option 2. If those pages are later built, each gets a route and these
  entries can name it: the new guard passes a groupPage that is not a sidebar sibling
  (demo 3), so it will not stand in the way.
- **The mid-crumb branch in `Breadcrumbs.jsx` is now inert** — no entry declares a group,
  so `roadmapSurfaceHidden(info.groupPage)` is never reached at runtime. Kept deliberately
  (with a comment saying so) as the contract a future landing page inherits. If the
  product decides section landing pages will never exist, the honest follow-up is to
  delete `group`/`groupPage` and the branch outright; that is a separate call, not this
  PR's.
- **No visual/CSS work.** Trails are one crumb shorter on eight pages; no styling changed
  and no new crumb variant (e.g. a non-clickable section label) was introduced.
- **Two stale comment references fixed in passing**, both in the file being changed and
  both zero-behaviour: `Layout.jsx` → `navConfig.js` for where NAV lives (#1437), and
  `App.jsx PAGE_TO_PATH` → `routes.js` (#1194). Flagged rather than buried.
- **`ui/src/featureFlags.js` untouched.** Its comment still says `ROADMAP_PAGES` is
  consumed by "the Breadcrumbs mid-crumb", which remains literally true (the call site
  exists) but is now inert. Left alone as out of scope.
- **Full `pytest -m "not integration"` was not run locally**; the change touches one JSX
  config literal and one test file, and `grep` confirms `backend/tests/test_breadcrumbs.py`
  is the only backend test that reads `Breadcrumbs.jsx`. CI's quality gate covers the rest.

Closes #1405