### PR TITLE
[frontend] Fix Explore price-chart x-axis dates (timezone shift, tick density, clipping)

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -62,4 +62,12 @@ export default defineConfig([
     files: ['postcss.config.js', 'vite.config.js', 'eslint.config.js'],
     languageOptions: { globals: { ...globals.node } },
   },
+  // `npm test` is `node --test`, so the suite executes in Node and may use
+  // Node globals (#1602 needs `process.env.TZ` to re-home the local calendar
+  // and prove the chart's date labels do not move with the viewer's timezone).
+  // Browser globals stay in scope too — these files also assert on UI source.
+  {
+    files: ['test/**/*.js', 'scripts/**/*.mjs'],
+    languageOptions: { globals: { ...globals.browser, ...globals.node } },
+  },
 ])

--- a/ui/src/chartTicks.js
+++ b/ui/src/chartTicks.js
@@ -1,0 +1,215 @@
+// x-axis tick logic for the Explore price charts (#1602).
+//
+// Extracted as a plain module (same precedent as statUtils.js) so the tick
+// formatter is directly unit-testable — `node --test` cannot parse JSX, so
+// logic that lives inside PriceHistoryChart.jsx can only ever be text-scanned,
+// never executed, by the UI suite.
+//
+// ── Why this exists ──────────────────────────────────────────────────────────
+//
+// The previous implementation round-tripped each timestamp through a Date
+// object and then read it back with LOCAL calendar accessors:
+//
+//     const d = new Date(Date.parse(ts.replace(' ', 'T')))
+//     `${d.getMonth() + 1}-${d.getDate()}`
+//
+// That is an off-by-one-day bug for every viewer west of UTC. A crypto daily
+// close stamped "2026-05-25 00:00:00+00:00" is UTC midnight; read back through
+// America/New_York's calendar it is 2026-05-24 20:00, so the axis labelled the
+// bar "05-24" — a date that does not appear anywhere in the series. Worse, it
+// was inconsistent: ECMA-262 parses an offset-bearing or date-ONLY string as an
+// absolute instant (shifted by local getters) but a tz-naive date-TIME string as
+// local wall time (not shifted). So "2026-05-25 00:00:00-04:00" rendered
+// correctly while "2026-05-25 00:00:00+00:00" rendered a day early, in the same
+// chart, depending on which range the user picked.
+//
+// The fix: never convert. A bar's label must report the bar's own wall clock,
+// which the series already carries in the string. We read the calendar fields
+// LEXICALLY and never construct a Date for display, so the rendered label is
+// the series timestamp by construction, in every timezone.
+//
+// (Re-zoning would also be wrong on the merits: a daily close for a US equity
+// is the May 25 *session*, and must not be relabelled "May 24" because the
+// viewer happens to be in Tokyo.)
+
+/** Leading calendar fields of an ISO-ish timestamp. The trailing UTC offset,
+ * if any, is deliberately NOT captured — see the module note above. Accepts
+ * "2026-05-25", "2026-05-25 00:00:00", "2026-05-25T09:35:00+00:00". */
+const TS_RE = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2}))?/
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Read the wall-clock calendar fields out of a series timestamp, lexically.
+ * Returns null for anything unparseable, so callers can fall back honestly
+ * instead of rendering "NaN-NaN".
+ */
+export function parseSeriesTimestamp(ts) {
+  if (typeof ts !== 'string') return null
+  const m = TS_RE.exec(ts.trim())
+  if (!m) return null
+  const year = Number(m[1])
+  const month = Number(m[2])
+  const day = Number(m[3])
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null
+  const hour = m[4] === undefined ? 0 : Number(m[4])
+  const minute = m[5] === undefined ? 0 : Number(m[5])
+  if (hour > 23 || minute > 59) return null
+  return { year, month, day, hour, minute }
+}
+
+/** Wall-clock fields → a comparable scalar. Date.UTC is used purely as
+ * calendar arithmetic on fields we already hold; because every stamp in a
+ * series goes through the same basis, differences are exact. No timezone
+ * conversion happens here and the result is never formatted for display. */
+function toComparable(f) {
+  return Date.UTC(f.year, f.month - 1, f.day, f.hour, f.minute)
+}
+
+/** Median gap between consecutive samples, in ms. Median (not the first pair,
+ * which is what the old `isIntraday` heuristic used) so one weekend gap or one
+ * missing bar cannot flip a whole axis into the wrong format. */
+export function medianStepMs(fields) {
+  if (!fields || fields.length < 2) return null
+  const steps = []
+  for (let i = 1; i < fields.length; i += 1) {
+    steps.push(Math.abs(toComparable(fields[i]) - toComparable(fields[i - 1])))
+  }
+  steps.sort((a, b) => a - b)
+  const mid = Math.floor(steps.length / 2)
+  return steps.length % 2 === 0 ? (steps[mid - 1] + steps[mid]) / 2 : steps[mid]
+}
+
+/**
+ * Choose the label format for a whole series.
+ *
+ * Resolution comes from the bar interval; the year/day qualifier comes from the
+ * span, so a label is never ambiguous about which day (or year) it marks:
+ *
+ *   intraday bars, one calendar day    → 'time'     "09:35"
+ *   intraday bars, several days        → 'dayTime'  "May 25 09:35"
+ *   daily+ bars, < 180d, one year      → 'day'      "May 25"
+ *   daily+ bars, < 180d, spans a NY    → 'dayYear'  "May 25, 2026"
+ *   daily+ bars, < ~3y                 → 'month'    "May 2026"
+ *   longer                             → 'year'     "2026"
+ *
+ * The 'dayTime' case is not hypothetical: the 1D range is served as period
+ * "2d" (asset_market_service._HISTORY_RANGE_MAP), so a 1D chart normally holds
+ * two calendar days of 5-minute bars. Labelling those with bare HH:MM repeats
+ * the same clock times twice across the axis.
+ */
+export function pickTickFormat(points) {
+  const fields = (points || []).map(p => parseSeriesTimestamp(p && p.ts)).filter(Boolean)
+  if (fields.length === 0) return 'day'
+
+  const step = medianStepMs(fields)
+  const intraday = step !== null && step < 12 * 60 * 60 * 1000
+
+  const first = fields[0]
+  const last = fields[fields.length - 1]
+  const spanMs = Math.abs(toComparable(last) - toComparable(first))
+
+  if (intraday) {
+    const sameDay =
+      first.year === last.year && first.month === last.month && first.day === last.day
+    return sameDay ? 'time' : 'dayTime'
+  }
+  if (spanMs < 180 * MS_PER_DAY) {
+    return first.year === last.year ? 'day' : 'dayYear'
+  }
+  if (spanMs < 1100 * MS_PER_DAY) return 'month'
+  return 'year'
+}
+
+const pad2 = n => String(n).padStart(2, '0')
+
+/**
+ * Render one series timestamp in the given format. Unparseable input falls
+ * back to the raw leading date text rather than inventing a date.
+ */
+export function formatTickLabel(ts, format) {
+  const f = parseSeriesTimestamp(ts)
+  if (!f) return typeof ts === 'string' ? ts.slice(0, 10) : ''
+  const mon = MONTHS[f.month - 1]
+  const hhmm = `${pad2(f.hour)}:${pad2(f.minute)}`
+  switch (format) {
+    case 'time':
+      return hhmm
+    case 'dayTime':
+      return `${mon} ${f.day} ${hhmm}`
+    case 'dayYear':
+      return `${mon} ${f.day}, ${f.year}`
+    case 'month':
+      return `${mon} ${f.year}`
+    case 'year':
+      return String(f.year)
+    case 'day':
+    default:
+      return `${mon} ${f.day}`
+  }
+}
+
+// Widest label each format produces, in characters — the basis for how many
+// ticks fit without colliding.
+const LABEL_CHARS = { time: 5, dayTime: 12, day: 6, dayYear: 12, month: 8, year: 4 }
+
+/** x-axis label size, in SVG user units. PriceHistoryChart sizes its viewBox to
+ * the measured container width, so one user unit is one CSS pixel and this is a
+ * real 11px at every screen width. */
+export const TICK_FONT_SIZE = 11
+/** Minimum clear space between two adjacent labels, in the same units. */
+const TICK_GAP = 16
+const MAX_TICKS = 6
+const MIN_TICKS = 2
+// Mean advance width per character for the UI sans stack at this size.
+const CHAR_WIDTH_RATIO = 0.62
+
+/**
+ * How many ticks fit across `plotWidth` without the labels touching.
+ *
+ * With n ticks the spacing is plotWidth/(n-1), so requiring
+ * spacing >= labelWidth + gap gives n <= plotWidth/(labelWidth + gap) + 1.
+ * Clamped to [2, 6]: two ticks always render (the first and last sample, which
+ * are the two a reader actually looks up), and six is as dense as this chart
+ * reads well even when there is room for more.
+ */
+export function chooseTickCount(plotWidth, format) {
+  const chars = LABEL_CHARS[format] ?? LABEL_CHARS.day
+  const labelWidth = chars * TICK_FONT_SIZE * CHAR_WIDTH_RATIO
+  const perTick = labelWidth + TICK_GAP
+  if (!Number.isFinite(plotWidth) || plotWidth <= 0) return MIN_TICKS
+  const fits = Math.floor(plotWidth / perTick) + 1
+  return Math.max(MIN_TICKS, Math.min(MAX_TICKS, fits))
+}
+
+/**
+ * Build the x-axis ticks for a series.
+ *
+ * Returns `{ index, label, anchor }` per tick. `index` is the position in
+ * `points` the tick marks, so the caller maps it through the same x-scale the
+ * line uses and a label can never drift from the sample it names.
+ *
+ * `anchor` keeps the first and last labels inside the plot: centring them (the
+ * previous behaviour) hung the first label into the y-axis gutter and pushed
+ * the last one past the right edge of the viewBox, where it was clipped.
+ */
+export function buildXTicks(points, { plotWidth, format } = {}) {
+  if (!points || points.length === 0) return []
+  const fmt = format || pickTickFormat(points)
+  const wanted = Math.min(chooseTickCount(plotWidth, fmt), points.length)
+  const lastIdx = points.length - 1
+
+  const indices = []
+  for (let i = 0; i < wanted; i += 1) {
+    const idx = wanted === 1 ? 0 : Math.round((i * lastIdx) / (wanted - 1))
+    if (indices[indices.length - 1] !== idx) indices.push(idx)
+  }
+
+  return indices.map((index, i) => ({
+    index,
+    label: formatTickLabel(points[index] && points[index].ts, fmt),
+    anchor: i === 0 ? 'start' : i === indices.length - 1 ? 'end' : 'middle',
+  }))
+}

