### PR TITLE
[docs][rigor] Make the E[max] docs match the formula #1559 actually installed

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -656,11 +656,12 @@ def _patch_dsr_with_pool_correlation(candidates: list[_CandidateResult]) -> None
     mutually independent trials. They're generated from the same user brief over
     overlapping universes, so they're typically strongly correlated (ρ̄ ≈ 0.5–0.9),
     and feeding ρ̄=0 over-deflates ``E[max_N]``, over-stating the gate's strictness.
-    Under equicorrelation the effective trial count is
-    ``N_eff = N / (1 + (N-1)·ρ̄)`` (Cheverud 2001; Nyholt 2004) — this patch estimates
-    the real ρ̄ across the pool's return series (``compute_average_pairwise_correlation``)
-    and recomputes DSR at the SAME ``dsr_num_trials`` each candidate was already
-    deflated at, so only the correlation term changes.
+    Under equicorrelation the expected best-of-N null Sharpe is the
+    independent-trial ``E[max]`` scaled by ``√(1 − ρ̄)`` (#1559) — this patch
+    estimates the real ρ̄ across the pool's return series
+    (``compute_average_pairwise_correlation``) and recomputes DSR at the SAME
+    ``dsr_num_trials`` each candidate was already deflated at, so only the
+    correlation term changes.
 
     Runs AFTER ``_patch_pbo`` and mirrors its shape and scope: fusion/debate
     candidates (``has_real_rigor=True``) carry a real DSR from their own CSCV
@@ -670,8 +671,8 @@ def _patch_dsr_with_pool_correlation(candidates: list[_CandidateResult]) -> None
     is left untouched — approach A (ρ̄=0) is the fallback, per the issue.
 
     A correlated pool can only RELAX the deflation relative to ρ̄=0 (never tighten
-    beyond it — ``N_eff <= N`` always), so ``dsr_p_value`` only ever moves up or
-    stays the same here, never down. ``passing`` is re-derived from the full set
+    beyond it — ``√(1 − ρ̄) <= 1`` for every ρ̄ ∈ [0, 1]), so ``dsr_p_value`` only
+    ever moves up or stays the same here, never down. ``passing`` is re-derived from the full set
     of admission legs (DSR, OOS/cliff, look-ahead) rather than AND-ed in, since a
     higher DSR p-value can flip a candidate from failing to passing, not just the
     reverse (unlike the PBO patch above, which can only tighten).

