### PR TITLE
[perf] Defer artifact_json on the latest-backtests hot read (Aurora read amplification)

### DIFF
--- a/backend/archimedes/services/backtest_repository.py
+++ b/backend/archimedes/services/backtest_repository.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, defer
 
 from archimedes.models.backtest import BacktestResult
 from archimedes.models.backtest_store import BacktestResultRecord
@@ -284,6 +284,40 @@ def latest_backtests_by_strategy(
     )
     latest_ids = select(ranked.c.id).where(ranked.c.rank == 1)
 
-    rows = session.query(BacktestResultRecord).filter(BacktestResultRecord.id.in_(latest_ids)).all()
+    # PROJECTION, not just row count (issue #1543). The inner query above already
+    # stopped this reader from hydrating N_refreshes x N_strategies ROWS; the
+    # outer query still selected every COLUMN of the winners, so each of the
+    # ~30-96 rows it does return dragged its `artifact_json` blob across the
+    # wire. Nothing downstream of this function reads that column:
+    # `BacktestResultRecord.to_backtest_result()` never touches it, and neither
+    # does any caller (strategy_provider._load_backtests, backtest_scheduler's
+    # staleness/backoff checks, the num_trials/returns/rigor route lookups, and
+    # audit_backtest_universe all read scalars or call to_backtest_result). The
+    # one reader that genuinely needs the blob, `get_daily_returns` above, issues
+    # its OWN single-row query and is unaffected by a per-query option here.
+    #
+    # Size, using this repo's own verified column averages (2026-08-19, quoted in
+    # scripts/archive_backtest_results.py): artifact_json ~349 KB/row against
+    # equity_curve_json ~63 KB/row, so the deferred column is ~85% of each
+    # returned row's payload bytes. equity_curve_json is deliberately NOT
+    # deferred: `to_backtest_result()` deserializes it and `api/risk_routes.py`
+    # consumes `BacktestResult.equity_curve` off the provider cache, so deferring
+    # it would either change what those surfaces return or trigger a lazy load
+    # against a session `strategy_provider._load_backtests` has already closed.
+    #
+    # `defer` (a per-query option) rather than `deferred=True` on the mapper: it
+    # keeps the change scoped to this hot read instead of silently re-shaping
+    # every other query against the table. Plain `defer`, not
+    # `defer(..., raiseload=True)`: a future caller that touches the attribute
+    # inside the session gets one extra small SELECT, whereas raiseload would
+    # raise into `_load_backtests`'s except-branch and silently degrade the whole
+    # library to "no backtests" — a fail-soft path turning a perf option into a
+    # correctness bug.
+    rows = (
+        session.query(BacktestResultRecord)
+        .options(defer(BacktestResultRecord.artifact_json))
+        .filter(BacktestResultRecord.id.in_(latest_ids))
+        .all()
+    )
 
     return {row.strategy_id: row for row in rows}

--- a/backend/tests/test_backtest_repository.py
+++ b/backend/tests/test_backtest_repository.py
@@ -356,3 +356,214 @@ def test_latest_backtests_empty_ids_short_circuits() -> None:
         assert latest_backtests_by_strategy(session, []) == {}
     finally:
         session.close()