--- a/ui/src/components/PriceHistoryChart.jsx
+++ b/ui/src/components/PriceHistoryChart.jsx
@@ -3,12 +3,31 @@
 // same charting approach instead of introducing a second pattern or a new
 // charting library.
 
+import { useEffect, useState } from 'react'
+
+import { buildXTicks, TICK_FONT_SIZE } from '../chartTicks'
+
 export function fmtPrice(v) {
   if (v == null || Number.isNaN(v)) return '—'
   if (v >= 1000) return `$${v.toFixed(0)}`
   if (v >= 10) return `$${v.toFixed(2)}`
   return `$${v.toFixed(4)}`
 }
+
+// Fallback viewBox width for the first paint, before the container is measured
+// (and for any environment without ResizeObserver).
+const DEFAULT_SVG_W = 720
+const MIN_SVG_W = 260
+const PAD_R = 18
+const PAD_T = 16
+const PAD_B = 36
+
+// Plot height tracks width within bounds. Because the viewBox is now sized in
+// CSS pixels the old `maxHeight: 320` letterbox no longer applies, so the same
+// shape is kept explicitly: ~260 at the 720 desktop width it used to assume,
+// up to 320 in a wide modal, and never below 220 on a phone (where a purely
+// proportional height would collapse the plot to ~130px).
+const heightFor = w => Math.min(320, Math.max(220, Math.round(w * 0.36)))
 
 /**
  * PriceHistoryChart — SVG line chart of one series of {ts, price} points.
@@ -31,16 +50,35 @@ export default function PriceHistoryChart({
   // wording) without forking the component (review).
   emptyHeadline = 'Historical chart unavailable for the selected range.',
 }) {
-  const SVG_W = 720
-  const SVG_H = 260
-  const PAD_L = 56
-  const PAD_R = 18
-  const PAD_T = 16
-  const PAD_B = 36
+  // Measure the container so the viewBox is 1:1 with CSS pixels (#1602).
+  // A fixed 720-unit viewBox scaled into a ~360px phone rendered the 9-unit
+  // axis text at ~4.5px, which is the "hard to read" half of the report.
+  // Sizing the viewBox to the real width keeps every label at a true
+  // TICK_FONT_SIZE px and lets the tick count adapt to the space that
+  // actually exists rather than to a constant.
+  const [wrapEl, setWrapEl] = useState(null)
+  const [measuredW, setMeasuredW] = useState(DEFAULT_SVG_W)
+
+  useEffect(() => {
+    if (!wrapEl || typeof ResizeObserver === 'undefined') return undefined
+    const apply = w => { if (w > 0) setMeasuredW(Math.round(w)) }
+    apply(wrapEl.getBoundingClientRect().width)
+    const ro = new ResizeObserver(entries => {
+      for (const entry of entries) apply(entry.contentRect.width)
+    })
+    ro.observe(wrapEl)
+    return () => ro.disconnect()
+  }, [wrapEl])
+
+  const SVG_W = Math.max(MIN_SVG_W, measuredW)
+  const SVG_H = heightFor(SVG_W)
+  // The y-label gutter is most of a phone's width at the desktop value, so it
+  // narrows with the chart. Axis prices stay right-aligned against it either way.
+  const PAD_L = SVG_W < 420 ? 44 : 56
 
   if (loading) {
     return (
-      <div style={{ height: SVG_H, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div ref={setWrapEl} style={{ height: SVG_H, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <div className="caption" style={{ color: 'var(--text-4)' }}>Loading price history…</div>
       </div>
     )
@@ -48,6 +86,7 @@ export default function PriceHistoryChart({
   if (error || !points || points.length === 0) {
     return (
       <div
+        ref={setWrapEl}
         style={{
           height: SVG_H,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -88,35 +127,11 @@ export default function PriceHistoryChart({
     return { y: toY(p), label: formatValue(p) }
   })
 
-  // x-axis labels (4 ticks at first/quarter/half/three-quarter/last)
-  const xTickIdx = [0, Math.floor((points.length - 1) / 3), Math.floor((2 * (points.length - 1)) / 3), points.length - 1]
-  // Heuristic: if the first two timestamps differ by less than a day, this
-  // is intraday data and we want HH:MM labels. Otherwise show MM-DD.
-  const isIntraday = (() => {
-    if (points.length < 2) return false
-    const a = Date.parse(points[0].ts.replace(' ', 'T'))
-    const b = Date.parse(points[1].ts.replace(' ', 'T'))
-    if (Number.isNaN(a) || Number.isNaN(b)) return false
-    return Math.abs(b - a) < 12 * 60 * 60 * 1000
-  })()
-  const xTicks = xTickIdx
-    .filter((idx, i, arr) => i === 0 || idx !== arr[i - 1])  // dedupe at edges
-    .map(idx => {
-      const tsStr = points[idx]?.ts || ''
-      // pandas Timestamps stringify as "2026-05-25 00:00:00+00:00" or
-      // "2026-05-25". Normalize and format based on intraday / daily.
-      const parsed = Date.parse(tsStr.replace(' ', 'T'))
-      let label = tsStr.slice(0, 10)
-      if (!Number.isNaN(parsed)) {
-        const d = new Date(parsed)
-        if (isIntraday) {
-          label = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-        } else {
-          label = `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-        }
-      }
-      return { x: toX(idx), label }
-    })
+  // x-axis labels. Count, format and edge anchoring all come from chartTicks —
+  // see that module for why the label is read lexically out of the series
+  // timestamp instead of via a Date round-trip (#1602).
+  const xTicks = buildXTicks(points, { plotWidth: SVG_W - PAD_L - PAD_R })
+    .map(t => ({ ...t, x: toX(t.index) }))
 
   // Coloring: green if last > first, red otherwise — matches the 24h
   // change badge convention.
@@ -126,37 +141,41 @@ export default function PriceHistoryChart({
   const fill = last >= first ? 'rgba(34,197,94,0.10)' : 'rgba(239,68,68,0.10)'
 
   return (
-    <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} width="100%" style={{ display: 'block', maxHeight: 320 }}>
-      {/* horizontal grid */}
-      {yTicks.map((t, i) => (
-        <line key={i} x1={PAD_L} y1={t.y} x2={SVG_W - PAD_R} y2={t.y}
-          stroke="var(--chart-grid)" strokeWidth="1" />
-      ))}
-      {/* axes */}
-      <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={SVG_H - PAD_B}
-        stroke="var(--chart-grid-strong)" strokeWidth="1" />
-      <line x1={PAD_L} y1={SVG_H - PAD_B} x2={SVG_W - PAD_R} y2={SVG_H - PAD_B}
-        stroke="var(--chart-grid-strong)" strokeWidth="1" />
+    <div ref={setWrapEl}>
+      <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} width="100%" height={SVG_H} style={{ display: 'block' }}>
+        {/* horizontal grid */}
+        {yTicks.map((t, i) => (
+          <line key={i} x1={PAD_L} y1={t.y} x2={SVG_W - PAD_R} y2={t.y}
+            stroke="var(--chart-grid)" strokeWidth="1" />
+        ))}
+        {/* axes */}
+        <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={SVG_H - PAD_B}
+          stroke="var(--chart-grid-strong)" strokeWidth="1" />
+        <line x1={PAD_L} y1={SVG_H - PAD_B} x2={SVG_W - PAD_R} y2={SVG_H - PAD_B}
+          stroke="var(--chart-grid-strong)" strokeWidth="1" />
 
