### PR TITLE
[frontend] Portalled dialogs stop painting text with the base decoration token (#1318)

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -51,15 +51,21 @@
      #8a8a93 on #16161a = 5.27:1 (was #71717a = 3.73:1).
 
      --text-4 (#3f3f46) is a border/decoration token here and must not be used
-     as a text colour on this palette — 1.73:1 on --surface-2. KNOWN OPEN
-     ISSUE, not a claim that the tree is clean: AssetModal.jsx and
-     AssetGroupModal.jsx portal to document.body, i.e. OUTSIDE .app-site, so
-     their "Current price" / "24h change" / "24h high" / "24h low" captions
-     resolve this base token and render at 1.73–1.83:1. Same portal mechanism
-     that forced the --chart-label fix below; the --text-4 half is unfixed
-     because raising the base token would also brighten every hairline that
-     legitimately uses it as decoration. It needs the call sites moved to
-     --text-3, not a token bump. */
+     as a text colour on this palette — 1.73:1 on --surface-2, 1.83:1 on
+     --surface-1. It stays dark on purpose: raising it would brighten every
+     hairline that legitimately uses it as decoration (the scrollbar-thumb
+     hover below, DepositFlow's spinner track, AuthPage's password-strength
+     meter segments), so the fix is to move call sites to --text-3, never to
+     bump the token — #1318.
+
+     What resolves this palette is everything rendered outside both shells:
+     the auth screen, the 404, the error-boundary fallback, and anything
+     portalled to document.body (createPortal escapes BOTH .app-site and
+     .public-site — the same mechanism that forced the --chart-label fix
+     below). Every portalled dialog that was painting text with --text-4 now
+     resolves --text-3 instead (5.59:1 on --surface-1, 5.27:1 on --surface-2);
+     ui/test/a11y.test.js computes those ratios and re-checks the dialogs, so
+     a new one cannot reintroduce the pairing. */
 	--text-1: #fafafa;
 	--text-2: #a1a1aa;
 	--text-3: #8a8a93;

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -64,8 +64,9 @@
      .public-site — the same mechanism that forced the --chart-label fix
      below). Every portalled dialog that was painting text with --text-4 now
      resolves --text-3 instead (5.59:1 on --surface-1, 5.27:1 on --surface-2);
-     ui/test/a11y.test.js computes those ratios and re-checks the dialogs, so
-     a new one cannot reintroduce the pairing. */
+     ui/test/a11y.test.js computes those ratios and re-checks every portalled
+     subtree it can find by walking src/ for createPortal, so a dialog added
+     later is covered without anyone remembering to register it. */
 	--text-1: #fafafa;
 	--text-2: #a1a1aa;
 	--text-3: #8a8a93;

--- a/ui/src/components/AssetGroupModal.jsx
+++ b/ui/src/components/AssetGroupModal.jsx
@@ -224,7 +224,7 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
         {/* Aggregate stat */}
         <div style={{ display: 'flex', gap: 24, alignItems: 'baseline', marginTop: 16, flexWrap: 'wrap' }}>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>
               {medianWindow ? `Median ${medianWindow} change` : 'Median change'} ({members.length} assets)
             </div>
             <div className={`mono ${changeClass(medianChange24h)}`} style={{ fontSize: '1.3rem', fontWeight: 600 }}>
@@ -251,7 +251,7 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
               {r}
             </button>
           ))}
-          <span className="caption" style={{ marginLeft: 'auto', color: 'var(--text-4)', fontSize: '0.7rem' }}>
+          <span className="caption" style={{ marginLeft: 'auto', color: 'var(--text-3)', fontSize: '0.7rem' }}>
             Equal-weight % change index
             {members.length > MAX_AGGREGATE_MEMBERS ? ` · first ${MAX_AGGREGATE_MEMBERS} of ${members.length} assets` : ''}
           </span>
@@ -271,7 +271,7 @@ export default function AssetGroupModal({ assetClass, assets, onClose }) {
 
         {/* Member list */}
         <div style={{ marginTop: 20, paddingTop: 14, borderTop: '1px solid var(--glass-border)' }}>
-          <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem', marginBottom: 8 }}>
+          <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem', marginBottom: 8 }}>
             Assets in this group
           </div>
           <div

--- a/ui/src/components/AssetModal.jsx
+++ b/ui/src/components/AssetModal.jsx
@@ -146,13 +146,13 @@ export default function AssetModal({ asset, onClose }) {
         {/* Price block */}
         <div style={{ display: 'flex', gap: 24, alignItems: 'baseline', marginTop: 18, flexWrap: 'wrap' }}>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Current price</div>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>Current price</div>
             <div className="mono" style={{ fontSize: '2rem', fontWeight: 600 }}>
               {fmtPrice(asset.current_price)}
             </div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>
               {changeWindowLabel(asset)} change
             </div>
             <div
@@ -164,11 +164,11 @@ export default function AssetModal({ asset, onClose }) {
             </div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>24h high</div>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>24h high</div>
             <div className="mono" style={{ fontSize: '1.1rem' }}>{fmtPrice(high24)}</div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>24h low</div>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>24h low</div>
             <div className="mono" style={{ fontSize: '1.1rem' }}>{fmtPrice(low24)}</div>
           </div>
         </div>
@@ -191,7 +191,7 @@ export default function AssetModal({ asset, onClose }) {
               {r}
             </button>
           ))}
-          <span className="caption" style={{ marginLeft: 'auto', color: 'var(--text-4)', fontSize: '0.7rem' }}>
+          <span className="caption" style={{ marginLeft: 'auto', color: 'var(--text-3)', fontSize: '0.7rem' }}>
             {range === '1D' ? 'Intraday 5-minute bars' : 'Daily close'}
           </span>
         </div>
@@ -213,29 +213,29 @@ export default function AssetModal({ asset, onClose }) {
           }}
         >
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Source</div>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>Source</div>
             <div className="body" style={{ fontSize: '0.9rem' }}>{sourceLabel(asset.price_source)}</div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Last updated</div>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>Last updated</div>
             <div className="mono" style={{ fontSize: '0.82rem' }}>
               {asset.last_updated ? new Date(asset.last_updated).toLocaleString() : '—'}
             </div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>7d change</div>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>7d change</div>
             <div className={`mono ${changeClass(asset.change_7d_pct)}`} title={rejectedTitle(asset, 'change_7d_pct')}>
               {fmtPct(asset.change_7d_pct)}
             </div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>30d change</div>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>30d change</div>
             <div className={`mono ${changeClass(asset.change_30d_pct)}`} title={rejectedTitle(asset, 'change_30d_pct')}>
               {fmtPct(asset.change_30d_pct)}
             </div>
           </div>
           <div>
-            <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
+            <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>
               Realized vol (30d, annualized)
             </div>
             <div className="mono" title={rejectedTitle(asset, 'realized_vol_30d')}>