+
+
+# ── Query SHAPE: the hot read must not select artifact_json (issue #1543) ──
+#
+# The row-count tests above pin how MANY rows this reader hydrates. They say
+# nothing about how WIDE each row is, and that is the other half of the same
+# defect: the outer query selected every column of the winners, so each
+# returned row dragged its `artifact_json` blob (~349 KB/row by this repo's own
+# verified 2026-08-19 averages, quoted in scripts/archive_backtest_results.py)
+# across the wire on a path that never reads it. These tests pin the projection.
+
+
+def _capture_sql(engine) -> tuple[list[str], object]:
+    """Attach a before_cursor_execute listener; return (statements, detach)."""
+    statements: list[str] = []
+
+    def _on_exec(_conn, _cursor, statement, _params, _context, _executemany) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _on_exec)
+
+    def _detach() -> None:
+        event.remove(engine, "before_cursor_execute", _on_exec)
+
+    return statements, _detach
+
+
+def _selects_from_backtest_results(statements: list[str]) -> list[str]:
+    """The captured statements that are SELECTs against backtest_results."""
+    return [s for s in statements if s.lstrip().upper().startswith("SELECT") and "backtest_results" in s]
+
+
+def _seeded_session_with_artifacts(n_strategies: int, n_cycles: int, artifact_bytes: int = 4096):
+    """Like _seeded_session, but every row carries a non-empty artifact_json.
+
+    A NULL blob would make "the reader does not transfer it" trivially true, so
+    the fixture gives the deferred column real content to omit.
+    """
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    ids = [f"strat_{i:03d}" for i in range(n_strategies)]
+    blob = '{"results": [{"metrics": {"pad": "' + ("x" * artifact_bytes) + '"}}]}'
+    for cycle in range(n_cycles):
+        for sid in ids:
+            insert_backtest_if_missing(
+                session,
+                strategy_id=sid,
+                content_hash=f"{sid}-cycle-{cycle}",
+                result=_sample_result(sid, float(cycle)),
+                source_pipeline="run_backtests",
+                run_id=f"run-{cycle}",
+                artifact_json=blob,
+            )
+    session.commit()
+    return session, SessionLocal, ids
+
+
+def test_latest_backtests_does_not_select_artifact_json() -> None:
+    """THE GUARD (#1543): the hot read must not put artifact_json in its SELECT.
+
+    Reverting the `.options(defer(...))` in latest_backtests_by_strategy makes
+    this fail — the ORM renders `backtest_results.artifact_json` in the column
+    list again.
+    """
+    session, _SessionLocal, ids = _seeded_session_with_artifacts(n_strategies=6, n_cycles=3)
+    try:
+        session.expunge_all()
+        statements, detach = _capture_sql(session.get_bind())
+        try:
+            latest = latest_backtests_by_strategy(session, ids)
+        finally:
+            detach()
+
+        assert set(latest) == set(ids)
+
+        selects = _selects_from_backtest_results(statements)
+        # Non-vacuity: if the listener never fired (wrong engine, wrong event)
+        # the "artifact_json absent" assertion below would pass over an empty
+        # list and guard nothing. Pin that a real, recognisable ORM projection
+        # was observed before trusting its contents.
+        assert selects, "captured no SELECT against backtest_results — the listener did not fire"
+        assert any("backtest_results.sharpe_ratio" in s for s in selects), (
+            "captured no hydrating SELECT with a column list; "
+            f"the assertion below would be vacuous. statements={selects!r}"
+        )
+
+        offenders = [s for s in selects if "artifact_json" in s]
+        assert not offenders, (
+            "latest_backtests_by_strategy selected artifact_json "
+            f"(~349 KB/row) on a path that never reads it: {offenders!r}"
+        )
+    finally:
+        session.close()
+
+
+def test_sql_capture_detects_artifact_json_when_it_is_present() -> None:
+    """ADVERSARIAL CONTROL: feed the guard a query that SHOULD fail it.
+
+    The un-projected query below is exactly what latest_backtests_by_strategy
+    emitted before the fix. If `_selects_from_backtest_results` + the substring
+    check could not see artifact_json here, the test above would be a
+    tautology that passes against the unfixed code too.
+    """
+    session, _SessionLocal, ids = _seeded_session_with_artifacts(n_strategies=3, n_cycles=2)
+    try:
+        session.expunge_all()
+        statements, detach = _capture_sql(session.get_bind())
+        try:
+            # No .options(defer(...)) — the pre-fix shape.
+            session.query(BacktestResultRecord).filter(BacktestResultRecord.strategy_id.in_(ids)).all()
+        finally:
+            detach()
+
+        selects = _selects_from_backtest_results(statements)
+        assert selects, "captured no SELECT against backtest_results"
+        assert any("artifact_json" in s for s in selects), (
+            "the detector failed to see artifact_json in an un-projected SELECT, "
+            "so it cannot prove the projected one omits it"
+        )
+    finally:
+        session.close()
+
+
+def test_deferred_artifact_json_does_not_change_what_callers_read() -> None:
+    """Projection is a transfer-size change, not a data change.
+
+    Every field to_backtest_result() exposes must survive, equity_curve
+    (deliberately NOT deferred — api/risk_routes.py consumes it off the
+    provider cache) included, and reading them must emit no follow-up SQL.
+    """
+    session, _SessionLocal, ids = _seeded_session_with_artifacts(n_strategies=4, n_cycles=3)
+    try:
+        session.expunge_all()
+        latest = latest_backtests_by_strategy(session, ids)
+
+        statements, detach = _capture_sql(session.get_bind())
+        try:
+            results = {sid: row.to_backtest_result() for sid, row in latest.items()}
+        finally:
+            detach()
+
+        assert not _selects_from_backtest_results(statements), (
+            "to_backtest_result() triggered a lazy load — the deferred column "
+            "is being touched on the hot path after all"
+        )
+        for sid in ids:
+            res = results[sid]
+            assert res.strategy_id == sid
+            assert res.sharpe_ratio == 2.0  # newest cycle
+            assert res.equity_curve == [100000, 101000]
+            assert res.monthly_returns == [0.01]
+            assert res.backtest_engine == "backtrader"
+            assert res.backtest_start == date(2020, 1, 1)
+    finally:
+        session.close()
+
+
+def test_deferred_artifact_json_is_still_reachable_in_session() -> None:
+    """Deferral must not make the column unreadable — only unfetched by default.
+
+    `defer` (not `defer(..., raiseload=True)`) is the deliberate choice: a
+    caller that does touch the attribute inside the session gets one extra
+    SELECT rather than an exception that strategy_provider._load_backtests
+    would swallow into "no backtests at all".
+    """
+    session, _SessionLocal, ids = _seeded_session_with_artifacts(n_strategies=2, n_cycles=2)
+    try:
+        session.expunge_all()
+        latest = latest_backtests_by_strategy(session, ids)
+        row = latest[ids[0]]
+        assert row.artifact_json is not None
+        assert "results" in row.artifact_json
+    finally:
+        session.close()
+
+
+def test_provider_backtest_load_does_not_select_artifact_json(tmp_path, monkeypatch) -> None:
+    """The production hot path, not just the repository helper.
+
+    LocalStrategyProvider._load_backtests is what runs on every
+    default_provider() construction (issue #1543's amplifier). Mocked at the
+    DB boundary only — the session factory — so the real provider method,
+    the real repository query and the real ORM mapping all execute.
+    """
+    from archimedes.services import strategy_provider as sp
+
+    session, SessionLocal, ids = _seeded_session_with_artifacts(n_strategies=5, n_cycles=3)
+    engine = session.get_bind()
+    session.close()
+
+    monkeypatch.setattr(sp, "get_session", SessionLocal)
+
+    # A non-existent strategies dir makes refresh() return early without any DB
+    # access, so construction cannot pollute the capture below.
+    provider = sp.LocalStrategyProvider(tmp_path / "no-such-strategies-dir")
+
+    statements, detach = _capture_sql(engine)
+    try:
+        loaded = provider._load_backtests(ids)
+    finally:
+        detach()
+
+    assert set(loaded) == set(ids)
+    selects = _selects_from_backtest_results(statements)
+    assert selects, "provider hot path emitted no SELECT against backtest_results"
+    assert any("backtest_results.sharpe_ratio" in s for s in selects), f"no hydrating SELECT captured: {selects!r}"
+    assert not [s for s in selects if "artifact_json" in s], (
+        f"provider hot path still transfers artifact_json: {[s for s in selects if 'artifact_json' in s]!r}"
+    )