-      {/* y-axis labels */}
-      {yTicks.map((t, i) => (
-        <text key={i} x={PAD_L - 6} y={t.y + 4} textAnchor="end"
-          fill="var(--chart-label)" fontSize="9" className="mono">
-          {t.label}
-        </text>
-      ))}
-      {/* x-axis labels */}
-      {xTicks.map((t, i) => (
-        <text key={i} x={t.x} y={SVG_H - PAD_B + 14} textAnchor="middle"
-          fill="var(--chart-label)" fontSize="9">
-          {t.label}
-        </text>
-      ))}
+        {/* y-axis labels */}
+        {yTicks.map((t, i) => (
+          <text key={i} x={PAD_L - 6} y={t.y + 3.5} textAnchor="end"
+            fill="var(--chart-label)" fontSize="10" className="mono">
+            {t.label}
+          </text>
+        ))}
+        {/* x-axis labels. The first and last are anchored to the plot edges
+            rather than centred on them, so neither hangs into the y-label
+            gutter nor gets clipped by the right edge of the viewBox. */}
+        {xTicks.map((t, i) => (
+          <text key={i} x={t.x} y={SVG_H - PAD_B + 15} textAnchor={t.anchor}
+            fill="var(--chart-label)" fontSize={TICK_FONT_SIZE}>
+            {t.label}
+          </text>
+        ))}
 
-      {/* area under the line */}
-      <path d={areaPath} fill={fill} stroke="none" />
-      {/* main line */}
-      <path d={linePath} fill="none" stroke={stroke} strokeWidth="1.8" strokeLinejoin="round" />
-    </svg>
+        {/* area under the line */}
+        <path d={areaPath} fill={fill} stroke="none" />
+        {/* main line */}
+        <path d={linePath} fill="none" stroke={stroke} strokeWidth="1.8" strokeLinejoin="round" />
+      </svg>
+    </div>
   )
 }

