### PR TITLE
[docs][frontend] Retire look_ahead_safe from the spec's live sections + fix the Landing LEAK receipt

### DIFF
--- a/docs/specs/strategy-dsl-spec.md
+++ b/docs/specs/strategy-dsl-spec.md
@@ -36,7 +36,6 @@ marked as such rather than described in the present tense.
   "exit": { "<condition tree>": "..." },
   "position_sizing": { "type": "<sizing type>" },
   "source_arxiv_ids": ["arxiv id", "..."],
-  "look_ahead_safe": true,
   "parameter_variants": { "<indicator alias>": [1, 2, "…2-8 numbers"] }
 }
 ```
@@ -178,10 +177,17 @@ calendar weeks or months. The live evaluator replays the same table
 (`dsl_to_backtrader.rebalance_period_bars`) so the two interpreters cannot drift
 on cadence (audit F3).
 
-### `look_ahead_safe`
+### `look_ahead_safe` (retired, #1599)
 
-Must be `true`. A spec with `look_ahead_safe: false` is rejected by the
-validator, not merely flagged.
+No longer part of the schema. The field was the generating model grading its
+own homework; the LEAK verdict is now derived structurally by the platform
+(`dsl_lookahead_audit` — the AST proof over the interpreter plus the spec
+walk, #1566) and nothing the model claims about its own safety is read. For
+backward compatibility a spec that still carries the key is accepted and the
+key is ignored (`strategy_dsl.LEGACY_IGNORED_FIELDS`) — including
+`look_ahead_safe: false`, which is deliberately not honoured (see the
+docstring there for why re-honouring it would let a model veto its own
+audit).
 
 ## Validation rules
 
@@ -200,7 +206,7 @@ validator, not merely flagged.
    `inverse_vol` rejects a `reference_vol_annual` that is present but not a
    positive number.
 8. `source_arxiv_ids` a list of non-empty strings.
-9. `look_ahead_safe` must be boolean **and** `true`.
+9. `look_ahead_safe`, if present, is ignored (retired, #1599 — see above).
 10. `parameter_variants` keys must reference an alias used in `entry`/`exit`;
     values must be lists of 2–8 numbers.
 
@@ -239,8 +245,7 @@ The reference spec, verbatim from `strategy_dsl.FABER_2007_SPEC`:
     {"gt": ["realized_vol_20", 0.35]}
   ]},
   "position_sizing": {"type": "inverse_vol", "reference_vol_annual": 0.15},
-  "source_arxiv_ids": ["0706.1497", "1704.03022"],
-  "look_ahead_safe": true
+  "source_arxiv_ids": ["0706.1497", "1704.03022"]
 }
 ```
 

--- a/ui/src/components/Landing.jsx
+++ b/ui/src/components/Landing.jsx
@@ -32,10 +32,12 @@ const CORE_CONTRACT_FIELDS = [
 //   OOS   — _rigor_helpers.compute_oos_sharpe:567-574, "a single chronological
 //           hold-out, NOT a rolling walk-forward re-estimation ... no purge/embargo
 //           gap at the train/test boundary." train_fraction defaults to 0.70.
-//   LEAK  — strategy_dsl.py:192-193 rejects look_ahead_safe=false at validation;
-//           generation_pipeline.py:1892 persists look_ahead_audit_source=
-//           "self_attested"; rigor_evaluator.look_ahead_audit (the real AST pass)
-//           runs only against cited library source.
+//   LEAK  — dsl_lookahead_audit.py proves every bar-indexed read in the
+//           interpreter is offset <= 0 (AST pass, #1566) and walks the
+//           validated spec against that audited surface; the generator's own
+//           safety claim is retired and ignored if present
+//           (strategy_dsl.LEGACY_IGNORED_FIELDS, #1599) — the verdict is
+//           derived, never self-attested.
 const RIGOR_CRITERIA = [
 	{
 		code: "DSR",


### PR DESCRIPTION
Follow-up to @onder-akkaya's #1599 review, which raced the merge by ~55 minutes. His two findings, both real on merged main:

1. **The spec still taught the dead field.** Main's 383-line spec rewrite (#1567 era) re-introduced `look_ahead_safe` as a live requirement in four places the branch's older copy never touched — exactly the hazard his review named. Now: schema/examples cleaned, a **retired (#1599)** section documents the `LEGACY_IGNORED_FIELDS` tolerance (including why `false` is deliberately not honoured), rule 9 says ignored-if-present.
2. **The Landing LEAK receipt cited three now-false references** (`strategy_dsl.py:192-193 rejects…`, `generation_pipeline.py:1892 persists self_attested`, audit-runs-only-on-cited-source). Rewritten to the true receipt: the #1566 AST proof + spec walk, self-attestation retired and ignored.

His union test matched ours independently (+24 passed, zero new failures; the 26 local reds were the bare-`alembic` PATH footgun). His third finding — the corpus loader ignoring `ARCHIMEDES_CORPUS_MANIFEST` in used worktrees — is filed separately with credit.

Evidence: `make docs-check` clean · UI 645/0 · `pytest -k 'strategy_dsl or lookahead'` 159/0 · remaining spec mentions of the field: 3, all inside the retired-section documentation.

Refs #1599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7