### PR DESCRIPTION
## What

One line of behaviour change: the `latest_backtests_by_strategy` read now defers the `artifact_json` column.

```python
rows = (
    session.query(BacktestResultRecord)
    .options(defer(BacktestResultRecord.artifact_json))
    .filter(BacktestResultRecord.id.in_(latest_ids))
    .all()
)
```

Plus query-**shape** regression tests, which this repo did not have (the existing guards on this function pin row **count**).

## Why

#1543 traced ~1.5 MB/s of sustained Aurora `NetworkTransmitThroughput` serving ~0.03 GB/day of ALB traffic, with `ReadIOPS` at 0.31–6.72/s and CPU ~3% — the same rows served out of buffer cache over and over. The issue names `default_provider()` rebuilding per call as the *frequency* half. This PR fixes the *width* half: how many bytes each of those rebuilds moves.

Traced, not inferred:

- `LocalStrategyProvider.refresh()` → `_load_backtests()` → `latest_backtests_by_strategy()` runs on **every** `default_provider()` construction.
- That function's inner window-function subquery already selects only `id` (a prior fix, PR comment still in the file), so it hydrates N rows, not N×refreshes. But the **outer** query was `session.query(BacktestResultRecord).filter(...)`, i.e. every column of the winners — including `artifact_json`.
- Nothing downstream reads that column. `BacktestResultRecord.to_backtest_result()` never references it (grep the mapper — 41 fields, `artifact_json` is not one). Neither does any caller: `strategy_provider._load_backtests` (calls `to_backtest_result`), `backtest_scheduler.needs_refresh` / `_remember_unresolved_missing` (read `created_at` + key presence), `strategies_routes` `_num_trials_*` and `/returns` (read `backtest_engine`, `num_trials_in_selection`, `backtest_start/end`), `selection_bias_routes` (reads `pbo_score`, `look_ahead_audit_passed`), `scripts/audit_backtest_universe`.
- The one reader that genuinely needs the blob — `get_daily_returns` — issues its own single-row query and is untouched by a per-query option here.

