### PR TITLE
[infra] Raise the ECS autoscaling floor to 2 tasks

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -74,9 +74,13 @@ variable "ecs_service_desired_count" {
 }
 
 variable "ecs_service_min_count" {
+  # 2, not 1 (owner decision 2026-08-31): a one-task fleet turns every deploy
+  # into a brief 502 window (rollout gap) and every backend crash into a
+  # user-facing outage — both bitten twice on 2026-08-31 (#1594, #1632).
+  # At 2, rollouts overlap and a single crash is invisible. ~$15-18/mo.
   description = "Application Auto Scaling floor for the archimedes-backend service."
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "ecs_service_max_count" {


### PR DESCRIPTION
Owner decision 2026-08-31 (asked, answered: raise). One variable default: `ecs_service_min_count` 1 → 2, with the incident rationale in the comment — a singleton fleet turned every deploy into a 502 window and every backend crash into an outage; both classes hit twice today (#1594, #1632 dossiers). Cost ~$15–18/mo of Fargate hours. Applies at the owner's next terraform apply.

Refs #1594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7