--- a/ui/test/chart-ticks.test.js
+++ b/ui/test/chart-ticks.test.js
@@ -1,0 +1,348 @@
+// x-axis tick guard for the Explore price charts (#1602).
+//
+// The owner report was "the x-axis dates look messed up and not accurate, hard
+// to read". The root cause was a Date round-trip in PriceHistoryChart.jsx:
+//
+//     const d = new Date(Date.parse(ts.replace(' ', 'T')))
+//     label = `${d.getMonth() + 1}-${d.getDate()}`
+//
+// `Date.parse` on an offset-bearing stamp yields an absolute instant, which
+// `getMonth`/`getDate` then read back through the VIEWER'S LOCAL calendar. In
+// America/New_York a UTC-midnight daily close "2026-05-25 00:00:00+00:00" came
+// out as "05-24" — a date that appears nowhere in the series.
+//
+// The property under test is therefore not "the formatter formats"; it is
+// **the rendered label equals the series timestamp's own calendar date, in
+// every timezone**. The timezone-matrix test below is the real guard: it fails
+// against the reverted implementation and passes against this one. Everything
+// in this file is pure — no DOM, no network, no clock read.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+	buildXTicks,
+	chooseTickCount,
+	formatTickLabel,
+	medianStepMs,
+	parseSeriesTimestamp,
+	pickTickFormat,
+} from '../src/chartTicks.js'
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+//
+// Shapes taken from what the backend actually emits: points are
+// `ExploreHistoryPoint(ts=str(pandas.Timestamp), price=float)`
+// (asset_market_service._fetch_yfinance_series), so `ts` is whatever a pandas
+// Timestamp stringifies to — tz-aware UTC for crypto, tz-aware exchange-local
+// for US equities, and tz-naive/date-only for resampled weekly and monthly
+// bars.
+
+/** 10 daily crypto closes, UTC-stamped. The exact shape that mislabelled. */
+const DAILY_UTC = [
+	{ ts: '2026-05-18 00:00:00+00:00', price: 100 },
+	{ ts: '2026-05-19 00:00:00+00:00', price: 101 },
+	{ ts: '2026-05-20 00:00:00+00:00', price: 102 },
+	{ ts: '2026-05-21 00:00:00+00:00', price: 103 },
+	{ ts: '2026-05-22 00:00:00+00:00', price: 104 },
+	{ ts: '2026-05-23 00:00:00+00:00', price: 105 },
+	{ ts: '2026-05-24 00:00:00+00:00', price: 106 },
+	{ ts: '2026-05-25 00:00:00+00:00', price: 107 },
+	{ ts: '2026-05-26 00:00:00+00:00', price: 108 },
+	{ ts: '2026-05-27 00:00:00+00:00', price: 109 },
+]
+
+/** 5 daily US-equity bars, stamped in exchange-local time (yfinance's default
+ * for an equity ticker). */
+const DAILY_EQUITY_ET = [
+	{ ts: '2026-05-18 00:00:00-04:00', price: 200 },
+	{ ts: '2026-05-19 00:00:00-04:00', price: 201 },
+	{ ts: '2026-05-20 00:00:00-04:00', price: 202 },
+	{ ts: '2026-05-21 00:00:00-04:00', price: 203 },
+	{ ts: '2026-05-22 00:00:00-04:00', price: 204 },
+]
+
+/** Intraday 5-minute bars inside one session. */
+const INTRADAY_ONE_DAY = [
+	{ ts: '2026-05-25 09:30:00-04:00', price: 10 },
+	{ ts: '2026-05-25 09:35:00-04:00', price: 11 },
+	{ ts: '2026-05-25 09:40:00-04:00', price: 12 },
+	{ ts: '2026-05-25 09:45:00-04:00', price: 13 },
+	{ ts: '2026-05-25 09:50:00-04:00', price: 14 },
+]
+
+/** Intraday bars spanning two calendar days — what the 1D range actually
+ * returns, because it is served as period "2d". */
+const INTRADAY_TWO_DAYS = [
+	{ ts: '2026-05-25 09:30:00-04:00', price: 10 },
+	{ ts: '2026-05-25 09:35:00-04:00', price: 11 },
+	{ ts: '2026-05-25 09:40:00-04:00', price: 12 },
+	{ ts: '2026-05-26 09:30:00-04:00', price: 13 },
+	{ ts: '2026-05-26 09:35:00-04:00', price: 14 },
+	{ ts: '2026-05-26 09:40:00-04:00', price: 15 },
+]
+
+/** Monthly bars over 10 years (the MAX / 10Y ranges). */
+const MONTHLY_DECADE = Array.from({ length: 121 }, (_, i) => {
+	const year = 2016 + Math.floor(i / 12)
+	const month = (i % 12) + 1
+	return { ts: `${year}-${String(month).padStart(2, '0')}-01 00:00:00`, price: 100 + i }
+})
+
+/** A short window that straddles New Year — "Jan 2" and "Dec 30" alone would
+ * not say which year each belongs to. */
+const STRADDLES_NEW_YEAR = [
+	{ ts: '2025-12-29', price: 50 },
+	{ ts: '2025-12-30', price: 51 },
+	{ ts: '2025-12-31', price: 52 },
+	{ ts: '2026-01-02', price: 53 },
+	{ ts: '2026-01-05', price: 54 },
+]
+
+// Plot widths: the desktop chart is a 720px container less the 56px y-gutter
+// and 18px right pad; the phone case is a 360px container less 44px and 18px.
+const DESKTOP_PLOT_W = 720 - 56 - 18 // 646
+const MOBILE_PLOT_W = 360 - 44 - 18 // 298
+
+// ── The regression guard: labels must not move with the viewer's timezone ───
+
+/** Run `fn` with process.env.TZ set, restoring it afterwards. Node reads TZ
+ * per Date construction, so this genuinely re-homes the local calendar. */
+function withTimezone(tz, fn) {
+	const prev = process.env.TZ
+	process.env.TZ = tz
+	try {
+		return fn()
+	} finally {
+		if (prev === undefined) delete process.env.TZ
+		else process.env.TZ = prev
+	}
+}
+
+// UTC-14 through UTC+14 in practice: one zone well west of UTC (where the old
+// code shifted dates backwards), UTC itself (where the old code was correct,
+// which is why this shipped), and one well east.
+const TIMEZONES = ['America/Los_Angeles', 'America/New_York', 'UTC', 'Europe/Berlin', 'Asia/Tokyo', 'Pacific/Kiritimati']
+
+test('#1602: a UTC-stamped daily close labels its OWN date in every timezone', () => {
+	// This is the exact reported defect. The last bar in the fixture is
+	// 2026-05-27; west of UTC the old implementation rendered "05-26".
+	for (const tz of TIMEZONES) {
+		withTimezone(tz, () => {
+			const ticks = buildXTicks(DAILY_UTC, { plotWidth: DESKTOP_PLOT_W })
+			assert.deepEqual(
+				ticks.map(t => t.label),
+				['May 18', 'May 20', 'May 22', 'May 23', 'May 25', 'May 27'],
+				`x-axis labels drifted in ${tz}`,
+			)
+		})
+	}
+})
+
+test('#1602: every tick label equals the calendar date of the sample it marks', () => {
+	// Stronger than the fixed-list assertion above: whatever ticks are chosen,
+	// each label must be derivable from that sample's own timestamp text. This
+	// is the "no index-as-label, no off-by-one" property stated directly.
+	for (const tz of TIMEZONES) {
+		withTimezone(tz, () => {
+			for (const series of [DAILY_UTC, DAILY_EQUITY_ET, MONTHLY_DECADE, INTRADAY_TWO_DAYS]) {
+				const fmt = pickTickFormat(series)
+				for (const tick of buildXTicks(series, { plotWidth: DESKTOP_PLOT_W })) {
+					const ts = series[tick.index].ts
+					assert.equal(tick.label, formatTickLabel(ts, fmt))
+					// And the label's date parts really are that timestamp's date parts.
+					const f = parseSeriesTimestamp(ts)
+					if (fmt === 'day' || fmt === 'dayYear' || fmt === 'dayTime') {
+						assert.match(tick.label, new RegExp(`\\b${f.day}\\b`), `${tick.label} vs ${ts} in ${tz}`)
+					}
+					if (fmt === 'dayYear' || fmt === 'month' || fmt === 'year') {
+						assert.match(tick.label, new RegExp(`\\b${f.year}\\b`), `${tick.label} vs ${ts} in ${tz}`)
+					}
+				}
+			}
+		})
+	}
+})
+
+test('#1602: a date-only stamp is not shifted either (Date.parse treats it as UTC)', () => {
+	// "2026-05-25" parses as UTC midnight per ECMA-262, so local getters moved
+	// it back a day west of UTC — the same bug through a different door.
+	for (const tz of TIMEZONES) {
+		withTimezone(tz, () => {
+			assert.equal(formatTickLabel('2026-05-25', 'day'), 'May 25')
+			assert.equal(formatTickLabel('2026-05-25', 'dayYear'), 'May 25, 2026')
+			assert.equal(formatTickLabel('2026-05-25', 'year'), '2026')
+		})
+	}
+})
+
+test('#1602: an intraday bar keeps the exchange clock it was stamped with', () => {
+	// A 09:30 ET open must read 09:30 on the axis, not 06:30 because the viewer
+	// is in Los Angeles or 22:30 because they are in Tokyo.
+	for (const tz of TIMEZONES) {
+		withTimezone(tz, () => {
+			const ticks = buildXTicks(INTRADAY_ONE_DAY, { plotWidth: DESKTOP_PLOT_W })
+			assert.equal(ticks[0].label, '09:30', `intraday open drifted in ${tz}`)
+			assert.equal(ticks[ticks.length - 1].label, '09:50', `intraday close drifted in ${tz}`)
+		})
+	}
+})
+
+// ── Lexical parsing ─────────────────────────────────────────────────────────
+
+test('parseSeriesTimestamp reads each pandas stringification the backend emits', () => {
+	assert.deepEqual(parseSeriesTimestamp('2026-05-25'), { year: 2026, month: 5, day: 25, hour: 0, minute: 0 })
+	assert.deepEqual(parseSeriesTimestamp('2026-05-25 00:00:00'), { year: 2026, month: 5, day: 25, hour: 0, minute: 0 })
+	assert.deepEqual(parseSeriesTimestamp('2026-05-25 09:35:00+00:00'), { year: 2026, month: 5, day: 25, hour: 9, minute: 35 })
+	assert.deepEqual(parseSeriesTimestamp('2026-05-25T09:35:00-04:00'), { year: 2026, month: 5, day: 25, hour: 9, minute: 35 })
+})
+
+test('parseSeriesTimestamp rejects junk instead of inventing a date', () => {
+	for (const bad of [null, undefined, 42, '', 'not-a-date', '2026-13-01', '2026-05-32', '2026-05-25 25:00', 'May 25 2026']) {
+		assert.equal(parseSeriesTimestamp(bad), null, `should reject ${JSON.stringify(bad)}`)
+	}
+})
+
+test('formatTickLabel falls back to the raw stamp rather than NaN for junk', () => {
+	// The old code produced "NaN-NaN" here; an honest fallback shows what came in.
+	assert.equal(formatTickLabel('not-a-date', 'day'), 'not-a-date')
+	assert.equal(formatTickLabel(undefined, 'day'), '')
+	assert.doesNotMatch(formatTickLabel('not-a-date', 'day'), /NaN/)
+})
+
+// ── Format selection ────────────────────────────────────────────────────────
+
+test('medianStepMs is robust to one gap (the old first-pair heuristic was not)', () => {
+	// A weekend or a halted session sits between the first two bars. The old
+	// `isIntraday` looked only at points[0] and points[1], so one leading gap
+	// flipped an entire intraday axis to date labels.
+	const gapFirst = [
+		{ ts: '2026-05-22 15:55:00-04:00' },
+		{ ts: '2026-05-25 09:30:00-04:00' }, // 3-day weekend gap
+		{ ts: '2026-05-25 09:35:00-04:00' },
+		{ ts: '2026-05-25 09:40:00-04:00' },
+		{ ts: '2026-05-25 09:45:00-04:00' },
+	].map(p => parseSeriesTimestamp(p.ts))
+	assert.equal(medianStepMs(gapFirst), 5 * 60 * 1000)
+	assert.equal(medianStepMs([]), null)
+	assert.equal(medianStepMs([parseSeriesTimestamp('2026-05-25')]), null)
+})
+
+test('pickTickFormat picks resolution from the bar interval and span', () => {
+	assert.equal(pickTickFormat(INTRADAY_ONE_DAY), 'time')
+	assert.equal(pickTickFormat(INTRADAY_TWO_DAYS), 'dayTime')
+	assert.equal(pickTickFormat(DAILY_UTC), 'day')
+	assert.equal(pickTickFormat(DAILY_EQUITY_ET), 'day')
+	assert.equal(pickTickFormat(STRADDLES_NEW_YEAR), 'dayYear')
+	assert.equal(pickTickFormat(MONTHLY_DECADE), 'year')
+	assert.equal(pickTickFormat([]), 'day')
+})
+
+test('a 1D chart spanning two sessions does not repeat the same clock times', () => {
+	// The 1D range is served as period "2d", so bare HH:MM labels read
+	// "09:30 … 09:30" across the axis with nothing to tell the days apart.
+	const labels = buildXTicks(INTRADAY_TWO_DAYS, { plotWidth: DESKTOP_PLOT_W }).map(t => t.label)
+	assert.deepEqual(labels, [
+		'May 25 09:30', 'May 25 09:35', 'May 25 09:40',
+		'May 26 09:30', 'May 26 09:35', 'May 26 09:40',
+	])
+	assert.equal(new Set(labels).size, labels.length, 'labels must be distinguishable')
+})
+
+test('a decade chart labels years, not bare month-days', () => {
+	// The reported "hard to read": 10 years of "05-25"-style labels carry no
+	// year at all, so every tick looks like it belongs to the same month.
+	const labels = buildXTicks(MONTHLY_DECADE, { plotWidth: DESKTOP_PLOT_W }).map(t => t.label)
+	assert.deepEqual(labels, ['2016', '2018', '2020', '2022', '2024', '2026'])
+})
+
+test('a New-Year-straddling window carries the year on every label', () => {
+	const labels = buildXTicks(STRADDLES_NEW_YEAR, { plotWidth: DESKTOP_PLOT_W }).map(t => t.label)
+	assert.deepEqual(labels, ['Dec 29, 2025', 'Dec 30, 2025', 'Dec 31, 2025', 'Jan 2, 2026', 'Jan 5, 2026'])
+	// The point of the format: "Dec 31" and "Jan 2" alone would not say which
+	// side of the year boundary each tick sits on.
+	assert.ok(labels.every(l => /\b20\d\d$/.test(l)))
+})
+
+// ── Tick density ────────────────────────────────────────────────────────────
+
+test('chooseTickCount never lets two labels touch, at any width', () => {
+	// The property: with n ticks the spacing is plotWidth/(n-1), which must
+	// leave a real gap after the widest label that format can produce.
+	const CHAR_W = 11 * 0.62
+	const WIDEST = { time: 5, dayTime: 12, day: 6, dayYear: 12, month: 8, year: 4 }
+	for (const fmt of Object.keys(WIDEST)) {
+		for (const w of [120, 180, 240, 298, 400, 520, 646, 900, 1400]) {
+			const n = chooseTickCount(w, fmt)
+			assert.ok(n >= 2 && n <= 6, `${fmt}@${w}: ${n} outside [2,6]`)
+			if (n > 2) {
+				const spacing = w / (n - 1)
+				assert.ok(
+					spacing >= WIDEST[fmt] * CHAR_W,
+					`${fmt}@${w}: ${n} ticks gives ${spacing.toFixed(1)}px spacing for a ${(WIDEST[fmt] * CHAR_W).toFixed(1)}px label`,
+				)
+			}
+		}
+	}
+})
+
+test('tick density actually adapts: a phone gets fewer ticks than a desktop', () => {
+	// Guards the whole point of measuring the container. If the viewBox were
+	// still a constant 720, these two would be identical and this fails.
+	const desktop = buildXTicks(MONTHLY_DECADE, { plotWidth: DESKTOP_PLOT_W, format: 'dayYear' })
+	const mobile = buildXTicks(MONTHLY_DECADE, { plotWidth: MOBILE_PLOT_W, format: 'dayYear' })
+	assert.equal(desktop.length, 6)
+	assert.equal(mobile.length, 4)
+	assert.ok(mobile.length < desktop.length)
+	// And the narrower axis still spans the whole series.
+	assert.equal(mobile[0].index, 0)
+	assert.equal(mobile[mobile.length - 1].index, MONTHLY_DECADE.length - 1)
+})
+
+test('chooseTickCount degrades safely on a nonsense width', () => {
+	for (const w of [0, -50, NaN, undefined, Infinity]) {
+		assert.equal(chooseTickCount(w, 'day'), 2, `width ${w} should fall back to 2 ticks`)
+	}
+})
+
+// ── Tick placement ──────────────────────────────────────────────────────────
+
+test('buildXTicks always marks the first and last sample', () => {
+	// These are the two values a reader actually looks up; an axis that omits
+	// the endpoints of the series it is drawing is lying about the range.
+	for (const series of [DAILY_UTC, DAILY_EQUITY_ET, MONTHLY_DECADE, INTRADAY_TWO_DAYS, STRADDLES_NEW_YEAR]) {
+		const ticks = buildXTicks(series, { plotWidth: DESKTOP_PLOT_W })
+		assert.equal(ticks[0].index, 0)
+		assert.equal(ticks[ticks.length - 1].index, series.length - 1)
+	}
+})
+
+test('buildXTicks anchors the edge labels inward so neither is clipped', () => {
+	// Centring the first label hung it into the y-axis gutter; centring the
+	// last pushed it past the right edge of the viewBox, where it was cut off.
+	const ticks = buildXTicks(DAILY_UTC, { plotWidth: DESKTOP_PLOT_W })
+	assert.equal(ticks[0].anchor, 'start')
+	assert.equal(ticks[ticks.length - 1].anchor, 'end')
+	for (const t of ticks.slice(1, -1)) assert.equal(t.anchor, 'middle')
+})
+
+test('buildXTicks indices are strictly increasing and inside the series', () => {
+	for (const series of [DAILY_UTC, MONTHLY_DECADE, INTRADAY_TWO_DAYS]) {
+		const idx = buildXTicks(series, { plotWidth: DESKTOP_PLOT_W }).map(t => t.index)
+		for (let i = 1; i < idx.length; i += 1) assert.ok(idx[i] > idx[i - 1], `not increasing: ${idx}`)
+		assert.ok(idx.every(i => i >= 0 && i < series.length))
+	}
+})
+
+test('buildXTicks handles degenerate series without duplicating a tick', () => {
+	assert.deepEqual(buildXTicks([], { plotWidth: DESKTOP_PLOT_W }), [])
+	assert.deepEqual(buildXTicks(null, { plotWidth: DESKTOP_PLOT_W }), [])
+
+	const one = buildXTicks([{ ts: '2026-05-25', price: 1 }], { plotWidth: DESKTOP_PLOT_W })
+	assert.equal(one.length, 1)
+	assert.equal(one[0].label, 'May 25')
+	assert.equal(one[0].anchor, 'start')
+
+	const two = buildXTicks([{ ts: '2026-05-25', price: 1 }, { ts: '2026-05-26', price: 2 }], { plotWidth: DESKTOP_PLOT_W })
+	assert.deepEqual(two.map(t => t.index), [0, 1])
+	assert.deepEqual(two.map(t => t.label), ['May 25', 'May 26'])
+})


