### PR TITLE
[cost] Serve the measured $/generation on the admin cost dashboard

### DIFF
--- a/backend/archimedes/api/metrics_private_routes.py
+++ b/backend/archimedes/api/metrics_private_routes.py
@@ -18,9 +18,13 @@ gets **401** (session check runs first).
 Account denominator comes from canonical Better Auth users, never cumulative
 request tallies or optional linked-wallet/profile counts.
 
-Today's cost fields are DRAFT/illustrative placeholders (the live Bedrock/infra
-billing wiring — AWS Cost Explorer + Bedrock token metering — is roadmap work);
-they are labelled ``draft`` so a reader can't mistake them for metered live spend.
+The account-level AWS cost fields are DRAFT/illustrative placeholders (the live
+Bedrock/infra billing wiring — AWS Cost Explorer + Bedrock token metering — is
+roadmap work); they are labelled ``draft`` so a reader can't mistake them for
+metered live spend. ``cost_per_generation_usd`` is the exception as of #1217:
+it is derived from real ``generation_costs`` measurements priced against the
+``GENERATION_COST_RATE_CARD`` env rate card (``services/generation_cost_rollup``),
+and carries its own provenance rather than sharing the ``draft`` label.
 Real distinct users are read live so the per-user denominators are honest.
 
 Owner directive (2026-08-20, SUPERSEDES issue #1028 D8 "public Insights page"):
@@ -56,6 +60,7 @@ from archimedes.models.telemetry import (
     WalletsResponse,
 )
 from archimedes.services.engagement_metrics import get_engagement_snapshot
+from archimedes.services.generation_cost_rollup import get_measured_generation_cost
 from archimedes.services.identity_metrics import (
     count_human_wallets,
     list_human_wallets,
@@ -123,24 +128,53 @@ async def get_private_cost(wallet: str = Depends(require_platform_admin)) -> dic
     """Account + admin-linked-wallet cost dashboard. Anonymous
     → 401; verified-but-non-admin → 403.
 
-    Cost fields are DRAFT placeholders until the live billing wiring lands
-    (roadmap: AWS Cost Explorer + Bedrock token metering). ``real_users`` is read
-    live so any per-user figure a consumer computes is anchored to the honest
-    distinct-user denominator, never the request counter.
+    **Two provenances on one payload, and they are labelled separately (#1217).**
+    The account-level AWS spend fields (``bedrock_*``, ``infra_monthly_usd``,
+    ``cost_per_user_usd``) are still DRAFT placeholders pending the live billing
+    wiring (roadmap: AWS Cost Explorer + Bedrock token metering) — that is what
+    the top-level ``source: "draft"`` describes, and it is deliberately
+    unchanged. ``cost_per_generation_usd`` is no longer one of them: it is now
+    derived from the ``generation_costs`` measurements this platform actually
+    recorded, priced against the ``GENERATION_COST_RATE_CARD`` environment rate
+    card, with the full distribution and the N-scaling breakdown under
+    ``generation_cost``.
+
+    It stays ``None`` — never ``0`` — when no rate card is configured or no
+    measured run was priceable, and ``generation_cost.rate_card_configured`` /
+    ``.unpriceable_reasons`` say which. A null here means "not measured or not
+    priceable", exactly as before; what changed is that it can now also be a
+    real, measured number.
+
+    ``real_users`` is read live so any per-user figure a consumer computes is
+    anchored to the honest distinct-user denominator, never the request counter.
+
+    This is the ONLY surface carrying the priced figure, and it is admin-gated:
+    the public ``/api/metrics`` family stays aggregate, PII-free and unpriced.
     """
     real_users = get_distinct_user_count()
+    generation_cost = get_measured_generation_cost()
+    measured = generation_cost.get("cost_per_generation_usd") or {}
     return {
-        "source": "draft",  # NOT live-metered spend — placeholders pending billing wiring.
+        # Describes the AWS-billing placeholders below, NOT generation_cost —
+        # which carries its own provenance (rate_card_configured / jobs_priced /
+        # unavailable) precisely so the two are never read as one claim.
+        "source": "draft",
         "real_users": real_users,
         "bedrock_monthly_usd": None,
         "bedrock_daily_usd": None,
         "infra_monthly_usd": None,
         "cost_per_user_usd": None,
-        "cost_per_generation_usd": None,
+        # The mean of the priced runs, or None. Kept flat for the existing
+        # consumer contract; read `generation_cost` for the distribution, the
+        # LLM-vs-compute split, and how many runs could not be priced.
+        "cost_per_generation_usd": measured.get("mean"),
+        "generation_cost": generation_cost,
         "note": (
-            "Draft placeholders. Per-user / per-generation figures must be derived from "
-            "real_users (canonical accounts) or strategy generations — never the cumulative "
-            "request tallies on /api/metrics (issue #830)."
+            "source='draft' applies to the bedrock_*/infra/cost_per_user placeholders only. "
+            "cost_per_generation_usd is measured: generation_costs rows priced against the "
+            "GENERATION_COST_RATE_CARD env rate card (null, never 0, when unset or unpriceable). "
+            "Per-user figures must be derived from real_users (canonical accounts) — never the "
+            "cumulative request tallies on /api/metrics (issue #830)."
         ),
         "authenticated_wallet": wallet,
         "timestamp": datetime.now(UTC).isoformat(),

--- a/backend/archimedes/services/generation_cost_model.py
+++ b/backend/archimedes/services/generation_cost_model.py
@@ -33,10 +33,13 @@ Three boundaries make this safe to add without weakening anything:
    columns precisely so a priced document can never be filed as a ``cost_v1``
    record, and that guard is what enforces it.
 
-Nothing in the serving path imports this module yet. Wiring it into
-``quote()`` is a separate, flag-gated change designed in
+**Nothing on a customer-facing path imports this module.** One reader exists —
+:mod:`archimedes.services.generation_cost_rollup`, which aggregates these
+estimates for the admin-only ``GET /api/metrics/private/cost`` dashboard
+(#1217). That is a *report*, not a charge. Wiring this into ``quote()`` is
+still a separate, flag-gated change designed in
 ``docs/adr/lambda-generation-offload.md``; the flat ``GENERATION_PRICE_USD``
-remains the default and this module changes no behaviour by existing.
+remains the default and what a user pays is unchanged by this module existing.
 """
 
 from __future__ import annotations
@@ -59,6 +62,18 @@ SCHEMA = "cost_model_v1"
 #: (or malformed) means "no measured pricing available", which is a supported
 #: state: the flat price is still the default.
 RATE_CARD_ENV = "GENERATION_COST_RATE_CARD"
+
+# Stable machine-readable codes for the ways an estimate can come out
+# incomplete. ``incomplete_reasons`` stays human prose (it is what a refusal
+# message quotes); these are what an aggregate groups by. A rollup that had to
+# group by the prose would be parsing a sentence containing a call count and a
+# model id — two unbounded values — so "3 calls without usage" and "4 calls
+# without usage" would be two different buckets for one cause.
+REASON_SCHEMA_MISMATCH = "schema_mismatch"
+REASON_LLM_USAGE_INCOMPLETE = "llm_usage_incomplete"
+REASON_NO_PER_MODEL_TOKENS = "llm_no_per_model_tokens"
+REASON_MODEL_NOT_ON_CARD = "model_not_on_rate_card"
+REASON_NO_WALL_SECONDS = "no_wall_seconds"
 
 #: USDC settles at six decimals, and circlekit's price strings are
 #: ``"$X.XXXXXX"``. Quoting more precision than the asset can express would be
@@ -204,32 +219,42 @@ def billed_seconds(wall_seconds: float | Decimal, card: RateCard) -> Decimal:
     return max(steps * card.billing_granularity_seconds, card.minimum_billed_seconds)
 
 
-def _llm_cost(snapshot: dict[str, Any], card: RateCard) -> tuple[Decimal, list[str]]:
+def _llm_cost(snapshot: dict[str, Any], card: RateCard) -> tuple[Decimal, list[tuple[str, str]], list[str]]:
     """Price the LLM term from the snapshot's per-model token counts.
 
     Per-model, never on the aggregate: models differ by an order of magnitude in
     price, so a total priced at one model's rate is not an estimate of anything.
+
+    Returns the priced total, the ``(code, prose)`` reasons it is incomplete,
+    and the model ids the card could not price.
     """
     llm = snapshot.get("llm") or {}
-    reasons: list[str] = []
+    reasons: list[tuple[str, str]] = []
+    unpriced_models: list[str] = []
     if not llm.get("usage_complete", False):
         missing = llm.get("calls_missing_usage")
-        reasons.append(f"cost_meter reported incomplete LLM usage ({missing} call(s) without a usage block)")
+        reasons.append(
+            (
+                REASON_LLM_USAGE_INCOMPLETE,
+                f"cost_meter reported incomplete LLM usage ({missing} call(s) without a usage block)",
+            )
+        )
 
     total = Decimal(0)
     by_model = llm.get("by_model") or {}
     if not by_model and llm.get("calls"):
-        reasons.append("snapshot records LLM calls but no per-model token counts")
+        reasons.append((REASON_NO_PER_MODEL_TOKENS, "snapshot records LLM calls but no per-model token counts"))
     for model_id, counts in by_model.items():
         rate = card.models.get(str(model_id))
         if rate is None:
-            reasons.append(f"no rate on the card for model {model_id!r}")
+            reasons.append((REASON_MODEL_NOT_ON_CARD, f"no rate on the card for model {model_id!r}"))
+            unpriced_models.append(str(model_id))
             continue
         input_tokens = _decimal(counts.get("input_tokens", 0), where=f"by_model[{model_id!r}].input_tokens")
         output_tokens = _decimal(counts.get("output_tokens", 0), where=f"by_model[{model_id!r}].output_tokens")
         total += input_tokens / _MILLION * rate.input_usd_per_mtok
         total += output_tokens / _MILLION * rate.output_usd_per_mtok
-    return total, reasons
+    return total, reasons, unpriced_models
 
 
 def estimate_cost(snapshot: dict[str, Any], card: RateCard) -> dict[str, Any]:
@@ -237,21 +262,25 @@ def estimate_cost(snapshot: dict[str, Any], card: RateCard) -> dict[str, Any]:
 
     Returns a self-describing estimate. ``complete`` is the only field a caller
     needs to read before deciding whether the total is safe to quote from;
-    ``incomplete_reasons`` says why when it is not.
+    ``incomplete_reasons`` says why when it is not, and
+    ``incomplete_reason_codes`` says the same thing in a form an aggregate can
+    group by without parsing prose.
     """
     if not isinstance(snapshot, dict):
         raise TypeError(f"snapshot must be a dict, got {type(snapshot).__name__}")
-    reasons: list[str] = []
+    reasons: list[tuple[str, str]] = []
     schema = snapshot.get("schema")
     if schema != "cost_v1":
-        reasons.append(f"snapshot schema {schema!r} is not the cost_v1 this model prices")
+        reasons.append((REASON_SCHEMA_MISMATCH, f"snapshot schema {schema!r} is not the cost_v1 this model prices"))
 
-    llm_usd, llm_reasons = _llm_cost(snapshot, card)
+    llm_usd, llm_reasons, unpriced_models = _llm_cost(snapshot, card)
     reasons.extend(llm_reasons)
 
     wall = snapshot.get("wall_seconds")
     if wall is None or (isinstance(wall, float) and not math.isfinite(wall)):
-        reasons.append("snapshot has no usable wall_seconds — the compute term cannot be priced")
+        reasons.append(
+            (REASON_NO_WALL_SECONDS, "snapshot has no usable wall_seconds — the compute term cannot be priced")
+        )
         seconds = Decimal(0)
     else:
         seconds = billed_seconds(wall, card)
@@ -262,7 +291,11 @@ def estimate_cost(snapshot: dict[str, Any], card: RateCard) -> dict[str, Any]:
         "schema": SCHEMA,
         "lane": card.lane,
         "complete": not reasons,
-        "incomplete_reasons": reasons,
+        "incomplete_reasons": [prose for _, prose in reasons],
+        # Deduplicated, first-seen order: two calls missing usage is one cause,
+        # not two, and a bucket count must not double-count one snapshot.
+        "incomplete_reason_codes": list(dict.fromkeys(code for code, _ in reasons)),
+        "unpriced_models": list(dict.fromkeys(unpriced_models)),
         "components": {
             "llm_usd": _fixed(llm_usd.quantize(_COMPONENT_EXPONENT, rounding=ROUND_HALF_UP)),
             "compute_usd": _fixed(compute_usd.quantize(_COMPONENT_EXPONENT, rounding=ROUND_HALF_UP)),

--- a/backend/archimedes/services/generation_cost_rollup.py
+++ b/backend/archimedes/services/generation_cost_rollup.py
@@ -1,0 +1,352 @@
+"""What a generation actually costs, in dollars, from the rows we measured (#1217).
+
+Three pieces already existed and never met:
+
+* :mod:`archimedes.services.cost_meter` measures one generation — tokens,
+  seconds, peak RSS, writes — and holds no pricing vocabulary at all.
+* :mod:`archimedes.models.generation_cost` keeps those ``cost_v1`` snapshots
+  durably, one row per ``(job_id, strategy_id)``.
+* :mod:`archimedes.services.generation_cost_model` converts **one** snapshot
+  plus a rate card into dollars, and refuses to total anything it could not
+  price.
+
+Nothing joined them, so the admin cost dashboard's ``cost_per_generation_usd``
+was a literal ``None`` placeholder while the measurements to answer it sat in
+the table. This module is that join: read the measured rows, price each one,
+and report the distribution — which is the number #1217 exists to produce
+("until this number exists, 'near-zero marginal cost' is an assumption wearing
+the clothes of a finding").
+
+**Four rules this module does not bend.**
+
+1. **A missing rate card is not a zero, and not an estimate.** The rates live in
+   the environment, never in this repo (``CLAUDE.md`` § Project: pricing and
+   margin strategy are private-docs material, and vendor prices change without
+   a deploy). With no card configured, every dollar field is ``None`` and
+   ``rate_card_configured`` is ``False``. There is no code path here that
+   invents a price.
+
+2. **An unpriceable run is excluded from the mean and counted out loud.** A
+   snapshot whose LLM usage was incomplete, or that used a model the card does
+   not price, produces an estimate with ``complete: False``; folding its partial
+   total into an average would quietly report a cost lower than the truth, which
+   is the specific error the issue's "do not estimate" anti-goal names. Those
+   runs land in ``jobs_unpriceable`` with a per-cause tally instead.
+
+3. **The rejected path is in the numbers.** The issue is explicit that a
+   generation failing the rigor gate spends the same backtest compute and is the
+   common case. Nothing here filters on outcome; every measured row is priced.
+   (What is *not* here is any run that failed before persisting a strategy —
+   those never get a ``generation_costs`` row at all. Stated in
+   ``coverage_note`` rather than left for a reader to assume.)
+
+4. **This is admin-only output, and it is priced.** It is served from
+   ``/api/metrics/private/cost`` behind ``PLATFORM_ADMIN_WALLETS`` and nowhere
+   else. Its keys are deliberately priced, so
+   :func:`archimedes.services.cost_meter.assert_measurement_only` **raises** on
+   this document — that is the enforcement keeping a priced rollup from ever
+   being filed back as a ``cost_v1`` measurement.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from archimedes.services.generation_cost_model import (
+    RateCard,
+    estimate_cost,
+    rate_card_from_env,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Bumped whenever this rollup's shape changes, same contract as ``cost_v1``
+#: and ``cost_model_v1`` — a stored or screenshotted rollup stays self-describing.
+SCHEMA = "cost_rollup_v1"
+
+#: Newest-first cap on how many distinct jobs are priced in one call. The
+#: aggregate needs every priced total in memory at once (a median is not
+#: streamable), so this is bounded on purpose rather than growing with the
+#: table. When the cap bites, ``truncated`` says so — a silently-windowed
+#: average would be presented as an all-time one.
+MAX_JOBS = 1000
+
+#: Aggregate dollars are rendered at the component precision of
+#: ``generation_cost_model``, not at USDC's six decimals: a compute term of
+#: $0.0000015 rounds to zero at six places and would read as "compute is free",
+#: which is the wrong conclusion to hand a reader. This is a report, not a
+#: quote — nothing downstream charges from it.
+_USD_EXPONENT = Decimal("0.00000001")
+
+
+def _usd(value: Decimal) -> str:
+    """Render a dollar figure in plain fixed-point, always.
+
+    ``str(Decimal("0.00000010"))`` is ``"1.0E-7"`` — Decimal flips to scientific
+    notation exactly in the range the compute term lives in, and ``1.0E-7`` is
+    not a string a dashboard or a spreadsheet will read as a price.
+    """
+    return format(value.quantize(_USD_EXPONENT), "f")
+
+
+def _mean(values: list[Decimal]) -> Decimal:
+    return sum(values, Decimal(0)) / Decimal(len(values))
+
+
+def _median(values: list[Decimal]) -> Decimal:
+    """Median of a non-empty list. Reported beside the mean deliberately.
+
+    One 300-second run among four 40-second ones drags a mean somewhere neither
+    describes; the pair is what makes a skewed distribution visible instead of
+    averaged away.
+    """
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / Decimal(2)
+
+
+def _decimal_or_none(raw: Any) -> Decimal | None:
+    try:
+        parsed = Decimal(str(raw))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
+
+
+def _number_or_none(raw: Any) -> float | None:
+    """A finite non-negative float, or ``None``.
+
+    Same refusal ``cost_meter._coerce_count`` makes on the way in: a string, a
+    bool, a NaN or a negative is *not measured*, and averaging it in would put
+    a fabricated number in a column whose whole purpose is to be trustworthy.
+    """
+    if isinstance(raw, bool) or raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if value != value or value in (float("inf"), float("-inf")) or value < 0:
+        return None
+    return value
+
+
+def _empty(
+    *,
+    card: RateCard | None,
+    unavailable: bool = False,
+    rows_scanned: int = 0,
+    jobs_seen: int = 0,
+) -> dict[str, Any]:
+    """The shape with no priced runs in it. Every dollar field ``None``."""
+    return {
+        "schema": SCHEMA,
+        "rate_card_configured": card is not None,
+        "lane": card.lane if card is not None else None,
+        "rows_scanned": rows_scanned,
+        "jobs_seen": jobs_seen,
+        "jobs_priced": 0,
+        "jobs_unpriceable": jobs_seen,
+        "unpriceable_reasons": {},
+        "unpriced_models": {},
+        "truncated": False,
+        "cost_per_generation_usd": None,
+        "by_n_candidates": [],
+        "unavailable": unavailable,
+        "coverage_note": _COVERAGE_NOTE,
+    }
+
+
+_COVERAGE_NOTE = (
+    "Priced from generation_costs rows only. A run that failed before persisting a strategy "
+    "(invalid brief, early crash) never gets a row, so it is absent here rather than counted "
+    "as cheap. Runs that failed the rigor gate ARE included — they spend the same backtest "
+    "compute. Dollar fields are null, never 0, when no rate card is configured or no run was "
+    "priceable."
+)
+
+
+def _bucket_key(measurement: dict[str, Any]) -> int | None:
+    """``meta.n_candidates_requested``, or ``None`` when the row does not say.
+
+    The N-scaling breakdown the issue asks for ("repeated for a multi-candidate
+    run so the scaling in N is visible, not assumed") is grouped on this. A row
+    with no usable value gets its own ``None`` bucket rather than being folded
+    into ``1`` — assuming N=1 for a run that never recorded N is exactly the
+    kind of plausible substitute this instrumentation exists to end.
+    """
+    meta = measurement.get("meta")
+    raw = meta.get("n_candidates_requested") if isinstance(meta, dict) else None
+    if isinstance(raw, bool) or raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value >= 0 else None
+
+
+def _iter_measurements(max_jobs: int) -> tuple[list[dict[str, Any]], int, int, bool]:
+    """Newest-first measurements, one per job. Raises on a DB failure.
+
+    De-duplicated by ``job_id`` because a ``generation_costs`` row is keyed to a
+    ``(job_id, strategy_id)`` pair while **the measurement is the job's**: if a
+    job ever persists more than one strategy (K>1), each row carries the *same*
+    job-level snapshot and pricing both would double-count that job into every
+    average. K=1 today makes this a no-op in practice; it is unconditional so a
+    future K>1 cannot silently start over-counting.
+    """
+    from archimedes.db import get_session
+    from archimedes.models.generation_cost import GenerationCostRecord
+
+    measurements: list[dict[str, Any]] = []
+    rows_scanned = 0
+    seen_jobs: set[str] = set()
+    truncated = False
+    session = get_session()
+    try:
+        query = (
+            session.query(GenerationCostRecord.job_id, GenerationCostRecord.measurement_json)
+            .order_by(GenerationCostRecord.recorded_at.desc(), GenerationCostRecord.id.desc())
+            .yield_per(200)
+        )
+        for job_id, raw in query:
+            rows_scanned += 1
+            if job_id in seen_jobs:
+                continue
+            if len(seen_jobs) >= max_jobs:
+                # Stop consuming rows, but remember that we stopped. Reporting
+                # the window as if it were the whole table is the failure mode
+                # this flag exists to prevent.
+                truncated = True
+                break
+            seen_jobs.add(job_id)
+            try:
+                measurement = json.loads(raw) if raw else None
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("generation_cost_rollup: corrupt measurement_json for job %s — unpriceable", job_id)
+                measurement = None
+            measurements.append({"job_id": job_id, "measurement": measurement})
+    finally:
+        session.close()
+    return measurements, rows_scanned, len(seen_jobs), truncated
+
+
+def get_measured_generation_cost(
+    card: RateCard | None = None,
+    *,
+    max_jobs: int = MAX_JOBS,
+) -> dict[str, Any]:
+    """Price every measured generation and return the distribution.
+
+    ``card`` defaults to :func:`generation_cost_model.rate_card_from_env`; pass
+    one explicitly in tests so no rate ever has to live in the repo. With no
+    card — the default in every environment that has not been given one — this
+    returns the empty shape with ``rate_card_configured: False`` and does not
+    touch the database: there is nothing it could honestly report.
+
+    Fail-safe like every other read instrument on this dashboard
+    (``engagement_metrics``, ``identity_metrics``, ``user_stats``): a DB error
+    logs and returns ``unavailable: True`` with null dollars, never a 5xx and
+    never a zero. A subsystem that cannot read must not be able to claim the
+    cost is nothing.
+    """
+    card = card if card is not None else rate_card_from_env()
+    if card is None:
+        return _empty(card=None)
+
+    try:
+        measurements, rows_scanned, jobs_seen, truncated = _iter_measurements(max_jobs)
+    except Exception:  # the dashboard degrades, it does not 500
+        logger.exception("generation_cost_rollup: could not read generation_costs")
+        return _empty(card=card, unavailable=True)
+
+    totals: list[Decimal] = []
+    llm_totals: list[Decimal] = []
+    compute_totals: list[Decimal] = []
+    overhead_totals: list[Decimal] = []
+    reason_counts: Counter[str] = Counter()
+    unpriced_model_counts: Counter[str] = Counter()
+    buckets: dict[int | None, dict[str, list]] = {}
+
+    for entry in measurements:
+        measurement = entry["measurement"]
+        if not isinstance(measurement, dict):
+            # Corrupt or absent JSON: the most incomplete case there is, so it
+            # is counted as unpriceable rather than skipped silently — a row we
+            # could not read at all must not leave the totals looking complete.
+            reason_counts["unreadable_measurement"] += 1
+            continue
+        try:
+            estimate = estimate_cost(measurement, card)
+        except Exception:  # one bad row must not blank the tile
+            logger.exception("generation_cost_rollup: could not price job %s", entry["job_id"])
+            reason_counts["pricing_error"] += 1
+            continue
+
+        if not estimate.get("complete"):
+            for code in estimate.get("incomplete_reason_codes") or ["unspecified"]:
+                reason_counts[code] += 1
+            for model_id in estimate.get("unpriced_models") or []:
+                unpriced_model_counts[model_id] += 1
+            continue
+
+        total = _decimal_or_none(estimate.get("total_usd_exact"))
+        if total is None:
+            reason_counts["pricing_error"] += 1
+            continue
+        components = estimate.get("components") or {}
+        totals.append(total)
+        llm_totals.append(_decimal_or_none(components.get("llm_usd")) or Decimal(0))
+        compute_totals.append(_decimal_or_none(components.get("compute_usd")) or Decimal(0))
+        overhead_totals.append(_decimal_or_none(components.get("overhead_usd")) or Decimal(0))
+
+        bucket = buckets.setdefault(_bucket_key(measurement), {"totals": [], "tokens": [], "wall": []})
+        bucket["totals"].append(total)
+        llm_block = measurement.get("llm")
+        tokens = _number_or_none((llm_block or {}).get("total_tokens")) if isinstance(llm_block, dict) else None
+        if tokens is not None:
+            bucket["tokens"].append(tokens)
+        wall = _number_or_none(measurement.get("wall_seconds"))
+        if wall is not None:
+            bucket["wall"].append(wall)
+
+    result = _empty(card=card, rows_scanned=rows_scanned, jobs_seen=jobs_seen)
+    result["jobs_priced"] = len(totals)
+    result["jobs_unpriceable"] = jobs_seen - len(totals)
+    result["unpriceable_reasons"] = dict(sorted(reason_counts.items()))
+    result["unpriced_models"] = dict(sorted(unpriced_model_counts.items()))
+    result["truncated"] = truncated
+    if totals:
+        result["cost_per_generation_usd"] = {
+            "mean": _usd(_mean(totals)),
+            "median": _usd(_median(totals)),
+            "min": _usd(min(totals)),
+            "max": _usd(max(totals)),
+            "llm_mean": _usd(_mean(llm_totals)),
+            "compute_mean": _usd(_mean(compute_totals)),
+            "overhead_mean": _usd(_mean(overhead_totals)),
+        }
+    result["by_n_candidates"] = [
+        {
+            # ``None`` = the run did not record N. Kept as its own row, never
+            # merged into N=1, so the scaling read off this table is read off
+            # runs that actually stated their N.
+            "n_candidates_requested": key,
+            "jobs_priced": len(bucket["totals"]),
+            "mean_usd": _usd(_mean(bucket["totals"])),
+            "median_usd": _usd(_median(bucket["totals"])),
+            "mean_total_tokens": (sum(bucket["tokens"]) / len(bucket["tokens"])) if bucket["tokens"] else None,
+            "mean_wall_seconds": (sum(bucket["wall"]) / len(bucket["wall"])) if bucket["wall"] else None,
+        }
+        # ``None`` sorts last; the numeric buckets ascend so the scaling in N
+        # reads top to bottom.
+        for key, bucket in sorted(buckets.items(), key=lambda kv: (kv[0] is None, kv[0] or 0))
+    ]
+    return result

--- a/backend/tests/test_generation_cost_rollup.py
+++ b/backend/tests/test_generation_cost_rollup.py
@@ -1,0 +1,337 @@
+"""The measured $/generation rollup (#1217) — arithmetic, and the refusals.
+
+The rollup joins three things that already existed: measured ``cost_v1``
+snapshots in ``generation_costs``, the per-snapshot pricing arithmetic in
+``generation_cost_model``, and the admin cost dashboard that had a literal
+``None`` where the number belonged.
+
+What is tested first-class here is not the averaging — it is the set of inputs
+that must NOT produce a number:
+
+* no rate card → nulls, never zeros, and no DB read at all;
+* a run whose LLM usage was incomplete, or whose model the card cannot price →
+  excluded from the mean and counted out loud, because folding a partial total
+  into an average reports a cost lower than the truth (the issue's "do not
+  estimate" anti-goal);
+* a corrupt row → unpriceable, not silently skipped;
+* two rows for one job (K>1) → priced once.
+
+Hermetic: a tmp-file SQLite DB via ``tests/db_isolation``, and a rate card built
+in-test from invented round numbers. Real vendor rates never live in this repo.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from archimedes.db import get_session
+from archimedes.models.generation_cost import GenerationCostRecord
+from archimedes.services import cost_meter
+from archimedes.services.generation_cost_model import RATE_CARD_ENV, RateCard
+from archimedes.services.generation_cost_rollup import (
+    SCHEMA,
+    get_measured_generation_cost,
+)
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+MODEL = "amazon.nova-micro-v1:0"
+OTHER_MODEL = "some.unpriced-model-v9:0"
+
+# Invented, round rates. $1.00/Mtok in, $10.00/Mtok out, $0.001 per GB-second
+# over 2 GB — so one second of compute is exactly $0.002 and the arithmetic
+# below is checkable by hand.
+CARD_JSON = {
+    "lane": "fargate_inline",
+    "compute_usd_per_gb_second": "0.001",
+    "compute_gb": "2",
+    "billing_granularity_seconds": "0.001",
+    "models": {MODEL: {"input_usd_per_mtok": "1.00", "output_usd_per_mtok": "10.00"}},
+}
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+def _card() -> RateCard:
+    return RateCard.from_mapping(CARD_JSON)
+
+
+def _measurement(
+    job_id: str,
+    *,
+    wall_seconds: float = 100.0,
+    input_tokens: int = 1_000_000,
+    output_tokens: int = 100_000,
+    model: str = MODEL,
+    usage_complete: bool = True,
+    n_candidates: int | None = 1,
+) -> dict:
+    meta: dict = {"outcome": "done"}
+    if n_candidates is not None:
+        meta["n_candidates_requested"] = n_candidates
+    return {
+        "schema": "cost_v1",
+        "job_id": job_id,
+        "wall_seconds": wall_seconds,
+        "cpu_seconds": wall_seconds * 0.9,
+        "llm": {
+            "calls": 3,
+            "calls_missing_usage": 0 if usage_complete else 2,
+            "usage_complete": usage_complete,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+            "by_model": {
+                model: {
+                    "calls": 3,
+                    "calls_missing_usage": 0 if usage_complete else 2,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                }
+            },
+        },
+        "stages": {"debate_backtest": {"wall_seconds": wall_seconds * 0.7, "cpu_seconds": 1.0, "runs": 1}},
+        "writes": {"strategy_store": 1},
+        "meta": meta,
+    }
+
+
+def _seed(measurement: dict | str, *, job_id: str, strategy_id: str | None = None, age_seconds: int = 0) -> None:
+    raw = measurement if isinstance(measurement, str) else json.dumps(measurement)
+    with get_session() as session:
+        session.add(
+            GenerationCostRecord(
+                job_id=job_id,
+                strategy_id=strategy_id or f"strat-{job_id}",
+                schema_version="cost_v1",
+                measurement_json=raw,
+                recorded_at=datetime.now(UTC) - timedelta(seconds=age_seconds),
+            )
+        )
+        session.commit()
+
+
+# ── The happy path, checkable by hand ────────────────────────────────────
+
+
+def test_prices_one_measured_generation(tmp_db):
+    """1M in @ $1 + 100k out @ $10 = $2.00 LLM; 100s × 2GB × $0.001 = $0.20 compute."""
+    _seed(_measurement("job-1"), job_id="job-1")
+
+    result = get_measured_generation_cost(_card())
+
+    assert result["schema"] == SCHEMA
+    assert result["rate_card_configured"] is True
+    assert result["lane"] == "fargate_inline"
+    assert result["jobs_priced"] == 1
+    assert result["jobs_unpriceable"] == 0
+    per_gen = result["cost_per_generation_usd"]
+    assert per_gen["llm_mean"] == "2.00000000"
+    assert per_gen["compute_mean"] == "0.20000000"
+    assert per_gen["mean"] == "2.20000000"
+    assert per_gen["median"] == "2.20000000"
+
+
+def test_mean_and_median_both_reported_for_a_skewed_distribution(tmp_db):
+    """A long tail must stay visible, not be averaged into a single number."""
+    _seed(_measurement("job-a", wall_seconds=100.0), job_id="job-a")
+    _seed(_measurement("job-b", wall_seconds=100.0), job_id="job-b")
+    _seed(_measurement("job-c", wall_seconds=1000.0), job_id="job-c")
+
+    per_gen = get_measured_generation_cost(_card())["cost_per_generation_usd"]
+
+    assert per_gen["min"] == "2.20000000"
+    assert per_gen["max"] == "4.00000000"  # $2 LLM + 1000s × 2GB × $0.001
+    assert per_gen["median"] == "2.20000000"
+    assert per_gen["mean"] == "2.80000000"
+
+
+# ── The refusals. Each one is a case that must NOT produce a number ───────
+
+
+def test_no_rate_card_yields_nulls_not_zeros(tmp_db):
+    """The whole point: an absent price is an absence, never $0.00.
+
+    Also asserts the string forms — a dashboard that received ``"0.00000000"``
+    would render "$0.00 per generation", which is a claim, not a gap.
+    """
+    _seed(_measurement("job-1"), job_id="job-1")
+
+    result = get_measured_generation_cost(None)
+
+    assert result["rate_card_configured"] is False
+    assert result["cost_per_generation_usd"] is None
+    assert result["by_n_candidates"] == []
+    assert result["lane"] is None
+    assert "0" not in json.dumps(result["cost_per_generation_usd"])
+
+
+def test_no_rate_card_does_not_read_the_database(monkeypatch):
+    """No card ⇒ nothing to report ⇒ no query. Deliberately has NO tmp_db fixture.
+
+    If the no-card path ever started reading, this test would hit whatever
+    process-global engine happens to be bound and the failure would be a
+    confusing one somewhere else; making the absence of a DB read explicit is
+    cheaper than debugging that later.
+    """
+    monkeypatch.delenv(RATE_CARD_ENV, raising=False)
+
+    def _explode():
+        raise AssertionError("the no-rate-card path must not open a DB session")
+
+    monkeypatch.setattr("archimedes.db.get_session", _explode)
+
+    result = get_measured_generation_cost()
+    assert result["rate_card_configured"] is False
+    assert result["cost_per_generation_usd"] is None
+
+
+def test_incomplete_llm_usage_is_excluded_from_the_mean(tmp_db):
+    """A ``usage_complete: false`` run is a floor, not a total.
+
+    Adversarial shape: the incomplete run is the CHEAP one. If it were folded
+    in, the mean would drop to $1.60 and the dashboard would report a cost
+    below the measured truth — the failure this exclusion exists to prevent.
+    """
+    _seed(_measurement("job-full", wall_seconds=100.0), job_id="job-full")
+    _seed(
+        _measurement("job-partial", wall_seconds=100.0, input_tokens=200_000, output_tokens=0, usage_complete=False),
+        job_id="job-partial",
+    )
+
+    result = get_measured_generation_cost(_card())
+
+    assert result["jobs_seen"] == 2
+    assert result["jobs_priced"] == 1
+    assert result["jobs_unpriceable"] == 1
+    assert result["unpriceable_reasons"] == {"llm_usage_incomplete": 1}
+    assert result["cost_per_generation_usd"]["mean"] == "2.20000000"  # not 1.60
+
+
+def test_model_the_card_cannot_price_is_excluded_and_named(tmp_db):
+    """An unknown model must not silently contribute only its compute term."""
+    _seed(_measurement("job-known"), job_id="job-known")
+    _seed(_measurement("job-unknown", model=OTHER_MODEL), job_id="job-unknown")
+
+    result = get_measured_generation_cost(_card())
+
+    assert result["jobs_priced"] == 1
+    assert result["unpriceable_reasons"] == {"model_not_on_rate_card": 1}
+    assert result["unpriced_models"] == {OTHER_MODEL: 1}
+    assert result["cost_per_generation_usd"]["mean"] == "2.20000000"
+
+
+def test_corrupt_row_is_counted_unpriceable_not_skipped(tmp_db):
+    """A row we cannot read at all is the MOST incomplete case.
+
+    Dropping it silently would leave ``jobs_priced == jobs_seen`` and the
+    totals looking like a complete accounting of the table.
+    """
+    _seed(_measurement("job-good"), job_id="job-good")
+    _seed("{not valid json", job_id="job-corrupt")
+
+    result = get_measured_generation_cost(_card())
+
+    assert result["jobs_seen"] == 2
+    assert result["jobs_priced"] == 1
+    assert result["jobs_unpriceable"] == 1
+    assert result["unpriceable_reasons"] == {"unreadable_measurement": 1}
+
+
+def test_k_gt_1_rows_for_one_job_are_priced_once(tmp_db):
+    """The row is (job, strategy); the MEASUREMENT is the job's.
+
+    Two strategy rows carrying the same job-level snapshot must not double the
+    job into the average — ``models/generation_cost.py``: "summing across rows
+    would double-count".
+    """
+    snapshot = _measurement("job-k")
+    _seed(snapshot, job_id="job-k", strategy_id="strat-a")
+    _seed(snapshot, job_id="job-k", strategy_id="strat-b")
+
+    result = get_measured_generation_cost(_card())
+
+    assert result["rows_scanned"] == 2
+    assert result["jobs_seen"] == 1
+    assert result["jobs_priced"] == 1
+
+
+def test_db_failure_degrades_to_unavailable_not_zero(tmp_db, monkeypatch):
+    """A read instrument that cannot read must not report a cost of nothing."""
+
+    def _boom():
+        raise RuntimeError("database is down")
+
+    monkeypatch.setattr("archimedes.db.get_session", _boom)
+
+    result = get_measured_generation_cost(_card())
+
+    assert result["unavailable"] is True
+    assert result["cost_per_generation_usd"] is None
+    assert result["jobs_priced"] == 0
+
+
+# ── The N-scaling breakdown the issue explicitly asks for ────────────────
+
+
+def test_by_n_candidates_makes_the_scaling_in_n_visible(tmp_db):
+    """ "Repeated for a multi-candidate run so the scaling in N is visible."""
+    _seed(_measurement("job-n1", wall_seconds=100.0, n_candidates=1), job_id="job-n1")
+    _seed(
+        _measurement("job-n5", wall_seconds=500.0, input_tokens=5_000_000, output_tokens=500_000, n_candidates=5),
+        job_id="job-n5",
+    )
+
+    buckets = get_measured_generation_cost(_card())["by_n_candidates"]
+
+    assert [b["n_candidates_requested"] for b in buckets] == [1, 5]
+    assert buckets[0]["mean_usd"] == "2.20000000"
+    # $5 in + $5 out = $10 LLM; 500s × 2GB × $0.001 = $1 compute.
+    assert buckets[1]["mean_usd"] == "11.00000000"
+    assert buckets[0]["mean_wall_seconds"] == 100.0
+    assert buckets[1]["mean_total_tokens"] == 5_500_000.0
+
+
+def test_run_that_did_not_record_n_gets_its_own_bucket(tmp_db):
+    """Never folded into N=1 — assuming an unrecorded N is a fabricated fact."""
+    _seed(_measurement("job-known-n", n_candidates=1), job_id="job-known-n")
+    _seed(_measurement("job-unknown-n", n_candidates=None), job_id="job-unknown-n")
+
+    buckets = get_measured_generation_cost(_card())["by_n_candidates"]
+
+    assert [b["n_candidates_requested"] for b in buckets] == [1, None]
+    assert all(b["jobs_priced"] == 1 for b in buckets)
+
+
+# ── The structural guard: a priced rollup can never be filed as a cost_v1 ─
+
+
+def test_rollup_is_structurally_barred_from_the_measurement_column(tmp_db):
+    """``assert_measurement_only`` must RAISE on this document.
+
+    That refusal is what keeps ``generation_costs.measurement_json`` free of
+    pricing — the two-column design of #1326 enforced, not merely intended. A
+    rollup that passed this screen would be storable as a measurement.
+    """
+    _seed(_measurement("job-1"), job_id="job-1")
+    result = get_measured_generation_cost(_card())
+
+    with pytest.raises(cost_meter.PricingLeakError):
+        cost_meter.assert_measurement_only(result, where="generation_costs.measurement_json")
+
+
+def test_truncation_is_reported_rather_than_silently_windowed(tmp_db):
+    """A capped window must say so; otherwise it reads as an all-time average."""
+    for i in range(3):
+        _seed(_measurement(f"job-{i}"), job_id=f"job-{i}", age_seconds=i)
+
+    result = get_measured_generation_cost(_card(), max_jobs=2)
+
+    assert result["truncated"] is True
+    assert result["jobs_seen"] == 2
+    assert result["jobs_priced"] == 2

--- a/backend/tests/test_metrics_private_routes.py
+++ b/backend/tests/test_metrics_private_routes.py
@@ -160,7 +160,8 @@ def test_private_cost_200_with_valid_admin_siwe_session(client):
     # The honest distinct-user count is present (denominator for any per-user $).
     assert body["real_users"] == 2
     assert body["authenticated_wallet"] == _ADMIN_WALLET.lower()
-    # Cost fields are draft placeholders until billing wiring lands.
+    # The AWS-billing fields are still draft placeholders; `source` describes
+    # THEM, not the measured generation cost (#1217 narrowed its scope).
     assert body["source"] == "draft"
 
 
@@ -169,6 +170,89 @@ def test_private_cost_admin_wallets_parsed_case_insensitively(client, monkeypatc
     monkeypatch.setenv("PLATFORM_ADMIN_WALLETS", _ADMIN_WALLET.upper())
     res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_ADMIN_WALLET))
     assert res.status_code == 200
+
+
+# ── The measured $/generation figure (#1217) ─────────────────────────────
+# `cost_per_generation_usd` was a hard-coded `None`. It is now the mean of the
+# `generation_costs` measurements priced against the env rate card. What these
+# tests pin is the pair of properties that make that safe: it is null (never 0)
+# when nothing can be priced, and it never leaves the admin gate.
+
+
+def test_private_cost_generation_cost_is_null_without_a_rate_card(client, monkeypatch):
+    """No rate card configured → null, and a stated reason. Never $0.00.
+
+    This is the default state of every environment that has not been handed a
+    card, so it is the shape the dashboard renders most of the time — and the
+    one where a plausible-looking zero would do the most damage.
+    """
+    monkeypatch.delenv("GENERATION_COST_RATE_CARD", raising=False)
+    res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_ADMIN_WALLET))
+    assert res.status_code == 200
+    body = res.json()
+    assert body["cost_per_generation_usd"] is None
+    assert body["generation_cost"]["rate_card_configured"] is False
+    assert body["generation_cost"]["schema"] == "cost_rollup_v1"
+
+
+def test_private_cost_serves_the_measured_figure_when_priceable(client, monkeypatch):
+    """A priced rollup reaches the flat field the dashboard already reads."""
+    rollup = {
+        "schema": "cost_rollup_v1",
+        "rate_card_configured": True,
+        "lane": "fargate_inline",
+        "jobs_priced": 2,
+        "cost_per_generation_usd": {"mean": "2.20000000", "median": "2.20000000"},
+        "by_n_candidates": [],
+        "unavailable": False,
+    }
+    with patch(
+        "archimedes.api.metrics_private_routes.get_measured_generation_cost",
+        return_value=rollup,
+    ):
+        res = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_ADMIN_WALLET))
+    assert res.status_code == 200
+    body = res.json()
+    assert body["cost_per_generation_usd"] == "2.20000000"
+    assert body["generation_cost"]["jobs_priced"] == 2
+
+
+def test_measured_generation_cost_never_reaches_a_public_surface(client, monkeypatch):
+    """Cost/ops data is admin-only — the measured $/generation included.
+
+    The adversarial half of the "surfaced, never public" claim: with a rollup
+    that WOULD price (a real card, a real number), sweep the public metrics
+    endpoints and assert the figure appears on none of them. A prose claim that
+    something is admin-only is worth exactly as much as the check behind it.
+    """
+    rollup = {
+        "schema": "cost_rollup_v1",
+        "rate_card_configured": True,
+        "lane": "fargate_inline",
+        "jobs_priced": 1,
+        "cost_per_generation_usd": {"mean": "2.20000000"},
+        "by_n_candidates": [],
+        "unavailable": False,
+    }
+    with patch(
+        "archimedes.api.metrics_private_routes.get_measured_generation_cost",
+        return_value=rollup,
+    ):
+        # Present behind the gate...
+        admin = client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_ADMIN_WALLET))
+        assert admin.status_code == 200
+        assert "2.20000000" in admin.text
+
+        # ...and absent from every public metrics surface.
+        for path in ("/api/metrics", "/api/metrics/funnel", "/api/metrics/visitors"):
+            public = client.get(path)
+            assert public.status_code in (200, 404), f"{path} → {public.status_code}"
+            assert "2.20000000" not in public.text, f"measured $/generation leaked onto {path}"
+            assert "cost_per_generation_usd" not in public.text, f"priced key leaked onto {path}"
+
+        # ...and unreadable by a non-admin wallet.
+        assert client.get("/api/metrics/private/cost", cookies=_siwe_cookies(_NON_ADMIN_WALLET)).status_code == 403
+        assert client.get("/api/metrics/private/cost").status_code == 401
 
 
 # ── /whoami — the admin-gate probe the frontend calls on entry to Insights

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`api/vaults-and-chain.md`](api/vaults-and-chain.md) | current | Dan Browne | 2026-08-20 | `/api/vaults/*`, `/api/traces/*`, `/api/swap/*`, `/api/config/contracts`, and the health/root endpoints. |
 | [`api/chat.md`](api/chat.md) | current | Dan Browne | 2026-08-20 | `/api/vaults/{address}/chat*` — per-vault chat: public reads, linked-wallet writes, internal-only system events. |
 | [`api/leaderboard-and-metrics.md`](api/leaderboard-and-metrics.md) | current | Dan Browne | 2026-08-20 | `/api/leaderboard` and the public, PII-free `/api/metrics/*` traction surface. |
