### PR TITLE
[backend] Version-stamp the paper grading engine so a re-grade is not reported as the user's history restating

### DIFF
--- a/backend/archimedes/api/leaderboard_routes.py
+++ b/backend/archimedes/api/leaderboard_routes.py
@@ -315,7 +315,17 @@ def _live_paper_ledgers(user_id: str) -> tuple[list[LivePaperLedger], bool, str]
                         inception=d.deployed_at,
                         returns=observations.get(d.id, []),
                         last_appended_at=last_appended.get(d.id),
-                        drift_detected=d.drift_detected_at is not None,
+                        # BOTH stamps, deliberately. #1449 narrowed
+                        # `drift_detected_at` to data-attributable drift and
+                        # routed engine re-grades to `engine_regrade_at`; reading
+                        # only the first here would make this board's negative
+                        # chip ("no replay disagreement recorded") false for a
+                        # re-graded deployment. The board's flag means what it
+                        # has always meant — a replay disagreed with written
+                        # rows — and its coarseness (it does not yet say WHICH
+                        # cause) is stated in the field description rather than
+                        # papered over.
+                        drift_detected=d.drift_detected_at is not None or d.engine_regrade_at is not None,
                     )
                     for d in deps
                 ],

--- a/backend/archimedes/api/leaderboard_schemas.py
+++ b/backend/archimedes/api/leaderboard_schemas.py
@@ -347,6 +347,12 @@ class LivePaperEntry(BaseModel):
     # The ledger is append-only by law; a replay that disagrees with already
     # written rows stamps the deployment instead of rewriting it. Surfaced so
     # a drifted track record is visibly drifted on the board too.
+    #
+    # True for EITHER cause (#1449): an upstream data restatement
+    # (`drift_detected_at`) or a grading-engine re-grade (`engine_regrade_at`).
+    # The board does not yet distinguish them — GET /api/paper/deployments does,
+    # per deployment. Widening this to a cause is follow-up work; what it must
+    # not do is go false while a disagreement stands.
     drift_detected: bool = False
 
 

--- a/backend/archimedes/models/paper_store.py
+++ b/backend/archimedes/models/paper_store.py
@@ -126,10 +126,32 @@ class PaperDeployment(Base):
     deployed_at: Mapped[date] = mapped_column(Date, nullable=False)
     status: Mapped[str] = mapped_column(String(16), nullable=False, default=STATUS_ACTIVE)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
-    # Set when a replay disagrees with already-written ledger rows (upstream
-    # data restatement). The ledger is never rewritten; this flags that a
-    # fresh replay would tell a different story — surfaced, not hidden.
+    # Set when a replay disagrees with already-written ledger rows AND the
+    # disagreement is ATTRIBUTABLE to the data, not to us: the row carries the
+    # same grading-engine version the replay just ran under, so the only thing
+    # left that can have moved is upstream history (#1449). The ledger is never
+    # rewritten; this flags that a fresh replay would tell a different story —
+    # surfaced, not hidden.
+    #
+    # Narrower than it was before #1449, deliberately. It used to fire on ANY
+    # disagreement, which meant a grading-side cost-model change (#1379's
+    # slippage floor) would stamp every open deployment at once and tell every
+    # user their track record had restated — a claim about THEM for a change
+    # that was ours. Those cases now land on ``engine_regrade_at`` instead.
     drift_detected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Set when a replay disagrees with already-written ledger rows and the
+    # cause is the GRADING ENGINE, not the data (#1449). Two ways in:
+    #
+    #   1. the disagreeing row carries a grading-engine version different from
+    #      the one this replay ran under — an expected, disclosed re-grade;
+    #   2. the row carries NO version at all (written before ``engine_version``
+    #      existed), so the disagreement cannot be attributed either way.
+    #
+    # Case 2 is annotated rather than alarmed for the same reason case 1 is:
+    # calling it a data restatement would assert something we cannot show. Both
+    # are still counted, logged, and reported on the deployment payload — what
+    # is withheld is the attribution, never the fact.
+    engine_regrade_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # Opt-in on-chain anchoring for this deployment's reasoning traces (#1575
     # §6). Default false, and PER DEPLOYMENT rather than a global switch,
     # because the commit-reveal `reveal()` puts `portfolio_before/after` —
@@ -181,6 +203,18 @@ class PaperDailyReturn(Base):
     date: Mapped[date] = mapped_column(Date, nullable=False)
     daily_return: Mapped[float] = mapped_column(Float, nullable=False)
     appended_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    # WHICH GRADING ENGINE produced this number (#1449) —