### PR DESCRIPTION
## What

Fixes the Explore price chart's x-axis: dates that did not match the series, labels with no year on multi-year ranges, repeated clock times on the 1D range, edge labels clipped by the viewBox, and ~4.5px axis text on a phone.

x-axis tick logic moves out of `PriceHistoryChart.jsx` into a new pure module `ui/src/chartTicks.js`. That is the `statUtils.js` precedent and it is load-bearing here: `npm test` is `node --test`, which cannot parse JSX, so logic living inside a `.jsx` file can only ever be *text-scanned* by the UI suite, never executed. Moving it out is what makes the formatter testable at all.

## Why — the actual defect

The old code read every timestamp back through the **viewer's local calendar**:

```js
const parsed = Date.parse(tsStr.replace(' ', 'T'))
const d = new Date(parsed)
label = `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
```

`Date.parse` on an offset-bearing stamp yields an absolute instant; `getMonth()`/`getDate()` then re-home that instant in whatever zone the browser is in. A crypto daily close stamped `2026-05-25 00:00:00+00:00` is UTC midnight, which is `2026-05-24 20:00` in `America/New_York` — so the axis labelled the bar **`05-24`**, a date that appears nowhere in the series.

It was also *inconsistent*, which is why it shipped. Per ECMA-262 a tz-naive date-**time** string parses as local wall time (never shifted) but a date-**only** string parses as UTC (shifted by the local getters). Reproduced against the pre-fix code:

```
$ TZ=America/New_York node repro.mjs      # series date is 2026-05-25 in every case
  2026-05-25 00:00:00+00:00    -> "05-24"   <-- wrong (crypto daily close)
  2026-05-25                   -> "05-24"   <-- wrong (resampled weekly/monthly bar)
  2026-05-25 00:00:00-04:00    -> "05-25"   <-- correct (US equity daily bar)
  2026-05-25 00:00:00          -> "05-25"   <-- correct
