### PR TITLE
[corpus] Paper search matches authors, and the box says what it searches

### DIFF
--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -26,7 +26,10 @@ papers_router = APIRouter(prefix="/api/papers", tags=["papers"])
 #
 # Neither applies to the title/abstract legs, which are free prose, so the
 # guard is scoped to the author leg only: a short or structural term still
-# searches title and abstract exactly as it did before.
+# searches title and abstract exactly as it did before. That scoping is the
+# easy thing to get wrong (drop the term from the whole predicate instead of
+# from one leg) and is enforced by
+# `test_papers_routes.py::TestAuthorLegGuardIsScopedToTheAuthorLeg`.
 AUTHOR_SEARCH_MIN_LEN = 3
 _JSON_STRUCTURAL_CHARS = frozenset('[]{}",\\')
 

--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -14,6 +14,39 @@ logger = logging.getLogger(__name__)
 
 papers_router = APIRouter(prefix="/api/papers", tags=["papers"])
 
+# The author leg of catalog search (issue #1451). `PaperRecord.authors` is a
+# JSON-serialised list of names stored in a Text column, so an ilike over the
+# raw column is crude — but correct — substring name matching. It is crude in
+# two specific ways, and both are rejected rather than shipped:
+#
+#   * a 1-2 character term ("a") is a substring of nearly every author list, so
+#     the author leg would turn search into "return everything";
+#   * a term made of the JSON *serialisation* rather than a name ('", "', '["',
+#     '],') matches the punctuation every row shares, with the same effect.
+#
+# Neither applies to the title/abstract legs, which are free prose, so the
+# guard is scoped to the author leg only: a short or structural term still
+# searches title and abstract exactly as it did before.
+AUTHOR_SEARCH_MIN_LEN = 3
+_JSON_STRUCTURAL_CHARS = frozenset('[]{}",\\')
+
+
+def _author_search_pattern(search: str) -> str | None:
+    """LIKE pattern for the author leg, or ``None`` when the term must not reach it.
+
+    Returns ``None`` for a term shorter than :data:`AUTHOR_SEARCH_MIN_LEN` or
+    containing any JSON structural character — see the note above. LIKE
+    wildcards inside an accepted term are escaped so a literal ``%`` searches
+    for a percent sign instead of matching every row.
+    """
+    term = search.strip()
+    if len(term) < AUTHOR_SEARCH_MIN_LEN:
+        return None
+    if any(c in _JSON_STRUCTURAL_CHARS for c in term):
+        return None
+    escaped = term.replace("%", r"\%").replace("_", r"\_")
+    return f"%{escaped}%"
+
 
 def _paper_row_to_dict(r) -> dict:
     """Shared DB-row → API-dict mapping so every read path (processed-only,
@@ -51,7 +84,16 @@ async def list_papers(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
     category: str | None = None,
-    search: str | None = None,
+    search: str | None = Query(
+        None,
+        description=(
+            "Case-insensitive substring match over title, abstract and author "
+            "names. Lexical only — no embeddings, no ranking, no stemming. The "
+            f"author leg needs at least {AUTHOR_SEARCH_MIN_LEN} characters and is "
+            "skipped for terms built from JSON structural characters, which would "
+            "otherwise match the serialised author list of every row."
+        ),
+    ),
     processed_only: bool = Query(
         True,
         description=(
@@ -90,7 +132,14 @@ async def list_papers(
             query = query.filter(PaperRecord.categories.contains(category))
         if search:
             pattern = f"%{search}%"
-            query = query.filter((PaperRecord.title.ilike(pattern)) | (PaperRecord.abstract.ilike(pattern)))
+            predicate = (PaperRecord.title.ilike(pattern)) | (PaperRecord.abstract.ilike(pattern))
+            # `authors` is populated but was never searched, so the single most
+            # natural query for a research corpus — a researcher's name — only
+            # hit papers that happened to mention that name in prose (#1451).
+            author_pattern = _author_search_pattern(search)
+            if author_pattern is not None:
+                predicate = predicate | PaperRecord.authors.ilike(author_pattern, escape="\\")
+            query = query.filter(predicate)
 
         total = query.count()
         rows = query.order_by(PaperRecord.published.desc()).offset((page - 1) * page_size).limit(page_size).all()

--- a/backend/tests/test_papers_routes.py
+++ b/backend/tests/test_papers_routes.py
@@ -393,3 +393,73 @@ class TestAuthorLegGuard:
             papers_routes.list_papers(page=1, page_size=20, category=None, search='", "', processed_only=True)
         )
         assert result["total"] == 0, "a JSON-structural term matched the serialisation of every author list"
+
+
+class TestAuthorLegGuardIsScopedToTheAuthorLeg:
+    """The guard must reject a term *for the author leg only*.
+
+    `_author_search_pattern` returning ``None`` means "do not add the author
+    leg", never "do not search". A guard applied one level too high — dropping
+    the whole predicate, or short-circuiting the `if search:` block — would
+    satisfy every test in :class:`TestAuthorLegGuard` while silently killing
+    prose search for short and punctuated terms.
+
+    That property was asserted in a code comment and in the PR description but
+    nothing enforced it: `TestAuthorSearch.test_title_and_abstract_legs_are_unchanged`
+    only searches "momentum", a 7-character term the guard never rejects, so it
+    passes either way. These two tests use terms the guard *does* reject.
+    """
+
+    def test_a_short_term_still_searches_title_and_abstract(self, session, monkeypatch):
+        """A 2-character term is refused by the author leg but must still match prose.
+
+        Real cost if this regresses: short surnames ("Xu", "Ho") and tickers
+        stop matching titles they literally appear in.
+        """
+        from archimedes.api import papers_routes
+
+        # "Xu" is in the TITLE of one row and in nobody's author list, so only
+        # the title leg can produce this hit.
+        _add_paper(session, "2601.50001", authors=["Ada Lovelace"], title="Xu estimator revisited", abstract="Zeta.")
+        _add_paper(session, "2601.50002", authors=["Alan Turing"], title="Unrelated work", abstract="Zeta.")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="Xu", processed_only=True)
+        )
+        assert result["total"] == 1, "the minimum-length guard leaked out of the author leg and broke prose search"
+        assert result["papers"][0]["arxiv_id"] == "2601.50001"
+
+    def test_a_structural_term_still_searches_title_and_abstract(self, session, monkeypatch):
+        """A comma is a JSON structural character, and also ordinary prose.
+
+        "Lopez de Prado, M. (2018)" is how an abstract cites a paper, so a
+        comma-bearing term is a real query — the author leg skips it (correctly:
+        a bare comma is a substring of every multi-author serialisation) while
+        the abstract leg must still find it.
+        """
+        from archimedes.api import papers_routes
+
+        _add_paper(
+            session,
+            "2601.50003",
+            authors=["Ada Lovelace"],
+            title="Zeta",
+            abstract="Following Lopez de Prado, M. (2018) we deflate the Sharpe ratio.",
+        )
+        _add_paper(session, "2601.50004", authors=["Alan Turing"], title="Eta", abstract="Unrelated.")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        assert papers_routes._author_search_pattern("Prado, M") is None, (
+            "precondition: the author leg refuses this term"
+        )
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="Prado, M", processed_only=True)
+        )
+        assert result["total"] == 1, (
+            "the structural-character guard leaked out of the author leg and broke prose search"
+        )
+        assert result["papers"][0]["arxiv_id"] == "2601.50003"

--- a/backend/tests/test_papers_routes.py
+++ b/backend/tests/test_papers_routes.py
@@ -220,3 +220,176 @@ class TestCatalogSearchOnUnprocessedCorpus:
             papers_routes.list_papers(page=1, page_size=20, category="q-fin.PM", search=None, processed_only=True)
         )
         assert result["total"] == 1
+
+
+def _seed_author_fixture(session):
+    """A corpus slice where author names and prose deliberately do not overlap.
+
+    Every title/abstract here is neutral filler: no row contains the string
+    "Harvey" (or any other surname) anywhere except in its `authors` column, so
+    a hit can only have come from the author leg of the predicate. That is what
+    makes `test_author_only_match_is_returned` fail when the author leg is
+    removed rather than passing for an incidental prose reason.
+    """
+    _add_paper(
+        session,
+        "2601.20001",
+        authors=["Campbell R. Harvey", "Yan Liu"],
+        title="A neutral title about factor construction",
+        abstract="A neutral abstract about factor construction.",
+    )
+    _add_paper(
+        session,
+        "2601.20002",
+        authors=["Marcos Lopez de Prado"],
+        title="Backtest overfitting under multiple testing",
+        abstract="Deflated performance statistics for repeated trials.",
+    )
+    _add_paper(
+        session,
+        "2601.20003",
+        authors=["Ada Lovelace"],
+        title="Cross-sectional momentum in equities",
+        abstract="Momentum sorted portfolios across a broad universe.",
+    )
+    session.commit()
+
+
+class TestAuthorSearch:
+    """Author matching — issue #1451 item 1.
+
+    `PaperRecord.authors` is populated but was never part of the search
+    predicate, so searching a researcher's name returned only the papers that
+    happened to mention that name in the title or abstract. On the real corpus
+    that is close to zero: authors are cited by name in *other* people's
+    abstracts far more often than in their own.
+    """
+
+    def test_author_only_match_is_returned(self, session, monkeypatch):
+        """THE REGRESSION: a paper whose AUTHOR matches but whose title and
+        abstract do not contain the term must be returned."""
+        from archimedes.api import papers_routes
+
+        _seed_author_fixture(session)
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="Harvey", processed_only=True)
+        )
+
+        assert result["total"] == 1, "author search returned nothing — the author leg is missing"
+        hit = result["papers"][0]
+        assert hit["arxiv_id"] == "2601.20001"
+        assert "Campbell R. Harvey" in hit["authors"]
+        # Proof the hit came from the author leg and not from prose.
+        assert "harvey" not in hit["title"].lower()
+        assert "harvey" not in hit["abstract"].lower()
+
+    def test_author_search_is_case_insensitive(self, session, monkeypatch):
+        """ilike, not like — "lopez" must find "Lopez"."""
+        from archimedes.api import papers_routes
+
+        _seed_author_fixture(session)
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="lopez", processed_only=True)
+        )
+        assert result["total"] == 1
+        assert result["papers"][0]["arxiv_id"] == "2601.20002"
+
+    def test_title_and_abstract_legs_are_unchanged(self, session, monkeypatch):
+        """The author leg is additive: prose matching still behaves as before."""
+        from archimedes.api import papers_routes
+
+        _seed_author_fixture(session)
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="momentum", processed_only=True)
+        )
+        assert result["total"] == 1
+        assert result["papers"][0]["arxiv_id"] == "2601.20003"
+
+    def test_author_search_still_discriminates(self, session, monkeypatch):
+        """A name nobody in the fixture carries returns nothing."""
+        from archimedes.api import papers_routes
+
+        _seed_author_fixture(session)
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="Zzzznobody", processed_only=True)
+        )
+        assert result["total"] == 0
+
+
+class TestAuthorLegGuard:
+    """The author leg must reject the terms that would make it match everything.
+
+    `authors` is serialised JSON, so a bare substring over it can match the
+    serialisation instead of a name. Two classes of term do that; both are
+    rejected before the leg is added to the predicate, while title/abstract
+    matching for the same term is left untouched.
+    """
+
+    @pytest.mark.parametrize("term", ["a", "Li", " a ", ""])
+    def test_short_terms_do_not_reach_the_author_leg(self, term):
+        from archimedes.api import papers_routes
+
+        assert papers_routes._author_search_pattern(term) is None
+
+    @pytest.mark.parametrize("term", ['", "', '["', '"]', "], [", "Harvey\\", '{"a"'])
+    def test_json_structural_terms_do_not_reach_the_author_leg(self, term):
+        from archimedes.api import papers_routes
+
+        assert papers_routes._author_search_pattern(term) is None
+
+    def test_a_real_name_does_reach_the_author_leg(self):
+        """Anti-vacuity: the guard must still let a genuine name through, or it
+        is rejecting everything rather than rejecting the bad cases."""
+        from archimedes.api import papers_routes
+
+        assert papers_routes._author_search_pattern("Harvey") == "%Harvey%"
+        assert papers_routes._author_search_pattern("  Lopez de Prado  ") == "%Lopez de Prado%"
+
+    def test_like_wildcards_in_an_accepted_term_are_escaped(self):
+        """A literal '%' must search for a percent sign, not match every row."""
+        from archimedes.api import papers_routes
+
+        assert papers_routes._author_search_pattern("a%b") == r"%a\%b%"
+        assert papers_routes._author_search_pattern("a_b") == r"%a\_b%"
+
+    def test_single_char_query_does_not_return_the_whole_corpus(self, session, monkeypatch):
+        """End-to-end form of the anti-goal (#1451: "do NOT make the author leg
+        match on a 1-2 character query").
+
+        Both rows carry an "a" in their author names and no "a" anywhere in
+        title or abstract, so an unguarded author leg returns the whole corpus
+        for a one-letter query and a guarded one returns nothing.
+        """
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.30001", authors=["Ada Lovelace"], title="Nine", abstract="Nine.")
+        _add_paper(session, "2601.30002", authors=["Alan Turing"], title="Ten", abstract="Ten.")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search="a", processed_only=True)
+        )
+        assert result["total"] == 0, "a one-character query reached the author leg and matched every row"
+
+    def test_structural_query_does_not_return_the_whole_corpus(self, session, monkeypatch):
+        """`", "` is the separator between every pair of serialised authors."""
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.30003", authors=["Ada Lovelace", "Alan Turing"], title="Zeta", abstract="Zeta.")
+        _add_paper(session, "2601.30004", authors=["Grace Hopper", "Jean Bartik"], title="Eta", abstract="Eta.")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=20, category=None, search='", "', processed_only=True)
+        )
+        assert result["total"] == 0, "a JSON-structural term matched the serialisation of every author list"

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -3421,6 +3421,15 @@ button:where(.tag) {
 	width: 180px;
 	flex-shrink: 0;
 }
+/* The search-scope sentence sits between the controls and the result count;
+   it is the input's accessible description (aria-describedby), so it must stay
+   rendered rather than being hidden on small viewports. */
+.catalog-search-scope {
+	font-size: 0.76rem;
+	color: var(--text-3);
+	margin: -8px 0 10px;
+	max-width: 62ch;
+}
 .catalog-results-info {
 	font-size: 0.8rem;
 	color: var(--text-2);

--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -234,8 +234,9 @@ function CatalogTab({ papers, total, page, loading, catalogError, onRetry, searc
         {/* The placeholder is not a label: it disappears on the first keystroke
             and the field is then anonymous to a screen reader (3.3.2). */}
         <input
-          type="text" placeholder="Search papers..." value={search}
-          aria-label="Search papers"
+          type="text" placeholder="Search title, abstract, authors..." value={search}
+          aria-label="Search papers by title, abstract or author name"
+          aria-describedby="catalog-search-scope"
           onChange={e => { setSearch(e.target.value); setPage(1) }}
           className="catalog-search"
         />
@@ -247,6 +248,18 @@ function CatalogTab({ papers, total, page, loading, catalogError, onRetry, searc
           options={[{ value: '', label: 'All Categories' }, ...categories.map(c => ({ value: c.name, label: `${c.label || c.name} (${c.count})` }))]}
         />
       </div>
+
+      {/* State the scope of the search, because the box cannot be judged
+          without it: a user who searches a surname and sees 4 rows has no way
+          to tell whether the corpus holds 4 or the author leg was never
+          consulted (#1451). Wording is deliberately literal — this is a
+          case-insensitive substring match over three text columns. There are
+          no embeddings behind the catalog, so nothing here may read as
+          semantic, ranked, or "smart". */}
+      <p id="catalog-search-scope" className="catalog-search-scope">
+        Substring match over title, abstract and author names — case-insensitive, no ranking.
+        Author names are matched from 3 characters up.
+      </p>
 
       {loading ? <div className="corpus-loading">Loading...</div> : catalogError ? (
         <div className="catalog-results-info" role="status">

--- a/ui/test/a11y.test.js
+++ b/ui/test/a11y.test.js
@@ -573,7 +573,11 @@ test("the generate form's fields are programmatically labelled", () => {
 });
 
 test("the corpus search field has a name that survives typing", () => {
-	assert.match(corpusExplorer, /aria-label="Search papers"/);
+	// The name widened with the author leg (#1451) — it now states the three
+	// columns the field actually searches, so match on the stable prefix rather
+	// than the exact old string.
+	assert.match(corpusExplorer, /aria-label="Search papers[^"]*"/);
+	assert.match(corpusExplorer, /aria-describedby="catalog-search-scope"/);
 });
 
 test("sign-up states why the confirm field is invalid and the button disabled", () => {

--- a/ui/test/corpus-search-scope.test.js
+++ b/ui/test/corpus-search-scope.test.js
@@ -1,0 +1,152 @@
+// Corpus catalog search: the box must say what it searches (#1451).
+//
+// Catalog search is a case-insensitive substring match over three text columns
+// — title, abstract and, as of #1451, the serialised author list. It is
+// LEXICAL. There are no embeddings behind /api/papers/: `corpus_meta` is 0
+// rows and the papers table has no embedding column, so any copy that reads as
+// semantic / similarity / "smart" search is a false claim on a public page.
+//
+// Three things are pinned here:
+//
+//   1. the input names authors, so the author leg is discoverable rather than
+//      an invisible backend behaviour;
+//   2. a scope sentence exists, is the input's accessible description, and
+//      names all three columns;
+//   3. no part of that copy claims semantic retrieval or ranking.
+//
+// Plus the acceptance criterion #1451 attached to the result count: `total`
+// comes from the response, never recomputed from `papers.length` (a page, not
+// a total).
+//
+// Same idiom as corpus-kg-tab-gate.test.js / oracle-copy.test.js: a raw
+// source-text scan with anti-vacuity coverage — every pattern is also run
+// against the canonical string it exists to reject, so a pattern that has
+// stopped matching anything fails loudly instead of guarding nothing.
+
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+function repoFile(rel) {
+	return new URL(`../${rel}`, import.meta.url);
+}
+
+const explorer = readFileSync(repoFile("src/components/CorpusExplorer.jsx"), "utf8");
+const css = readFileSync(repoFile("src/App.css"), "utf8");
+
+// Block comments (including JSX `{/* */}`) are stripped before the
+// false-claim scan: the rule is about copy a visitor reads, and the source
+// legitimately explains *why* there are no embeddings. `//` comments are left
+// alone because stripping them would also eat `https://` inside a string.
+const explorerCopy = explorer.replace(/\/\*[\s\S]*?\*\//g, "");
+
+// The exact pre-fix markup. Every guard below is checked against it, so a
+// guard can never pass by having stopped matching the real source.
+const PRE_FIX_INPUT = `<input
+          type="text" placeholder="Search papers..." value={search}
+          aria-label="Search papers"
+          onChange={e => { setSearch(e.target.value); setPage(1) }}
+          className="catalog-search"
+        />`;
+
+const NAMES_AUTHORS = /placeholder="[^"]*authors[^"]*"/i;
+const LABEL_NAMES_AUTHORS = /aria-label="[^"]*author[^"]*"/i;
+const DESCRIBED_BY = /aria-describedby="catalog-search-scope"/;
+const SCOPE_SENTENCE = /id="catalog-search-scope"[\s\S]{0,400}?<\/p>/;
+
+// Words that would turn an honest substring match into a claim the corpus
+// cannot back. "no ranking" is allowed — a negation is not a claim.
+const SEMANTIC_CLAIM = /\b(semantic|embedding|embeddings|vector search|similarity search|relevance[- ]ranked|smart search|AI[- ]powered)\b/i;
+
+test("the search box names authors", () => {
+	assert.match(
+		explorer,
+		NAMES_AUTHORS,
+		"the catalog placeholder must name authors — the author leg is otherwise invisible to the user",
+	);
+	assert.match(
+		explorer,
+		LABEL_NAMES_AUTHORS,
+		"the accessible name must match what the field actually searches (3.3.2)",
+	);
+});
+
+test("a scope sentence exists and is the input's accessible description", () => {
+	assert.match(explorer, DESCRIBED_BY, "the input must point at the scope sentence via aria-describedby");
+
+	const scope = explorer.match(SCOPE_SENTENCE);
+	assert.ok(scope, "no #catalog-search-scope element found in CorpusExplorer.jsx");
+	const copy = scope[0];
+
+	for (const column of ["title", "abstract", "author"]) {
+		assert.ok(
+			copy.toLowerCase().includes(column),
+			`the scope sentence must name the ${column} column — it exists so the user can judge a result count`,
+		);
+	}
+	assert.match(copy, /substring/i, "say what the match actually is: a substring match, not a ranked search");
+	assert.ok(
+		/3 characters/.test(copy),
+		"the author leg's minimum length is user-visible behaviour (a 2-letter name silently misses) and must be stated",
+	);
+});
+
+test("no copy on the catalog claims semantic retrieval", () => {
+	// Retrieval is lexical. corpus_meta is 0 rows; there is no embedding column
+	// on `papers`. Anything below would be a false claim, not a stretch.
+	const offenders = (explorerCopy.match(SEMANTIC_CLAIM) || []).join(", ");
+	assert.equal(offenders, "", `CorpusExplorer.jsx claims semantic retrieval over a lexical index: ${offenders}`);
+});
+
+test("the result count is the response total, never papers.length", () => {
+	// #1451 acceptance criterion 2: `papers` is one page, `total` is the corpus
+	// match count. Recomputing from the array would silently cap the number at
+	// page_size and read as "20 papers found" for a 900-hit query.
+	assert.match(
+		explorer,
+		/\{total\.toLocaleString\(\)\} papers found/,
+		"the count must render the response's `total` verbatim",
+	);
+	assert.ok(
+		!/papers\.length\}?\s*papers found/.test(explorer),
+		"the count is recomputed from the current page instead of the response total",
+	);
+	assert.match(
+		explorer,
+		/setTotalPapers\(data\.total \|\| 0\)/,
+		"`total` must come off the API response, not be derived client-side",
+	);
+});
+
+test("the guards reject the exact pre-fix markup they exist to catch", () => {
+	// Anti-vacuity. If any of these start passing against the old source, the
+	// corresponding guard above is decorative.
+	assert.ok(
+		!NAMES_AUTHORS.test(PRE_FIX_INPUT),
+		'the placeholder guard matches "Search papers..." — it is guarding nothing',
+	);
+	assert.ok(
+		!LABEL_NAMES_AUTHORS.test(PRE_FIX_INPUT),
+		'the aria-label guard matches the old "Search papers" label — it is guarding nothing',
+	);
+	assert.ok(!DESCRIBED_BY.test(PRE_FIX_INPUT), "the aria-describedby guard matches markup that had no description");
+	assert.ok(
+		!SCOPE_SENTENCE.test(PRE_FIX_INPUT),
+		"the scope-sentence guard matches source with no scope sentence in it",
+	);
+	// And the semantic-claim pattern must still catch a real false claim.
+	assert.match(
+		"Semantic search over the paper corpus",
+		SEMANTIC_CLAIM,
+		"the semantic-claim pattern no longer matches a false claim — it would let one ship",
+	);
+});
+
+test("the scope sentence is styled, not left unstyled or display:none", () => {
+	assert.match(css, /\.catalog-search-scope \{/, "the scope sentence needs a rule in App.css");
+	const rule = css.match(/\.catalog-search-scope \{[^}]*\}/)[0];
+	assert.ok(
+		!/display:\s*none/.test(rule),
+		"the scope sentence is the input's accessible description — hiding it removes the description too",
+	);
+});


### PR DESCRIPTION
## What

Adds the **author leg** to corpus catalog search (`GET /api/papers/`), and makes the search box state its own scope.

`PaperRecord.authors` is populated on all 10,000 rows but was never in the search predicate:

```python
query = query.filter((PaperRecord.title.ilike(pattern)) | (PaperRecord.abstract.ilike(pattern)))
```

So searching a researcher's name — the most natural query for a research corpus — returned only the papers that happened to mention that name in *someone's* prose. On a real corpus that is close to zero: authors are named in other people's abstracts far more often than in their own.

**Backend** (`backend/archimedes/api/papers_routes.py`)
- `PaperRecord.authors.ilike(...)` joins the existing `|` chain.
- `authors` is a JSON-serialised list in a `Text` column, so the leg is a substring match over the *serialisation*. That is correct for names and wrong for two classes of term, both of which `_author_search_pattern()` refuses before the leg is added to the predicate:
  - a 1–2 character term (`"a"`) is a substring of nearly every author list → issue anti-goal "do NOT make the author leg match on a 1-2 character query";
  - a term built from JSON structure (`'", "'`, `'["'`, `'],'`) matches the punctuation every row shares.
- LIKE wildcards inside an accepted term are escaped (`ilike(pattern, escape="\\")`). **Scope of that claim, precisely:** it makes the *author leg* treat a literal `%` as a percent sign. It does **not** make the endpoint safe against `%` — `search=%` still returns the whole catalog through the pre-existing, unescaped title/abstract legs (`pattern = f"%{search}%"`), which this PR does not touch. Demonstration 2 shows which leg produces that hit. Called out again under "Not done here" rather than left to be read as an endpoint-level property.
- **The guard is scoped to the author leg only.** Title and abstract matching is byte-for-byte unchanged — a short or structural term still searches prose exactly as it did before. This is now *enforced* (`TestAuthorLegGuardIsScopedToTheAuthorLeg`), not merely asserted; see Demonstration 3 for why that mattered.
- The `search` query param gained a description, so `/docs` states the scope too.

**UI** (`ui/src/components/CorpusExplorer.jsx`, `ui/src/App.css`)
- Placeholder and `aria-label` now name authors; a scope sentence is wired as the input's `aria-describedby`.
- Copy is deliberately literal: *"Substring match over title, abstract and author names — case-insensitive, no ranking. Author names are matched from 3 characters up."* **Retrieval is lexical.** There is no embedding column on `papers` and `corpus_meta` is 0 rows, so nothing on this surface may read as semantic, ranked, or "smart" — a test enforces that.

## Why

Follow-up to #1450, which restored catalog search to a floor. Per @dbrowneup's 2026-08-30 comment on #1451, items 2 (visible result count) and 3 (category facets from a live `GROUP BY`) already shipped on `main`; this PR is item 1, which remained unaddressed.

Both already-shipped items are verified rather than re-implemented:
- item 2 — `CorpusExplorer.jsx:260` renders `{total.toLocaleString()} papers found` from `data.total`. It had **no test**, so the machine-checkable criterion ("a test asserts it is not recomputed client-side from `papers.length`") was unmet; this PR adds that one source-scan assertion so the issue can close honestly.
- item 3 — `corpus_routes.py:161-165` is a real `GROUP BY PaperRecord.primary_category`, already covered by `test_corpus_routes_overview.py::test_category_and_year_counts_match_full_catalog`. Untouched here.

## Test evidence

All commands run with the env's absolute toolchain (`/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/...`), from the repo root.

**New + existing backend tests for the touched module**

```
$ pytest backend/tests/test_papers_routes.py -q -p no:randomly
======================== 28 passed, 1 warning in 1.66s =========================
```

**Hermetic gate** (no `.env`, no network, no Redis/Postgres — in-memory SQLite only)

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_papers_routes.py -q -p no:randomly
======================== 28 passed, 1 warning in 1.36s =========================
```

**Full CI unit suite** (the exact command `quality-gate.yml` runs, from the repo root, per CLAUDE.md rule 2)

```
$ pytest -m "not integration" -q
=== 4810 passed, 3 skipped, 2 deselected, 320 warnings in 456.29s (0:07:36) ====
```

**UI suite** (`ui/test/corpus-search-scope.test.js` is new; `ui/test/a11y.test.js` updated for the widened `aria-label`)

```
$ cd ui && npm test
ℹ tests 620
ℹ pass 620
ℹ fail 0
```

**Lint**

```
$ ruff format backend/archimedes/api/papers_routes.py backend/tests/test_papers_routes.py
2 files left unchanged
$ ruff check backend/archimedes/api/papers_routes.py backend/tests/test_papers_routes.py
All checks passed!
$ ruff format --check .            # the blocking ruff-gate, whole repo
669 files already formatted
$ ruff check --select E9,F63,F7,F40,F82 .
All checks passed!
$ cd ui && ./node_modules/.bin/eslint src/components/CorpusExplorer.jsx test/corpus-search-scope.test.js test/a11y.test.js
(no output — exit 0)
```

> The Quality Gate comment's `ruff linter (python) ❌ 47` is the whole-repo **informational** report, not the blocking gate. `ruff check . --output-format=json | len` returns **47 on `origin/main` and 47 on this branch** — identical, and none of the 47 are in a file this PR touches. The blocking `Ruff — format + critical lint rules` job passes.

## Demonstration 1 — revert the fix, the regression test fails

Per CLAUDE.md "Before you approve a merge" rule 3. The author-search fixture is built so a hit can *only* have come from the author leg: no row contains "Harvey" anywhere except its `authors` column, and the test asserts that (`assert "harvey" not in hit["title"].lower()`).

Removed exactly these three lines from `list_papers`:

```python
            author_pattern = _author_search_pattern(search)
            if author_pattern is not None:
                predicate = predicate | PaperRecord.authors.ilike(author_pattern, escape="\\")
```

```
$ pytest backend/tests/test_papers_routes.py -q -p no:randomly
E   AssertionError: author search returned nothing — the author leg is missing
E   assert 0 == 1
E   assert 0 == 1
FAILED backend/tests/test_papers_routes.py::TestAuthorSearch::test_author_only_match_is_returned - AssertionError: author search returned nothing — the author leg is missing
FAILED backend/tests/test_papers_routes.py::TestAuthorSearch::test_author_search_is_case_insensitive - assert 0 == 1
=================== 2 failed, 24 passed, 1 warning in 3.07s ====================
```

The fix was restored before committing (`git status` clean against the merge base).

## Demonstration 2 — the guard is shown to reject bad input

Per CLAUDE.md rule 4. Two-row in-memory corpus driven through the **real route**; titles/abstracts are `"Nine"` and `"Ten"`, so **every name exists only in the `authors` column** and the prose legs cannot mask the effect. Only `_author_search_pattern` is toggled between the two columns.

```
2-row corpus. Titles/abstracts are 'Nine'/'Ten'; every name lives ONLY in `authors`.
term           note                                                 pattern          ON   OFF
----------------------------------------------------------------------------------------------
'a'            1 char — anti-goal: must not reach the author leg    None              0     2  <-- guard changed the answer
'Li'           2 chars — anti-goal                                  None              0     0
'", "'         JSON separator between every pair of authors         None              0     2  <-- guard changed the answer
'["'           JSON list opener on every row                        None              0     2  <-- guard changed the answer
'"]'           JSON list closer on every row                        None              0     2  <-- guard changed the answer
'%'            LIKE wildcard, 1 char                                None              2     2
'%%%'          LIKE wildcards, 3 chars — long enough to pass min-len %\%\%\%%          2     2
'___'          LIKE single-char wildcards x3                        %\_\_\_%          2     2
'   '          whitespace only                                      None              0     0
'Ada'          REAL NAME — must still match                         %Ada%             1     1
'Hopper'       REAL NAME — must still match                         %Hopper%          1     1
'Zzzznobody'   REAL NAME that is absent — must not match            %Zzzznobody%      0     0
```

`'a'`, `'", "'`, `'["'` and `'"]'` each return the **whole corpus** without the guard and **zero** with it, while real names (`'Ada'`, `'Hopper'`) are unaffected in both — so the guard rejects the bad inputs without rejecting everything.

**The three `%`/`_` rows are the honest part of this table.** They return 2 in *both* columns, so the guard is not what saves them. The author-leg pattern is correctly escaped (`%\%\%\%%` matches a literal percent sign, of which these rows have none); the whole-corpus hit comes from the **unescaped title/abstract legs**, which predate this PR:

```
search='%'    title/abstract LIKE pattern (UNESCAPED, pre-existing) = '%%%'    author-leg pattern (escaped) = None
search='%%%'  title/abstract LIKE pattern (UNESCAPED, pre-existing) = '%%%%%'  author-leg pattern (escaped) = '%\\%\\%\\%%'
search='___'  title/abstract LIKE pattern (UNESCAPED, pre-existing) = '%___%'  author-leg pattern (escaped) = '%\\_\\_\\_%'
```

Listed under "Not done here" rather than papered over.

The two whole-corpus cases are also pinned as end-to-end tests. Deleting the two `return None` branches from `_author_search_pattern`:

```
$ pytest backend/tests/test_papers_routes.py -q -p no:randomly -k "AuthorLegGuard and (single_char or structural_query)"
E   AssertionError: a one-character query reached the author leg and matched every row
E   AssertionError: a JSON-structural term matched the serialisation of every author list
FAILED backend/tests/test_papers_routes.py::TestAuthorLegGuard::test_single_char_query_does_not_return_the_whole_corpus
FAILED backend/tests/test_papers_routes.py::TestAuthorLegGuard::test_structural_query_does_not_return_the_whole_corpus
```

`test_a_real_name_does_reach_the_author_leg` is the anti-vacuity half: it fails if the guard degenerates into rejecting everything.

The UI test carries the same discipline (`corpus-search-scope.test.js`, "the guards reject the exact pre-fix markup they exist to catch"): every source pattern is re-run against the literal pre-fix `<input>` markup and must *not* match it, and the semantic-claim pattern is re-run against `"Semantic search over the paper corpus"` and must match — so a pattern that stops matching anything fails loudly instead of guarding nothing.

## Demonstration 3 — the scoping claim was untested, and now fails when violated

This one came out of re-reading the PR against CLAUDE.md rule 4's last line: *"a PR description asserting a property the code does not enforce is the same defect, just harder to grep for."*

The claim was **"the guard is scoped to the author leg only — a short or structural term still searches title and abstract exactly as it did before"**, made in both the code comment and this description. Nothing enforced it. `TestAuthorSearch::test_title_and_abstract_legs_are_unchanged` searches `"momentum"` — 7 characters, no structural characters — a term the guard *never rejects*, so it passes identically whether the guard is scoped correctly or applied one level too high.

Commit `958ad75` adds `TestAuthorLegGuardIsScopedToTheAuthorLeg`, which searches terms the guard **does** reject:
- `"Xu"` (2 chars) must still match a title containing it — real cost if this regresses: short surnames and tickers stop matching titles they literally appear in;
- `"Prado, M"` (a comma is a JSON structural character *and* ordinary prose) must still match an abstract citing `"Lopez de Prado, M. (2018)"`.

Mutation — the natural way to get this wrong, dropping the rejected term from the whole predicate rather than from one leg:

```python
            author_pattern = _author_search_pattern(search)
            if author_pattern is None:
                predicate = None                      # <-- guard applied one level too high
            else:
                predicate = predicate | PaperRecord.authors.ilike(author_pattern, escape="\\")
            if predicate is not None:
                query = query.filter(predicate)
```

```
$ pytest backend/tests/test_papers_routes.py -q -p no:randomly
E   AssertionError: a one-character query reached the author leg and matched every row
E   AssertionError: a JSON-structural term matched the serialisation of every author list
E   AssertionError: the minimum-length guard leaked out of the author leg and broke prose search
E   AssertionError: the structural-character guard leaked out of the author leg and broke prose search
FAILED backend/tests/test_papers_routes.py::TestAuthorLegGuard::test_single_char_query_does_not_return_the_whole_corpus
FAILED backend/tests/test_papers_routes.py::TestAuthorLegGuard::test_structural_query_does_not_return_the_whole_corpus
FAILED backend/tests/test_papers_routes.py::TestAuthorLegGuardIsScopedToTheAuthorLeg::test_a_short_term_still_searches_title_and_abstract
FAILED backend/tests/test_papers_routes.py::TestAuthorLegGuardIsScopedToTheAuthorLeg::test_a_structural_term_still_searches_title_and_abstract
=================== 4 failed, 24 passed, 1 warning in 2.12s ====================
```

Before this commit that mutation failed **2** tests, all of them about the author leg matching too much; the two new ones catch it matching too *little*. Production behaviour is unchanged by `958ad75` — it is tests plus a comment pointing from the claim to the test that now enforces it.

## Not done here

- **Ranking, stemming, semantic retrieval** — explicitly out of scope per the issue; the KB pipeline (#1090) is the proper home. No copy in this PR implies any of it.
- **The title/abstract legs are still unescaped, and this PR does not change that.** `search=%` returns the whole catalog through them (Demonstration 2). It is pre-existing behaviour, it is not what #1451 asked for, and escaping it would change the result of every existing prose query — so it belongs in its own PR, not this one. Say the word and I will file it.
- **Author matching is a substring match over serialised JSON, not a name index.** `"Liu"` matches `"Yan Liu"` and would also match a hypothetical `"Liuxin Wang"`; there is no tokenisation, no initials handling, no diacritic folding, and no relevance ordering (results stay `published DESC`). A proper author index is a real project.
- **A comma-bearing query never reaches the author leg** — `"Harvey, Campbell"` and `"de Prado, M."` are refused as structural. I checked what that actually costs before deciding to leave it: the corpus stores names in `"Firstname Lastname"` form — **0 of 1006 author names sampled from `data/corpus/manifest.jsonl` contain a comma** — so `"Lastname, Firstname"` matches nothing by substring whether or not the guard lets it through. The rejection costs nothing real *against this corpus*, and would matter only for a corpus storing the inverted form. Documented rather than fixed, because fixing it would change a guard this PR demonstrates.
- **No DB index on `authors`.** The leg adds a third `ILIKE '%…%'` to a query that already does two, all unindexable sequential scans. At 10K rows that is fine; it is not a plan for 10× that.
- **The 3-character minimum is a blunt rule.** It silently misses genuinely short surnames (e.g. "Xu", "Ho") from the author leg — those queries still search title and abstract (now tested). Making the leg exact-match for 1–2 character terms instead would be strictly better and is a follow-up, not a quick win.
- **Not verified against production.** The issue's `curl "$HOST/api/papers/?search=Harvey" | jq '.total'` check needs the deployed build; evidence above is the hermetic fixture-corpus equivalent. Worth re-running against `archimedes-arc.com` after this deploys.
- **Item 3's live-`GROUP BY` criterion is verified, not re-tested here** — it already has a test (`test_category_and_year_counts_match_full_catalog`); `corpus_routes.py` is untouched.

Closes #1451
