### PR TITLE
[infra][perf] Share the rigor cache across tasks so the gate recompute amortises instead of multiplying

### DIFF
--- a/backend/archimedes/api/selection_bias_routes.py
+++ b/backend/archimedes/api/selection_bias_routes.py
@@ -367,7 +367,19 @@ async def evaluate_rigor_gate(
     # hit changes no served or stored value; it just skips a redundant write. The
     # moment underlying returns change, the cache key changes and the write-back
     # resumes on the next (now-live) call.
-    from archimedes.services.rigor_cache import cohort_key, get_or_compute
+    # #1518: this memo is now TWO layers — the in-process dict, and a shared
+    # Redis-backed store underneath it. In-process alone did not amortise across
+    # the fleet, it multiplied by it: with N Fargate tasks behind the ALB, each
+    # holds its own copy and round-robin routing means a request can land on a
+    # task that has not computed this cohort yet and pays the whole ~21s
+    # recompute (measured on prod: 21.9s → 0.68s → 20.9s within a minute, which a
+    # 600s TTL cannot produce). `model_list_codec(StrategyRigorResult)` is what
+    # lets the value cross the process boundary — JSON via pydantic, so a cache
+    # HIT decodes to a value indistinguishable from what a MISS computed,
+    # four-state verdict vocabulary (`passes_all` / `pending` / `degenerate`)
+    # included. Both invalidation triggers survive the move: the key below still
+    # carries `cohort_key`, and `rigor_cache.clear()` now bumps a shared epoch.
+    from archimedes.services.rigor_cache import cohort_key, get_or_compute, model_list_codec
 
     code_versions = {s.id: getattr(s, "strategy_code_hash", None) for s in strategies}
     cache_key = f"selection_bias_gate:strictness={strictness}:" + cohort_key(
@@ -538,7 +550,12 @@ async def evaluate_rigor_gate(
     # strategies_routes.py's `_live_rigor_results_for_strategies` (same failure
     # class: an empty result must never get "sticky" for the TTL) and costs
     # nothing when `_compute()` returns its normal non-empty list.
-    results = get_or_compute(cache_key, _compute, cache_if=bool)
+    results = get_or_compute(
+        cache_key,
+        _compute,
+        cache_if=bool,
+        shared_codec=model_list_codec(StrategyRigorResult),
+    )
 
     # Copilot review (PR #1040): on a rigor_cache HIT, `results` are memoized
     # StrategyRigorResult objects whose `library_pbo` reflects whatever was

--- a/backend/archimedes/services/rigor_cache.py
+++ b/backend/archimedes/services/rigor_cache.py
@@ -1,4 +1,4 @@
-"""Process-level TTL cache for the (expensive but always-honest) live rigor gate.
+"""Two-layer TTL cache for the (expensive but always-honest) live rigor gate.
 
 **Why this exists (perf):** ``GET /api/strategies/`` and ``GET /api/selection-bias/gate``
 each recompute the full rigor gate LIVE on every request — cohort PBO, average
@@ -19,22 +19,41 @@ is pure memoization of an idempotent, deterministic function of its inputs.
 is caught and the call falls back to ``compute_fn()`` — a live, correct result. A cache
 bug can only ever cost a slow request, never a wrong or crashed one.
 
+**Why there are two layers (#1518).** The in-process layer alone does not amortise
+across the fleet, it multiplies by it. With N ECS tasks behind the ALB, each task holds
+its own copy and round-robin routing means a request can land on a task that has not
+computed this cohort yet and pays the full recompute — so the ~21s
+``/api/selection-bias/gate`` miss is paid N times per TTL window, and any deploy or
+scale event resets every copy at once. Measured against prod (#1518): the gate went
+21.9s → 0.68s → 20.9s inside about a minute, which a 600s TTL cannot explain. So a
+second, SHARED layer sits underneath the process layer: one task computes, every task
+reads. The shared layer is opt-in per call site via ``shared_codec`` (see
+``get_or_compute``) because the cached value has to be serialisable to cross a process
+boundary — a call site that passes no codec behaves exactly as it did before this
+change, process-local only.
+
 ``cachetools`` is NOT currently a dependency (checked ``backend/requirements.txt`` and
 ``environment.yml`` on 2026-07-06) — rather than add one for a single call site, this
 is a small hand-rolled dict-with-timestamps cache. If ``cachetools`` becomes a
 dependency for an unrelated reason later, ``_Store`` below can be swapped for
 ``cachetools.TTLCache`` without changing the public API (``cohort_key`` /
-``get_or_compute`` / ``clear``).
+``get_or_compute`` / ``clear``). The shared layer adds no dependency either: the sync
+``redis`` client is already used by ``api/limiter.py`` and
+``services/kb_runner.RedisLeaseClient``, and Redis is already in the stack.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
+import os
 import threading
 import time
 from array import array
 from collections.abc import Callable
+from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -156,10 +175,291 @@ def cohort_key(
     return hasher.hexdigest()
 
 
+# ───────────────────────── shared (cross-process) layer ─────────────────────────
+#
+# Everything below implements the second layer described in the module docstring.
+# Design constraints, in the order they bind:
+#
+#   1. A cached verdict must NEVER outlive the data it grades. The shared layer
+#      inherits BOTH of the process layer's invalidation triggers, unchanged:
+#        a) the data-version token — `cohort_key` is already part of `key`, so the
+#           shared entry key changes the instant any strategy's persisted returns
+#           or code hash changes, exactly as the in-process key does; and
+#        b) `clear()` — which now bumps a shared EPOCH counter (below), so a
+#           `clear()` on ANY task makes every task's shared lookup miss on the
+#           next request. Without (b), moving the cache off-process would make a
+#           stale entry strictly MORE durable than it is today: today a task
+#           restart drops it, in Redis it would survive both the restart and the
+#           writer that invalidated it, and every task would serve it.
+#   2. Fail-open, always. Every Redis touch is wrapped; any failure degrades to
+#      the process layer and then to a live `compute_fn()`. A Redis outage can
+#      only make the gate slow, never wrong.
+#   3. Never add latency to a healthy request. Reads carry a hard socket timeout,
+#      and a single failure opens a circuit breaker for `_SHARED_BACKOFF_SECONDS`
+#      so a down Redis costs one timeout per backoff window, not one per request.
+#
+# Invalidation is an EPOCH bump rather than a key sweep on purpose: `clear()` is
+# called from `backtest_repository.insert_backtest_if_missing` on the write path,
+# so it has to be O(1) and atomic. `INCR` is both. A `SCAN`+`DEL` sweep would be
+# O(keyspace) against a Redis shared with the agent state store, and a key-index
+# SET would need its own unbounded-growth story. Superseded entries are simply
+# unreachable and die on their own TTL.
+
+_SHARED_KEY_PREFIX = "archimedes:rigor_cache:v1:"
+_SHARED_EPOCH_KEY = _SHARED_KEY_PREFIX + "epoch"
+
+# Hard ceilings on what a sick Redis can cost a request. Both are small because
+# the shared layer is an OPTIMISATION: if it cannot answer in a few hundred
+# milliseconds there is nothing to gain by waiting for it.
+_SHARED_SOCKET_TIMEOUT = 0.5
+_SHARED_CONNECT_TIMEOUT = 0.25
+
+# Circuit breaker. After any shared-layer error, skip the shared layer entirely
+# for this long. Without it, a Redis outage would add `_SHARED_CONNECT_TIMEOUT`
+# to EVERY request for the duration of the outage — turning a perf feature into
+# a perf regression at exactly the wrong moment.
+_SHARED_BACKOFF_SECONDS = 30.0
+
+_shared_lock = threading.Lock()
+_shared_override: Any | None = None
+_shared_override_set = False
+_shared_default: Any | None = None
+_shared_default_built = False
+_shared_disabled_until: float = 0.0
+
+
+@dataclass(frozen=True)
+class SharedCodec:
+    """How one call site's cached value crosses a process boundary.
+
+    ``encode``/``decode`` must be exact inverses — a value that round-trips
+    through them has to be indistinguishable from the value ``compute_fn()``
+    returned, because a shared cache HIT serves the decoded value verbatim. If a
+    field is dropped or coerced by the codec, the fleet serves a different answer
+    than the computing task did, which is the "claims must be true" line.
+
+    ``schema_token`` fingerprints the SHAPE the codec writes, and is part of the
+    shared key. Two tasks running different code versions (a rolling deploy is
+    exactly this, for a few minutes) must not read each other's payloads under a
+    changed model: a shape change moves the token, so the old payload becomes
+    unreachable rather than being mis-parsed into a plausible-looking verdict.
+    """
+
+    encode: Callable[[Any], str]
+    decode: Callable[[str], Any]
+    schema_token: str
+
+
+@lru_cache(maxsize=8)
+def model_list_codec(model_cls: type) -> SharedCodec:
+    """``SharedCodec`` for a ``list`` of one pydantic model.
+
+    JSON, not pickle, and deliberately: the shared store is a network service
+    whose contents are trusted by every task in the fleet, and
+    ``pickle.loads`` on data read from a network service is arbitrary code
+    execution if that service is ever reachable by anything else. JSON can only
+    ever produce a value the model itself validates.
+
+    The ``schema_token`` is a hash of ``model_json_schema()`` — which includes
+    nested models via ``$defs`` — so ADDING, REMOVING, or RETYPING any field
+    (including one on ``RigorGateDetail`` / ``LibraryPbo``) changes the token and
+    orphans every payload written under the old shape.
+    """
+    schema = json.dumps(model_cls.model_json_schema(), sort_keys=True, default=str)
+    token = hashlib.sha256(schema.encode("utf-8")).hexdigest()[:16]
+
+    def _encode(value: Any) -> str:
+        return json.dumps([item.model_dump(mode="json") for item in value], separators=(",", ":"))
+
+    def _decode(payload: str) -> Any:
+        return [model_cls.model_validate(item) for item in json.loads(payload)]
+
+    return SharedCodec(encode=_encode, decode=_decode, schema_token=token)
+
+
+def _build_default_backend() -> Any | None:
+    """The production shared backend: a sync Redis client, or ``None``.
+
+    ``None`` (i.e. process-local only, exactly the pre-#1518 behaviour) when:
+
+      - ``TESTING`` is set — the unit suite is hermetic by mandate (see
+        CLAUDE.md § Testing conventions) and must never open a socket. Tests that
+        exercise the shared layer inject a fake through ``set_shared_backend``,
+        which is a boundary mock, not an internals mock.
+      - ``REDIS_URL`` is not explicitly set — a bare dev machine has no Redis, and
+        defaulting to ``localhost`` there would spend a connect attempt per
+        request to learn that. ECS injects ``REDIS_URL`` from SSM
+        (``infra/ecs.tf``) and docker compose sets it (``docker-compose.yml``),
+        so both real deployments get the shared layer.
+    """
+    if os.getenv("TESTING"):
+        return None
+    url = (os.getenv("REDIS_URL") or "").strip()
+    if not url:
+        logger.info("rigor_cache: REDIS_URL not set — shared layer disabled, cache is process-local only")
+        return None
+    import redis as sync_redis
+
+    return sync_redis.Redis.from_url(
+        url,
+        decode_responses=True,
+        socket_timeout=_SHARED_SOCKET_TIMEOUT,
+        socket_connect_timeout=_SHARED_CONNECT_TIMEOUT,
+        retry_on_timeout=False,
+    )
+
+
+def set_shared_backend(client: Any | None) -> None:
+    """Install an explicit shared backend (or ``None`` to disable the layer).
+
+    The seam tests use to substitute a fake Redis at the client boundary. Also
+    resets the circuit breaker, so an injected backend is always given a chance.
+    """
+    global _shared_override, _shared_override_set, _shared_disabled_until
+    with _shared_lock:
+        _shared_override = client
+        _shared_override_set = True
+        _shared_disabled_until = 0.0
+
+
+def reset_shared_backend() -> None:
+    """Forget any injected backend, any memoized default, and the breaker state."""
+    global _shared_override, _shared_override_set, _shared_default, _shared_default_built, _shared_disabled_until
+    with _shared_lock:
+        _shared_override = None
+        _shared_override_set = False
+        _shared_default = None
+        _shared_default_built = False
+        _shared_disabled_until = 0.0
+
+
+def _shared_client() -> Any | None:
+    """The active shared backend, or ``None`` when the layer is unavailable."""
+    global _shared_default, _shared_default_built
+    try:
+        with _shared_lock:
+            if _shared_disabled_until and time.monotonic() < _shared_disabled_until:
+                return None
+            if _shared_override_set:
+                return _shared_override
+            if _shared_default_built:
+                return _shared_default
+        client = _build_default_backend()
+        with _shared_lock:
+            if not _shared_default_built:
+                _shared_default = client
+                _shared_default_built = True
+            return _shared_default
+    except Exception as exc:  # pragma: no cover - defensive; never break a request
+        logger.warning("rigor_cache: shared backend unavailable (%s) — process-local cache only", exc)
+        _trip_shared_breaker()
+        return None
+
+
+def _trip_shared_breaker() -> None:
+    """Skip the shared layer for ``_SHARED_BACKOFF_SECONDS`` after any failure."""
+    global _shared_disabled_until
+    try:
+        with _shared_lock:
+            _shared_disabled_until = time.monotonic() + _SHARED_BACKOFF_SECONDS
+    except Exception:  # pragma: no cover - defensive, best-effort only
+        pass
+
+
+def _shared_entry_key(epoch: int, codec: SharedCodec, key: str) -> str:
+    return f"{_SHARED_KEY_PREFIX}e{epoch}:{codec.schema_token}:{key}"
+
+
+def _shared_epoch(client: Any) -> int:
+    """Current invalidation epoch. Absent (never cleared) reads as 0.
+
+    If this key is ever evicted the epoch falls back to 0, which could make a
+    surviving epoch-0 entry reachable again. That is bounded by the entries' own
+    TTL — i.e. the worst case is exactly the ``_TTL_SECONDS`` staleness backstop
+    this module already documents, never worse.
+    """
+    raw = client.get(_SHARED_EPOCH_KEY)
+    if raw is None:
+        return 0
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    return int(raw)
+
+
+def _shared_lookup(key: str, codec: SharedCodec) -> tuple[bool, Any, int | None]:
+    """``(hit, value, epoch)``. ``epoch`` is captured for the eventual WRITE.
+
+    Writing under the epoch observed at LOOKUP time (not at write time) closes a
+    real staleness hole: the leader's ``compute_fn()`` can run for ~20s, and a
+    ``clear()`` landing inside that window must not be undone by the leader then
+    publishing a pre-``clear()`` verdict under the post-``clear()`` epoch. Writing
+    under the captured epoch means such a result lands somewhere nobody will look.
+    """
+    client = _shared_client()
+    if client is None:
+        return False, None, None
+    try:
+        epoch = _shared_epoch(client)
+        payload = client.get(_shared_entry_key(epoch, codec, key))
+    except Exception as exc:
+        logger.warning("rigor_cache: shared lookup failed (%s) — falling back to the process cache", exc)
+        _trip_shared_breaker()
+        return False, None, None
+    if payload is None:
+        return False, None, epoch
+    try:
+        if isinstance(payload, bytes):
+            payload = payload.decode("utf-8")
+        return True, codec.decode(payload), epoch
+    except Exception as exc:
+        # A payload we cannot decode exactly is a MISS, never a partial verdict.
+        # This is the rolling-deploy case the schema_token already tries to
+        # prevent, plus plain corruption; either way the only honest answer is to
+        # recompute live.
+        logger.warning("rigor_cache: shared payload failed to decode (%s) — treating as a miss", exc)
+        return False, None, epoch
+
+
+def _shared_store(key: str, codec: SharedCodec, value: Any, epoch: int | None) -> None:
+    """Publish ``value`` for the whole fleet. Best-effort; never raises."""
+    client = _shared_client()
+    if client is None:
+        return
+    try:
+        if epoch is None:
+            epoch = _shared_epoch(client)
+        client.setex(_shared_entry_key(epoch, codec, key), int(_TTL_SECONDS), codec.encode(value))
+    except Exception as exc:
+        logger.warning("rigor_cache: shared store failed (%s) — serving the live result anyway", exc)
+        _trip_shared_breaker()
+
+
+def _shared_clear() -> None:
+    """Bump the epoch so every task's shared lookup misses from now on."""
+    client = _shared_client()
+    if client is None:
+        return
+    try:
+        client.incr(_SHARED_EPOCH_KEY)
+    except Exception as exc:
+        logger.warning("rigor_cache: shared invalidation failed (%s) — shared entries expire on their TTL", exc)
+        _trip_shared_breaker()
+
+
+def _local_put(key: str, value: Any) -> None:
+    """Write to the process layer with the same bound-keeping a normal write does."""
+    with _lock:
+        store_time = time.monotonic()
+        _prune_expired_locked(store_time)
+        _store[key] = (store_time, value)
+        _evict_oldest_locked(_MAX_STORE_SIZE)
+
+
 def get_or_compute(
     key: str,
     compute_fn: Callable[[], Any],
     cache_if: Callable[[Any], bool] = lambda _value: True,
+    shared_codec: SharedCodec | None = None,
 ) -> Any:
     """Return the cached value for ``key`` if present and still fresh; else compute
     it via ``compute_fn()``, cache it (subject to ``cache_if``), and return it.
@@ -200,7 +500,19 @@ def get_or_compute(
     calling ``compute_fn()`` directly, and — critically — never leaves a
     follower waiting forever: any Event this call created is always released
     before that fallback returns.
+
+    SHARED LAYER (#1518): when ``shared_codec`` is supplied, a process-layer miss
+    consults the cross-process store before computing, and a computed result is
+    published there as well as locally — so one task's ~21s recompute serves the
+    whole fleet instead of being repeated on every task. The process layer is
+    still checked FIRST and answers without touching Redis, so a warm task's hit
+    path stays O(1) and survives a Redis outage entirely. Omitting
+    ``shared_codec`` leaves a call site exactly as it was: process-local, no
+    serialisation, no Redis. The shared write happens on the SAME condition as
+    the local one (``cache_if`` accepted the value), so a failure sentinel can no
+    more get sticky across the fleet than it can within one task.
     """
+    shared_epoch: int | None = None
     try:
         now = time.monotonic()
         with _lock:
@@ -209,6 +521,15 @@ def get_or_compute(
             stored_at, value = entry
             if now - stored_at < _TTL_SECONDS:
                 return value
+        if shared_codec is not None:
+            hit, shared_value, shared_epoch = _shared_lookup(key, shared_codec)
+            if hit:
+                # Populate the process layer so this task's SUBSEQUENT requests
+                # skip Redis entirely. Safe by construction: the entry exists in
+                # the shared store only because the writing task's `cache_if`
+                # accepted it, under a key that already encodes the data version.
+                _local_put(key, shared_value)
+                return shared_value
     except Exception as exc:  # pragma: no cover - defensive; cache lookup must never break the request
         logger.warning("rigor_cache: lookup failed, falling back to live compute: %s", exc)
         return compute_fn()
@@ -287,17 +608,18 @@ def get_or_compute(
 
     if should_cache:
         try:
-            with _lock:
-                store_time = time.monotonic()
-                # Opportunistic bound-keeping on every write (never on the read
-                # path, so a cache hit stays O(1)): first reclaim anything
-                # that's aged out, then enforce the hard size cap. See the
-                # `_MAX_STORE_SIZE` docstring above for why both are needed.
-                _prune_expired_locked(store_time)
-                _store[key] = (store_time, value)
-                _evict_oldest_locked(_MAX_STORE_SIZE)
+            # Opportunistic bound-keeping on every write (never on the read
+            # path, so a cache hit stays O(1)): first reclaim anything
+            # that's aged out, then enforce the hard size cap. See the
+            # `_MAX_STORE_SIZE` docstring above for why both are needed.
+            _local_put(key, value)
         except Exception as exc:  # pragma: no cover - defensive; cache store must never break the request
             logger.warning("rigor_cache: store failed, serving live result anyway: %s", exc)
+        if shared_codec is not None:
+            # Publish for the rest of the fleet. `_shared_store` swallows every
+            # failure itself, so this can only ever cost the NEXT task a
+            # recompute — never this request its result.
+            _shared_store(key, shared_codec, value, shared_epoch)
 
     # Release any followers waiting on this key — they'll read the entry we
     # just (attempted to) store above, or fall back to their own live compute
@@ -323,6 +645,26 @@ def clear() -> None:
     changes the moment the underlying returns change, which is what makes an
     un-cleared cache still safe — this only tightens the window between "data
     written" and "next read recomputes" from up to ``_TTL_SECONDS`` to ~0.
+
+    **Both layers (#1518).** This clears the process store AND bumps the shared
+    epoch, so every other task's shared lookup misses on its next request. That
+    is not optional politeness: an entry in Redis outlives the process that wrote
+    it and is visible to every task, so a ``clear()`` that reached only the local
+    dict would leave the fleet serving a verdict the writer already invalidated —
+    strictly worse than the pre-#1518 behaviour, where a task restart at least
+    dropped it. ``test_rigor_cache_shared.py`` pins this by reverting it.
+
+    The local clear runs first and unconditionally, so a Redis failure can never
+    stop the calling task from dropping its own copy.
+
+    What this still does NOT do, stated plainly: it cannot reach ANOTHER task's
+    in-process dict. A task that already holds the entry locally keeps serving it
+    until its own ``_TTL_SECONDS`` expires or the data-version key changes —
+    exactly the pre-#1518 behaviour for every task, unchanged by this work. The
+    data-version token in the key remains the real invalidation mechanism; this
+    call is the backstop, and #1518 restores the backstop's reach to the one new
+    place a cached verdict can now live.
     """
     with _lock:
         _store.clear()
+    _shared_clear()

--- a/backend/tests/test_rigor_cache_shared.py
+++ b/backend/tests/test_rigor_cache_shared.py
@@ -1,0 +1,701 @@
+"""Tests for the SHARED (cross-process) layer of ``services.rigor_cache`` — #1518.
+
+The defect: ``rigor_cache`` was in-process only, so the selection-bias gate's
+~21s recompute did not amortise across the Fargate fleet, it multiplied by it —
+one recompute per task per TTL window, and every copy reset together on a deploy.
+Measured on prod, three rounds seconds apart: 21.9s → 0.68s → 20.9s, which a 600s
+TTL cannot produce.
+
+What must hold, and is proven below:
+
+  (a) SHARED, not per-process. Two genuinely independent module instances (each
+      with its own ``_store``/``_lock``/``_inflight``, which is what a second ECS
+      task is) pointed at one backend see the same entry, and the miss path runs
+      ONCE.
+  (b) A cached verdict never outlives the data it grades. BOTH pre-existing
+      invalidation triggers still reach the new place a verdict can live:
+      the data-version token in the key, and ``clear()``. Each has a
+      revert-demo test that fails when its trigger is broken.
+  (c) The four-state verdict vocabulary round-trips EXACTLY — ``pass`` / ``fail``
+      / ``pending`` / ``degenerate`` — and no ``board_fdr*`` key rides the wire
+      (#1580's drift guard, extended to this new serialisation surface).
+  (d) Fail-open, everywhere. A missing, broken, slow, or corrupt shared backend
+      degrades to the process layer and then to a live compute. It can make the
+      gate slow; it can never make it wrong.
+
+Hermetic: the Redis client is mocked at the client boundary (``_FakeRedis``), and
+``rigor_cache`` refuses to build a real backend while ``TESTING`` is set, so this
+file opens no socket.
+
+  env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \\
+      backend/tests/test_rigor_cache_shared.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import sys
+from typing import Any
+
+import pytest
+from archimedes.api.selection_bias_routes import RigorGateResponse, StrategyRigorResult
+from archimedes.services import rigor_cache
+
+# ── Boundary mock: the sync redis client, not the cache's internals ──────────
+
+
+class _FakeRedis:
+    """In-memory stand-in for the ``redis.Redis`` surface the shared layer uses.
+
+    Implements exactly the three commands ``rigor_cache`` issues — ``GET`` /
+    ``SETEX`` / ``INCR`` — with real TTL semantics off an injectable clock, and
+    records every op so a test can assert what did and did not reach the wire.
+    ``fail_on`` makes a named command raise, for the fail-open tests.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[float | None, str]] = {}
+        self.ops: list[tuple] = []
+        self.now = 0.0
+        self.fail_on: set[str] = set()
+
+    def _maybe_fail(self, cmd: str) -> None:
+        if cmd in self.fail_on:
+            raise ConnectionError(f"fake redis: {cmd} unavailable")
+
+    def get(self, key: str) -> str | None:
+        self.ops.append(("get", key))
+        self._maybe_fail("get")
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if expires_at is not None and self.now >= expires_at:
+            del self._data[key]
+            return None
+        return value
+
+    def setex(self, key: str, ttl: int, value: str) -> None:
+        self.ops.append(("setex", key, ttl))
+        self._maybe_fail("setex")
+        assert isinstance(value, str), "the shared layer must write a str payload, never a pickle/bytes blob"
+        self._data[key] = (self.now + float(ttl), value)
+
+    def incr(self, key: str) -> int:
+        self.ops.append(("incr", key))
+        self._maybe_fail("incr")
+        _expires_at, current = self._data.get(key, (None, "0"))
+        new = int(current) + 1
+        self._data[key] = (None, str(new))
+        return new
+
+    # Test conveniences (not part of the mocked surface) ────────────────────
+    def entry_keys(self) -> list[str]:
+        return [k for k in self._data if not k.endswith(":epoch")]
+
+    def ops_named(self, name: str) -> list[tuple]:
+        return [op for op in self.ops if op[0] == name]
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Redirect DATABASE_URL to a per-test temp SQLite file — same pattern as
+    test_rigor_cache.py, so the route tests below touch a real but isolated DB."""
+    from archimedes.db import init_db
+
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'test_rigor_cache_shared.db'}")
+    init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_inflight():
+    """``clear()`` deliberately does not touch the single-flight bookkeeping (see
+    its docstring), so reset it here purely for test isolation."""
+    rigor_cache._inflight.clear()
+    yield
+    rigor_cache._inflight.clear()
+
+
+@pytest.fixture
+def fake_redis() -> Any:
+    """A fake shared backend installed on the primary module instance."""
+    fake = _FakeRedis()
+    rigor_cache.set_shared_backend(fake)
+    yield fake
+    rigor_cache.reset_shared_backend()
+
+
+_worker_seq = itertools.count()
+
+
+def _worker_b():
+    """A SECOND, genuinely independent instance of ``rigor_cache``.
+
+    Executing the module file under its own name gives a distinct module object
+    with a fresh ``_store`` / ``_lock`` / ``_inflight`` / breaker state — which is
+    exactly what a second ECS task is. This is the faithful way to test "shared
+    vs per-process" inside one interpreter: clearing the primary instance's dict
+    instead would leave the two "workers" sharing every other module global, and
+    would keep passing for a cache that was never shared at all.
+    """
+    name = f"rigor_cache_worker_b_{next(_worker_seq)}"
+    spec = importlib.util.spec_from_file_location(name, rigor_cache.__file__)
+    module = importlib.util.module_from_spec(spec)
+    # `@dataclass` resolves its own module through `sys.modules`, so the copy has
+    # to be registered under its own (unique) name. It stays a distinct module
+    # object with its own globals — which is the point.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _result(
+    sid: str,
+    *,
+    passes_all: bool = False,
+    pending: bool = False,
+    degenerate: bool = False,
+    dsr_p_value: float | None = None,
+) -> StrategyRigorResult:
+    return StrategyRigorResult(
+        strategy_id=sid,
+        strategy_name=f"Paper {sid}",
+        passes_all=passes_all,
+        gate_details={"dsr": "PASS" if passes_all else "FAIL"},
+        dsr_p_value=dsr_p_value,
+        pending=pending,
+        degenerate=degenerate,
+    )
+
+
+def _codec(module=rigor_cache):
+    return module.model_list_codec(StrategyRigorResult)
+
+
+def _dump(results) -> list[dict]:
+    return [r.model_dump(mode="json") for r in results]
+
+
+# ── (a) the entry is SHARED, and the miss path runs once for the fleet ───────
+
+
+def test_two_independent_instances_share_one_entry_and_compute_once(fake_redis):
+    """#1518 acceptance, literally: two independent cache clients see the same
+    entry, and the miss path runs once."""
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    calls: list[int] = []
+
+    def _compute():
+        calls.append(1)
+        return [_result("s1", passes_all=True), _result("s2")]
+
+    a = rigor_cache.get_or_compute("gate:k", _compute, cache_if=bool, shared_codec=_codec())
+    assert len(calls) == 1, "worker A must pay the miss"
+
+    assert worker_b._store == {}, "worker B starts cold — no in-process entry to hit"
+    b = worker_b.get_or_compute("gate:k", _compute, cache_if=bool, shared_codec=_codec(worker_b))
+
+    assert len(calls) == 1, (
+        "worker B recomputed — the cache is still per-process. One task's compute must serve the whole fleet."
+    )
+    assert _dump(b) == _dump(a)
+    assert all(isinstance(r, StrategyRigorResult) for r in b), "a shared hit must decode to models, not dicts"
+
+
+def test_a_shared_hit_populates_the_process_layer_so_the_next_hit_skips_redis(fake_redis):
+    """The process layer is still layer one: after one shared hit, this task's
+    subsequent requests must not touch the backend at all (a Redis outage cannot
+    slow down an already-warm task)."""
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    rigor_cache.get_or_compute("gate:k", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec())
+    worker_b.get_or_compute("gate:k", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec(worker_b))
+
+    before = len(fake_redis.ops)
+    worker_b.get_or_compute("gate:k", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec(worker_b))
+    assert len(fake_redis.ops) == before, "a warm process-layer hit must issue no Redis commands"
+
+
+def test_no_codec_means_no_shared_traffic_at_all(fake_redis):
+    """A call site that passes no ``shared_codec`` behaves exactly as it did
+    before #1518 — process-local, no serialisation, nothing on the wire."""
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    calls: list[int] = []
+
+    def _compute():
+        calls.append(1)
+        return [_result("s1")]
+
+    rigor_cache.get_or_compute("gate:k", _compute, cache_if=bool)
+    worker_b.get_or_compute("gate:k", _compute, cache_if=bool)
+
+    assert calls == [1, 1], "without a codec each process must compute for itself, as before"
+    assert fake_redis.ops == [], "no codec must mean no Redis traffic"
+
+
+# ── (b) invalidation trigger 1: the data-version token in the key ────────────
+
+
+def test_changed_returns_are_never_served_the_old_shared_verdict(fake_redis):
+    """REVERT DEMO (staleness). Mutate the underlying returns; a cold worker must
+    grade the NEW data, never be handed the entry the old data produced.
+
+    The guard is that the shared entry key carries ``cohort_key`` — the
+    data-version token — exactly as the in-process key always has. Revert that
+    (key the shared entry on the route/schema alone, the naive "the gate result
+    is a small keyed blob" implementation) and worker B is served worker A's
+    verdict for data worker A never saw.
+    """
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    ids = ["s1"]
+    returns_v1 = {"s1": [0.01] * 5 + [-0.004] * 5}
+    returns_v2 = {"s1": [-0.01] * 5 + [0.004] * 5}  # same length, opposite sign: a real data change
+
+    def _verdict_for(returns: dict[str, list[float]]):
+        # Stand-in for the live gate: a deterministic function OF THE DATA, so
+        # "served the old verdict" is observable as a wrong answer, not just as
+        # a call count.
+        mean = sum(returns["s1"]) / len(returns["s1"])
+        return [_result("s1", passes_all=mean > 0, dsr_p_value=round(mean, 6))]
+
+    key_v1 = "selection_bias_gate:strictness=1:" + rigor_cache.cohort_key(ids, returns_v1)
+    key_v2 = "selection_bias_gate:strictness=1:" + rigor_cache.cohort_key(ids, returns_v2)
+    assert key_v1 != key_v2, "sanity: cohort_key must react to the returns change this test makes"
+
+    a = rigor_cache.get_or_compute(key_v1, lambda: _verdict_for(returns_v1), cache_if=bool, shared_codec=_codec())
+    assert a[0].passes_all is True
+
+    b = worker_b.get_or_compute(key_v2, lambda: _verdict_for(returns_v2), cache_if=bool, shared_codec=_codec(worker_b))
+    assert b[0].passes_all is False, (
+        "the shared cache served the verdict computed from the OLD returns — a cached verdict "
+        "outlived the data it grades"
+    )
+    assert b[0].dsr_p_value == pytest.approx(-0.003)
+
+
+# ── (b) invalidation trigger 2: clear() ──────────────────────────────────────
+
+
+def test_clear_invalidates_the_shared_entry_for_every_worker(fake_redis):
+    """REVERT DEMO (staleness). ``clear()`` must reach the shared copy too.
+
+    ``backtest_repository.insert_backtest_if_missing`` calls ``clear()`` on the
+    write path. It exists as the BACKSTOP for a data change the key cannot see,
+    so this test deliberately holds the key fixed and changes what the compute
+    returns — that is the only case ``clear()`` is responsible for.
+
+    Before #1518 a stale entry died with the process; in Redis it survives the
+    restart AND the writer that invalidated it, and every task serves it. Revert
+    ``clear()`` to the process store only and worker B is served the pre-clear
+    verdict.
+    """
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    verdict = {"passes": True}
+
+    def _compute():
+        return [_result("s1", passes_all=verdict["passes"])]
+
+    key = "selection_bias_gate:strictness=1:fixed-data-version-token"
+    a = rigor_cache.get_or_compute(key, _compute, cache_if=bool, shared_codec=_codec())
+    assert a[0].passes_all is True
+    assert fake_redis.entry_keys(), "sanity: worker A must actually have published a shared entry"
+
+    # The underlying returns were rewritten and the writer invalidated the cache.
+    verdict["passes"] = False
+    rigor_cache.clear()
+
+    b = worker_b.get_or_compute(key, _compute, cache_if=bool, shared_codec=_codec(worker_b))
+    assert b[0].passes_all is False, (
+        "clear() did not reach the shared layer — the fleet is serving a verdict the writer already invalidated"
+    )
+
+
+def test_clear_bumps_the_shared_epoch_exactly_once(fake_redis):
+    rigor_cache.clear()
+    assert fake_redis.ops_named("incr") == [("incr", rigor_cache._SHARED_EPOCH_KEY)]
+
+
+def test_clear_still_drops_the_local_copy_when_the_shared_bump_fails(fake_redis):
+    """A Redis failure must never stop the calling task from dropping its own
+    entry — the local clear runs first and unconditionally."""
+    rigor_cache.get_or_compute("gate:k", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec())
+    assert rigor_cache._store, "sanity: something is cached locally"
+
+    fake_redis.fail_on.add("incr")
+    rigor_cache.clear()
+    assert rigor_cache._store == {}
+
+
+def test_a_result_computed_before_a_clear_is_never_published_after_it(fake_redis):
+    """The leader's ``compute_fn`` can run for ~20s. A ``clear()`` landing inside
+    that window must not be undone by the leader then publishing its pre-clear
+    result under the post-clear epoch. The write goes under the epoch observed at
+    LOOKUP time, so such a result lands somewhere nobody will look."""
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    key = "selection_bias_gate:strictness=1:fixed-data-version-token"
+
+    def _slow_compute():
+        rigor_cache.clear()  # the writer invalidates while we are still computing
+        return [_result("s1", passes_all=True)]
+
+    rigor_cache.get_or_compute(key, _slow_compute, cache_if=bool, shared_codec=_codec())
+
+    calls: list[int] = []
+
+    def _fresh():
+        calls.append(1)
+        return [_result("s1", passes_all=False)]
+
+    b = worker_b.get_or_compute(key, _fresh, cache_if=bool, shared_codec=_codec(worker_b))
+    assert calls == [1], "worker B must recompute — the pre-clear result must be unreachable"
+    assert b[0].passes_all is False
+
+
+# ── (c) the four-state verdict vocabulary round-trips exactly ────────────────
+
+
+_FOUR_STATES = [
+    ("pass", {"passes_all": True, "pending": False, "degenerate": False}),
+    ("fail", {"passes_all": False, "pending": False, "degenerate": False}),
+    ("pending", {"passes_all": False, "pending": True, "degenerate": False}),
+    ("degenerate", {"passes_all": False, "pending": False, "degenerate": True}),
+]
+
+
+def test_the_four_state_verdict_vocabulary_round_trips_exactly(fake_redis):
+    """``pass`` / ``fail`` / ``pending`` / ``degenerate`` are four DISTINCT states
+    (CLAUDE.md § fail-soft): collapsing "never evaluated" or "nothing was
+    measurable" into "evaluated and lost" is the exact defect #1358 fixed. A
+    shared cache hit serves the decoded value verbatim, so the codec has to
+    preserve all four — and every other field with them."""
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    computed = [_result(name, **flags) for name, flags in _FOUR_STATES]
+    a = rigor_cache.get_or_compute("gate:states", lambda: computed, cache_if=bool, shared_codec=_codec())
+    b = worker_b.get_or_compute("gate:states", list, cache_if=bool, shared_codec=_codec(worker_b))
+
+    assert _dump(b) == _dump(a), "the shared round-trip changed the served payload"
+    for row, (name, flags) in zip(b, _FOUR_STATES, strict=True):
+        assert row.strategy_id == name
+        for field, expected in flags.items():
+            assert getattr(row, field) is expected, f"{name}: {field} did not survive the shared round-trip"
+
+
+def test_the_four_states_stay_distinguishable_after_the_round_trip(fake_redis):
+    """Anti-vacuity for the test above: the four states must remain four, not
+    collapse into two. A codec that dropped ``pending``/``degenerate`` would
+    still pass a field-by-field check against a payload that had already lost
+    them, so assert the states are pairwise distinct on the DECODED side."""
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    computed = [_result(name, **flags) for name, flags in _FOUR_STATES]
+    rigor_cache.get_or_compute("gate:states", lambda: computed, cache_if=bool, shared_codec=_codec())
+    b = worker_b.get_or_compute("gate:states", list, cache_if=bool, shared_codec=_codec(worker_b))
+
+    signatures = {(r.passes_all, r.pending, r.degenerate) for r in b}
+    assert len(signatures) == 4, f"the four verdict states collapsed to {len(signatures)} after the round trip"
+
+
+# ── (c) #1580's drift guard, extended to the shared-payload surface ──────────
+
+
+def _board_fdr_json_paths(node, path: str = "$") -> list[str]:
+    """Every JSON path whose key mentions board-level FDR. Same shape of scan as
+    ``_relational_json_keys`` in test_selection_bias_routes.py, applied to the
+    payload the shared cache writes."""
+    found: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            here = f"{path}.{key}"
+            if "board_fdr" in key or "board_level_fdr" in key:
+                found.append(here)
+            found.extend(_board_fdr_json_paths(value, here))
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            found.extend(_board_fdr_json_paths(value, f"{path}[{i}]"))
+    return found
+
+
+def test_the_board_fdr_scan_flags_a_deliberate_reappearance():
+    """Adversarial pass: build the payload that SHOULD fail the scan and show it
+    does — including the NESTED per-strategy position a shallow scan would miss."""
+    bad = [{"strategy_id": "a", "board_fdr_significant": False, "library_pbo": {"board_level_fdr": 1}}]
+    flagged = _board_fdr_json_paths(bad)
+    assert "$[0].board_fdr_significant" in flagged
+    assert "$[0].library_pbo.board_level_fdr" in flagged
+
+
+def test_the_shared_payload_carries_no_board_fdr_key(fake_redis):
+    """#1580 moved board-level FDR onto the leaderboard and off the per-strategy
+    gate. The shared cache is a NEW place that shape could drift back in, so the
+    same guard applies to what actually goes on the wire."""
+    codec = _codec()
+    payload = codec.encode([_result(name, **flags) for name, flags in _FOUR_STATES])
+    assert _board_fdr_json_paths(json.loads(payload)) == []
+    assert "board_fdr" not in payload and "board_level_fdr" not in payload
+
+
+def test_the_gate_response_model_still_carries_no_board_fdr_field():
+    """Belt to the above: the model the payload is built from is still clean, so
+    a reappearance would have to be introduced on purpose in two places."""
+    for model in (StrategyRigorResult, RigorGateResponse):
+        assert [f for f in model.model_fields if "board_fdr" in f or "board_level_fdr" in f] == []
+
+
+# ── (c) cross-version safety: the schema token orphans a changed shape ───────
+
+
+def test_a_shape_change_orphans_payloads_written_under_the_old_shape(fake_redis):
+    """A rolling deploy runs two code versions against one Redis for a few
+    minutes. A task must never mis-parse a neighbour's payload into a
+    plausible-looking verdict, so the shared key carries a hash of the model's
+    JSON schema: change the shape, and old payloads become unreachable rather
+    than readable."""
+    from pydantic import BaseModel
+
+    class _V1(BaseModel):
+        strategy_id: str = ""
+        passes_all: bool = False
+
+    class _V2(BaseModel):
+        strategy_id: str = ""
+        passes_all: bool = False
+        board_fdr_significant: bool | None = None  # the exact drift #1580 forbids
+
+    v1, v2 = rigor_cache.model_list_codec(_V1), rigor_cache.model_list_codec(_V2)
+    assert v1.schema_token != v2.schema_token, "the schema token does not react to a field being added"
+
+    rigor_cache.get_or_compute("gate:k", lambda: [_V1(strategy_id="s1")], cache_if=bool, shared_codec=v1)
+
+    calls: list[int] = []
+
+    def _compute_v2():
+        calls.append(1)
+        return [_V2(strategy_id="s1")]
+
+    rigor_cache._store.clear()  # a task that has not computed this cohort yet
+    rigor_cache.get_or_compute("gate:k", _compute_v2, cache_if=bool, shared_codec=v2)
+    assert calls == [1], "a reader on a different shape must MISS, never decode a neighbour's payload"
+
+
+def test_the_schema_token_is_stable_across_instances():
+    """The token has to be the same number in every task, or the fleet shards
+    itself and nothing is shared."""
+    worker_b = _worker_b()
+    assert _codec().schema_token == _codec(worker_b).schema_token
+
+
+# ── (d) fail-open: a sick shared layer costs latency, never correctness ──────
+
+
+@pytest.mark.parametrize("failing_command", ["get", "setex"])
+def test_a_broken_shared_backend_still_serves_a_live_result(fake_redis, failing_command):
+    fake_redis.fail_on.add(failing_command)
+    out = rigor_cache.get_or_compute(
+        "gate:k", lambda: [_result("s1", passes_all=True)], cache_if=bool, shared_codec=_codec()
+    )
+    assert out[0].passes_all is True
+
+
+def test_a_corrupt_shared_payload_is_a_miss_not_a_partial_verdict(fake_redis):
+    """Anything we cannot decode EXACTLY must recompute. Half a verdict is worse
+    than a slow one."""
+    rigor_cache.get_or_compute("gate:k", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec())
+    (entry_key,) = fake_redis.entry_keys()
+    fake_redis._data[entry_key] = (None, "{not json")
+
+    calls: list[int] = []
+
+    def _compute():
+        calls.append(1)
+        return [_result("s1", passes_all=True)]
+
+    rigor_cache._store.clear()
+    out = rigor_cache.get_or_compute("gate:k", _compute, cache_if=bool, shared_codec=_codec())
+    assert calls == [1]
+    assert out[0].passes_all is True
+
+
+def test_one_shared_failure_opens_the_circuit_for_the_backoff_window(fake_redis):
+    """A down Redis must cost one timeout per backoff window, not one per
+    request — otherwise the perf feature becomes a perf regression at exactly
+    the wrong moment."""
+    fake_redis.fail_on.add("get")
+    rigor_cache.get_or_compute("gate:k", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec())
+    ops_after_first = len(fake_redis.ops)
+
+    rigor_cache._store.clear()
+    rigor_cache.get_or_compute("gate:k2", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec())
+    assert len(fake_redis.ops) == ops_after_first, "the breaker did not open — every request pays the failure"
+
+
+def test_a_failure_sentinel_is_never_published_to_the_fleet(fake_redis):
+    """``cache_if`` guards both layers. A transient cohort-compute failure that
+    got sticky in Redis would strand the WHOLE fleet, not just one task."""
+    rigor_cache.get_or_compute("gate:k", list, cache_if=bool, shared_codec=_codec())
+    assert fake_redis.entry_keys() == [], "an empty/failure result must never be published"
+
+
+def test_the_shared_entry_carries_the_module_ttl(fake_redis):
+    rigor_cache.get_or_compute("gate:k", lambda: [_result("s1")], cache_if=bool, shared_codec=_codec())
+    ((_cmd, _key, ttl),) = fake_redis.ops_named("setex")
+    assert ttl == int(rigor_cache._TTL_SECONDS)
+
+
+def test_an_expired_shared_entry_is_not_served(fake_redis):
+    """The TTL is the backstop against any invalidation-hook gap, and it has to
+    hold in the shared layer too."""
+    worker_b = _worker_b()
+    worker_b.set_shared_backend(fake_redis)
+
+    rigor_cache.get_or_compute("gate:k", lambda: [_result("s1", passes_all=True)], cache_if=bool, shared_codec=_codec())
+    fake_redis.now += rigor_cache._TTL_SECONDS + 1
+
+    calls: list[int] = []
+
+    def _compute():
+        calls.append(1)
+        return [_result("s1")]
+
+    worker_b.get_or_compute("gate:k", _compute, cache_if=bool, shared_codec=_codec(worker_b))
+    assert calls == [1], "an expired shared entry must not be served"
+
+
+# ── the default backend: hermetic, and built from the deployment's own config ─
+
+
+def test_no_backend_is_built_while_testing_is_set(monkeypatch):
+    """The unit suite is hermetic by mandate — this file's tests inject a fake,
+    and nothing else in the suite may open a socket."""
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.setenv("REDIS_URL", "redis://should-never-be-dialled:6379/0")
+    assert rigor_cache._build_default_backend() is None
+
+
+def test_no_backend_without_an_explicit_redis_url(monkeypatch):
+    """A bare dev box has no Redis; it must get exactly the pre-#1518 behaviour
+    rather than spend a connect attempt per request learning that."""
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    assert rigor_cache._build_default_backend() is None
+
+
+def test_the_default_backend_is_built_from_redis_url_with_bounded_timeouts(monkeypatch):
+    """Prod (``infra/ecs.tf``) and docker compose both inject ``REDIS_URL``. The
+    client must carry hard socket timeouts, or a hung Redis becomes the page's
+    latency. Patched at the redis boundary — no socket is opened."""
+    import redis as sync_redis
+
+    captured: dict = {}
+
+    def _from_url(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return "sentinel-client"
+
+    monkeypatch.setattr(sync_redis.Redis, "from_url", staticmethod(_from_url))
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("REDIS_URL", "rediss://elasticache.example:6379/0")
+
+    assert rigor_cache._build_default_backend() == "sentinel-client"
+    assert captured["url"] == "rediss://elasticache.example:6379/0"
+    assert captured["kwargs"]["socket_timeout"] == rigor_cache._SHARED_SOCKET_TIMEOUT
+    assert captured["kwargs"]["socket_connect_timeout"] == rigor_cache._SHARED_CONNECT_TIMEOUT
+    assert captured["kwargs"]["decode_responses"] is True
+
+
+# ── the call site is actually wired ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_selection_bias_gate_passes_a_shared_codec(monkeypatch):
+    """A perfect shared layer nobody calls fixes nothing. Assert the route that
+    #1518 measured hands ``get_or_compute`` the codec for the model it caches."""
+    from archimedes.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    seen: dict = {}
+    real = rigor_cache.get_or_compute
+
+    def _spy(key, compute_fn, cache_if=lambda _v: True, shared_codec=None):
+        seen["shared_codec"] = shared_codec
+        return real(key, compute_fn, cache_if=cache_if, shared_codec=shared_codec)
+
+    monkeypatch.setattr(rigor_cache, "get_or_compute", _spy)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/selection-bias/gate")
+    assert resp.status_code == 200
+
+    codec = seen.get("shared_codec")
+    assert codec is not None, "/api/selection-bias/gate is not using the shared cache layer"
+    assert codec.schema_token == _codec().schema_token
+
+
+@pytest.mark.asyncio
+async def test_a_cold_task_serves_the_gate_from_the_shared_cache(fake_redis, monkeypatch):
+    """End to end, on the real route and the real gate: a task that has never
+    computed this cohort must answer from the shared entry instead of paying the
+    recompute — which is the whole of #1518."""
+    import numpy as np
+    from archimedes.api import selection_bias_routes as routes
+    from archimedes.main import app
+    from archimedes.services.rigor_evaluator import run_rigor_gate as real_run_rigor_gate
+    from httpx import ASGITransport, AsyncClient
+
+    strategies = routes._provider().list_strategies()
+    assert strategies, "the curated corpus must be non-empty for this to bite"
+
+    # Force a usable persisted series for every strategy so the route takes the
+    # EXPENSIVE branch (the one that calls run_rigor_gate) rather than reporting
+    # every row `pending` — otherwise the call-count assertion below is vacuous.
+    returns = {
+        s.id: np.random.default_rng(abs(hash(s.id)) % 10_000).normal(0.001, 0.01, 300).tolist() for s in strategies
+    }
+    monkeypatch.setattr(
+        "archimedes.services.backtest_repository.get_all_daily_returns",
+        lambda session, ids: dict(returns),
+    )
+
+    calls: list[int] = []
+
+    def _spy(*args, **kwargs):
+        calls.append(1)
+        return real_run_rigor_gate(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "run_rigor_gate", _spy)
+
+    async def _get():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            return await client.get("/api/selection-bias/gate")
+
+    first = await _get()
+    assert first.status_code == 200
+    assert calls, "the first request must run the live gate"
+    warm = len(calls)
+
+    # Simulate the request landing on a DIFFERENT task: same shared Redis, empty
+    # in-process store. (`clear()` is deliberately not used here — it would also
+    # invalidate the shared entry, which is a different scenario, covered above.)
+    rigor_cache._store.clear()
+
+    second = await _get()
+    assert second.status_code == 200
+    assert len(calls) == warm, "a cold task recomputed the whole cohort — the shared cache is not being read"
+    assert second.json()["strategies"] == first.json()["strategies"]


### PR DESCRIPTION
## What

`rigor_cache` gains a **second, shared layer** underneath the existing in-process
dict. One task computes the selection-bias gate cohort; every task reads it.

- `backend/archimedes/services/rigor_cache.py` — shared layer: `SharedCodec` /
  `model_list_codec`, a lazily-built sync Redis client, epoch-based invalidation,
  circuit breaker, and a `shared_codec` parameter on `get_or_compute`.
- `backend/archimedes/api/selection_bias_routes.py` — the one route #1518 measured
  now passes `shared_codec=model_list_codec(StrategyRigorResult)`.
- `backend/tests/test_rigor_cache_shared.py` — new, 27 cases.

## Why

`/api/selection-bias/gate` measured **21.9s → 0.68s → 20.9s inside about a
minute** on prod (#1518). A 600s TTL cannot produce a re-miss on that timescale;
N tasks each holding their own copy can. In-process caching did not amortise
across the fleet, it multiplied by it — the ~21s recompute was paid once per task
per TTL window, and every copy reset together on a deploy.

## Design, and the correctness bar

**Both existing invalidation triggers survive the move off-process.** This is the
load-bearing part, because an entry in Redis is *more* durable than one in a
process dict — it outlives the restart that used to drop it, and every task sees it.

1. **The data-version token.** `cohort_key` is already inside `key`, and the
   shared entry key is built from `key`, so a returns or code-hash change moves
   the shared key exactly as it moves the local one.
2. **`clear()`** (called by `backtest_repository.insert_backtest_if_missing` on
   the write path) now bumps a shared **epoch** counter, so a `clear()` on any
   task makes every task's shared lookup miss on its next request. `INCR` is O(1)
   and atomic, which a write-path hook has to be; a `SCAN`+`DEL` sweep would be
   O(keyspace) against the Redis the agent state store lives in, and a key-index
   SET would need its own unbounded-growth story. Superseded entries are simply
   unreachable and die on their own TTL.

The **write** goes under the epoch observed at *lookup* time, not at write time —
so a `clear()` landing inside the leader's ~20s compute cannot be undone by the
leader then publishing its pre-`clear()` verdict under the post-`clear()` epoch.

**Round-trip fidelity.** JSON via pydantic, never pickle (`pickle.loads` on data
from a network service is RCE if that service is ever reachable by anything else;
JSON can only produce a value the model itself validates). The four-state verdict
vocabulary — `pass` / `fail` / `pending` / `degenerate` — is asserted to survive
field-by-field **and** to remain four distinct states, not two. #1580's board-FDR
drift guard stays green and is **extended to the new surface**: the shared payload
is scanned for `board_fdr*` / `board_level_fdr` keys.

**Cross-version safety.** A rolling deploy runs two code versions against one
Redis for a few minutes. The shared key carries a hash of the model's
`model_json_schema()` (nested `$defs` included), so a shape change orphans old
payloads rather than letting them be mis-parsed into a plausible-looking verdict.

**Fail-open, at every touch.** No backend, a broken backend, a timeout, or a
corrupt payload all degrade to the process layer and then to a live compute. One
failure opens a 30s circuit breaker, and reads carry hard socket timeouts
(0.25s connect / 0.5s), so a Redis outage costs one timeout per backoff window
rather than one per request — a perf feature must not become a perf regression at
exactly the wrong moment. A warm process-layer hit issues **zero** Redis commands.

## Tests

```
$ /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest \
      backend/tests -k "selection_bias or rigor or leaderboard" -q
========= 576 passed, 4246 deselected, 15 warnings in 63.29s (0:01:03) =========

$ ... -m pytest backend/tests/test_rigor_cache_shared.py \
      backend/tests/test_rigor_cache.py backend/tests/test_selection_bias_routes.py -q
======================= 119 passed, 1 warning in 29.60s ========================

# the exact command CI runs, from the repo root
$ ... -m pytest -m "not integration" -q
=== 4817 passed, 3 skipped, 2 deselected, 320 warnings in 434.91s (0:07:14) ====

# hermetic gate (no .env, no network, no DB/Redis)
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
      .../bin/python -m pytest backend/tests/test_rigor_cache_shared.py \
      backend/tests/test_rigor_cache.py -q
======================== 50 passed, 1 warning in 10.75s ========================

$ ruff format --check <3 touched files>   → 3 files already formatted
$ ruff check <3 touched files>            → All checks passed!
```

The new tests are hermetic: the sync Redis client is mocked at the **client
boundary** (`_FakeRedis`, implementing exactly the `GET`/`SETEX`/`INCR` surface
the layer issues, with real TTL semantics off an injectable clock), and
`_build_default_backend()` refuses to construct a real client while `TESTING` is
set. No socket is opened.

"Two independent cache clients" is literal: `_worker_b()` executes the module file
under its own name, producing a distinct module object with its own `_store` /
`_lock` / `_inflight` / breaker state — which is what a second ECS task is.
Clearing the primary instance's dict instead would leave both "workers" sharing
every other module global and would keep passing for a cache that was never
shared at all.

## Adversarial / revert demos — run, failure confirmed, reverted

Every block below was produced by reverting the named line in the working tree,
running the command shown, and pasting its output. All four reverts were then
restored; `git status --porcelain` is empty at the tip of this branch and the
suites above were re-run green afterwards.

### 1. Staleness — `clear()` reverted to the process store only

The invalidation trigger that has to survive the move off-process. An entry in
Redis outlives the restart that used to drop it and is visible to every task, so
a `clear()` reaching only the local dict leaves the fleet serving a verdict the
writer already invalidated.

```python
-    with _lock:
-        _store.clear()
-    _shared_clear()
+    with _lock:
+        _store.clear()
```

```
$ pytest backend/tests/test_rigor_cache_shared.py -p no:randomly -q \
      -k "clear_invalidates or clear_bumps or before_a_clear"
E   AssertionError: clear() did not reach the shared layer — the fleet is serving a verdict the writer already invalidated
E   assert True is False
E    +  where True = StrategyRigorResult(strategy_id='s1', strategy_name='Paper s1', passes_all=True, gate_details=RigorGateDetail(dsr='PAS...vel=1, min_passing_level=None, blocked_by_floor=False, num_trials_scope='unspecified', pending=False, degenerate=False).passes_all
E   AssertionError: assert [] == [('incr', 'ar...he:v1:epoch')]
E     Right contains one more item: ('incr', 'archimedes:rigor_cache:v1:epoch')
E   AssertionError: worker B must recompute — the pre-clear result must be unreachable
E   assert [] == [1]
E     Right contains one more item: 1
FAILED ...::test_clear_invalidates_the_shared_entry_for_every_worker
FAILED ...::test_clear_bumps_the_shared_epoch_exactly_once
FAILED ...::test_a_result_computed_before_a_clear_is_never_published_after_it
================= 3 failed, 24 deselected, 1 warning in 1.43s ==================
```

### 2. Staleness — the shared key reverted to ignore the data-version token

The other invalidation trigger, and the naive reading of "the gate result is a
small keyed blob": one entry per route. Mutate the underlying returns; the old
verdict is served for data it never graded.

```python
-    return f"{_SHARED_KEY_PREFIX}e{epoch}:{codec.schema_token}:{key}"
+    return f"{_SHARED_KEY_PREFIX}e{epoch}:{codec.schema_token}:selection_bias_gate"
```

```
$ pytest backend/tests/test_rigor_cache_shared.py -p no:randomly -q -k "changed_returns"
E   AssertionError: the shared cache served the verdict computed from the OLD returns — a cached verdict outlived the data it grades
E   assert True is False
E    +  where True = StrategyRigorResult(strategy_id='s1', strategy_name='Paper s1', passes_all=True, gate_details=RigorGateDetail(dsr='PAS...vel=1, min_passing_level=None, blocked_by_floor=False, num_trials_scope='unspecified', pending=False, degenerate=False).passes_all
FAILED ...::test_changed_returns_are_never_served_the_old_shared_verdict
================= 1 failed, 26 deselected, 1 warning in 1.26s ==================
```

### 3. Guard shown to reject a bad input — schema token dropped from the key

The bad input built on purpose: a payload written under a model shape that
carries `board_fdr_significant`, read back by a task on the other shape — the
rolling-deploy case, where two code versions share one Redis for a few minutes.
With the token dropped, pydantic decodes it happily (the extra field just
defaults) and the reader serves a neighbour's payload.

```python
-    return f"{_SHARED_KEY_PREFIX}e{epoch}:{codec.schema_token}:{key}"
+    return f"{_SHARED_KEY_PREFIX}e{epoch}:{key}"
```

```
$ pytest backend/tests/test_rigor_cache_shared.py -p no:randomly -q -k "shape_change"
E   AssertionError: a reader on a different shape must MISS, never decode a neighbour's payload
E   assert [] == [1]
E     Right contains one more item: 1
FAILED ...::test_a_shape_change_orphans_payloads_written_under_the_old_shape
================= 1 failed, 26 deselected, 1 warning in 1.45s ==================
```

### 4. Wiring — the route reverted to process-local

A perfect shared layer nobody calls fixes nothing.

```python
-    results = get_or_compute(cache_key, _compute, cache_if=bool,
-                             shared_codec=model_list_codec(StrategyRigorResult))
+    results = get_or_compute(cache_key, _compute, cache_if=bool)
```

```
$ pytest backend/tests/test_rigor_cache_shared.py -p no:randomly -q \
      -k "selection_bias_gate_passes or cold_task"
E   AssertionError: /api/selection-bias/gate is not using the shared cache layer
E   assert None is not None
E   AssertionError: a cold task recomputed the whole cohort — the shared cache is not being read
E   assert 68 == 34
E    +  where 68 = len([1, 1, 1, 1, 1, 1, ...])
FAILED ...::test_the_selection_bias_gate_passes_a_shared_codec
FAILED ...::test_a_cold_task_serves_the_gate_from_the_shared_cache
================= 2 failed, 25 deselected, 1 warning in 4.62s ==================
```

Two further guards carry their own in-test non-vacuity proof rather than a source
revert: `test_the_board_fdr_scan_flags_a_deliberate_reappearance` runs the payload
scan against a payload that *does* carry `board_fdr_significant` (including the
nested position a shallow scan would miss) and asserts it is flagged, and
`test_the_four_states_stay_distinguishable_after_the_round_trip` asserts the four
verdict states remain four on the decoded side — a codec that dropped
`pending`/`degenerate` would otherwise pass a field-by-field check against a
payload that had already lost them.

## Not done here — honest list

- **`GET /api/strategies/` still caches process-locally.** `_live_rigor_results_for_strategies`
  memoizes `dict[str, RigorGateResult]`, and `RigorGateResult` is a hand-rolled
  class carrying a `RigorProfile` plus derived properties — no lossless codec
  exists for it today, and a lossy one would silently change served numbers.
  That route measured 11.3s → 0.68s in the same #1518 pull, so it is worth doing;
  it needs its own change with its own round-trip proof. It behaves exactly as it
  does on `main` after this PR.
- **The prod acceptance criterion is not verified here.** "`X-Response-Time-Ms`
  stays sub-second across repeated requests, including immediately after a task
  replacement" can only be measured against the deployed stack. The issue also
  asks to confirm `desiredCount > 1` first; I have no account access and did not
  run `aws ecs describe-services`. If the service runs a single task the
  diagnosis in #1518 is wrong — this change is still correct (it survives task
  replacement, which a single-task service also does), but the measured win would
  be smaller than the issue predicts.
- **A remote `clear()` still cannot reach another task's in-process dict.** That
  task keeps its local entry until its own TTL or a key change — exactly the
  pre-#1518 behaviour, unchanged. The data-version token remains the real
  invalidation mechanism; `clear()` is the backstop, and this PR restores the
  backstop's reach to the one new place a verdict can live. Making the local
  layer epoch-aware would put a Redis round-trip on every warm hit, which is the
  cost this whole change exists to avoid.
- **No new dependency, no infra change, no migration.** The sync `redis` client
  is already used by `api/limiter.py` and `services/kb_runner.RedisLeaseClient`;
  `REDIS_URL` is already injected by `infra/ecs.tf` and `docker-compose.yml`. No
  Terraform, no SSM parameter, no docs change — so no `docs/README.md` index row
  is required.
- **Blocking Redis I/O inside an `async def` route.** `evaluate_rigor_gate`
  already does blocking DB reads and ~20s of numpy on the event loop; two bounded
  `GET`s do not change that shape, and they are the smaller of the two problems.
  Making the route non-blocking is a separate change.

Closes #1518