$ TZ=UTC node repro.mjs
  ...all four -> "05-25"                     <-- correct, which is why this was never caught
```

Half the ranges rendered correctly and half were a day early, in the same chart — exactly "look messed up and not accurate."

**The fix is to never convert.** A bar's label must report the bar's own wall clock, which the series already carries in the string. `parseSeriesTimestamp` reads the calendar fields **lexically** and no `Date` is ever constructed for display, so the rendered label equals the series timestamp by construction, in every timezone. (Re-zoning would also be wrong on the merits: a US equity daily close is the May 25 *session* and must not be relabelled "May 24" because the viewer is in Tokyo.)

Also fixed, all from the same report:

| | before | after |
|---|---|---|
| 5Y / 10Y / MAX | `05-25` — no year at all across a decade | `2016 … 2026` |
| 1D (served as period `2d`) | `09:30 … 09:30` repeating across two sessions | `May 25 09:30 … May 26 09:40` |
| window straddling New Year | `Dec 31`, `Jan 2` — which year? | `Dec 31, 2025`, `Jan 2, 2026` |
| first/last label | centred on the plot edge → hung into the y-gutter / clipped by the viewBox | anchored `start` / `end` |
| tick count | always 4, fixed | derived from available width, never overlapping |
| axis text on a 360px phone | ~4.5px (9 units in a fixed 720 viewBox) | true 11px (viewBox sized to the measured container) |
| intraday detection | `points[0]` vs `points[1]` — one weekend gap flipped the whole axis | median step |

## Test commands + output

```
$ cd ui && npm ci && npm test
ℹ tests 633
ℹ suites 0
ℹ pass 633
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1425.889375
```

633 = 614 on `main` before this change + 19 new. New file only:

```
$ node --test test/chart-ticks.test.js
ℹ tests 19
ℹ pass 19
ℹ fail 0
```

```
$ npx eslint .          # whole ui/, clean, no output
$ npm run build
✓ built in 2.04s
```

Tests are hermetic: pure functions, no DOM, no network, no DB, no `.env`, no clock read. The only environment they touch is `process.env.TZ`, which they set and restore themselves.

## Demonstration 1 — the regression test fails with the fix reverted

Reverted `parseSeriesTimestamp` to the pre-#1602 `Date` round-trip, changing nothing else:

```js
export function parseSeriesTimestamp(ts) {
  if (typeof ts !== 'string') return null
  const parsed = Date.parse(ts.replace(' ', 'T'))
  if (Number.isNaN(parsed)) return null
  const d = new Date(parsed)
  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate(),
           hour: d.getHours(), minute: d.getMinutes() }
}
```

```
$ TZ=America/Los_Angeles node --test test/chart-ticks.test.js
✖ #1602: a UTC-stamped daily close labels its OWN date in every timezone
✔ #1602: every tick label equals the calendar date of the sample it marks
✖ #1602: a date-only stamp is not shifted either (Date.parse treats it as UTC)
✖ #1602: an intraday bar keeps the exchange clock it was stamped with
✖ parseSeriesTimestamp reads each pandas stringification the backend emits
✖ parseSeriesTimestamp rejects junk instead of inventing a date
✔ formatTickLabel falls back to the raw stamp rather than NaN for junk
✔ medianStepMs is robust to one gap (the old first-pair heuristic was not)
✔ pickTickFormat picks resolution from the bar interval and span
✖ a 1D chart spanning two sessions does not repeat the same clock times
✔ a decade chart labels years, not bare month-days
✖ a New-Year-straddling window carries the year on every label
✔ chooseTickCount never lets two labels touch, at any width
✔ tick density actually adapts: a phone gets fewer ticks than a desktop
✔ chooseTickCount degrades safely on a nonsense width
✔ buildXTicks always marks the first and last sample
✔ buildXTicks anchors the edge labels inward so neither is clipped
✔ buildXTicks indices are strictly increasing and inside the series
✖ buildXTicks handles degenerate series without duplicating a tick
ℹ pass 11
ℹ fail 8
```

The headline guard, verbatim:

```
✖ #1602: a UTC-stamped daily close labels its OWN date in every timezone
  AssertionError [ERR_ASSERTION]: x-axis labels drifted in America/Los_Angeles
  + actual - expected

    [
  +   'May 17',
  +   'May 19',
  +   'May 21',
  -   'May 18',
  -   'May 20',
      'May 22',
  +   'May 24',
  +   'May 26'
  -   'May 23',
  -   'May 25',
  -   'May 27'
    ]