-| [`api/admin-private.md`](api/admin-private.md) | current | Dan Browne | 2026-08-20 | `/api/metrics/private/*` — the platform-admin-gated cost/ops dashboard and per-wallet identity roster. |
+| [`api/admin-private.md`](api/admin-private.md) | current | Dan Browne | 2026-08-31 | `/api/metrics/private/*` — the platform-admin-gated cost/ops dashboard (incl. the measured `$/generation`) and per-wallet identity roster. |
 | [`api-surface-status.md`](api-surface-status.md) | current | Dan Browne | 2026-08-20 | Census of every router `backend/archimedes/main.py` registers: prefix, auth model, status, and whether a detailed doc above covers it (15/30 do). Backed by a completeness test that fails CI if a registered router has no row. |
 
 ## Product
@@ -82,7 +82,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 
 | Doc | Status | Owner | Last verified | What it is |
 |---|---|---|---|---|
-| [`generation-cost-instrumentation.md`](generation-cost-instrumentation.md) | current | Dan Browne | 2026-08-20 | What one generation actually consumes: per-job token counts, per-stage wall/CPU seconds, peak RSS, row writes. Raw measurement only — the quote seam stays `flat_v1`. |
+| [`generation-cost-instrumentation.md`](generation-cost-instrumentation.md) | current | Dan Browne | 2026-08-31 | What one generation actually consumes: per-job token counts, per-stage wall/CPU seconds, peak RSS, row writes — plus the measured `$/generation` those counts price to on the admin-only cost endpoint. The customer-facing quote seam stays `flat_v1`. |
 | [`corpus-architecture.md`](corpus-architecture.md) | target-state | Dan Browne | 2026-08-20 | 10,000 arXiv preprints (not peer-reviewed), metadata + abstracts only. **Describes embeddings/clusters/KG as built; in prod none of the three exist** (#778). Selection is a **keyword filter** and only that candidate set is re-scored at request time — nothing is precomputed; `/health` `paper_rag` names the live scorer, and the graph/KG endpoints 503 or return empty. |
 | [`specs/multi-agent-debate-spec.md`](specs/multi-agent-debate-spec.md) | shipped | Dan Browne | 2026-07-28 | The debate society — the sole generation pipeline. |
 | [`specs/strategy-fusion-spec.md`](specs/strategy-fusion-spec.md) | shipped | Dan Browne | 2026-07-28 | Multi-paper synthesis feeding the debate proposals. |

--- a/docs/adr/lambda-generation-offload.md
+++ b/docs/adr/lambda-generation-offload.md
@@ -393,10 +393,14 @@ Why:
 
 ## Consequences
 
-- Two new modules exist and nothing calls them. `run_generation_job.py` has no importer in
-  the serving path; `generation_cost_model.py` is not referenced by `generation_payment`.
-  The flat `GENERATION_PRICE_USD` is untouched and remains the default; no payment flag
-  changed.
+- Two new modules exist and neither is on a payment path. `run_generation_job.py` has no
+  importer in the serving path; `generation_cost_model.py` is still not referenced by
+  `generation_payment`. The flat `GENERATION_PRICE_USD` is untouched and remains the
+  default; no payment flag changed.
+  **Update (2026-08-31, #1217):** `generation_cost_model.py` now has one reader —
+  `services/generation_cost_rollup.py`, which aggregates its estimates for the admin-only
+  `GET /api/metrics/private/cost` dashboard. That is a report, not a charge: the quote seam
+  is untouched and the customer price is still flat.
 - The entrypoint is lane-agnostic on purpose. Whichever lane wins — Lambda, `RunTask`, or
   a worker process — it is a deployment decision on top of the same function, not a fork
   of the pipeline.

--- a/docs/api/admin-private.md
+++ b/docs/api/admin-private.md
@@ -2,10 +2,11 @@
 
 > **status:** current
 > **owner:** Dan Browne
-> **updated:** 2026-08-20 (round 4 rewrite — see the four corrections below)
+> **updated:** 2026-08-31 (measured $/generation on `/cost`, #1217)
 
 `/api/metrics/private/*` — the internal cost/ops dashboard: Bedrock/infra spend (currently
-draft placeholders), the current-schema engagement/adoption dashboard-v2 tiles, the
+draft placeholders), the measured per-generation cost (#1217), the current-schema
+engagement/adoption dashboard-v2 tiles, the
 admin-gate probe the frontend uses, and the per-wallet identity roster that the public,
 PII-free `GET /api/metrics` deliberately does not expose. Landed in #1373 (closing #1366)
 after a full-tree audit found `GET /api/metrics/wallets` and `GET
@@ -201,15 +202,31 @@ Account + admin cost/ops dashboard. | **Auth**: platform-admin | **Flags**:
 Request: none.
 Response: `{source: "draft", real_users: int, bedrock_monthly_usd: null,
 bedrock_daily_usd: null, infra_monthly_usd: null, cost_per_user_usd: null,
-cost_per_generation_usd: null, note: str, authenticated_wallet: str, timestamp: str}`.
+cost_per_generation_usd: str|null, generation_cost: {...}, note: str,
+authenticated_wallet: str, timestamp: str}`.
 Errors: `401` — no session. `403` — session without a linked wallet, or a linked wallet
 not on the admin allowlist (see the two-flavor 403 note above).
 
-Every cost field is an explicit `null` placeholder — **not live-metered spend**. The live
-AWS Cost Explorer + Bedrock token-metering wiring is roadmap work, not yet built; only
+**Two provenances on one payload, labelled separately.** The AWS-billing fields
+(`bedrock_*`, `infra_monthly_usd`, `cost_per_user_usd`) are explicit `null` placeholders —
+**not live-metered spend**; the AWS Cost Explorer + Bedrock token-metering wiring is
+roadmap work. That is what the top-level `source: "draft"` describes.
+
+`cost_per_generation_usd` is **not** one of them (#1217). It is the mean of the
+`generation_costs` measurements this platform actually recorded, priced against the
+`GENERATION_COST_RATE_CARD` environment rate card, with the full distribution, the
+LLM-vs-compute split, the per-`n_candidates` scaling breakdown and the unpriceable tally
+under `generation_cost`. It is `null` — never `0` — when no rate card is configured or no
+run was priceable, and `generation_cost.rate_card_configured` /
+`.unpriceable_reasons` / `.unavailable` say which. Shape and refusals:
+[`generation-cost-instrumentation.md`](../generation-cost-instrumentation.md) §
+Pricing the measurement.
+
 `real_users` (canonical Better Auth account count) is read live, so any per-user math a
 consumer does downstream is anchored to an honest denominator rather than the cumulative
-request tallies on the public `GET /api/metrics` (issue #830).
+request tallies on the public `GET /api/metrics` (issue #830). This endpoint is the only
+surface carrying the priced per-generation figure; the public metrics family stays
+aggregate and unpriced.
 
 ```bash
 curl -sS -b /tmp/session.jar http://localhost:8080/api/metrics/private/cost

--- a/docs/generation-cost-instrumentation.md
+++ b/docs/generation-cost-instrumentation.md
@@ -2,7 +2,7 @@
 
 > **status:** current
 > **owner:** Dan Browne
-> **updated:** 2026-08-20
+> **updated:** 2026-08-31
 
 Every generation now carries a measurement record: how many tokens the debate
 society actually consumed, how long each pipeline phase took in wall and CPU
@@ -16,12 +16,16 @@ and CSCV backtests the debate society runs across every candidate. Issue #1217:
 *"until this number exists, 'near-zero marginal cost' is an assumption wearing
 the clothes of a finding."*
 
-**This layer records counts and seconds. It does not price anything.** The
-paywall quote seam (`generation_payment.quote()`, `GET /api/generate/quote`)
-remains `pricing_model: "flat_v1"` and is untouched. Converting the counts into
-dollars happens off-server against the current Bedrock and Fargate rate cards;
-the point of the instrumentation is that the conversion stops being applied to
-a guess.
+**The measurement layer records counts and seconds. It does not price
+anything.** The paywall quote seam (`generation_payment.quote()`, `GET
+/api/generate/quote`) remains `pricing_model: "flat_v1"` and is untouched.
+
+The conversion from those counts to dollars now has one home, and it is
+**admin-only and read-only**: `GET /api/metrics/private/cost` serves a measured
+`$/generation` derived from the recorded rows (see [Pricing the
+measurement](#pricing-the-measurement-generation_cost-on-the-admin-cost-endpoint)
+below). Nothing on a customer-facing path consults it — what we *charge* is
+still the flat price.
 
 ## Where it lives
 
@@ -33,8 +37,10 @@ a guess.
 | Persistence onto the job (expires with `JOB_TTL`) | `JobStore.merge_result` in [`backend/archimedes/services/job_queue.py`](../backend/archimedes/services/job_queue.py) |
 | Durable persistence (`generation_costs`) | [`backend/archimedes/models/generation_cost.py`](../backend/archimedes/models/generation_cost.py) + migration `e2b7f4c81d93`, written from `run_generation`'s `finally` |
 | Read surfaces | `GET /api/generate/jobs/{job_id}/cost`, the `cost` field on `GET /api/generate/jobs`, `generation_cost` on `GET /api/strategies/{id}` and `GET /api/strategies/generated` |
+| Pricing arithmetic, one snapshot at a time | [`backend/archimedes/services/generation_cost_model.py`](../backend/archimedes/services/generation_cost_model.py) |
+| The measured `$/generation` aggregate (admin-only) | [`backend/archimedes/services/generation_cost_rollup.py`](../backend/archimedes/services/generation_cost_rollup.py) → `GET /api/metrics/private/cost` |
 | UI | passport card + library column via [`ui/src/generationCost.js`](../ui/src/generationCost.js) |
-| Tests | [`backend/tests/test_generation_cost_meter.py`](../backend/tests/test_generation_cost_meter.py), [`backend/tests/test_generation_cost_persistence.py`](../backend/tests/test_generation_cost_persistence.py), [`ui/test/generation-cost.test.js`](../ui/test/generation-cost.test.js) |
+| Tests | [`backend/tests/test_generation_cost_meter.py`](../backend/tests/test_generation_cost_meter.py), [`backend/tests/test_generation_cost_persistence.py`](../backend/tests/test_generation_cost_persistence.py), [`backend/tests/test_generation_cost_model.py`](../backend/tests/test_generation_cost_model.py), [`backend/tests/test_generation_cost_rollup.py`](../backend/tests/test_generation_cost_rollup.py), [`ui/test/generation-cost.test.js`](../ui/test/generation-cost.test.js) |
 
 The meter is bound to a `contextvars` context for the duration of one job, so
 the LLM boundary records usage without threading a parameter through the debate
@@ -240,6 +246,74 @@ for them is precisely the failure this instrumentation exists to end.
    would refuse it anyway. The table's *name* is fine; a counter label inside a
    `cost_v1` snapshot is not.
 
+## Pricing the measurement: `generation_cost` on the admin cost endpoint
+
+`GET /api/metrics/private/cost` used to return `cost_per_generation_usd: null`
+as a hard-coded DRAFT placeholder while the measurements to answer it sat in the
+table. It now returns the mean of the priced runs, plus a `generation_cost`
+block carrying the whole distribution.
+
+**The rates are not in this repo, and they never will be.** A rate card arrives
+as one JSON environment variable, `GENERATION_COST_RATE_CARD`, parsed by
+[`generation_cost_model.rate_card_from_env`](../backend/archimedes/services/generation_cost_model.py):
+
+```json
+{
+  "lane": "fargate_inline",
+  "compute_usd_per_gb_second": "0.0000133",
+  "compute_gb": "3",
+  "billing_granularity_seconds": "1",
+  "minimum_billed_seconds": "0",
+  "models": {"<model-id>": {"input_usd_per_mtok": "…", "output_usd_per_mtok": "…"}}
+}
+```
+
+Vendor prices and margin strategy are private-docs material (`CLAUDE.md` §
+Project) and vendor prices change without a deploy — both reasons point the same
+way. **With no card configured, every dollar field is `null` and no database
+read happens at all.** The example above carries no real numbers; fill it from
+the current Bedrock and Fargate price lists in the private docs repo.
+
+### What it will and will not tell you
+
+| Field | Meaning |
+|---|---|
+| `cost_per_generation_usd` (flat, top level) | The **mean** of the priced runs, or `null`. |
+| `generation_cost.cost_per_generation_usd` | `mean` / `median` / `min` / `max`, plus the `llm_mean` / `compute_mean` / `overhead_mean` split — the issue's "state the LLM and compute terms separately". |
+| `generation_cost.by_n_candidates` | The same figures bucketed by `meta.n_candidates_requested`, so **the scaling in N is read off real runs rather than assumed**. |
+| `generation_cost.jobs_priced` / `jobs_unpriceable` | How much of the table the average actually covers. |
+| `generation_cost.unpriceable_reasons` | Why the rest was excluded, by stable code (`llm_usage_incomplete`, `model_not_on_rate_card`, `unreadable_measurement`, …). |
+| `generation_cost.rate_card_configured` / `unavailable` / `truncated` | The three ways this can be an honest gap rather than a number. |
+
+Four refusals are load-bearing, each covered by a test that has been shown to
+fail when the guard is removed
+([`test_generation_cost_rollup.py`](../backend/tests/test_generation_cost_rollup.py)):
+
+1. **A missing rate card is `null`, never `$0.00`.** An absent price gets the
+   same treatment as an absent measurement.
+2. **An unpriceable run is excluded from the mean and counted out loud.** A run
+   whose `usage_complete` is `false`, or that used a model the card cannot
+   price, would drag the average *below* the measured truth if folded in —
+   precisely the issue's "do not estimate" anti-goal. It lands in
+   `jobs_unpriceable` instead.
+3. **Rows are de-duplicated by `job_id`.** The row is keyed `(job_id,
+   strategy_id)` but the measurement is the *job's*; a future K>1 must not
+   double-count one job into every average.
+4. **The rejected path is in the numbers.** Nothing filters on outcome — a run
+   that failed the rigor gate spent the same backtest compute. What is *not*
+   here is any run that died before persisting a strategy, because those never
+   get a row at all; `coverage_note` says so on every response.
+
+**It is admin-only, and that is enforced, not asserted.** The endpoint sits
+behind `PLATFORM_ADMIN_WALLETS` (401 anonymous / 403 non-admin), and
+`test_measured_generation_cost_never_reaches_a_public_surface` sweeps
+`/api/metrics`, `/api/metrics/funnel` and `/api/metrics/visitors` asserting the
+figure appears on none of them.
+
+**The rollup is structurally barred from ever being stored as a measurement.**
+Its keys are priced, so `cost_meter.assert_measurement_only` raises on it — the
+same screen that keeps `generation_costs.measurement_json` free of money.
+
 ## Measurement procedure
 
 Both runs below are `n_candidates=1` and `n_candidates>1`, so the scaling in N is
@@ -281,9 +355,12 @@ aws ecs describe-tasks --cluster <cluster> --tasks <task> \
   --query 'tasks[0].{cpu:cpu,memory:memory}'
 ```
 
-Turning `cpu_seconds` + task size into a per-generation Fargate figure, and
-`llm.total_tokens` + the model's rate card into a per-generation inference
-figure, is deliberately left outside the server. Related:
+Turning `llm.total_tokens` + `wall_seconds` into dollars is what the admin
+rollup above does, from a rate card supplied by the environment. What it
+**cannot** do is correlate that model against the actual AWS invoice: the task's
+allocated size is what Fargate bills, and per-task utilisation lives in
+CloudWatch, not in the worker process. That correlation is still outstanding on
+#1217. Related:
 [`bedrock-model-cost-comparison.md`](bedrock-model-cost-comparison.md) for the
 rate card, and [`cost-estimates/generate-llm-costs.md`](cost-estimates/generate-llm-costs.md)
 for the estimate this instrumentation exists to replace.


### PR DESCRIPTION
## What this closes, and what it does not

Closes #1217.

The instrumentation half of this issue has been live since #1314/#1326 — every generation records a `cost_v1` snapshot (wall seconds, CPU seconds, peak RSS, per-model Bedrock token counts off `response.usage`, per-stage timings, row writes), durably keyed to the strategy it produced. Dan's 2026-08-30 status refresh names what was still outstanding: **the $/generation conversion, an N>1 scaling run, CloudWatch billing correlation, and the private business-doc update.**

This PR does the first two. The last two are out of this repo's reach and are listed honestly below.

The specific gap: `GET /api/metrics/private/cost` returned

```python
"cost_per_generation_usd": None,   # DRAFT placeholder
```

as a hard-coded null, while the measurements to answer it sat in `generation_costs` and the arithmetic to price them sat unused in `services/generation_cost_model.py` ("Nothing in the serving path imports this module yet"). Three pieces that never met.

## The change

**New `backend/archimedes/services/generation_cost_rollup.py`** — reads the measured rows, prices each one against the `GENERATION_COST_RATE_CARD` environment rate card, and reports the distribution. Wired into the existing admin endpoint; the flat `cost_per_generation_usd` field is now the mean of the priced runs, with the full picture under a new `generation_cost` block:

| Field | What it answers |
|---|---|
| `cost_per_generation_usd.{mean,median,min,max}` | What a generation costs, and how skewed that is |
| `.{llm_mean,compute_mean,overhead_mean}` | The issue's *"LLM and compute terms stated separately"* |
| `by_n_candidates[]` | The issue's *"repeated for a multi-candidate run so the scaling in N is visible, not assumed"* — bucketed by `meta.n_candidates_requested`, read off whatever real runs exist |
| `jobs_priced` / `jobs_unpriceable` / `unpriceable_reasons` | How much of the table the average actually covers, and why the rest was excluded |
| `rate_card_configured` / `unavailable` / `truncated` | The three ways this can be an honest gap instead of a number |

**Rates are not in this repo and never will be.** The card is one JSON env var, per `CLAUDE.md` § Project (pricing/margin is private-docs material) and because vendor prices change without a deploy. With no card configured the endpoint returns nulls and does not even open a DB session.

**The customer price is unchanged.** `generation_payment.quote()` is untouched and still `pricing_model: "flat_v1"`. This is a report, not a charge.

## Adversarial demos — every guard shown to reject something

Per `CLAUDE.md` § "A guard must be shown to reject something" and § "revert the fix and confirm the test fails". Each demo patches the guard out, runs the suite, and restores.

**1. An absent price must not become $0.00.** Patch `_empty()` to return `{"mean": "0.00000000", ...}` instead of `None`:

```
FAILED test_no_rate_card_yields_nulls_not_zeros - assert {'mean': '0.00000000', ...} is None
FAILED test_no_rate_card_does_not_read_the_database - assert {'mean': '0.00000000', ...} is None
FAILED test_db_failure_degrades_to_unavailable_not_zero - assert {'mean': '0.00000000', ...} is None
3 failed, 10 passed
```

**2. An unpriceable run must not be folded into the mean.** Delete the `continue` after `if not estimate.get("complete")` — i.e. price incomplete estimates anyway:

```
FAILED test_incomplete_llm_usage_is_excluded_from_the_mean - assert 2 == 1
FAILED test_model_the_card_cannot_price_is_excluded_and_named - assert 2 == 1
2 failed, 11 passed
```

Both fixtures are built so the excluded run is the *cheap* one — folding it in drags the reported cost **below** the measured truth, which is exactly the issue's "do not estimate" anti-goal.

**3. K>1 rows for one job must not double-count.** Remove the `if job_id in seen_jobs: continue` de-dup:

```
FAILED test_k_gt_1_rows_for_one_job_are_priced_once - assert 2 == 1
1 failed, 12 passed
```

**4. The priced figure must never reach a public surface.** Add `cost_per_generation_usd` to `MetricsResponse` and populate it on the public `GET /api/metrics`:

```
FAILED test_measured_generation_cost_never_reaches_a_public_surface - AssertionError: priced key leaked onto /api/metrics
E   assert 'cost_per_generation_usd' not in '{"cost_per_...6532+00:00"}'
1 failed, 26 passed
```

That test sweeps `/api/metrics`, `/api/metrics/funnel` and `/api/metrics/visitors` for both the figure and the key name, then re-confirms 403 for a non-admin wallet and 401 for anonymous. The prose claim "admin-only" is backed by a check, not by the docstring.

**5. A priced rollup is structurally barred from the measurement column.** `test_rollup_is_structurally_barred_from_the_measurement_column` asserts `cost_meter.assert_measurement_only(rollup)` **raises** `PricingLeakError` — the same screen that keeps `generation_costs.measurement_json` free of money. Verified positively (the raise is the assertion), not by absence.

## Test evidence

```
# New + touched suites
pytest backend/tests/test_generation_cost_rollup.py backend/tests/test_generation_cost_model.py \
       backend/tests/test_metrics_private_routes.py backend/tests/test_engagement_metrics.py \
       backend/tests/test_generation_cost_persistence.py backend/tests/test_generation_cost_meter.py -q
→ 177 passed

# The exact command CI runs, from the repo root
pytest -m "not integration" -q
→ 5041 passed, 3 skipped, 2 deselected in 515.49s

# Hermetic gate (CLAUDE.md § Testing conventions)
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest backend/tests/test_generation_cost_rollup.py -q
→ 13 passed
env -i ... backend/tests/test_metrics_private_routes.py -q
→ 27 passed

ruff format --check backend/  → 569 files already formatted
ruff check <changed files>    → All checks passed
make docs-check               → 1511 links, 0 broken; 163/163 indexed, 0 orphaned
```

Toolchain: `/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/{pytest,ruff}` (Python 3.12.13), never a bare `pytest`.

Branched from `origin/main` at `bad63978` and re-fetched before push — `git rev-list --count HEAD..origin/main` = 0, so the green check describes current `main` (§ "A stale PR's green check describes a base that no longer exists").

## Not done — honestly

- **No dollar figure is produced by merging this.** No environment has a `GENERATION_COST_RATE_CARD` yet, so `cost_per_generation_usd` stays `null` on prod the moment this lands. Filling the card from the current Bedrock + Fargate price lists is a config action, and the numbers belong in the private docs repo, not here. **This PR builds the instrument; it does not read it.**
- **CloudWatch billing correlation is not done.** `wall_seconds` × the card is a *model* of the Fargate term, not the invoice. The task's allocated size is what actually bills, and per-task `CpuUtilized`/`MemoryUtilized` live in CloudWatch — outside the server. Issue #1217's `aws ecs describe-tasks` line is still an unrun manual step.
- **The private business-model doc (`BUSINESS-MODEL-REDERIVATION-2026-07-28.md` §3) is not updated.** Different repo, Dan's access.
- **`by_n_candidates` reports whatever N values the table happens to contain.** If prod only ever ran N=1, it shows one bucket. It makes an N>1 run *legible when someone does one*; it does not perform one.
- **No UI tile.** `Insights.jsx` does not currently call `/private/cost` at all (see its line-53 comment) — the endpoint is the surface. A dashboard tile is a follow-up, not this change.
- **`compute_mean` inherits `wall_seconds`, not `cpu_seconds`.** Wall is what a Fargate/Lambda lane bills; `cpu_seconds` remains `process_wide_delta` and is not attributable under concurrency. Called out because someone will reasonably expect the CPU figure to be the one priced.
- **Per-module coverage not measured.** `pytest --cov` aborts in this env with a pre-existing `numpy: cannot load module more than once per process` conflict — reproduced on an untouched module (`--cov=archimedes.services.user_stats`), so it is not caused by this change. Stating the gap rather than a number I did not measure.

## Review notes

- **Cross-lane:** backend Python layer is Daniel R.'s lane, the cost/business framing is Dan's. Flagging per `CLAUDE.md` § Team rather than gating on it.
- `generation_cost_model.py` gains two additive fields (`incomplete_reason_codes`, `unpriced_models`) so the rollup can bucket by a stable code instead of parsing prose that embeds a call count and a model id. No existing key changed shape; its 20 tests pass unmodified.
- Two stale prose claims corrected in the same commit, since this PR falsifies them: the module docstring's "Nothing in the serving path imports this module yet" and the ADR's "nothing calls them".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
