### PR TITLE
[backend] Arm faulthandler at the entrypoint so the next SIGSEGV names its frames

### DIFF
--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -5,8 +5,17 @@ chain services that read/write Arc smart contracts.
 """
 
 import asyncio
+import faulthandler
 import logging
 import os
+
+# #1632: the backend has died twice with a bare exit 139 (SIGSEGV) under RPC
+# distress and left NOTHING in the logs — the crash context had to be inferred
+# from the preceding lines. faulthandler dumps every thread's Python traceback
+# to stderr on SIGSEGV/SIGFPE/SIGABRT/SIGBUS, which the ECS awslogs driver
+# ships like any other stderr line, so the NEXT native crash names its frames.
+# Enabled unconditionally: it costs nothing at rest and only speaks on faults.
+faulthandler.enable()
 
 # Load .env into os.environ at import time for modules that use os.getenv()
 # (circle_signer, oracle_updater) — pydantic ChainSettings handles ARC_ vars itself.

--- a/backend/tests/test_faulthandler_enabled.py
+++ b/backend/tests/test_faulthandler_enabled.py
@@ -1,0 +1,48 @@
+"""#1632: the entrypoint must arm faulthandler.
+
+The backend died twice with a bare exit 139 and no trace (issue #1632); the
+one-line defense is ``faulthandler.enable()`` at import time in ``main.py``.
+
+Asserted in a SUBPROCESS, not in-process: pytest ships a built-in faulthandler
+plugin that arms the test process itself, so an in-process
+``faulthandler.is_enabled()`` check is true with the fix deleted — a vacuous
+guard (caught by this file's own revert-demo during #1632's development). The
+subprocess first proves faulthandler is NOT pre-armed in a bare interpreter,
+then imports the app and asserts the import armed it — so the pass can only
+come from ``main.py``.
+
+Uses the repo's clean-subprocess idiom (whitelist env, no .env leak) — see
+test_security_hardening.py for the precedent.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+
+_PROBE = (
+    "import faulthandler\n"
+    "assert not faulthandler.is_enabled(), 'pre-armed: this probe proves nothing'\n"
+    "import archimedes.main\n"
+    "assert faulthandler.is_enabled(), 'importing archimedes.main did not arm faulthandler (#1632)'\n"
+    "print('ARMED-BY-IMPORT')\n"
+)
+
+
+def test_importing_main_arms_faulthandler_in_a_bare_interpreter():
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        cwd=_BACKEND_DIR,
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+            "PYTHONPATH": _BACKEND_DIR,
+        },
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"probe failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert "ARMED-BY-IMPORT" in result.stdout


### PR DESCRIPTION
Item 1 of #1632's acceptance — the one-line change that makes the recurring backend segfault diagnosable instead of silent.

## What
`faulthandler.enable()` at the top of `main.py`: on SIGSEGV/SIGFPE/SIGABRT/SIGBUS, every thread's Python traceback goes to stderr, which the ECS awslogs driver ships like any other line. Costs nothing at rest; only speaks on faults.

## Why now
Two bare exit-139 deaths today (task-defs :170 and :177 — #1632 has the dossier), both leaving zero trace. The crash context had to be inferred from preceding log lines. Next time the native frames arrive in CloudWatch.

## Guard (with a confession)
`test_faulthandler_enabled.py` asserts a **bare subprocess** interpreter is NOT pre-armed, imports `archimedes.main`, and asserts the import armed it. The first version checked in-process and was **vacuous** — pytest's built-in faulthandler plugin pre-arms the test runner, so the guard passed with the fix deleted. Its own revert-demo caught that; the subprocess form is what shipped.

## Adversarial demo
```
-- enable() replaced with pass:
1 failed  (AssertionError: importing archimedes.main did not arm faulthandler (#1632))
-- restored:
1 passed
```

Part of #1632 (items 2–4 — the abandonment-path audit, fault-injection test, and week-of-prod acceptance — remain open there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