```

Restoring the fix returns `19 pass / 0 fail`.

**The reverted tally is itself timezone-dependent — read the failing-test names, not the count.** The transcript above is `TZ=America/Los_Angeles`. Two of those eight tests (`a New-Year-straddling window…`, `buildXTicks handles degenerate series…`) use date-only stamps and inherit the runner's ambient zone, so they only break west of UTC:

```
$ for tz in UTC America/Chicago America/Los_Angeles Asia/Tokyo; do TZ=$tz node --test test/chart-ticks.test.js; done
UTC                  -> 13 pass / 6 fail
America/Chicago      -> 11 pass / 8 fail
America/Los_Angeles  -> 11 pass / 8 fail
Asia/Tokyo           -> 13 pass / 6 fail
```

**Six tests fail under revert in every zone tested, including UTC** — those are the real guards, and they bite because they set `TZ` themselves rather than inheriting it:

```
✖ #1602: a UTC-stamped daily close labels its OWN date in every timezone
✖ #1602: a date-only stamp is not shifted either (Date.parse treats it as UTC)
✖ #1602: an intraday bar keeps the exchange clock it was stamped with
✖ parseSeriesTimestamp reads each pandas stringification the backend emits
✖ parseSeriesTimestamp rejects junk instead of inventing a date
✖ a 1D chart spanning two sessions does not repeat the same clock times
```

The **committed** suite is zone-independent, which is the property that actually matters — `parseSeriesTimestamp` is lexical and constructs no `Date`, so there is nothing left for the ambient zone to move. Verified across the full UI suite:

```
$ for tz in UTC America/New_York America/Los_Angeles Asia/Tokyo Pacific/Kiritimati Australia/Sydney; do TZ=$tz npm test; done
UTC                  -> 633 pass / 0 fail
America/New_York     -> 633 pass / 0 fail
America/Los_Angeles  -> 633 pass / 0 fail
Asia/Tokyo           -> 633 pass / 0 fail
Pacific/Kiritimati   -> 633 pass / 0 fail
Australia/Sydney     -> 633 pass / 0 fail
```

Note that one test — "every tick label equals the calendar date of the sample it marks" — **passes both ways**. It compares `buildXTicks`'s label against `formatTickLabel` on the same timestamp, so both sides move together under the reverted code. It is a useful internal-consistency check but it is **not** a regression guard for this bug, and I am not counting it as one (CLAUDE.md rule 3).

### End-to-end, not just the module

The pure module is only half the claim, so I bundled the real `PriceHistoryChart.jsx` with the project's own bundler and server-rendered it, then read the `<text>` elements the browser actually receives. Fixture series spans **2026-05-18 → 2026-05-27**:

```
### WITH THE FIX
America/New_York       "May 18" "May 20" "May 22" "May 23" "May 25" "May 27"
UTC                    "May 18" "May 20" "May 22" "May 23" "May 25" "May 27"
Asia/Tokyo             "May 18" "May 20" "May 22" "May 23" "May 25" "May 27"
Pacific/Kiritimati     "May 18" "May 20" "May 22" "May 23" "May 25" "May 27"