--- a/backend/archimedes/services/_rigor_helpers.py
+++ b/backend/archimedes/services/_rigor_helpers.py
@@ -696,13 +696,19 @@ def compute_average_pairwise_correlation(
 ) -> float:
     """Average off-diagonal Pearson correlation across a set of return series.
 
-    Feeds the Deflated Sharpe Ratio's effective-number-of-trials correction:
-    the expected best-of-N null Sharpe is computed at the effective trial count
-    ``N_eff = N / (1 + (N-1)*rho_bar)`` (the equicorrelated effective number of
-    independent tests) when the N trials are correlated, because correlated
-    trials carry fewer *independent* bets than their nominal count. The caller
+    Feeds the Deflated Sharpe Ratio's correlated-trials correction: the
+    expected best-of-N null Sharpe is the independent-trial ``E[max]`` scaled by
+    ``sqrt(1 - rho_bar)``, because under equicorrelation the factor common to
+    every trial passes straight through the maximum (see ``_dsr_from_stats``
+    for the one-factor derivation). Correlated trials offer fewer distinct
+    chances to get lucky, so the expected best-of-N null is lower. The caller
     that holds the selection set (the strategy library, or a parameter-variant
     grid) computes this and passes it into ``compute_dsr`` / ``run_rigor_gate``.
+
+    #1558/#1559: this previously fed an effective trial count
+    ``N_eff = N / (1 + (N-1)*rho_bar)``. That is the Kish design effect, not an
+    expectation-of-maximum, and it under-deflated by 2x-10x; do not reintroduce
+    it here or in the callers.
 
     Args:
         returns: Either ``{id: series}`` or a 2-D array/list (rows = trials,

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -203,10 +203,14 @@ class TestPoolCorrelationDSR:
         # A materially correlated pool should show a REAL relaxation somewhere, not a no-op.
         assert any(p > b for b, p in zip(baseline_p, patched_p, strict=True))
 
-    def test_correlated_pool_uses_n_eff_below_nominal_count(self):
-        """Acceptance criterion #1: the society DSR uses N_eff < N + library_size for a
-        correlated pool. Cross-check via compute_dsr directly at N_eff vs. the nominal
-        count, on the same series the patch would have used."""
+    def test_correlated_pool_deflates_less_than_the_nominal_count(self):
+        """Acceptance criterion #1 (#822): a correlated pool must deflate LESS than the
+        same pool treated as independent. Cross-check via compute_dsr directly at the
+        measured ρ̄ vs. ρ̄=0, on the same series the patch would have used.
+
+        Asserts the direction only, which is what #822 asked for and what holds under
+        the ``√(1−ρ̄)`` shrinkage #1559 installed. Named for an ``N_eff`` mechanism
+        until 2026-08-31; that form never was the correlated ``E[max]`` (see #1558)."""
         from archimedes.services.rigor_evaluator import compute_average_pairwise_correlation, compute_dsr
 
         series_list = self._correlated_pool(n=5, rho_target=0.75)
@@ -242,7 +246,7 @@ class TestPoolCorrelationDSR:
     def test_independent_pool_is_a_near_noop(self):
         """A genuinely independent pool (ρ̄ ≈ 0) should leave the DSR verdict close to the
         approach-A baseline — the correction only bites when candidates are actually
-        correlated, consistent with N_eff → N as ρ̄ → 0."""
+        correlated, consistent with ``√(1−ρ̄) → 1`` as ρ̄ → 0."""
         series_list = self._independent_pool(n=5)
         candidates = [_candidate(f"cand_{i}", s, self._NUM_TRIALS) for i, s in enumerate(series_list)]
         baseline_p = [c.rigor_verdict["dsr_p_value"] for c in candidates]

--- a/docs/quant/backtest-interpretation.md
+++ b/docs/quant/backtest-interpretation.md
@@ -129,8 +129,9 @@ illusion.
 
 **What detects it.** `compute_average_pairwise_correlation(...)` computes the mean
 off-diagonal correlation across a set of return series, and it feeds the DSR's
-**effective-N** correction (`N_eff = N / (1 + (N−1)·ρ̄)`): if the "trials" are
-highly correlated, the deflation correctly counts them as *fewer independent tests*.
+correlated-trials correction, which scales the expected best-of-N null Sharpe by
+`√(1−ρ̄)` (#1559): if the "trials" are highly correlated, the deflation correctly
+prices them as fewer distinct chances to get lucky.
 On the construction side, `correlation_pairs(...)` lists the top correlation pairs,
 and the Ledoit–Wolf shrinkage (`ledoit_wolf_shrinkage(...)`) keeps a
 near-singular correlation matrix from blowing up the optimizer.

--- a/docs/quant/methodology.md
+++ b/docs/quant/methodology.md
@@ -132,25 +132,37 @@ Read it left to right:
   `N = len(strategy_library)` so the correction is meaningful, and a warning is
   logged when `N = 1` while the library holds more than one strategy.
 
-#### Effective-N for correlated trials
+#### Correlated trials shrink `E[max]`, they do not shrink `N`
 
 A parameter sweep whose variants move together does **not** constitute `N`
 *independent* tests. `compute_dsr` accepts an `average_correlation` argument and
-converts the nominal trial count to an effective count under an equicorrelation
-model:
+shrinks the expected best-of-N null directly. For `N` standard normals with
+equicorrelation `ρ̄ ≥ 0`, the one-factor representation
+`Xᵢ = √ρ̄·Z + √(1−ρ̄)·εᵢ` gives each `Xᵢ` unit variance and pairwise correlation
+`ρ̄`, and the term `Z` common to all of them factors straight out of the maximum:
 
 ```
-N_eff = N / (1 + (N − 1)·ρ̄)
+max_i Xᵢ    = √ρ̄·Z + √(1−ρ̄)·max_i εᵢ
+E[max_i Xᵢ] = √(1−ρ̄) · E[max of N iid]
 ```
 
-This is the standard "effective number of independent tests" (Cheverud 2001;
-Nyholt 2004). At `ρ̄ = 0` we get `N_eff = N` (full multiple-testing penalty); at
-`ρ̄ = 1` all variants collapse to a single test (`N_eff = 1`, no deflation). The
-helper `compute_average_pairwise_correlation(...)` computes `ρ̄` from the library's
+So the correlated `E[max]` is exactly the independent one scaled by `√(1−ρ̄)`.
+This is Bailey–López de Prado's own `√(V[{SRₙ}])` term specialised to
+equicorrelation. At `ρ̄ = 0` the full multiple-testing penalty applies; at
+`ρ̄ = 1` all variants are one test and there is nothing to deflate. The helper
+`compute_average_pairwise_correlation(...)` computes `ρ̄` from the library's
 return matrix and clamps negative (diversifying) correlations to `0.0` — a
-conservative "no penalty relief" default. The two-quantile `E[max]` approximation
-diverges as `N → 1`, so the code evaluates it at `max(2, N_eff)` and linearly
-tapers to zero across `N_eff ∈ [1, 2]`.
+conservative "no penalty relief" default.
+
+> **Superseded (#1558 / #1559, 2026-08-31).** This section previously documented
+> an effective-trial-count form `N_eff = N / (1 + (N − 1)·ρ̄)`, attributed to
+> Cheverud 2001 / Nyholt 2004, evaluated at `max(2, N_eff)` with a linear taper
+> across `N_eff ∈ [1, 2]`. That is the Kish design effect — an effective sample
+> size for a *mean*, not an expectation of a *maximum*. It under-deflated by
+> 2×–10× across `ρ̄ ∈ [0.3, 0.9]`, and it was wrong in shape as well as scale:
+> `N_eff → 1/ρ̄` as `N` grows, so the penalty saturated and a 10,000-variant
+> sweep drew the same deflation as a 64-variant one. The formula, the citation,
+> and the taper are all gone from the code; none of them should be reintroduced.
 
 #### Outputs
 

--- a/docs/specs/selection-bias-corrections-spec.md
+++ b/docs/specs/selection-bias-corrections-spec.md
@@ -145,9 +145,14 @@ the additive count is the conservative, defensible deflation. It can only make t
 **stricter** (anti-goal compliant): with `n_candidates ≥ 1` it is always `≥ library_size`,
 the prior (under-deflating) value.
 
-**Why not effective-N (correlation-adjusted) here.** `compute_dsr` already accepts an
-`average_correlation` and can deflate by effective *independent* trials
-`N_eff = N / (1 + (N-1)ρ̄)` — the principled refinement when candidates are correlated
+**Why not correlation-adjusted deflation here.** *(#1558/#1559, 2026-08-31: this
+paragraph originally named `N_eff = N / (1 + (N-1)ρ̄)` as the correlation refinement.
+That form — the Kish design effect — was never the correlated `E[max]`; the shipped
+correction scales the independent-trial `E[max]` by `√(1−ρ̄)`. The reasoning below is
+unaffected: it turns on shipping the additive count first, not on which correlation
+form the refinement uses.)* `compute_dsr` already accepts an
+`average_correlation` and can deflate by scaling `E[max]` by `√(1−ρ̄)`
+— the principled refinement when candidates are correlated
 (same brief, overlapping universes). We deliberately ship the **simple additive count
 first** (smaller blast radius, strictly conservative) and leave the candidate-pool
 correlation correction as a follow-up; over-deflation (treating correlated candidates as
@@ -223,7 +228,8 @@ independent searches they aren't.
 
 **What ships.** The live society path (`agents/generation_pipeline.py`) estimates ρ̄ from
 the candidate pool's own return series via `compute_average_pairwise_correlation` (no
-change to that function or to `compute_dsr`'s `N_eff` formula — both are reused as-is) and
+change to that function or to `compute_dsr`'s correlation term — both are reused as-is;
+that term was the `N_eff` form when this addendum was written and is `√(1−ρ̄)` as of #1559) and
 feeds it into the same `compute_dsr` call each candidate's DSR was already computed with,
 at the same `num_trials`. `_patch_dsr_with_pool_correlation` runs once every candidate's
 return series is known (mirroring the existing `_patch_pbo` two-pass shape: DSR is first
@@ -238,8 +244,10 @@ from their own CSCV evaluator over a parameter-variant grid, not the buy-and-hol
 series this correlation estimate is scoped to, and are excluded from the pool the same way
 `_patch_pbo` already excludes them from cross-candidate PBO.
 
-**Why this can only relax, never loosen past the no-correction floor.** `N_eff = N / (1 +
-(N-1)ρ̄)` satisfies `1 ≤ N_eff ≤ N` for any `ρ̄ ∈ [0, 1]`, so the corrected DSR p-value sits
+**Why this can only relax, never loosen past the no-correction floor.** *(#1559: argued
+here from `1 ≤ N_eff ≤ N`; the conclusion is unchanged under the shipped form, but the
+premise is now `0 ≤ √(1−ρ̄) ≤ 1`, which shrinks `E[max]` by at most a factor of one.)*
+`√(1−ρ̄)` satisfies `0 ≤ √(1−ρ̄) ≤ 1` for any `ρ̄ ∈ [0, 1]`, so the corrected DSR p-value sits
 between the ρ̄=0 (approach A) value and the value at `num_trials=1` (no multiple-testing
 penalty at all) — it never exceeds the latter, so the gate is never made looser than the
 IID-Sharpe baseline. At ρ̄→1 (candidates fully collapse to one effective trial) the

--- a/openwiki/rigor/selection-bias-controls.md
+++ b/openwiki/rigor/selection-bias-controls.md
@@ -1,7 +1,7 @@
 ---
 type: method-reference
 title: Selection-bias controls
-description: The mathematics behind each rigor control — DSR with its raw-kurtosis convention and effective-N correction, PBO via CSCV, walk-forward and CPCV, the look-ahead audit, FDR versus FWER, and the circular block bootstrap — with what is implemented separated from what is only written down.
+description: The mathematics behind each rigor control — DSR with its raw-kurtosis convention and equicorrelated-E[max] correction, PBO via CSCV, walk-forward and CPCV, the look-ahead audit, FDR versus FWER, and the circular block bootstrap — with what is implemented separated from what is only written down.
 tags: [dsr, pbo, cscv, cpcv, look-ahead, fdr, bootstrap, methodology]
 verified:
   - by: openwiki/0.4.3
@@ -69,20 +69,26 @@ from the null, and the spec's reference cases use 504 / 1260 / 2520 bars.
 At `num_trials = 1`, `E[max_N] = 0` and **no correction is applied** — there was no
 selection, so there is nothing to deflate.
 
-### Effective-N for correlated trials
+### Correlated trials shrink `E[max]`, not `N`
 
-A parameter sweep whose variants move together is not `N` *independent* tests. The nominal
-count is converted under an equicorrelation model:
+A parameter sweep whose variants move together is not `N` *independent* tests. Under an
+equicorrelation model the factor common to every trial passes straight through the
+maximum, so the expected best-of-N null is the independent-trial value scaled by
+`√(1−ρ̄)`:
 
 ```
-N_eff = N / (1 + (N − 1)·ρ̄)
+E[max of N equicorrelated] = √(1−ρ̄) · E[max of N iid]
 ```
 
 At `ρ̄ = 0` the full multiple-testing penalty applies; at `ρ̄ = 1` all variants collapse to a
 single test and no deflation occurs. Negative (diversifying) correlations are **clamped to
-0.0** — a conservative "no penalty relief" default. Because the two-quantile `E[max]`
-approximation diverges as `N → 1`, it is evaluated at `max(2, N_eff)` and tapered linearly
-to zero across `N_eff ∈ [1, 2]`.
+0.0** — a conservative "no penalty relief" default. Unlike an effective-trial-count form,
+this keeps growing with `N`: a 10,000-variant sweep is charged more than a 64-variant one.
+
+> This section described an effective-trial-count form `N_eff = N / (1 + (N − 1)·ρ̄)` with a
+> `max(2, N_eff)` taper when it was generated on 2026-08-31 from
+> `docs/quant/methodology.md`, which was itself stale. See #1558/#1559 — that form was the
+> Kish design effect, not an expectation of a maximum, and it under-deflated by 2×–10×.
 
 ### What it returns
 


### PR DESCRIPTION
Follow-up to #1559 / #1558. Docs only — no arithmetic changes.

#1559 replaced the DSR's correlated-trials term with the equicorrelated `E[max] = √(1−ρ̄)·E[max of N iid]` and deleted the effective-trial-count form. I changed the implementation and left the old formula documented as current in seven places, including the docstring of the function that produces `ρ̄`.

That is the defect shape of #1558 itself — a documented formula that does not match the code, sitting where a reader goes to learn what the correction is. It has already propagated once: last night's OpenWiki run (#1597) read `docs/quant/methodology.md` and regenerated the deleted formula, `max(2, N_eff)` taper included, into `openwiki/rigor/selection-bias-controls.md`, whose front matter carries `verified: openwiki/0.4.3` and whose description advertised "effective-N correction" as a feature. Its `sources` field cites the stale doc by path.

## Proof it changes no behaviour

Strip every docstring, compare ASTs against `HEAD`:

```
IDENTICAL  (docstrings stripped)  backend/archimedes/services/_rigor_helpers.py
IDENTICAL  (docstrings stripped)  backend/archimedes/agents/generation_pipeline.py
DIFFERS    (docstrings stripped)  backend/tests/test_generation_pipeline.py
   removed: ['test_correlated_pool_uses_n_eff_below_nominal_count']
   added:   ['test_correlated_pool_deflates_less_than_the_nominal_count']
```

The two production modules are AST-identical. The only structural change in the whole diff is the one test rename, and that test only ever asserted a direction (`p_neff >= p_nominal`), which still holds under `√(1−ρ̄)` — its *name* claimed a mechanism that no longer exists.

## Sites

| File | What was stale |
|---|---|
| `_rigor_helpers.py` | `compute_average_pairwise_correlation`'s docstring named the consumer form it feeds. Replaced, with a do-not-reintroduce note. |
| `generation_pipeline.py` | Formula, the Cheverud 2001 / Nyholt 2004 attribution, and the monotonicity argument. The conclusion holds; the premise was `N_eff ≤ N` and is now `√(1−ρ̄) ≤ 1`. |
| `docs/quant/methodology.md` | Documented the `max(2, N_eff)` taper that #1559 deleted. Rewritten with the one-factor derivation, plus a superseded note. |
| `docs/quant/backtest-interpretation.md` | Same formula, one sentence. |
| `docs/specs/selection-bias-corrections-spec.md` | Three sites **annotated, not rewritten**, matching the "kept verbatim for history" pattern the spec already uses for its #1075 scope note. |
| `openwiki/rigor/selection-bias-controls.md` | The generated section and the front-matter description. |
| `test_generation_pipeline.py` | One test name + two docstrings. `#822` acceptance marker kept. |

The OpenWiki page's source doc is corrected in this same PR, so a regeneration now produces this text rather than reverting it.

## Checks

- `pytest backend/tests/test_generation_pipeline.py backend/tests/test_rigor_evaluator.py -q` → **251 passed**
- `ruff format --check` on all three touched Python files → clean
- `ruff check` → 2 hits, both pre-existing `SIM905` on `HEAD` in an untouched block of `generation_pipeline.py`; not introduced here and not fixed here (one logical change per PR)
- `make docs-check` → exit 0, **0 broken links of 1385**, index 159/159, 0 orphaned
- Every anchor in the edit script asserted to match exactly once

## Note for #1598

This was **not** among the seven conflicts that issue lists, so the OpenWiki pass did not flag it — the page reproduced its source faithfully and the source was wrong. Worth treating as an eighth item there, or considering it closed by this PR. Commenting on #1598 separately.

## Anti-goals held

- No change to any formula, threshold, or arithmetic — see the AST proof.
- The Kish form is not deleted from history: every surviving mention is inside an explicit superseded/history note, so the next reader learns what was wrong rather than rediscovering it as authoritative.
- The frozen spec is annotated, never silently rewritten.