@@ -251,7 +251,7 @@ export default function AssetModal({ asset, onClose }) {
               a card whose displayed price actually came from that oracle (#1371). */}
           {asset.oracle_address && asset.price_source === 'oracle' && (
             <div>
-              <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Oracle address</div>
+              <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>Oracle address</div>
               <div className="mono" style={{ fontSize: '0.72rem', wordBreak: 'break-all' }}>
                 {asset.oracle_address}
               </div>

--- a/ui/src/components/CreateVaultModal.jsx
+++ b/ui/src/components/CreateVaultModal.jsx
@@ -305,7 +305,7 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
           className="card-elevated p-6 max-w-[560px] w-[92vw]"
           style={{ background: 'var(--surface-1)', maxHeight: '90vh', overflowY: 'auto' }}
         >
-          <div className="caption mb-2 uppercase tracking-wider text-[var(--text-4)]">Agent setup pending</div>
+          <div className="caption mb-2 uppercase tracking-wider text-[var(--text-3)]">Agent setup pending</div>
           <h3 id="agent-pending-title" className="font-serif text-[1.5rem] mb-1">Vault created — agent not authorized</h3>
           <p className="caption mb-4 leading-relaxed">
             Your vault was created on-chain, but the second step (<code>setAgent</code>,
@@ -362,7 +362,7 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
         onClick={e => e.stopPropagation()}
         style={{ background: 'var(--surface-1)', maxHeight: '90vh', overflowY: 'auto' }}
       >
-        <div className="caption mb-2 uppercase tracking-wider text-[var(--text-4)]">Deploy vault</div>
+        <div className="caption mb-2 uppercase tracking-wider text-[var(--text-3)]">Deploy vault</div>
         <h3 id="deploy-modal-title" className="font-serif text-[1.5rem] mb-1">
           {strategy?.paper_title || 'Deploy strategy'}
         </h3>
@@ -430,7 +430,7 @@ export default function CreateVaultModal({ strategy, walletAddr, strictnessLevel
               className="chat-input w-full p-2.5 mono"
               disabled={submitting}
             />
-            <p className="caption mt-1 text-[var(--text-4)]">
+            <p className="caption mt-1 text-[var(--text-3)]">
               Amount to deposit via the 3-step deposit flow after vault creation.
             </p>
           </label>

--- a/ui/src/components/DepositFlow.jsx
+++ b/ui/src/components/DepositFlow.jsx
@@ -60,7 +60,7 @@ function StatusIcon({ status }) {
   if (status === FAILED) return <span className="i-lucide-x w-[1.1rem] h-[1.1rem]" style={{ color: 'var(--negative, #ef4444)' }} />
   if (status === CONFIRMING) return <span className="spin" style={{ display: 'inline-block', width: 16, height: 16, border: '2px solid var(--text-4)', borderTopColor: 'var(--accent)', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
   if (status === WAITING) return <span className="i-lucide-hourglass w-[1.1rem] h-[1.1rem]" style={{ color: 'var(--accent)' }} />
-  return <span className="i-lucide-circle w-[1.1rem] h-[1.1rem]" style={{ color: 'var(--text-4)' }} />
+  return <span className="i-lucide-circle w-[1.1rem] h-[1.1rem]" style={{ color: 'var(--text-3)' }} />
 }
 
 // Marker so the catch blocks can tell a bad-input parse failure apart from an
@@ -284,13 +284,13 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
         style={{ background: 'var(--surface-1)', maxHeight: '90vh', overflowY: 'auto' }}
       >
         {/* Header */}
-        <div className="caption mb-2 uppercase tracking-wider text-[var(--text-4)]">
+        <div className="caption mb-2 uppercase tracking-wider text-[var(--text-3)]">
           {allDone ? 'Deposit complete' : 'Fund your vault'}
         </div>
         <h3 id="deposit-flow-title" className="font-serif text-[1.5rem] mb-1">
           {strategy?.paper_title || 'Strategy Vault'}
         </h3>
-        <p className="caption mb-1 mono text-[var(--text-4)]">
+        <p className="caption mb-1 mono text-[var(--text-3)]">
           Vault: {vaultAddress?.slice(0, 10)}…{vaultAddress?.slice(-6)}
         </p>
         <p className="caption mb-4 leading-relaxed">
@@ -397,7 +397,7 @@ function EoaDepositFlow({ vaultAddress, depositAmount = '100', strategy, onClose
         {/* Allocation detail (collapsible) */}
         {!allDone && currentStep >= 1 && (
           <div className="mt-3 card-flat p-3">
-            <div className="caption mb-1 text-[var(--text-4)]">Target allocation (equal weight)</div>
+            <div className="caption mb-1 text-[var(--text-3)]">Target allocation (equal weight)</div>
             <div className="flex flex-wrap gap-2">
               {defaultAllocations().labels.map((label, i) => (
                 <span key={i} className="tag tag-muted" style={{ fontSize: '0.7rem' }}>{label}</span>
@@ -526,13 +526,13 @@ function PasskeyDepositFlow({ vaultAddress, depositAmount = '100', strategy, onC
         onClick={e => e.stopPropagation()}
         style={{ background: 'var(--surface-1)', maxHeight: '90vh', overflowY: 'auto' }}
       >
-        <div className="caption mb-2 uppercase tracking-wider text-[var(--text-4)]">
+        <div className="caption mb-2 uppercase tracking-wider text-[var(--text-3)]">
           {isDone ? 'Deposit complete' : 'Fund your vault'}
         </div>
         <h3 id="passkey-deposit-title" className="font-serif text-[1.5rem] mb-1">
           {strategy?.paper_title || 'Strategy Vault'}
         </h3>
-        <p className="caption mb-1 mono text-[var(--text-4)]">
+        <p className="caption mb-1 mono text-[var(--text-3)]">
           Vault: {vaultAddress?.slice(0, 10)}…{vaultAddress?.slice(-6)}
         </p>
         <p className="caption mb-4 leading-relaxed">
@@ -561,7 +561,7 @@ function PasskeyDepositFlow({ vaultAddress, depositAmount = '100', strategy, onC
         {/* What this batches — surface honestly so users know what they're signing */}
         {!isDone && (
           <div className="card-flat p-3 mb-3">
-            <div className="caption mb-2 text-[var(--text-4)]">
+            <div className="caption mb-2 text-[var(--text-3)]">
               One passkey signature authorizes:
             </div>
             <ul style={{ paddingLeft: 18, margin: 0 }}>
@@ -575,7 +575,7 @@ function PasskeyDepositFlow({ vaultAddress, depositAmount = '100', strategy, onC
                 Set target allocation across {defaultAllocations().labels.length} synthetics
               </li>
             </ul>
-            <div className="caption mt-2" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
+            <div className="caption mt-2" style={{ color: 'var(--text-3)', fontSize: '0.7rem' }}>
               Gas sponsored by Circle Gas Station — you pay $0.
             </div>
           </div>
@@ -596,7 +596,7 @@ function PasskeyDepositFlow({ vaultAddress, depositAmount = '100', strategy, onC
         {/* Completion */}
         {isDone && result?.txHash && (
           <div className="card-flat p-3 mt-3">
-            <div className="caption mb-1 text-[var(--text-4)]">Confirmed on Arc Testnet</div>
+            <div className="caption mb-1 text-[var(--text-3)]">Confirmed on Arc Testnet</div>
             <a
               href={`${ARCSCAN_TX}/${result.txHash}`}
               target="_blank"

--- a/ui/src/components/RigorExplainer.jsx
+++ b/ui/src/components/RigorExplainer.jsx
@@ -44,7 +44,7 @@ export default function RigorExplainer() {
           }}>1</div>
           <div>
             <div className="label">Deflated Sharpe Ratio (DSR)</div>
-            <div className="caption" style={{ color: 'var(--text-4)' }}>Bailey & López de Prado (2014)</div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>Bailey & López de Prado (2014)</div>
           </div>
           <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>confidence ≥ 0.90 (badge)</span>
         </div>
@@ -64,7 +64,7 @@ export default function RigorExplainer() {
           <div className="body" style={{ fontFamily: 'var(--mono, monospace)', fontSize: '0.82rem', color: 'var(--text-2)', lineHeight: 1.5 }}>
             z = (SR̂ − SR₀) × √(T−1) / √(1 − γ₃SR̂ + ((γ₄−1)/4)SR̂²)
             <br />
-            <span style={{ color: 'var(--text-4)', fontSize: '0.75rem' }}>
+            <span style={{ color: 'var(--text-3)', fontSize: '0.75rem' }}>
               where SR₀ = expected best Sharpe of N iid trials, γ₃ = skewness, γ₄ = raw kurtosis
             </span>
           </div>
@@ -79,7 +79,7 @@ export default function RigorExplainer() {
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Our threshold</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>Our threshold</div>
             <div className="body" style={{ fontWeight: 600 }}>confidence ≥ 0.90 → 0.50</div>
             <div className="caption" style={{ color: 'var(--text-3)' }}>
               The Verified badge needs ≥90% confidence the Sharpe is genuine. The strictness
@@ -88,7 +88,7 @@ export default function RigorExplainer() {
             </div>
           </div>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library example</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>Library example</div>
             <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
               Moreira-Muir: DSR = 0.55, p = 0.995
             </div>
@@ -112,7 +112,7 @@ export default function RigorExplainer() {
           }}>2</div>
           <div>
             <div className="label">Probability of Backtest Overfitting (PBO)</div>
-            <div className="caption" style={{ color: 'var(--text-4)' }}>Bailey, Borwein, López de Prado & Zhu (2014) — CSCV</div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>Bailey, Borwein, López de Prado & Zhu (2014) — CSCV</div>
           </div>
           <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>PBO &lt; 50%</span>
         </div>
@@ -138,7 +138,7 @@ export default function RigorExplainer() {
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Our threshold</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>Our threshold</div>
             <div className="body" style={{ fontWeight: 600 }}>PBO &lt; 50%</div>
             <div className="caption" style={{ color: 'var(--text-3)' }}>
               Less likely than random to underperform median out-of-sample.
@@ -146,7 +146,7 @@ export default function RigorExplainer() {
             </div>
           </div>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library example</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>Library example</div>
             <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
               Both Tier-1 strategies: PBO ≈ 39%
             </div>
@@ -168,7 +168,7 @@ export default function RigorExplainer() {
           }}>3</div>
           <div>
             <div className="label">Walk-Forward Out-of-Sample Sharpe</div>
-            <div className="caption" style={{ color: 'var(--text-4)' }}>Chronological 70/30 train-test split</div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>Chronological 70/30 train-test split</div>
           </div>
           <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>OOS ≥ 50% of in-sample</span>
         </div>
@@ -183,14 +183,14 @@ export default function RigorExplainer() {
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Our threshold</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>Our threshold</div>
             <div className="body" style={{ fontWeight: 600 }}>OOS ≥ 50% of in-sample Sharpe</div>
             <div className="caption" style={{ color: 'var(--text-3)' }}>
               Prevents strategies that look good historically but degrade on modern data.
             </div>
           </div>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library examples</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>Library examples</div>
             <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
               Moreira-Muir: in-sample 0.77, OOS 0.97
             </div>
@@ -212,7 +212,7 @@ export default function RigorExplainer() {
           }}>4</div>
           <div>
             <div className="label">Look-Ahead Audit</div>
-            <div className="caption" style={{ color: 'var(--text-4)' }}>Static code review — binary pass/fail</div>
+            <div className="caption" style={{ color: 'var(--text-3)' }}>Static code review — binary pass/fail</div>
           </div>
           <span className="tag tag-positive" style={{ marginLeft: 'auto' }}>All pass</span>
         </div>
@@ -228,7 +228,7 @@ export default function RigorExplainer() {
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>What we check</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>What we check</div>
             <ul className="body" style={{ paddingLeft: 16, lineHeight: 1.7, fontSize: '0.83rem', color: 'var(--text-2)' }}>
               <li>No fills at intrabar extremes (open/close only)</li>
               <li>Signal computed on bar N, filled on bar N+1</li>
@@ -237,7 +237,7 @@ export default function RigorExplainer() {
             </ul>
           </div>
           <div className="card-flat" style={{ padding: 12 }}>
-            <div className="caption" style={{ color: 'var(--text-4)', marginBottom: 4 }}>Library result</div>
+            <div className="caption" style={{ color: 'var(--text-3)', marginBottom: 4 }}>Library result</div>
             <div className="body" style={{ fontWeight: 600, color: 'var(--positive)' }}>
               All 6 strategies: audit passed
             </div>
@@ -319,7 +319,7 @@ export default function RigorExplainer() {
             </tbody>
           </table>
         </div>
-        <div className="caption" style={{ marginTop: 10, color: 'var(--text-4)', fontSize: '0.72rem' }}>
+        <div className="caption" style={{ marginTop: 10, color: 'var(--text-3)', fontSize: '0.72rem' }}>
           Badge (Conservative/level-1) thresholds: DSR conf ≥ 0.90 · PBO &lt; 50% · OOS ≥ 50% of in-sample Sharpe.
           The strictness slider relaxes these toward the always-on floors (look-ahead pass · OOS &gt; 0 · DSR conf ≥ 0.50).
           Numbers above are a snapshot from the most recent seed backtest run; the verdict is recomputed by the
@@ -327,7 +327,7 @@ export default function RigorExplainer() {
         </div>
       </div>
 
-      <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.72rem', lineHeight: 1.6 }}>
+      <div className="caption" style={{ color: 'var(--text-3)', fontSize: '0.72rem', lineHeight: 1.6 }}>
         Bailey & López de Prado (2014) "The Deflated Sharpe Ratio" ·
         Bailey, Borwein, López de Prado & Zhu (2014) "The Probability of Backtest Overfitting"
       </div>

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -1187,7 +1187,7 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
               <button
                 type="button"
                 onClick={closeRigorExplainer}
-                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-4)' }}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-3)' }}
                 aria-label="Close"
               >
                 <span className="i-lucide-x" style={{ width: 20, height: 20 }} />

--- a/ui/src/components/WalletConnect.jsx
+++ b/ui/src/components/WalletConnect.jsx
@@ -356,7 +356,7 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
                           className="caption"
                           style={{
                             display: 'flex', alignItems: 'center', gap: 8,
-                            margin: '6px 0', color: 'var(--text-4)',
+                            margin: '6px 0', color: 'var(--text-3)',
                             fontSize: '0.7rem', textTransform: 'uppercase',
                             letterSpacing: '0.05em',
                           }}
@@ -436,7 +436,7 @@ export default function WalletConnect({ address, displayName, onConnect, onDisco
                               Create new wallet
                             </button>
                           </div>
-                          <span style={{ fontSize: '0.72rem', color: 'var(--text-4)', lineHeight: 1.4 }}>
+                          <span style={{ fontSize: '0.72rem', color: 'var(--text-3)', lineHeight: 1.4 }}>
                             <strong style={{ color: 'var(--text-3)' }}>Open existing wallet</strong> opens your passkey
                             picker — choose the wallet you want. <strong style={{ color: 'var(--text-3)' }}>Create new</strong> mints a fresh wallet under the name above (or an auto-generated one).
                           </span>

--- a/ui/src/components/WelcomeProfileModal.jsx
+++ b/ui/src/components/WelcomeProfileModal.jsx
@@ -103,7 +103,7 @@ export default function WelcomeProfileModal({ walletAddr, onDone, mode = 'welcom
           boxShadow: '0 24px 60px rgba(0,0,0,0.55)',
         }}
       >
-        <div className="caption mb-3 uppercase tracking-wider text-[var(--text-4)]" style={{ fontSize: '0.78rem' }}>
+        <div className="caption mb-3 uppercase tracking-wider text-[var(--text-3)]" style={{ fontSize: '0.78rem' }}>
           {isEdit ? 'Your Profile' : 'Welcome to Archimedes'}
         </div>
         <h3 id="welcome-modal-title" className="font-serif mb-2" style={{ fontSize: '1.85rem', lineHeight: 1.2, letterSpacing: '-0.02em' }}>
@@ -132,7 +132,7 @@ export default function WelcomeProfileModal({ walletAddr, onDone, mode = 'welcom
 
           <label className="block">
             <span className="block mb-1.5" style={{ fontSize: '0.9rem', color: 'var(--text-2)', fontWeight: 500 }}>
-              Email <span style={{ color: 'var(--text-4)', fontWeight: 400 }}>(optional)</span>
+              Email <span style={{ color: 'var(--text-3)', fontWeight: 400 }}>(optional)</span>
             </span>
             <input
               type="email"
@@ -166,7 +166,7 @@ export default function WelcomeProfileModal({ walletAddr, onDone, mode = 'welcom
 
           <label className="block">
             <span className="block mb-1.5" style={{ fontSize: '0.9rem', color: 'var(--text-2)', fontWeight: 500 }}>
-              Attribution <span style={{ color: 'var(--text-4)', fontWeight: 400 }}>(optional)</span>
+              Attribution <span style={{ color: 'var(--text-3)', fontWeight: 400 }}>(optional)</span>
             </span>
             <input
               type="text"

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -165,30 +165,71 @@ test("base and public palettes keep muted text above the 4.5:1 floor", () => {
 	assert.doesNotMatch(authPage, /text-\[var\(--text-4\)\]/);
 });
 
-// Files whose ENTIRE render is portalled to document.body, plus
-// RigorExplainer, which has no call site outside Strategies' portalled rigor
-// modal — everything they draw resolves the base palette. WalletConnect and
-// Strategies are deliberately NOT in this list: they render inside .app-site
-// and only open a portal, so they are checked by portalRegions() below.
-const PORTALLED_DIALOGS = [
-	"components/AssetGroupModal.jsx",
-	"components/AssetModal.jsx",
-	"components/CreateVaultModal.jsx",
-	"components/DepositFlow.jsx",
-	"components/RigorExplainer.jsx",
-	"components/WelcomeProfileModal.jsx",
+// RigorExplainer is the one file that is entirely portalled without calling
+// createPortal itself: it has no call site outside Strategies' portalled
+// rigor modal, so everything it draws resolves the base palette. It has to be
+// named. Every OTHER portalled subtree is DISCOVERED below rather than listed,
+// so a dialog added later is covered without anyone remembering to add it —
+// a hand-maintained list would have silently excluded CustomSelect and
+// OnboardingTour, which both portal to document.body and were outside the
+// first version of this guard.
+const ALWAYS_PORTALLED = ["components/RigorExplainer.jsx"];
+
+// Every .jsx under src/ that opens a portal, as repo-relative paths.
+function filesCallingCreatePortal() {
+	const files = [];
+	const walk = (dir) => {
+		for (const entry of readdirSync(dir)) {
+			const full = join(dir, entry);
+			if (statSync(full).isDirectory()) walk(full);
+			else if (/\.jsx$/.test(entry)) files.push(full);
+		}
+	};
+	const root = new URL("../src", import.meta.url).pathname;
+	walk(root);
+	return files
+		.filter((f) => readFileSync(f, "utf8").includes("createPortal("))
+		.map((f) => f.slice(root.length + 1));
+}
+
+// Inside a portalled subtree --text-4 is a 1.83:1 hairline, so the only
+// legitimate use of it there is DECORATION. This is deliberately an
+// allowlist of the decoration spellings rather than a denylist of the text
+// spellings: anchoring on `color:` would silently miss a colour reached
+// through a ternary or a fallback — `x ? 'var(--negative)' : 'var(--text-4)'`,
+// `TYPE_COLORS[t] || 'var(--text-4)'`, `const muted = 'var(--text-4)'` — and
+// this tree contains five such text colours today (CorpusKG, Strategies x2,
+// RigorStrictnessControl, RejectedCandidates). All five render inside
+// .app-site rather than in a portal, so none is a defect here, but a
+// denylist would not have caught one if it were.
+const TEXT_4_AS_DECORATION = [
+	// DepositFlow's CONFIRMING spinner track: a 2px ring, not text.
+	/border:\s*['"]2px solid var\(--text-4\)['"]/,
 ];
 
-// The two spellings a --text-4 TEXT colour can take in this tree: an inline
-// style object and an UnoCSS arbitrary colour. Decoration spellings
-// (`border: '2px solid var(--text-4)'` on DepositFlow's spinner track,
-// `fill={muted}` on OnboardingTour's aria-hidden illustrations) are
-// deliberately not matched — --text-4 is a decoration token on this palette
-// and those uses are the reason it must stay dark.
-const TEXT_4_AS_COLOUR = [
-	/color:\s*['"]var\(--text-4\)['"]/,
-	/text-\[var\(--text-4\)\]/,
-];
+// A --text-4 mention that is not one of the allowed decoration spellings.
+// Comment lines are skipped so a note explaining why the token is avoided
+// does not read as a use of it.
+function text4Offenders(label, source) {
+	const found = [];
+	for (const line of source.split("\n")) {
+		if (!line.includes("--text-4")) continue;
+		const trimmed = line.trim();
+		if (/^(\/\/|\/\*|\*)/.test(trimmed)) continue;
+		// Strip the allowed decoration spellings and re-check, rather than
+		// skipping the whole line when one matches. DepositFlow's spinner is a
+		// single long inline-style line, so a line-level skip would let a text
+		// colour ride along on it — verified: that input passed a skip-based
+		// version of this guard and fails this one.
+		let rest = line;
+		for (const pattern of TEXT_4_AS_DECORATION) {
+			rest = rest.split(pattern).join("");
+		}
+		if (!rest.includes("--text-4")) continue;
+		found.push(`${label} — ${trimmed.slice(0, 100)}`);
+	}
+	return found;
+}
 
 test("portalled dialogs never paint text with the base decoration token", () => {
 	// #1318 residual. A dialog opened from .app-site still resolves the BASE
@@ -230,24 +271,26 @@ test("portalled dialogs never paint text with the base decoration token", () => 
 	);
 
 	const offenders = [];
-	for (const file of PORTALLED_DIALOGS) {
-		const source = src(file);
-		for (const pattern of TEXT_4_AS_COLOUR) {
-			if (pattern.test(source)) offenders.push(`${file} — ${pattern}`);
-		}
+	for (const file of ALWAYS_PORTALLED) {
+		offenders.push(...text4Offenders(file, src(file)));
 	}
-	for (const [file, source] of [
-		["components/Strategies.jsx", strategies],
-		["components/WalletConnect.jsx", walletConnect],
-	]) {
-		const regions = portalRegions(source);
+
+	// Region-slice every file that opens a portal. A component can render
+	// inside .app-site AND open a portal (WalletConnect's topbar menu,
+	// Strategies' rigor modal), so only the portalled subtree is on the base
+	// palette — a whole-file check would be wrong in both directions, and
+	// Strategies legitimately keeps 9 --text-4 call sites outside its portal.
+	const portalFiles = filesCallingCreatePortal();
+	assert.ok(
+		portalFiles.includes("components/Strategies.jsx") &&
+			portalFiles.includes("components/CustomSelect.jsx"),
+		`portal discovery found ${portalFiles.length} files but missed a known one: ${portalFiles.join(", ")}`,
+	);
+	for (const file of portalFiles) {
+		const regions = portalRegions(src(file));
 		assert.ok(regions.length > 0, `${file}: no createPortal region found`);
 		for (const region of regions) {
-			for (const pattern of TEXT_4_AS_COLOUR) {
-				if (pattern.test(region)) {
-					offenders.push(`${file} (portalled subtree) — ${pattern}`);
-				}
-			}
+			offenders.push(...text4Offenders(`${file} (portalled subtree)`, region));
 		}
 	}
 	assert.deepEqual(

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -67,6 +67,24 @@ function nestedCssBlock(blockText, selector) {
 	return m[1];
 }
 
+// createPortal(node, document.body) mounts OUTSIDE both shells, so the
+// portalled subtree resolves the BASE palette even when a .app-site page
+// opened it. For a component that renders inside a shell AND opens a portal
+// (WalletConnect's topbar menu, Strategies' rigor modal) only that subtree is
+// on the base palette, so a whole-file check would be wrong in both
+// directions. Slice from each `createPortal(` to the `document.body` argument
+// that closes the call.
+function portalRegions(source) {
+	const regions = [];
+	const re = /createPortal\(/g;
+	let m;
+	while ((m = re.exec(source))) {
+		const end = source.indexOf("document.body", m.index);
+		if (end !== -1) regions.push(source.slice(m.index, end));
+	}
+	return regions;
+}
+
 function relativeLuminance(hex) {
 	const h = hex.replace("#", "");
 	const full = h.length === 3 ? [...h].map((c) => c + c).join("") : h;
@@ -145,6 +163,98 @@ test("base and public palettes keep muted text above the 4.5:1 floor", () => {
 	// --text-4 is a border/decoration token on the base palette (it is #3f3f46
 	// there = 1.73:1) and must never be used as text on the auth screen.
 	assert.doesNotMatch(authPage, /text-\[var\(--text-4\)\]/);
+});
+
+// Files whose ENTIRE render is portalled to document.body, plus
+// RigorExplainer, which has no call site outside Strategies' portalled rigor
+// modal — everything they draw resolves the base palette. WalletConnect and
+// Strategies are deliberately NOT in this list: they render inside .app-site
+// and only open a portal, so they are checked by portalRegions() below.
+const PORTALLED_DIALOGS = [
+	"components/AssetGroupModal.jsx",
+	"components/AssetModal.jsx",
+	"components/CreateVaultModal.jsx",
+	"components/DepositFlow.jsx",
+	"components/RigorExplainer.jsx",
+	"components/WelcomeProfileModal.jsx",
+];
+
+// The two spellings a --text-4 TEXT colour can take in this tree: an inline
+// style object and an UnoCSS arbitrary colour. Decoration spellings
+// (`border: '2px solid var(--text-4)'` on DepositFlow's spinner track,
+// `fill={muted}` on OnboardingTour's aria-hidden illustrations) are
+// deliberately not matched — --text-4 is a decoration token on this palette
+// and those uses are the reason it must stay dark.
+const TEXT_4_AS_COLOUR = [
+	/color:\s*['"]var\(--text-4\)['"]/,
+	/text-\[var\(--text-4\)\]/,
+];
+
+test("portalled dialogs never paint text with the base decoration token", () => {
+	// #1318 residual. A dialog opened from .app-site still resolves the BASE
+	// palette once it is portalled to document.body, and there --text-4 is
+	// #3f3f46: 1.83:1 on --surface-1, the surface every one of these dialogs
+	// paints its card with. Eight of them were using it for body text — the
+	// asset / asset-group price captions, DepositFlow's step labels,
+	// CreateVaultModal's section headers, WelcomeProfileModal's "(optional)"
+	// hints, WalletConnect's passkey copy, the rigor modal's close control and
+	// the whole of RigorExplainer.
+	//
+	// Both sides are computed rather than pinned, for the reason the contrast
+	// helpers exist: the replacement token's ratio is asserted, not assumed,
+	// and the ban explains itself with --text-4's live ratio instead of a
+	// snapshot that can go stale.
+	const base = cssBlock(css, ":root");
+	assert.match(base, /--surface-1:/, "first :root block is not the base palette");
+	const text3 = resolveHex(base, tokenValue(base, "text-3"));
+	const text4 = resolveHex(base, tokenValue(base, "text-4"));
+
+	// --surface-1 is `.modal`'s background and AssetModal's card background;
+	// --surface-2 backs the nested blocks inside them; --surface-3 is
+	// `.table-container thead th`, which RigorExplainer renders inside the
+	// portalled rigor modal.
+	for (const surfaceName of ["surface-1", "surface-2", "surface-3"]) {
+		const surfaceHex = resolveHex(base, tokenValue(base, surfaceName));
+		const ratio = contrastRatio(text3, surfaceHex);
+		assert.ok(
+			ratio >= 4.5,
+			`--text-3 (${text3}) on --${surfaceName} (${surfaceHex}) is ${ratio.toFixed(2)}:1, below the 4.5:1 floor — portalled dialogs resolve these values`,
+		);
+	}
+
+	const surface1 = resolveHex(base, tokenValue(base, "surface-1"));
+	const decorationRatio = contrastRatio(text4, surface1);
+	assert.ok(
+		decorationRatio < 4.5,
+		`base --text-4 (${text4}) now measures ${decorationRatio.toFixed(2)}:1 on --surface-1. If that raise is deliberate it is no longer a decoration-only token — retire this guard and the App.css note with it (#1318).`,
+	);
+
+	const offenders = [];
+	for (const file of PORTALLED_DIALOGS) {
+		const source = src(file);
+		for (const pattern of TEXT_4_AS_COLOUR) {
+			if (pattern.test(source)) offenders.push(`${file} — ${pattern}`);
+		}
+	}
+	for (const [file, source] of [
+		["components/Strategies.jsx", strategies],
+		["components/WalletConnect.jsx", walletConnect],
+	]) {
+		const regions = portalRegions(source);
+		assert.ok(regions.length > 0, `${file}: no createPortal region found`);
+		for (const region of regions) {
+			for (const pattern of TEXT_4_AS_COLOUR) {
+				if (pattern.test(region)) {
+					offenders.push(`${file} (portalled subtree) — ${pattern}`);
+				}
+			}
+		}
+	}
+	assert.deepEqual(
+		offenders,
+		[],
+		`these portalled dialogs paint text with --text-4 (${text4} = ${decorationRatio.toFixed(2)}:1 on --surface-1, a decoration token on the base palette) instead of --text-3:\n${offenders.join("\n")}`,
+	);
 });
 
 test("--accent is a fill token; accent-coloured TEXT resolves --accent-text", () => {


### PR DESCRIPTION
## What

Portalled dialogs stop painting their text with the base palette's decoration token.

`createPortal(node, document.body)` mounts **outside both shells**, so a dialog opened from
`.app-site` does not inherit `.app-site`'s tokens — it resolves the bare `:root` palette. On
that palette `--text-4` is `#3f3f46`: **1.83:1 on `--surface-1`**, the surface every one of
these dialogs paints its card with. It is dark on purpose (it is a hairline/decoration token:
the scrollbar-thumb hover, DepositFlow's spinner track, AuthPage's password-strength meter
segments), which is why the fix is to move the call sites, not to bump the token.

Eight dialogs were using it as body text; they now resolve `--text-3` (**5.59:1** on
`--surface-1`, **5.27:1** on `--surface-2`):

| file | sites | what was unreadable |
| --- | --- | --- |
| `RigorExplainer.jsx` | 15 | every citation line, "Our threshold" / "Library example" label and the two footnotes — the whole rigor explainer, which has no call site outside the portalled modal |
| `AssetModal.jsx` | 11 | "Current price", "24h change/high/low", "Source", "Last updated", "7d/30d change", "Oracle address" |
| `DepositFlow.jsx` | 9 | step section headers, the mono vault/tx lines, "Target allocation", "Confirmed on Arc Testnet", the not-started step dot |
| `AssetGroupModal.jsx` | 3 | median-change caption, index caption, "Assets in this group" |
| `WelcomeProfileModal.jsx` | 3 | section kicker, both "(optional)" field hints |
| `CreateVaultModal.jsx` | 3 | "Agent setup pending", "Deploy vault", the deposit-amount hint |
| `WalletConnect.jsx` | 2 | the passkey section kicker and the "Open existing wallet / Create new" explainer (portalled subtree only) |
| `Strategies.jsx` | 1 | the rigor modal's Close control (portalled subtree only) |

`App.css`'s `--text-4` note was rewritten in the same commit: it said "KNOWN OPEN ISSUE …
the `--text-4` half is unfixed", which is no longer true and would have been a false claim
left in the tree.

## Why this shape, and what was verified before touching anything

Per the instruction to re-verify each residual against the post-rebrand tree first:

- **Still real.** Base `--text-4` `#3f3f46` measures **1.83:1** on `--surface-1` / **1.73:1**
  on `--surface-2`; `AssetModal.jsx` and `AssetGroupModal.jsx` still `createPortal(…, document.body)`.
  The rebrand did not fix it.
- **Wider than the issue's wording.** The issue named "the portalled asset modals". Six more
  components portal to `document.body` and hit the identical palette, and `RigorExplainer` —
  the largest offender at 15 sites — is a child of one of them. Fixing only the two named
  modals would have left the same defect at 1.8:1 in six other dialogs.
- **Narrower than a blanket sweep.** `.public-site`'s `--text-4` was already raised to
  `#8b9f97` (≥4.71:1) in #1348, so the 16 public-shell call sites pass and are untouched —
  this is the "triage, not mechanical" part. `WalletConnect` and `Strategies` render *inside*
  `.app-site` and merely *open* a portal, so only their `createPortal` subtrees were changed;
  their in-shell call sites are deliberately left alone.
- **Decoration uses left alone**, because they are the reason the token must stay dark:
  `DepositFlow`'s `border: '2px solid var(--text-4)'` spinner track, `OnboardingTour`'s
  `fill={muted}` inside `aria-hidden="true"` illustrations (1.4.3's incidental exception —
  "part of a picture that contains significant other visual content"), `AuthPage`'s
  strength-meter segment backgrounds, the scrollbar-thumb hover.

## Test evidence

```
$ cd ui && node --test test/a11y.test.js
✔ portalled dialogs never paint text with the base decoration token (0.612ms)
...
ℹ tests 27
ℹ suites 0
ℹ pass 27
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 334.9135
```

```
$ cd ui && npm test
✔ the circle signing path involves no WebAuthn ceremony at all (#1467) (0.635042ms)
ℹ tests 615
ℹ suites 0
ℹ pass 615
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1334.944625
```

```
$ cd ui && npm run lint

> ui@0.0.0 lint
> eslint .

(no output — clean)
```

No Python touched, so `ruff` / `pytest` are not in scope for this diff; no docs touched, so no
`make docs-check` / `docs/README.md` row is due.

## Revert demo — the new assertion fails against the unfixed tree

Reverse-applied the whole source diff (test file kept), per CLAUDE.md § "A test that passes
against the unfixed code proves nothing":

```
$ git diff -- ui/src/components > /tmp/1318-fix.patch && git apply -R /tmp/1318-fix.patch
$ cd ui && node --test test/a11y.test.js
✖ portalled dialogs never paint text with the base decoration token (18.923708ms)
ℹ pass 26
ℹ fail 1

✖ failing tests:
test at test/a11y.test.js:193:1
✖ portalled dialogs never paint text with the base decoration token (18.923708ms)
  AssertionError [ERR_ASSERTION]: these portalled dialogs paint text with --text-4
  (#3f3f46 = 1.83:1 on --surface-1, a decoration token on the base palette) instead of --text-3:
  components/AssetGroupModal.jsx — /color:\s*['"]var\(--text-4\)['"]/
  components/AssetModal.jsx — /color:\s*['"]var\(--text-4\)['"]/
  components/CreateVaultModal.jsx — /text-\[var\(--text-4\)\]/
  components/DepositFlow.jsx — /color:\s*['"]var\(--text-4\)['"]/
  components/DepositFlow.jsx — /text-\[var\(--text-4\)\]/
  components/RigorExplainer.jsx — /color:\s*['"]var\(--text-4\)['"]/
  components/WelcomeProfileModal.jsx — /color:\s*['"]var\(--text-4\)['"]/
  components/WelcomeProfileModal.jsx — /text-\[var\(--text-4\)\]/
  components/Strategies.jsx (portalled subtree) — /color:\s*['"]var\(--text-4\)['"]/
  components/WalletConnect.jsx (portalled subtree) — /color:\s*['"]var\(--text-4\)['"]/
```

Restored with `git apply /tmp/1318-fix.patch` → back to `pass 27 / fail 0`.

## Adversarial demos — the guard was shown to reject bad input, and shown not to over-fire

Per CLAUDE.md § "A guard must be shown to reject something". Three inputs, all reverted after.

**A1 — a `--text-4` colour introduced INSIDE `Strategies`' portalled subtree → rejected.**
Added `data-adversarial={{ color: 'var(--text-4)' }}` next to the rigor modal's Close button
(line ~1191, between `createPortal(` and `document.body`):

```
✖ portalled dialogs never paint text with the base decoration token (4.738ms)
ℹ pass 26
ℹ fail 1
  components/Strategies.jsx (portalled subtree) — /color:\s*['"]var\(--text-4\)['"]/
```

**A2 — the byte-identical string OUTSIDE the portal subtree → correctly NOT flagged.**
Added `const ADVERSARIAL_OUTSIDE_PORTAL = { color: 'var(--text-4)' }` at module scope in the
same file (above `STATUS_ORDER`, i.e. before `createPortal(`):

```
✔ portalled dialogs never paint text with the base decoration token (1.886167ms)
ℹ pass 27
ℹ fail 0
```

This is the load-bearing half: `Strategies.jsx` legitimately keeps 11 `--text-4` call sites
that render inside `.app-site` (see "Not done here"), so a whole-file grep would have been a
guard that can only be satisfied by changing code that is not broken. The region slice is
what makes the assertion mean what it says.

**B — the computed contrast floor, not a pinned literal.** Regressed base `--text-3` to its
pre-#1311 value `#71717a` in `App.css` (leaving every call site correct):

```
ℹ pass 25
ℹ fail 2
  AssertionError [ERR_ASSERTION]: --text-3 (#71717a) on --surface-1 (#0f0f12) is 3.96:1,
  below the 4.5:1 floor — portalled dialogs resolve these values
```

The new test resolves both sides of the pair out of the live `:root` block and computes the
WCAG ratio, so the background can no longer drift out from under the guard — the same
reasoning the existing `--accent-text` / `--text-4` public-palette tests in this file use.
The ban's failure message also carries `--text-4`'s live ratio rather than a snapshot, and if
someone ever promotes `--text-4` to a real text token the guard fails with an instruction to
retire itself rather than silently ossifying the ban.

## Not done here

**This PR does not close #1318 — deliberately, and `Closes` is omitted for that reason.**
Two of the issue's items survive:

**1. `--text-4` as body text on `.app-site` raised cards (the "~175 call sites" item).**
Re-measured on this tree, still failing, **85 call sites in 22 files** remain.

> **Correction.** An earlier revision of this description said "91 call sites in 23 files".
> That was wrong — it came from `grep -c`, which counts matching *lines*, not occurrences,
> and did not separate the shells. Counted properly with the same two patterns the guard
> uses: **101 occurrences in 23 files** tree-wide, of which **16 are `Architecture.jsx`**
> (the only `.public-site` component with any, and they pass at ≥4.71:1 since #1348),
> leaving **85 in 22 files** on the app shell. Public membership was resolved from
> `App.jsx`'s `route.kind === "public"` branch (Landing / Security / Architecture), the only
> place `PublicLayout` is mounted.

| palette | `--text-4` | `--surface-1` | `--surface-2` (raised) | `--surface-3` |
| --- | --- | --- | --- | --- |
| `.app-site` dark | `#71867e` | 4.53:1 | **3.94:1** | **3.38:1** |
| `.app-site` light | `#60746b` | 4.99:1 | **4.16:1** | **3.88:1** |

I did not execute the issue's prescribed remedy ("triage to `--text-3`") because measuring it
first shows it is **not sufficient**, and shipping it would have produced a false "fixed":

| palette | `--text-3` | `--surface-2` | `--surface-3` |
| --- | --- | --- | --- |
| `.app-site` dark | `#8b9e96` | 5.41:1 | 4.64:1 |
| `.app-site` light | `#566a61` | 4.83:1 | **4.4950:1 — fails** |

`--surface-3` *is* a text background in this shell (`.chat-msg` bubbles, `.table-container
thead th`, `.strat-placeholder-note`, `.cs-dropdown`), and `.strat-placeholder-note` /
`.chat-msg-time` pair `color: var(--text-4)` with it directly. So the light theme needs
`--text-3` moved too, i.e. this is a palette decision, not a substitution — it needs the
owner's design read, exactly as the issue says.

For whoever picks it up: unlike the base palette, `.app-site`'s `--text-4` has only **three**
decoration consumers in the whole tree —
`::-webkit-scrollbar-thumb:hover` (`App.css:1809`) and `Explore.jsx:254,339`
(`borderColor` on hover) — both hover-state affordances that only improve at higher contrast.
That materially weakens the "a token bump would brighten every hairline" objection *for this
palette specifically*, so a palette adjustment is on the table there in a way it is not on the
base palette. Raising `--text-4` alone still will not clear `--surface-3` without moving
`--text-3` with it. Owner's call; I did not make it.

**2. Formal conformance evaluation** (screen-reader pass, 200%/400% reflow, text-spacing
override, motion review, automated axe/Lighthouse against the live app). Untouched. This
cannot be discharged by a source-parsing test or by me — it needs a human driving real
assistive tech against the running site. No conformance claim is made anywhere in this diff.

**3. Out of scope by construction.** `.public-site`'s 16 `--text-4` text call sites (pass,
≥4.71:1 since #1348), the 21 `color: var(--text-4)` rules in `App.css` (all render in
`.app-site` or `.public-site`, none inside a portal — verified by matching each selector's
call sites against the portalled subtrees), and the decoration uses listed above. `AuthPage`
and `NotFound` also resolve the base palette and were checked: neither paints text with
`--text-4` (AuthPage's only use is a strength-meter *background*), and the pre-existing
`assert.doesNotMatch(authPage, /text-\[var\(--text-4\)\]/)` already pins that.

**4. Guard reach.** The repo still has no DOM-rendering test framework, so this remains a
static source pin like every other guard in `ui/test/a11y.test.js` — it reads source, not
rendered output.

> **Correction.** An earlier revision of this description disclosed a blind spot and got its
> extent wrong: it said the indirection "is currently only used for `fill` on decorative
> illustrations". That is false. Five *text* colours in this tree reach `--text-4` through a
> ternary or a fallback — `CorpusKG.jsx:532` (`TYPE_COLORS[t] || 'var(--text-4)'`),
> `Strategies.jsx:315,335`, `RigorStrictnessControl.jsx:113`, `RejectedCandidates.jsx:25`.
> All five render inside `.app-site` and none is inside a portal, so none is a defect this
> PR should have fixed — but the guard as first written could not have caught one if it
> were. **Closed in `4a13548a`** rather than left as a disclosure (see the fourth demo
> below); that commit also found and closed two further gaps I had not disclosed at all.

---

## Second commit (`4a13548a`) — hardening the guard against itself

The first commit's guard was adversarially probed rather than assumed correct. Three gaps
turned up. Each was **demonstrated first**, then fixed; all three inputs were reverted after.

Net effect on the shipped source fix: **none** — no unfixed defect was found. Every gap was
in the *guard*, i.e. in what would be caught next time.

### C — a colour reached through a ternary, inside the portal → was MISSED, now rejected

Injected into `Strategies.jsx`'s rigor-modal Close button, inside the `createPortal` region:

```
color: rigorModalOpen ? 'var(--text-4)' : 'var(--text-3)'
```

```
--- would the ORIGINAL denylist patterns have matched? ---
OLD denylist match: False   <- False means the first version of the guard MISSED it

--- tightened guard ---
✖ portalled dialogs never paint text with the base decoration token
ℹ pass 26
ℹ fail 1
  components/Strategies.jsx (portalled subtree) — style={{ background: 'none', border: 'none', cursor: 'pointer', color: rigorModalOpen ? 'var(--text-
```

Fix: the guard now allowlists the *decoration* spellings instead of denylisting the *text*
spellings. Inside a portalled subtree, any `--text-4` that is not the spinner's 2px ring is
an offender, however it is spelled.

### D — a text colour smuggled onto the allowlisted line → was MISSED, now rejected

`DepositFlow`'s spinner is a single long inline-style line, and the first version of the
allowlist skipped the whole line when a decoration spelling matched it:

```
border: '2px solid var(--text-4)', color: 'var(--text-4)'
```

```
--- skip-based allowlist ---
ℹ pass 27
ℹ fail 0          <- the smuggled text colour passed

--- strip-and-recheck allowlist ---
✖ portalled dialogs never paint text with the base decoration token
ℹ pass 26
ℹ fail 1
```

Fix: the allowed spellings are stripped from the line and the remainder is re-checked.

### E — a brand-new portalled dialog nobody registered → was UNREACHED, now rejected

The portalled-file list was hand-maintained, and was already incomplete: `CustomSelect.jsx`
and `OnboardingTour.jsx` both `createPortal(…, document.body)` and were outside the guard
entirely. I checked both before changing anything — neither uses `--text-4` inside its portal
region (`OnboardingTour`'s two uses sit at lines 342/378, outside its regions at 407–425 and
456–492), so **nothing was unfixed**; the guard simply did not reach them.

Added an unlisted file to prove the discovery works:

```
$ cat > src/components/AdversarialNewModal.jsx   # createPortal(…, document.body)
      <p style={{ color: 'var(--text-4)' }}>a brand-new portalled dialog</p>

✖ portalled dialogs never paint text with the base decoration token
ℹ pass 26
ℹ fail 1
  components/AdversarialNewModal.jsx (portalled subtree) — <p style={{ color: 'var(--text-4)' }}>a brand-new portalled dialog</p>
```

Fix: files that open a portal are discovered by walking `src/` (the same `readdirSync` walk
the `--danger` test in this file already uses). Only `RigorExplainer` stays hand-named — it is
entirely portalled but calls no `createPortal` of its own. The `App.css` note was corrected in
the same commit: it claimed a new dialog "cannot reintroduce the pairing", which only became
true once discovery existed.

### A2 re-verified under the tightened guard — the region slice still does not over-fire

```
A2 re-run under the TIGHTENED guard: identical string at module scope, OUTSIDE the portal
✔ portalled dialogs never paint text with the base decoration token
ℹ pass 27
ℹ fail 0
```

Still load-bearing: `Strategies.jsx` keeps 9 legitimate `--text-4` call sites that render
inside `.app-site`.

### Revert demo re-run against the hardened guard

```
$ git diff HEAD~1 HEAD -- ui/src > /tmp/1318-src.patch && git apply -R /tmp/1318-src.patch
$ node --test test/a11y.test.js
✖ portalled dialogs never paint text with the base decoration token
ℹ pass 26
ℹ fail 1
  components/AssetGroupModal.jsx — <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>
  components/AssetModal.jsx — <div className="caption" style={{ color: 'var(--text-4)', fontSize: '0.7rem' }}>Current price</div>
  … 47 offender lines total — one per fixed call site, matching the table above
```

Restored → `pass 27 / fail 0`.

### Independent re-verification of this PR's other claims

Checked before trusting them, since the description asserts things no test enforces:

- **Every contrast number recomputed from `App.css`.** Base `--text-4` 1.83:1 / 1.73:1;
  base `--text-3` 5.59:1 / 5.27:1; `.app-site` dark 4.53 / 3.94 / 3.38; `.app-site` light
  4.99 / 4.16 / 3.88. All exact. The load-bearing one for deferring — `.app-site` light
  `--text-3` on `--surface-3` — is **4.4950:1**, genuinely below 4.5, so "triage to
  `--text-3` is not sufficient" holds and the deferral is justified rather than convenient.
- **"None of the 18 `color: var(--text-4)` rules in `App.css` applies inside a portal."**
  Verified mechanically: extracted every selector carrying that declaration, expanded to
  class names, and intersected against every `className` used inside a portalled subtree →
  empty. (The description's "21 rules" is a miscount of the same set; the 18 that set a text
  `color` are the ones that matter, and three of them — `.rigor-matrix__label`,
  `.vault-card-arrow`, `.strat-placeholder-note` — are dead CSS with zero JSX call sites.)
- **`.strat-placeholder-note` is cited in "Not done here" as a `--surface-3` text
  consumer.** It is dead CSS. The argument it supports still stands on `.chat-msg-time`
  (`VaultChat.jsx:33`), which is live.

## Full test evidence (final state, both commits)

```
$ cd ui && npm test
ℹ tests 615
ℹ pass 615
ℹ fail 0

$ npm run lint
> eslint .
(no output — clean)

$ npm run check:routes
check-orphans: OK (115 src files scanned, 0 orphans in components/ or data/)
check-sitemap: OK (6 public route(s) from routes.js all present in sitemap.xml)
```

No Python touched → `ruff` / `pytest` not in scope. No docs touched → no `make docs-check` or
`docs/README.md` row due. (The repo's quality-gate bot reports 47 pre-existing `ruff` errors
on this PR; they are on `main`, not from this diff, which is CSS/JSX/JS only.)

Refs #1318