Size, from this repo's own verified 2026-08-19 column averages (`scripts/archive_backtest_results.py` lines 119–120): `artifact_json` **349 000 B/row** vs `equity_curve_json` **63 000 B/row**. The deferred column is **~85% of each returned row's payload bytes** on this path.

`equity_curve_json` is deliberately **not** deferred: `to_backtest_result()` deserializes it and `api/risk_routes.py` consumes `BacktestResult.equity_curve` off the provider cache (lines 115, 375–377, 489), so deferring it would either change what those surfaces return or trigger a lazy load against a session `_load_backtests` has already closed.

`defer` (per-query option) rather than `deferred=True` on the mapper, so this does not silently re-shape every other query against the table. Plain `defer`, not `defer(..., raiseload=True)` — a future caller touching the attribute inside the session pays one extra small SELECT, whereas `raiseload` would raise into `_load_backtests`' `except` branch and silently degrade the whole library to "no backtests", turning a perf option into a correctness bug.

## Migrations

**No migration in this PR.** `defer()` is an ORM query option; there is no DDL. Verified the head is unchanged and singular:

```
$ cd backend && alembic heads
d7c41f9b2e58 (head)

$ git status --porcelain backend/migrations/
(no output — no migration files added or changed)
```

## Tests

All commands run with the env's absolute interpreter, hermetically (`env -i`, no `.env`, no network, no DB — in-memory SQLite only).

**1. Touched file + the two migration suites named in scope**

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend TESTING=1 \
    /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest \
    backend/tests/test_backtest_repository.py \
    backend/tests/test_alembic_migrations.py \
    backend/tests/test_account_deletion_cascade.py -q --no-header -p no:cacheprovider

=================== 46 passed, 1 warning in 75.73s (0:01:15) ===================
```

**2. Every consumer of the changed read path**

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend TESTING=1 \
    /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest \
    backend/tests/test_backtest_scheduler.py backend/tests/test_risk_routes.py \
    backend/tests/test_selection_bias_routes.py \
    backend/tests/test_selection_bias_generated_gate.py -q --no-header -p no:cacheprovider

====================== 106 passed, 12 warnings in 24.47s =======================
```

**3. The full CI unit command, from the repo root**

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend TESTING=1 \
    /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/python -m pytest \
    -m "not integration" -q --no-header -p no:cacheprovider

=== 4795 passed, 3 skipped, 2 deselected, 320 warnings in 441.97s (0:07:21) ====
```

**4. Lint on touched files**

```
$ ruff format --check backend/archimedes/services/backtest_repository.py backend/tests/test_backtest_repository.py
2 files already formatted

$ ruff check backend/archimedes/services/backtest_repository.py backend/tests/test_backtest_repository.py
All checks passed!
```

## Revert demo (rule 3 — the test must fail against the unfixed code)

Reverted the fix in place — `.options(defer(...))` removed, restoring the exact pre-fix line — and re-ran the file:

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend TESTING=1 python -m pytest \
    backend/tests/test_backtest_repository.py -q --no-header -p no:cacheprovider --tb=no -rf

=========================== short test summary info ============================
FAILED backend/tests/test_backtest_repository.py::test_latest_backtests_does_not_select_artifact_json - AssertionError: latest_backtests_by_strategy selected artifact_json (~349 K...
FAILED backend/tests/test_backtest_repository.py::test_provider_backtest_load_does_not_select_artifact_json - AssertionError: provider hot path still transfers artifact_json: ['SELECT b...
=================== 2 failed, 13 passed, 1 warning in 2.78s ====================
```