+    # ``fusion_evaluator.GRADING_ENGINE_VERSION`` at append time. The row is
+    # append-only like every other column here, so this is the durable record of
+    # the cost basis and replay semantics the user was actually shown.
+    #
+    # Nullable, and NEVER backfilled: rows written before this column existed
+    # were graded by a build that did not record its own version, and stamping
+    # them with today's string would be inventing provenance to make a
+    # comparison come out clean — the exact class of claim this ledger exists to
+    # oppose. NULL means "unrecorded", and ``paper_trading.classify_drift`` gives
+    # it its own bucket rather than folding it into either answer.
+    engine_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     __table_args__ = (
         UniqueConstraint("deployment_id", "date", name="uq_paper_daily_returns_dep_date"),

--- a/backend/archimedes/services/fusion_evaluator.py
+++ b/backend/archimedes/services/fusion_evaluator.py
@@ -211,6 +211,28 @@ DEFAULT_SLIPPAGE_BPS = 5
 # analytics_engine.costs.cost_model_fingerprint (no per-symbol overrides here).
 DEFAULT_COST_MODEL_ID = f"cm1:d{_DEFAULT_TX_BPS:g}:s{DEFAULT_SLIPPAGE_BPS:g}"
 
+# Hand-bumped when this engine's REPLAY BEHAVIOR changes for a reason the cost
+# fingerprint above cannot see: interpreter semantics, indicator warmup, sleeve
+# capitalization, order timing. Bump it in the same commit as the behavior
+# change.
+#
+# It is manual on purpose, and the failure direction of a MISSED bump is the
+# safe one: a genuine engine change that nobody stamped looks like a data
+# restatement — loud and wrong — rather than being quietly absolved. A derived
+# alternative (hashing this module's source) would churn on every comment edit
+# and re-grade every open paper deployment for a typo fix, which is the
+# opposite failure and the worse one.
+_GRADING_SEMANTICS_REV = 1
+
+#: The version of the GRADED path, stamped on every paper ledger row this
+#: engine writes (#1449). ``paper_trading`` has no independent opinion on cost
+#: model by design, so a change HERE re-grades every open deployment's replayed
+#: history at once; the version string is what lets that re-grade be recognised
+#: as ours and annotated, instead of being reported to users as their strategy
+#: restating its own past. Note the cost half moves BY ITSELF: #1379 wiring the
+#: slippage leg took it from ``cm1:d10:s0`` to ``cm1:d10:s5`` with no edit here.
+GRADING_ENGINE_VERSION = f"{ENGINE_SINGLE_FEED}.r{_GRADING_SEMANTICS_REV}/{DEFAULT_COST_MODEL_ID}"
+
 # The only price-data provenance that is NOT admissible for Tier-1 rigor
 # certification. Everything else (real CSV, an explicitly provided feed) is
 # trusted to be real market data — the caller owns that contract.

--- a/backend/archimedes/services/paper_trading.py
+++ b/backend/archimedes/services/paper_trading.py
@@ -19,10 +19,27 @@ construction" coupling cuts both ways: this module has NO independent
 opinion on cost model, commission, or slippage — a real historical
 restatement (yfinance revising a bar) and a change to the GRADED path's own
 cost model between two replays (e.g. wiring a previously-inert slippage
-parameter, #1242/#1379) produce the identical drift signature. Don't assume
-the cause is upstream data — see ``advance_deployment``'s log message, which
-names both candidates rather than asserting the one that happens to be more
-common.
+parameter, #1242/#1379) produce the identical drift signature.
+
+THE ENGINE-VERSION POLICY (#1449). Those two causes used to be genuinely
+indistinguishable, so every ledger row now carries the grading engine's own
+version (``fusion_evaluator.GRADING_ENGINE_VERSION``) at append time and a
+disagreement is classified against it:
+
+  - the row was graded by THIS engine version → the engine did not move, so
+    the data did. Loud: ``drift_detected_at``, a WARNING, the leaderboard's
+    drift flag.
+  - the row was graded by a DIFFERENT version → we re-graded it. Expected and
+    disclosed: ``engine_regrade_at``, annotated on the deployment payload, and
+    explicitly NOT a claim that the user's track record restated itself.
+  - the row carries NO version (written before this column existed) → we
+    cannot attribute it. Also ``engine_regrade_at``, because asserting a data
+    restatement here would be asserting something we cannot show. What is
+    withheld is the ATTRIBUTION, never the fact: the count is on the payload
+    and the log says exactly why it is unattributable.
+
+The ledger is still never rewritten, and nothing is suppressed — this only
+decides which of two true sentences a disagreement gets reported as.
 """
 
 from __future__ import annotations
@@ -39,6 +56,65 @@ logger = logging.getLogger(__name__)
 
 # |replayed - ledgered| beyond this is a restatement, not float noise.
 _DRIFT_EPS = 1e-9
+
+#: How a disagreement between a fresh replay and an already-written ledger row
+#: was attributed (#1449). Exactly one applies to each disagreeing row, and all
+#: three are reported — they differ in what they let us CLAIM, not in whether
+#: the disagreement is surfaced.
+#:
+#: ``DRIFT_DATA``       the row was graded by the engine version running now,
+#:                      so the engine did not move and the data did. Loud.
+#: ``DRIFT_ENGINE``     the row was graded by a different engine version. Our
+#:                      change, not the user's history. Annotated.
+#: ``DRIFT_UNVERSIONED`` the row predates ``engine_version``. Unattributable;
+#:                      annotated, and named as unattributable in the log.
+DRIFT_DATA = "data"
+DRIFT_ENGINE = "engine"
+DRIFT_UNVERSIONED = "unversioned"
+
+
+def grading_engine_version() -> str:
+    """The GRADED path's version string, read from the engine that grades.
+
+    Read rather than re-declared here for the same reason
+    ``_sleeve_initial_cash`` reads ``_DEFAULT_CASH``: a second copy of the
+    number would let the stamp and the behavior it claims to describe drift
+    apart, and a stamp that lies about which engine produced a row is worse
+    than no stamp at all.
+
+    Imported lazily (``fusion_evaluator`` pulls backtrader) and resolved as a
+    MODULE ATTRIBUTE by its callers, so a test can substitute a version without
+    reaching into the engine — the same call-time-resolution seam ``replay``
+    uses, and for the same reason.
+    """
+    from archimedes.services.fusion_evaluator import GRADING_ENGINE_VERSION
+
+    return GRADING_ENGINE_VERSION
+
+
+def classify_drift(row_version: str | None, current_version: str | None) -> str:
+    """Attribute one disagreeing ledger row to the data, to us, or to neither.
+
+    The guard that matters is the ``current`` check. Every quiet answer below
+    is reached by finding a DIFFERENCE between two version strings, so a blank,
+    missing, or whitespace ``current_version`` would make every row look
+    re-graded and silence the loud path globally — a config-shaped way to turn
+    off the one alarm this ledger owes its users. A version we cannot read is
+    therefore not a licence to absolve anything: it FAILS CLOSED to
+    ``DRIFT_DATA``, the loudest answer, which over-reports at worst.
+
+    (The mirror-image guard on ``row_version`` is deliberately NOT fail-closed:
+    an unstamped row is a real, expected population — every row written before
+    the column existed — and calling those a data restatement is precisely the
+    false claim #1449 was filed about. They get their own bucket instead.)
+    """
+    current = (current_version or "").strip()
+    if not current:
+        return DRIFT_DATA
+    stamped = (row_version or "").strip()
+    if not stamped:
+        return DRIFT_UNVERSIONED
+    return DRIFT_DATA if stamped == current else DRIFT_ENGINE
 
 
 class PaperReplayError(RuntimeError):
@@ -667,43 +743,72 @@ def advance_deployment(session, dep: PaperDeployment, *, replay=None, decision_r
         replayed = (replay or replay_spec)(spec_dict, dep.deployed_at)
         decisions = (decision_replay or (lambda *_: {}))(spec_dict, dep.deployed_at)
 
+    # The ROWS, not just their values: the drift classification needs each row's
+    # engine_version, and re-querying per disagreement would be a query per date.
     existing = {
-        row.date: row.daily_return
-        for row in session.query(PaperDailyReturn).filter(PaperDailyReturn.deployment_id == dep.id)
+        row.date: row for row in session.query(PaperDailyReturn).filter(PaperDailyReturn.deployment_id == dep.id)
     }
 
     # Reasoning first, ledger second (§3): the return a trace explains must not
     # become part of the user's track record before the reasoning is recorded.
     trace_result = _publish_decision_traces(session, dep, spec_dict, decisions, set(existing))
 
-    drift = 0
+    version = grading_engine_version()
+    drift = dict.fromkeys((DRIFT_DATA, DRIFT_ENGINE, DRIFT_UNVERSIONED), 0)
     appended = 0
     for d, r in sorted(replayed.items()):
-        if d in existing:
-            if abs(existing[d] - r) > _DRIFT_EPS:
-                drift += 1
+        row = existing.get(d)
+        if row is not None:
+            if abs(row.daily_return - r) > _DRIFT_EPS:
+                drift[classify_drift(row.engine_version, version)] += 1
         else:
-            session.add(PaperDailyReturn(deployment_id=dep.id, date=d, daily_return=r))
+            session.add(PaperDailyReturn(deployment_id=dep.id, date=d, daily_return=r, engine_version=version))
             appended += 1
 
-    if drift:
-        dep.drift_detected_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    if drift[DRIFT_DATA]:
+        dep.drift_detected_at = now
         logger.warning(
-            "paper: deployment %s — fresh replay disagrees with %d already-written ledger row(s). "
-            "Two known causes produce this identical signature: (1) upstream data restatement "
-            "(yfinance revised a historical bar) or (2) a change to the GRADED path's own replay "
-            "behavior between runs (cost model, commission, slippage, or interpreter semantics) — "
-            "replay_spec calls the same run_dsl_backtest the grader uses, by design, so a grading-side "
-            "change moves every open deployment's history along with it. This log cannot distinguish "
-            "the two; do not assume upstream data without checking whether the graded path changed. "
+            "paper: deployment %s — fresh replay disagrees with %d already-written ledger row(s) that "
+            "were graded by THIS engine version (%s). The engine did not move between the two runs, so "
+            "the remaining cause is upstream: a historical bar was restated (yfinance revised it). "
             "The ledger is append-only and was NOT rewritten; the deployment is stamped "
             "drift_detected_at so the discrepancy is surfaced, not hidden.",
             dep.id,
-            drift,
+            drift[DRIFT_DATA],
+            version,
+        )
+    regraded = drift[DRIFT_ENGINE] + drift[DRIFT_UNVERSIONED]
+    if regraded:
+        dep.engine_regrade_at = now
+        logger.warning(
+            "paper: deployment %s — fresh replay disagrees with %d already-written ledger row(s) whose "
+            "grading provenance is NOT this engine version (%s): %d were graded by a different version, "
+            "%d carry no version at all (written before engine_version existed, so the cause cannot be "
+            "attributed either way). This is a RE-GRADE, not a restatement of the user's track record — "
+            "replay_spec calls the same run_dsl_backtest the grader uses by design, so a grading-side "
+            "change (cost model, commission, slippage, interpreter semantics) moves every open "
+            "deployment's history at once. The ledger is append-only and was NOT rewritten; the "
+            "deployment is stamped engine_regrade_at, NOT drift_detected_at.",
+            dep.id,
+            regraded,
+            version,
+            drift[DRIFT_ENGINE],
+            drift[DRIFT_UNVERSIONED],
         )
     session.flush()
     _refresh_position_cache(session, dep, getattr(replayed, "positions", None))
-    return {"appended": appended, "drift": drift, **trace_result}
+    return {
+        "appended": appended,
+        # Narrowed by #1449: `drift` counts only disagreements attributable to
+        # the DATA. The other two classes are reported alongside rather than
+        # folded in — a caller that summed them would be back to the conflation
+        # the issue was filed about.
+        "drift": drift[DRIFT_DATA],
+        "drift_engine": drift[DRIFT_ENGINE],
+        "drift_unversioned": drift[DRIFT_UNVERSIONED],
+        **trace_result,
+    }
 
 
 def _refresh_position_cache(session, dep: PaperDeployment, positions: PositionSet | None) -> None:
@@ -743,12 +848,21 @@ def advance_all(session) -> dict:
     deps = session.query(PaperDeployment).filter(PaperDeployment.status == STATUS_ACTIVE).all()
     ok = failed = appended = coverage_broken = 0
     traces = dict.fromkeys(("decisions", "published", "failed", "unowned", "disabled"), 0)
+    # Reported per CYCLE because a grading-side change is a FLEET event, not a
+    # per-deployment one: it re-grades every open deployment on the same pass
+    # (#1449). One cycle line showing `drift_engine` across the fleet is how an
+    # operator recognises "we changed the engine" instead of reading N
+    # per-deployment warnings as N independent data problems.
+    drift = dict.fromkeys((DRIFT_DATA, DRIFT_ENGINE, DRIFT_UNVERSIONED), 0)
     for dep in deps:
         try:
             result = advance_deployment(session, dep)
             appended += result["appended"]
             for key in traces:
                 traces[key] += result.get(key, 0)
+            drift[DRIFT_DATA] += result.get("drift", 0)
+            drift[DRIFT_ENGINE] += result.get("drift_engine", 0)
+            drift[DRIFT_UNVERSIONED] += result.get("drift_unversioned", 0)
             ok += 1
         except (PaperReplayError, DSLError) as exc:
             failed += 1
@@ -774,6 +888,11 @@ def advance_all(session) -> dict:
         "ok": ok,
         "failed": failed,
         "appended": appended,
+        # Kept as three keys, never one total: "the data restated" and "we
+        # re-graded" are different incidents with different owners.
+        "drift": drift[DRIFT_DATA],
+        "drift_engine": drift[DRIFT_ENGINE],
+        "drift_unversioned": drift[DRIFT_UNVERSIONED],
         "decisions": traces["decisions"],
         "traces_published": traces["published"],
         # Named separately from the deployment-level "failed" above, which
@@ -857,9 +976,19 @@ def deployment_summary(session, dep: PaperDeployment) -> dict:
     )
     equity = 1.0
     series = []
+    # What the ledger's own rows say they were graded by (#1449). Collected here
+    # rather than inferred by the UI: "this history spans a cost-model change"
+    # is a fact the rows carry, and a client that guessed it from a timestamp
+    # would be re-deriving provenance it was already handed.
+    versions: set[str] = set()
+    unversioned = 0
     for row in rows:
         equity *= 1.0 + row.daily_return
         series.append({"date": row.date.isoformat(), "daily_return": row.daily_return, "equity_index": equity})
+        if row.engine_version:
+            versions.add(row.engine_version)
+        else:
+            unversioned += 1
     # The latest intraday mark rides along so the ledger card can render a
     # live value without a second round trip per deployment. It is ALWAYS a
     # separate key from `total_return`, never folded into it: `total_return`
@@ -878,6 +1007,18 @@ def deployment_summary(session, dep: PaperDeployment) -> dict:
         "days": len(rows),
         "total_return": equity - 1.0,
         "drift_detected_at": dep.drift_detected_at.isoformat() if dep.drift_detected_at else None,
+        # The engine-version half of the drift story (#1449). Separate keys from
+        # `drift_detected_at` on purpose: a client must be able to render "we
+        # changed how this is graded" WITHOUT it looking like "your track record
+        # restated itself", which is the conflation the issue was filed about.
+        "engine_regrade_at": dep.engine_regrade_at.isoformat() if dep.engine_regrade_at else None,
+        "grading_engine_version": grading_engine_version(),
+        "ledger_engine_versions": sorted(versions),
+        # Rows written before engine_version existed. Never backfilled, so this
+        # only ever shrinks by the ledger growing past it — it is the size of
+        # the population whose drift cannot be attributed, stated rather than
+        # implied.
+        "unversioned_rows": unversioned,
         # The provenance claim, reported alongside the numbers it explains
         # (#1575 §7). A gap here is the honest degraded state; a page that
         # rendered performance without it would be asserting coverage it does

--- a/backend/archimedes/services/paper_trading.py
+++ b/backend/archimedes/services/paper_trading.py
@@ -107,6 +107,19 @@ def classify_drift(row_version: str | None, current_version: str | None) -> str:
     an unstamped row is a real, expected population — every row written before
     the column existed — and calling those a data restatement is precisely the
     false claim #1449 was filed about. They get their own bucket instead.)
+
+    KNOWN LIMIT, stated because this function's whole job is honest attribution:
+    ``DRIFT_ENGINE`` MASKS a co-occurring data restatement. Once the engine has
+    moved, a row graded by the old version disagrees for two reasons at once —
+    our cost model changed AND upstream may also have revised that bar — and
+    this returns the engine answer for both. Separating them would require
+    re-running the RETIRED engine version against today's data, which is not
+    possible: the old code is gone, only its version string survives. So the
+    engine bucket means "at least a re-grade", not "only a re-grade". The
+    alternative — reporting these as data drift — would assert an upstream
+    restatement we equally cannot show, and would re-create exactly the false
+    claim this policy exists to prevent. Over-attributing to OURSELVES is the
+    honest direction to fail: it blames us, not the user's track record.
     """
     current = (current_version or "").strip()
     if not current:

--- a/backend/migrations/versions/a7f2c93b1d64_paper_grading_engine_version.py
+++ b/backend/migrations/versions/a7f2c93b1d64_paper_grading_engine_version.py
@@ -1,0 +1,71 @@
+"""stamp the grading engine on paper ledger rows; separate re-grade from drift
+
+Issue #1449. ``paper_trading.replay_spec`` calls the SAME ``run_dsl_backtest``
+the grader uses — by design, so paper semantics track graded semantics — which
+means a change to the graded path's own cost model re-grades every open
+deployment's replayed history at once. #1379 (the Engine C slippage floor) is
+exactly such a change. Before this revision the resulting disagreement was
+indistinguishable from an upstream data restatement, so it would have stamped
+``drift_detected_at`` on every active deployment and told every user their
+track record had restated itself — a claim about THEM for a change that was
+OURS.
+
+Two columns, one decision:
+
+  1. ``paper_daily_returns.engine_version`` — which grading engine produced
+     this number (``fusion_evaluator.GRADING_ENGINE_VERSION`` at append time).
+  2. ``paper_deployments.engine_regrade_at`` — set when a replay disagrees
+     with written rows and the cause is the engine, not the data.
+
+**No backfill, on purpose.** Rows written before this column existed were
+graded by a build that did not record its own version, and there is no
+recoverable fact that says which. Stamping them with today's string would
+manufacture the provenance needed to make a comparison come out clean; deriving
+one from ``appended_at`` versus a deploy timestamp would encode an operator
+guess as data. NULL means "unrecorded", and ``paper_trading.classify_drift``
+gives NULL its own bucket (``DRIFT_UNVERSIONED``) — annotated on
+``engine_regrade_at``, counted on the deployment payload as ``unversioned_rows``,
+and named as unattributable in the log — rather than folding it into either
+answer.
+
+The consequence is disclosed rather than hidden: a genuine upstream restatement
+of a PRE-EXISTING row will read as unattributable rather than as loud data
+drift, permanently, because the ledger is append-only and those rows are never
+rewritten to gain a stamp. Every row appended from this revision onward carries
+one, so the blind spot is bounded to history that already exists on the day
+this ships.
+
+The ledger itself is untouched. This revision adds columns; it rewrites no
+``daily_return``, which is the whole law of the table.
+
+Revision ID: a7f2c93b1d64
+Revises: d7c41f9b2e58
+Create Date: 2026-08-31 09:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7f2c93b1d64"
+down_revision: str | Sequence[str] | None = "d7c41f9b2e58"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    # Nullable with no server_default: "unrecorded" must stay distinguishable
+    # from any real version string. A default would silently assert that every
+    # historical row was graded by whatever value we picked.
+    op.add_column("paper_daily_returns", sa.Column("engine_version", sa.String(length=64), nullable=True))
+    op.add_column("paper_deployments", sa.Column("engine_regrade_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("paper_deployments", "engine_regrade_at")
+    op.drop_column("paper_daily_returns", "engine_version")

--- a/backend/tests/services/test_paper_trading.py
+++ b/backend/tests/services/test_paper_trading.py
@@ -17,6 +17,13 @@ the part that must never regress silently:
   6. THE MARKS LOOP READS, NEVER WRITES: the daily advance stamps a position
      cache and that is the only channel to the intraday loop, so marks cannot
      change what the strategy does (intraday design §4.0/§4.1).
+  7. A RE-GRADE IS NOT A RESTATEMENT (#1449): every appended row records the
+     grading engine that produced it, and a disagreement is reported as the
+     data's fault ONLY when the engine did not move. A grading-side change
+     (#1379's slippage floor) lands on engine_regrade_at, and a row with no
+     recorded version is called unattributable rather than blamed on either
+     side. The quiet answers are guarded — an unreadable current version
+     fails closed to loud.
 """
 
 from __future__ import annotations
@@ -114,6 +121,12 @@ def test_restatement_is_surfaced_never_repaired(caplog):
         assert row.daily_return == pytest.approx(-0.02)  # original stands
         assert dep.drift_detected_at is not None
         assert any("NOT rewritten" in r.message for r in caplog.records)
+        # Law 7's other half: the engine did NOT move between the two replays
+        # (both rows carry the same version), so this stays attributed to the
+        # data and must not be excused as a re-grade.
+        assert out["drift_engine"] == 0
+        assert out["drift_unversioned"] == 0
+        assert dep.engine_regrade_at is None
 
 
 def test_spec_snapshot_survives_strategy_mutation():
@@ -288,3 +301,173 @@ def test_the_summary_carries_the_latest_mark_and_none_means_none():
         assert summary["latest_mark"]["prices"] == {"SPY": 512.34}
         # The settled figure is unmoved by the presence of a mark.
         assert summary["total_return"] == pytest.approx((1.01 * 0.98 * 1.005) - 1.0)
+
+
+# ── Law 7: a re-grade is not a restatement (#1449) ─────────────────────
+
+
+def _restated(spec_dict, deployed_at):
+    """`_replay_v1` with one historical date coming back different.
+
+    The ONE input every test below shares, so the only thing that varies
+    between them is the engine-version provenance of the row it disagrees with
+    — which is exactly the discrimination under test.
+    """
+    out = _replay_v1(spec_dict, deployed_at)
+    out[date(2026, 8, 4)] = -0.5
+    return out
+
+
+def test_every_appended_row_records_the_engine_that_graded_it():
+    """The stamp is what makes the classification possible at all. It comes from
+    the GRADED path (fusion_evaluator.GRADING_ENGINE_VERSION), not a literal
+    re-typed here — a second copy could drift from the behavior it describes."""
+    from archimedes.services.fusion_evaluator import GRADING_ENGINE_VERSION
+
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        advance_deployment(s, dep, replay=_replay_v1)
+        rows = s.query(PaperDailyReturn).filter_by(deployment_id=dep.id).all()
+        assert rows
+        assert {row.engine_version for row in rows} == {GRADING_ENGINE_VERSION}
+        summary = deployment_summary(s, dep)
+        assert summary["ledger_engine_versions"] == [GRADING_ENGINE_VERSION]
+        assert summary["unversioned_rows"] == 0
+        assert summary["engine_regrade_at"] is None
+
+
+def test_an_engine_version_change_is_a_regrade_not_the_users_history_restating(monkeypatch, caplog):
+    """#1449's whole point. Rows graded under engine v1; the engine moves (this
+    is #1379 wiring the slippage floor); the replay now disagrees. That must NOT
+    stamp drift_detected_at — the user's track record did not restate itself,
+    we changed how it is graded."""
+    from archimedes.services import paper_trading
+
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        monkeypatch.setattr(paper_trading, "grading_engine_version", lambda: "dsl-fusion.r1/cm1:d10:s0")
+        advance_deployment(s, dep, replay=_replay_v1)
+        assert dep.drift_detected_at is None
+
+        # The cost model moves. Same data, same spec, different graded numbers.
+        monkeypatch.setattr(paper_trading, "grading_engine_version", lambda: "dsl-fusion.r1/cm1:d10:s5")
+        with caplog.at_level("WARNING"):
+            out = advance_deployment(s, dep, replay=_restated)
+
+        assert out["drift_engine"] == 1
+        assert out["drift"] == 0  # NOT reported as a data restatement
+        assert out["drift_unversioned"] == 0
+        assert dep.drift_detected_at is None
+        assert dep.engine_regrade_at is not None
+        # Surfaced, never suppressed: the ledger still stands, and the log says
+        # which of the two sentences this is.
+        assert s.query(PaperDailyReturn).filter_by(date=date(2026, 8, 4)).one().daily_return == pytest.approx(-0.02)
+        assert any("RE-GRADE, not a restatement" in r.message for r in caplog.records)
+        assert not any("drift_detected_at so the discrepancy" in r.message for r in caplog.records)
+
+
+def test_a_row_written_before_versioning_is_called_unattributable_not_restated(caplog):
+    """The migration backfills nothing, so pre-#1449 rows carry no version. A
+    disagreement with one of those cannot be blamed on the data OR on us — it
+    gets its own bucket and its own honest log line, and the count is on the
+    payload rather than implied."""
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        advance_deployment(s, dep, replay=_replay_v1)
+        # Exactly what the migration leaves behind for history written before
+        # the column existed.
+        for row in s.query(PaperDailyReturn).filter_by(deployment_id=dep.id):
+            row.engine_version = None
+        s.flush()
+
+        with caplog.at_level("WARNING"):
+            out = advance_deployment(s, dep, replay=_restated)
+
+        assert out["drift_unversioned"] == 1
+        assert out["drift"] == 0
+        assert out["drift_engine"] == 0
+        assert dep.drift_detected_at is None
+        assert dep.engine_regrade_at is not None
+        assert any("cannot be attributed either way" in r.message for r in caplog.records)
+        summary = deployment_summary(s, dep)
+        assert summary["unversioned_rows"] == 3
+        assert summary["engine_regrade_at"] is not None
+
+
+def test_an_unreadable_engine_version_fails_closed_to_loud_data_drift(monkeypatch, caplog):
+    """THE GUARD. Every quiet answer is reached by finding a DIFFERENCE between
+    two version strings, so a blank current version would make every row look
+    re-graded and switch off the loud path fleet-wide — a config-shaped way to
+    silence the one alarm this ledger owes its users.
+
+    The adversarial input is a version string that is present but worthless
+    (whitespace): presence alone must not buy absolution."""
+    from archimedes.services import paper_trading
+
+    with _session() as s:
+        dep = create_deployment(s, strategy_id="s1", spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+        monkeypatch.setattr(paper_trading, "grading_engine_version", lambda: "dsl-fusion.r1/cm1:d10:s0")
+        advance_deployment(s, dep, replay=_replay_v1)
+
+        monkeypatch.setattr(paper_trading, "grading_engine_version", lambda: "   ")
+        with caplog.at_level("WARNING"):
+            out = advance_deployment(s, dep, replay=_restated)
+
+        # A genuine engine change, but with an unreadable version we refuse to
+        # claim it: loud, not quiet.
+        assert out["drift"] == 1
+        assert out["drift_engine"] == 0
+        assert out["drift_unversioned"] == 0
+        assert dep.drift_detected_at is not None
+        assert dep.engine_regrade_at is None
+        assert any("NOT rewritten" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    ("row_version", "current_version", "expected"),
+    [
+        ("e1", "e1", "data"),  # engine held still → the data moved
+        ("e1", "e2", "engine"),  # we moved
+        (None, "e1", "unversioned"),  # written before the column existed
+        ("", "e1", "unversioned"),  # a stored blank is still "unrecorded"
+        ("e1", None, "data"),  # guard: unreadable current → fail closed
+        ("e1", "", "data"),
+        ("e1", "  \t ", "data"),
+        (None, None, "data"),  # both unreadable → still the loud answer
+    ],
+)
+def test_classify_drift_truth_table(row_version, current_version, expected):
+    from archimedes.services.paper_trading import classify_drift
+
+    assert classify_drift(row_version, current_version) == expected
+
+
+def test_advance_all_reports_the_fleet_regrade_as_ours_not_as_n_data_problems(monkeypatch):
+    """A grading-side change is a FLEET event: it re-grades every open
+    deployment on the same pass. The cycle line has to let an operator read that
+    as one incident of OURS, not as N independent data problems of the users'.
+
+    Patches the settle-path seam ``replay_spec_with_decisions`` — the one
+    ``advance_all`` actually reaches — rather than ``replay_spec``, which is
+    only used when a caller injects a replay."""
+    from archimedes.services import paper_trading
+
+    monkeypatch.setattr(paper_trading, "grading_engine_version", lambda: "dsl-fusion.r1/cm1:d10:s0")
+    with _session() as s:
+        for name in ("a", "b"):
+            dep = create_deployment(s, strategy_id=name, spec_dict=_SPEC, owner_wallet="0xAB", deployed_at=_DEPLOY)
+            advance_deployment(s, dep, replay=_replay_v1)
+        s.flush()
+
+        monkeypatch.setattr(paper_trading, "grading_engine_version", lambda: "dsl-fusion.r1/cm1:d10:s5")
+        monkeypatch.setattr(
+            paper_trading,
+            "replay_spec_with_decisions",
+            lambda spec_dict, deployed_at: (_restated(spec_dict, deployed_at), {}),
+        )
+        summary = advance_all(s)
+
+        assert summary["ok"] == 2 and summary["failed"] == 0
+        assert summary["drift_engine"] == 2
+        assert summary["drift"] == 0
+        assert summary["drift_unversioned"] == 0

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -1646,3 +1646,84 @@ def test_alembic_paper_marks_matches_a_fresh_create_all_schema(tmp_path):
         assert _columns(create_all_db, table) == _columns(alembic_db, table), (
             f"{table} columns differ between create_all() and alembic upgrade head"
         )
+
+
+def test_alembic_grading_engine_version_columns_added_and_removed(tmp_path):
+    """#1449: ``paper_daily_returns.engine_version`` and
+    ``paper_deployments.engine_regrade_at`` land on upgrade, are gone on
+    downgrade, and come back on re-upgrade.
+
+    Two things this asserts beyond the up/down/idempotent contract:
+
+      * the LEDGER ROWS survive the round trip. This revision adds columns to
+        an append-only, user-facing track record; a downgrade that took rows
+        with it would be the one failure this table exists to prevent.
+      * ``engine_version`` comes back NULL for a pre-existing row rather than
+        carrying a default. The migration deliberately backfills nothing —
+        stamping historical rows with today's engine string would invent the
+        provenance needed to make a drift comparison come out clean.
+
+    Same derived-target discipline as the tests above: the downgrade target is
+    this revision's OWN ``down_revision``, never a hardcoded hash.
+    """
+    db_path = tmp_path / "engine_version.db"
+    database_url = f"sqlite:///{db_path}"
+
+    def _cols(table: str) -> set[str]:
+        con = sqlite3.connect(str(db_path))
+        try:
+            cur = con.cursor()
+            cur.execute(f"PRAGMA table_info({table})")
+            return {row[1] for row in cur.fetchall()}
+        finally:
+            con.close()
+
+    def _sql(statement: str, *params):
+        con = sqlite3.connect(str(db_path))
+        try:
+            cur = con.cursor()
+            cur.execute(statement, params)
+            con.commit()
+            return cur.fetchall()
+        finally:
+            con.close()
+
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(Config(str(_BACKEND_DIR / "alembic.ini")))
+    target = script.get_revision("a7f2c93b1d64").down_revision
+
+    upgrade = _run_alembic("upgrade", "head", database_url=database_url)
+    assert upgrade.returncode == 0, upgrade.stderr
+    assert "engine_version" in _cols("paper_daily_returns")
+    assert "engine_regrade_at" in _cols("paper_deployments")
+
+    # A ledger row written by a build that never recorded its engine version —
+    # the population the "no backfill" decision is about.
+    _sql(
+        "INSERT INTO paper_daily_returns (deployment_id, date, daily_return, appended_at) VALUES (?, ?, ?, ?)",
+        "dep-1449",
+        "2026-08-04",
+        -0.02,
+        "2026-08-05 00:00:00",
+    )
+
+    downgrade = _run_alembic("downgrade", target, database_url=database_url)
+    assert downgrade.returncode == 0, downgrade.stderr
+    assert "engine_version" not in _cols("paper_daily_returns")
+    assert "engine_regrade_at" not in _cols("paper_deployments")
+    assert _sql("SELECT daily_return FROM paper_daily_returns WHERE deployment_id = ?", "dep-1449") == [(-0.02,)]
+
+    reupgrade = _run_alembic("upgrade", "head", database_url=database_url)
+    assert reupgrade.returncode == 0, reupgrade.stderr
+    assert "engine_version" in _cols("paper_daily_returns")
+    assert "engine_regrade_at" in _cols("paper_deployments")
+    # NULL, not a default: "unrecorded" stays distinguishable from any real
+    # version string.
+    assert _sql("SELECT daily_return, engine_version FROM paper_daily_returns WHERE deployment_id = ?", "dep-1449") == [
+        (-0.02, None)
+    ]
+
+    reupgrade_again = _run_alembic("upgrade", "head", database_url=database_url)
+    assert reupgrade_again.returncode == 0, reupgrade_again.stderr


### PR DESCRIPTION
## What

Paper ledger rows now record **which grading engine produced them**, and a replay that disagrees with already-written rows is attributed instead of being reported as one undifferentiated "drift".

- `fusion_evaluator.GRADING_ENGINE_VERSION` — the graded path's own version. Two halves: the cost-model fingerprint (which moves **by itself** — #1379 took it from `cm1:d10:s0` to `cm1:d10:s5` with no edit) and a hand-bumped `_GRADING_SEMANTICS_REV` for changes the fingerprint cannot see (interpreter semantics, warmup, sleeve capitalization).
- `paper_daily_returns.engine_version` (new, nullable) — stamped on every appended row.
- `paper_deployments.engine_regrade_at` (new, nullable) — the annotation stamp.
- `paper_trading.classify_drift(row_version, current_version)` — the policy, as one pure function:

| row's version | verdict | stamp | volume |
| --- | --- | --- | --- |
| == the version running now | `data` — the engine held still, so the data moved | `drift_detected_at` | loud |
| != the version running now | `engine` — we re-graded it | `engine_regrade_at` | annotated |
| absent (pre-migration row) | `unversioned` — unattributable | `engine_regrade_at` | annotated, and the log says *why* it is unattributable |

`advance_deployment` returns `drift` / `drift_engine` / `drift_unversioned` as three keys, `advance_all` sums them per cycle (a grading-side change is a **fleet** event, not N independent data problems), and `deployment_summary` gains `engine_regrade_at`, `grading_engine_version`, `ledger_engine_versions`, `unversioned_rows`.

**The ledger is not rewritten and nothing is suppressed.** Every disagreement is still counted, still logged, still on the payload. What changed is which of two true sentences it is reported as.

## Why

`replay_spec` calls the same `run_dsl_backtest` the grader uses — by design, so paper semantics track graded semantics — which means a change to the graded path's cost model re-grades **every open deployment's entire replayed history** on the next `advance_all`. #1379 (the Engine C slippage floor) is exactly such a change. Before this PR that would have stamped `drift_detected_at` on every active deployment and told every user their track record had restated itself, for a change that was ours. Issue #1449 named three options; this is option 1 (pin/version the cost basis per row) rather than option 2 (one-time suppression, which rewrites the meaning of past rows) or option 3 (accept the mass drift event).

`drift_detected_at` is now **narrower** than it was: it fires only when the disagreement is attributable to the data. That is the point of the change, and it is documented on the column.

## Tests

```
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest backend/tests -k "paper" -q
...
SKIPPED [1] backend/tests/test_paper_trace_pipeline.py:411: trace_references_strategy lands with #1569 (dbrowneup/user-reachable-traces)
========= 332 passed, 1 skipped, 4476 deselected, 6 warnings in 55.14s =========
```

```
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest backend/tests/test_alembic_migrations.py -q
================== 26 passed, 1 warning in 109.24s (0:01:49) ===================
```
(plus the new `test_alembic_grading_engine_version_columns_added_and_removed`, run again after it landed: `1 passed, 26 deselected`)

Hermetic gate — no `.env`, no network, no DB:

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
  /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest backend/tests/services/test_paper_trading.py -q
======================== 24 passed, 1 warning in 2.41s =========================
```

The exact CI command, from the repo root:

```
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest -m "not integration" -q
FAILED backend/tests/test_oracle_health_telemetry.py::TestOracleHealthProbeBudget::test_slow_rpc_is_a_loud_timeout_not_a_slow_success - assert 0.6936273323372006 < 0.4
= 1 failed, 4803 passed, 3 skipped, 2 deselected, 320 warnings in 547.59s (0:09:07) =
```

**That one failure is a wall-clock flake under full-suite load, not this change.** It asserts a probe finished in under 0.4s; nothing in this diff touches oracle telemetry. Re-run in isolation:

```
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest backend/tests/test_oracle_health_telemetry.py -q
======================== 20 passed, 4 warnings in 6.25s ========================
```

Ruff (format + check) clean on all eight touched files.

Re-verified after the docstring commit `8ff4918b` (docs only, no behavior change), with the branch level with current `origin/main` (0 commits behind):

```
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest backend/tests -k "paper" -q
========= 332 passed, 1 skipped, 4476 deselected, 6 warnings in 41.71s =========

/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest backend/tests -q -k "leaderboard"
=============== 70 passed, 4739 deselected, 3 warnings in 11.26s ===============

/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest backend/tests/test_alembic_migrations.py -q -k "grading_engine_version"
================= 1 passed, 26 deselected, 1 warning in 7.45s ==================

ruff format --check <8 touched files>  →  8 files already formatted
ruff check <8 touched files>           →  All checks passed!
```

Both demos below were reproduced from scratch on a clean tree, not quoted from an earlier run.

## Revert demo — the regression test fails with the fix removed

Policy removed: `classify_drift` reduced to its pre-#1449 behavior, `return DRIFT_DATA` for every disagreement.

```
$ python -m pytest backend/tests/services/test_paper_trading.py -q

FAILED ...::test_an_engine_version_change_is_a_regrade_not_the_users_history_restating - assert 0 == 1
FAILED ...::test_a_row_written_before_versioning_is_called_unattributable_not_restated - assert 0 == 1
FAILED ...::test_classify_drift_truth_table[e1-e2-engine] - AssertionError: assert 'data' == 'engine'
FAILED ...::test_classify_drift_truth_table[None-e1-unversioned] - AssertionError: assert 'data' == 'unversioned'
FAILED ...::test_classify_drift_truth_table[-e1-unversioned] - AssertionError: assert 'data' == 'unversioned'
FAILED ...::test_advance_all_reports_the_fleet_regrade_as_ours_not_as_n_data_problems - assert 0 == 2
=================== 6 failed, 18 passed, 1 warning in 2.34s ====================
```

An engine-version change misclassifies as data drift — exactly the defect #1449 describes — and the tests catch it. Restored, and `24 passed`.

## Adversarial demo — the guard is shown to reject something

The guard: **every quiet answer is reached by finding a DIFFERENCE between two version strings**, so a blank/missing/whitespace *current* version would make every row look re-graded and switch off the loud path fleet-wide. That is the `AGENT_DRY_RUN=1 silently meant LIVE` shape — presence checked, value not. `classify_drift` therefore fails closed to `DRIFT_DATA` when the current version is unreadable.

The bad input: a version string that is **present but worthless** (`"   "`), fed through a genuine engine change that would otherwise be absolved.

With the guard removed (`current = current_version`, no blank check):

```
$ python -m pytest backend/tests/services/test_paper_trading.py -q -k "unreadable or truth_table"

FAILED ...::test_an_unreadable_engine_version_fails_closed_to_loud_data_drift - assert 0 == 1
FAILED ...::test_classify_drift_truth_table[e1-None-data] - AssertionError: assert 'engine' == 'data'
FAILED ...::test_classify_drift_truth_table[e1--data] - AssertionError: assert 'engine' == 'data'
FAILED ...::test_classify_drift_truth_table[e1-  \t -data] - AssertionError: assert 'engine' == 'data'
FAILED ...::test_classify_drift_truth_table[None-None-data] - AssertionError: assert 'unversioned' == 'data'
============ 5 failed, 4 passed, 15 deselected, 1 warning in 2.48s =============
```

A whitespace version silently buys absolution (`'engine'` instead of `'data'`). With the guard in place it does not. Restored, and `24 passed`.

## Migration

`a7f2c93b1d64` (revises `d7c41f9b2e58`, the current single head). Two nullable columns, **no backfill and no server_default** — a historical row was graded by a build that did not record its version, and stamping it with today's string would invent the provenance needed to make a drift comparison come out clean. `test_alembic_grading_engine_version_columns_added_and_removed` asserts the up/down/re-up round trip, that **ledger rows survive the downgrade**, and that a pre-existing row comes back with `engine_version IS NULL` rather than a default.

## Honest limitations, stated rather than hidden

**An engine re-grade masks a co-occurring data restatement.** Once the engine has moved, a row graded by the old version disagrees for two reasons at once — our cost model changed, *and* upstream may also have revised that bar — and `classify_drift` returns the engine answer for both. Separating them would require re-running the **retired** engine version against today's data, which is not possible: the old code is gone, only its version string survives. So `DRIFT_ENGINE` means *"at least a re-grade"*, not *"only a re-grade"*. Reporting these as data drift instead would assert an upstream restatement we equally cannot show — re-creating the exact false claim this policy exists to prevent. Over-attributing to **ourselves** is the honest direction to fail: it blames us, not the user's track record. Documented at the decision point in `classify_drift` (commit `8ff4918b`).

Rows written **before** this migration carry no version and are never rewritten (append-only), so a genuine upstream restatement of one of those will read as `unversioned` — annotated — rather than as loud data drift, permanently. That is disclosed in the migration docstring, in `classify_drift`, in the WARNING text, and as `unversioned_rows` on the deployment payload. Every row appended from this revision onward carries a stamp, so the blind spot is bounded to history that already exists on the day this ships. The alternative — back-stamping — would be fabricating provenance, which is worse.

## Not done here

- **UI.** No `ui/` file is touched. `PaperTrading.jsx` still renders only the `drift_detected_at` chip, so an `engine_regrade_at`-only deployment shows no chip at all. The new payload keys (`engine_regrade_at`, `grading_engine_version`, `ledger_engine_versions`, `unversioned_rows`) exist for a follow-up that renders "re-graded on <date>, cost model X → Y" as an annotation rather than a warning. Needs product copy.
- **The leaderboard does not distinguish the two causes.** `LivePaperLedger.drift_detected` now ORs both stamps, deliberately: narrowing it to `drift_detected_at` alone would have made the board's negative tooltip ("no replay disagreement recorded") **false** for a re-graded deployment. So the board keeps exactly today's meaning and today's coarseness. Splitting it into a third chip is follow-up work; what it must not do is go false while a disagreement stands.
- **`_GRADING_SEMANTICS_REV` is manual.** A non-cost change to replay semantics only registers if someone bumps it. The failure direction of a missed bump is the safe one (a real engine change reads as loud data drift — wrong, but loud, not quietly absolved), and that reasoning is in the constant's comment. A derived alternative (source hashing) would re-grade every open deployment for a typo fix.
- **No ADR.** The policy is documented in the `paper_trading` module docstring, on both new columns, and in the migration. If the owner wants it as a decision record, that is a separate docs commit (needs `make docs-check` + a `docs/README.md` index row).
- **Nothing is backfilled and no existing ledger row is modified**, per the append-only rule.

Closes #1449

