### PR TITLE
[docs] Add a PR template that prompts for the closing keyword

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+One logical change per PR. Merge with `gh pr merge <n> --merge` — squash and rebase are off.
+
+Release tag: the bump marker is read from the END of the PR TITLE. `!minor` for a new
+user-facing capability, `!version-release` for a major milestone, nothing otherwise.
+
+Delete any section below that does not apply. Comments like this one do not render.
+-->
+
+## What
+
+<!-- One or two sentences. What changed. -->
+
+## Why
+
+<!-- The problem this solves. Link the issue, ADR, or incident. -->
+
+## Issues
+
+<!--
+Use a real closing keyword so the issue closes when this merges: `Closes #123`,
+`Fixes #123`, `Resolves #123`. The keyword goes immediately before each `#`, once per
+issue — `Closes #1 and #2` closes only #1.
+
+Without a keyword the work lands and the issue stays open forever. That is how a pile of
+already-fixed-but-still-open issues accumulates, and nobody ever goes back to drain it.
+
+Referencing without closing is correct for partial work — write it so the intent is
+legible: `Part of #123`, `See #123`, `Supersedes #123`.
+-->
+
+Closes #
+
+## Verification
+
+<!--
+The commands you ran and their output. Not "tests pass".
+
+Two things a reviewer cannot check for you (CLAUDE.md § Before you approve a merge):
+
+  - A regression test must fail with the fix reverted. Revert it, run the test, paste the
+    failure. A test that passes against the unfixed code guards nothing.
+  - A guard must be shown to reject something. Build the input that should fail it, run it,
+    paste the rejection.
+
+If the PR body asserts a property, the code has to enforce it — a claim in prose is the
+same defect, just harder to grep for.
+
+Drop this section for pure copy or docs changes that cannot be exercised.
+-->
+
+## What a reviewer should push back on
+
+<!-- Trade-offs, scope you deliberately left out, anything you are unsure about. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,13 @@ Live picture: [`docs/architecture.md`](docs/architecture.md). Deployed contract 
   `--graph` show unit-of-work boundaries. Rebase-merge confuses `git branch --merged`
   (rewritten commits aren't ancestors of `main`) and loses the "this was a single PR" signal
   needed for post-hoc forensics.
+- **Close the issue from the PR body with a real keyword.** `Closes #123` / `Fixes #123` /
+  `Resolves #123`, the keyword immediately before each `#`, repeated once per issue —
+  `Closes #1 and #2` closes only #1. Without one the work merges and the issue stays open,
+  which is how a pile of already-fixed-but-still-open issues accumulates that nobody goes
+  back to drain. Referencing without closing is correct for partial work; write `Part of
+  #123` so the non-closing reference reads as deliberate.
+  [`.github/pull_request_template.md`](.github/pull_request_template.md) prompts for it.
 - **The few hard rules — universal, and they do not impede speed:** never force-push
   `main`; never commit secrets or `.env`; one logical change per PR. Force-pushing your
   *own* unmerged feature branch is fine and expected (rebase-before-merge).


### PR DESCRIPTION
## What

Adds `.github/pull_request_template.md` (the repo had none) and one bullet to CLAUDE.md's
branch-model list. Two files, no code.

## Why

Work merges, the issue stays open, and the backlog looks permanent.

By GitHub's own parse — not a grep, the `closingIssuesReferences` field it builds from the
body — **40 of the last 100 merged PRs auto-close an issue.** Three that did not, where the
issue number was sitting in the branch name the whole time:

| PR | branch | merged | issue | closed by hand |
| --- | --- | --- | --- | --- |
| #1440 | `dbrowneup/1371-backlog` | 08-21 | #1371 | 08-28, 7 days later |
| #1375, #1373 | `dbrowneup/1366-*` | 08-20 | #1366 | 08-28, 8 days later |
| #1393 | `dbrowneup/1355-backlog` | 08-20 | #1355 | 08-28, 8 days later |

That is the whole mechanism. A week of an issue being open is a week of it being counted,
re-read, and re-triaged by whoever is looking at the board.

The other half of the fix is giving the *deliberate* non-closing reference a form. Plenty of
mention-without-close is correct — #1614 mentions #1558/#1559 as history, and #1608 spells
out `Refs #1283 — deliberately not Closes #1283` with the reason. The template names
`Part of` / `See` / `Supersedes` so a missing keyword reads as an omission rather than as an
unstated intention.

While the file was being written it also picks up the two verifications a reviewer cannot do
for you — a regression test shown failing with the fix reverted, and a guard shown rejecting
its bad input. Both are already CLAUDE.md rules 3 and 4 and the better PR bodies already do
them; the template just stops it being a thing you have to remember.

CLAUDE.md gets the rule without the 40-of-100 measurement. That file says outright that
anything which decays does not belong in it, and a rate like that decays.

## Issues

No issue — this came out of reviewing what was left in the open-PR queue on 2026-08-28.
Filing one to close it in the same breath would be noise.

## Verification

```
$ make docs-check
links: scanned 1504 in 168 markdown files; broken 0 (0.0%)
index: 163 docs under docs/; 163 indexed, 0 orphaned.
staleness: 0 of 68 `current` docs older than 60 days
```

That covers the new CLAUDE.md link to `.github/pull_request_template.md` — root markdown is
in the link gate's scope, so a wrong path would have failed here.

The measurement, re-runnable:

```bash
gh pr list --state merged --limit 100 --json number,body,closingIssuesReferences --jq '[.[] | select((.closingIssuesReferences|length) > 0)] | length'
```

**One claim I did not test, stated plainly.** The template and the CLAUDE.md bullet both say
`Closes #1 and #2` closes only #1. That is GitHub's documented linking rule — the keyword has
to precede each reference — but I did not demonstrate it, because no PR in the last 150 used
that form, so there is nothing in this repo's history to check it against. I was not going to
open a throwaway issue to find out.

**No effect until this merges.** GitHub reads the template from the base branch, so this PR
does not show it and cannot. The first PR opened after this lands is the test.

## What a reviewer should push back on

- **Length.** 54 lines, most of it HTML comments that do not render. I sized it against the
  PR bodies this repo actually writes, which run to hundreds of lines with mutation
  transcripts in them. If you think it will get select-all-deleted on the first use, cut the
  Verification block and keep Issues.
- **The Verification section may be redundant** with the review rules it restates. I included
  it because the rules live in a file people read at session start and then act from memory
  for the next four hours; the template is in front of you at the moment you would skip it.
- **Nothing enforces this.** It is a prompt, not a gate. A CI check that fails a PR touching
  `backend/` with no issue reference would be enforcement, and would also be wrong maybe a
  fifth of the time. Not proposing it, but that is the honest ceiling on what this buys.