The failure message carries the offending SQL, which is the pre-fix shape verbatim:

```
E   AssertionError: latest_backtests_by_strategy selected artifact_json (~349 KB/row) on a path that never reads it:
    ['SELECT backtest_results.id AS backtest_results_id, ... backtest_results.look_ahead_audit_source AS
      backtest_results_look_ahead_audit_source, backtest_results.artifact_json AS backtest_results_artifact_json,
      backtest_results.created_at AS backtest_results_created_at, ...
      FROM backtest_results
      WHERE backtest_results.id IN (SELECT anon_1.id FROM (SELECT backtest_results.id AS id, row_number() OVER
      (PARTITION BY backtest_results.strategy_id ORDER BY backtest_results.created_at DESC, backtest_results.id DESC)
      AS rank FROM backtest_results WHERE backtest_results.strategy_id IN (?, ?, ?, ?, ?, ?)) AS anon_1
      WHERE anon_1.rank = ?)']
```

Fix restored → `15 passed`.

## Adversarial demo (rule 4 — the guard must be shown to reject something)

A SQL-shape assertion has one obvious way to be a tautology: if the event listener never fires, the captured statement list is empty and `"artifact_json" not in <nothing>` passes while guarding nothing. Both halves were built and run.

**a) Positive control, shipped as a permanent test.** `test_sql_capture_detects_artifact_json_when_it_is_present` runs the *un-projected* query — literally the pre-fix shape — through the same capture helper and asserts the detector **does** see `artifact_json`. If it could not, the guard above would be meaningless. It passes.

**b) The non-vacuity assertion, fed the input it should reject.** A throwaway probe attached the capture to an unrelated engine (nothing ever executes there — the "listener silently didn't fire" failure mode) and ran the guard's assertion chain:

```
$ python -m pytest backend/tests/test_zz_vacuity_probe.py -q --no-header --tb=short

backend/tests/test_zz_vacuity_probe.py:32:
    assert selects, "captured no SELECT against backtest_results — the listener did not fire"
E   AssertionError: captured no SELECT against backtest_results — the listener did not fire
E   assert []
========================= 1 failed, 1 warning in 1.51s =========================
```

Rejected as required. The probe file was deleted before commit; the assertion it exercised (`assert selects` + `assert any("backtest_results.sharpe_ratio" in s ...)`) ships inside both guard tests.

**c) The test fixture cannot pass trivially.** `_seeded_session_with_artifacts` writes a **non-empty** `artifact_json` on every row. A `NULL` blob would make "this reader does not transfer it" true by accident.

## Not done here — honest scope

**This PR does not close #1543, and I did not write `Closes #1543`.** The issue's acceptance is *"an order-of-magnitude drop in `NetworkTransmitThroughput`, measured before/after"*. This change removes ~85% of the per-row payload on the hot read (~6.6×, not 10×), and I cannot measure prod CloudWatch from here. Leaving the issue open with this landed is the honest state.

Specifically still open:

1. **The frequency half — `default_provider()` rebuilding per call** (`strategy_provider.py:707`), which is the mechanism #1543 names. Caching the provider changes staleness semantics and needs its own invalidation story against the fail-soft rule; it is a separate logical change and a separate PR.
2. **The before/after CloudWatch measurement.** Needs prod access and a post-deploy window. Until it exists, no one should claim a percentage drop in production from this PR — the ~85% figure above is a payload-bytes calculation from the repo's own measured column averages, not a measured `NetworkTransmitThroughput` delta.
3. **`equity_curve_json` (~63 KB/row) still crosses the wire on this path**, including for the two `backtest_scheduler` callers that only need `created_at` and key presence. Narrowing those to a dedicated projection is a further win and a further logical change.
4. **`get_all_daily_returns` still issues one full-row query per strategy** (`get_daily_returns` in a loop), each pulling `artifact_json` — which that reader genuinely needs, so it is an N+1 shape question, not a projection one. Untouched.
5. No index was added. The `latest per strategy` and `get_daily_returns` orderings are already covered by the existing `ix_backtest_strategy_created` (`strategy_id`, `created_at`); adding another would have been unfounded.

Refs #1543.