### WITH THE FIX REVERTED
America/New_York       "May 17" "May 19" "May 21" "May 22" "May 24" "May 26"   <-- whole axis a day early
UTC                    "May 18" "May 20" "May 22" "May 23" "May 25" "May 27"
Asia/Tokyo             "May 18" "May 20" "May 22" "May 23" "May 25" "May 27"
```

Rendered layout attributes confirm the anchoring and sizing fixes:

```
viewBox: 0 0 720 259 | height attr: 259
   x=   56.0  anchor=start   "May 18"      <-- was anchor=middle, hung into the y-gutter
   x=  199.6  anchor=middle  "May 20"
   x=  343.1  anchor=middle  "May 22"
   x=  414.9  anchor=middle  "May 23"
   x=  558.4  anchor=middle  "May 25"
   x=  702.0  anchor=end     "May 27"      <-- was anchor=middle, overhung the 720 viewBox
```

## Demonstration 2 — the guards reject bad input

Each guard was fed the input it is supposed to catch, and confirmed to fail.

**2a. Tick-density guard, bounds half.** Cranked `MAX_TICKS` 6 → 12, the plausible "let's show more ticks" edit:

```
$ node --test --test-name-pattern "never lets two labels touch"
✖ chooseTickCount never lets two labels touch, at any width
  AssertionError [ERR_ASSERTION]: time@400: 8 outside [2,6]
ℹ pass 0
ℹ fail 1
```

**2b. Tick-density guard, spacing half.** 2a fired on the bounds assertion, so the *spacing* assertion is separately un-vacuous-ed by making the formula under-estimate label width (`CHAR_WIDTH_RATIO` 0.62 → 0.20, `TICK_GAP` 16 → 0):

```
$ node --test --test-name-pattern "never lets two labels touch"
✖ chooseTickCount never lets two labels touch, at any width
  AssertionError [ERR_ASSERTION]: time@120: 6 ticks gives 24.0px spacing for a 34.1px label
ℹ pass 0
ℹ fail 1
```

**2c. Index-as-label** — the exact anti-bug named on the issue. Replaced the label with the array index:

```js
-    label: formatTickLabel(points[index] && points[index].ts, fmt),
+    label: String(index),
```

```
$ node --test test/chart-ticks.test.js
ℹ pass 12
ℹ fail 7
```

**2d. Junk timestamps.** `parseSeriesTimestamp` is asserted to return `null` — not a fabricated date — for `null`, `undefined`, `42`, `''`, `'not-a-date'`, `'2026-13-01'`, `'2026-05-32'`, `'2026-05-25 25:00'`, `'May 25 2026'`, and `formatTickLabel` is asserted never to emit `NaN` (the old code rendered `"NaN-NaN"` on unparseable input).

All modifications above were reverted; the committed tree is `633 pass / 0 fail`.

## Files

- `ui/src/chartTicks.js` — **new**, pure tick logic
- `ui/test/chart-ticks.test.js` — **new**, 19 tests
- `ui/src/components/PriceHistoryChart.jsx` — consume the module; measured viewBox; edge anchors; axis font 9→11 (x) and 9→10 (y)
- `ui/eslint.config.js` — give `test/**` Node globals (`npm test` *is* `node --test`; the timezone matrix needs `process.env.TZ`). Repo lint was clean before and after; the only 4 errors this introduced were the ones this line fixes.

## Not done here

- **No data-fetch changes and no charting-library swap** — both anti-goals on the issue. `AssetModal`/`AssetGroupModal` fetch code is untouched; the chart is still hand-rolled SVG.
- **The "light Explore cleanup alongside #1218" mentioned on the issue is NOT done.** I scoped this to the chart the report was about. The issue does not say what that cleanup is, and I did not want to guess at owner intent in a PR whose testable claim is about dates. Worth a follow-up issue with specifics.
- **No visual/screenshot regression test.** The repo has no DOM or snapshot test infra for `ui/` and adding one is well beyond this issue. The end-to-end render above was a one-off verification run, not committed — the committed guard is the pure-module suite.
- **`CHAR_WIDTH_RATIO = 0.62` is an estimate**, not a measured text advance. It is deliberately conservative (real sans digits/letters at 11px average below this), and the guard asserts the resulting spacing clears the widest label each format can produce. A browser `measureText` would be exact but needs a canvas at render time.
- **Plot height is now `clamp(220, width*0.36, 320)`** rather than a fixed 260-unit viewBox with `maxHeight: 320`. At the 720px width the old code assumed this is 259 vs 260, and in the widest modal (860px) it is 310 vs the old ~320 — visually equivalent. Called out because it is a rendered-size change beyond the x-axis.
- **`pickTickFormat` thresholds (12h / 180d / 1100d) are judgement calls**, tested at the boundaries the real ranges produce but not tuned against every possible series.

Closes #1602

