### PR TITLE
[test] Update the oracle-stale anti-goal pin to the #1601 retune values

### DIFF
--- a/backend/tests/test_cloudwatch_alarms.py
+++ b/backend/tests/test_cloudwatch_alarms.py
@@ -387,7 +387,11 @@ class TestAntiGoals:
         assert _string_attr(alarm, "comparison_operator") == "GreaterThanOrEqualToThreshold"
         assert _int_attr(alarm, "threshold") == 3
         assert _int_attr(alarm, "period") == 300
-        assert _int_attr(alarm, "evaluation_periods") == 1
+        # 1 -> 3 with datapoints_to_alarm 2: the #1601 retune (2-of-3 windows must
+        # breach before paging), merged after this fence was written. The fence's
+        # point stands -- these values change only via a deliberate, cited retune.
+        assert _int_attr(alarm, "evaluation_periods") == 3
+        assert _int_attr(alarm, "datapoints_to_alarm") == 2
         assert _string_attr(alarm, "treat_missing_data") == "notBreaching"
 
     def test_the_oracle_stale_filter_is_untouched(self) -> None:


### PR DESCRIPTION
One-test fix-forward: the union suite on merged main found `test_the_oracle_stale_alarm_is_untouched` failing (`assert 3 == 1`) — the anti-goal fence from the alarm wave pinned `evaluation_periods=1`, and #1601's retune (2-of-3 windows) legitimately changed it after the fence was written. Both green alone; red in union.

The pin now asserts the retuned values (`evaluation_periods=3`, `datapoints_to_alarm=2`) with a comment citing the retune, so the fence keeps its purpose: these values change only deliberately, with a citation.

Adversarial demo: the old pin against current `cloudwatch.tf` is the union failure itself — the fence demonstrably rejects a divergent value.

`pytest backend/tests/test_cloudwatch_alarms.py -q` → **52 passed**.

Part of #1594.