### PR TITLE
[frontend] Bound every displayed metric to its mathematical domain — no more −130% drawdowns, no more reasonless dashes

### DIFF
--- a/ui/src/components/Leaderboard.jsx
+++ b/ui/src/components/Leaderboard.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '../AuthContext'
 import { apiGet } from '../api'
+import MetricValue from './MetricValue'
+import { formatMetric } from '../metricDomain.js'
 
 // Single-user leaderboard (MVP pivot — no publish mechanism exists yet, so
 // ranking a global cohort was incoherent; nobody had opted into competing).
@@ -58,17 +60,15 @@ const REGIMES = [
 
 const MEDAL = { gold: '🥇', silver: '🥈', bronze: '🥉' }
 
+// Residual local formatter for page furniture that is NOT a strategy metric —
+// the StockBench benchmark sentence. Every metric with a declared domain goes
+// through MetricValue / metricDomain.js instead (#1651), so this must never
+// grow a new call site for one. The Number.isFinite guard is the reason it is
+// still allowed to exist at all: `Number(NaN).toFixed(2)` renders the literal
+// string "NaN", which is its own flavour of impossible number on the page.
 function fmt(v, d = 2) {
-  return v != null ? Number(v).toFixed(d) : '—'
-}
-function fmtPct(v, d = 1) {
-  return v != null ? `${(v * 100).toFixed(d)}%` : '—'
-}
-// Signed, so a forward return never reads as a bare magnitude.
-function fmtSignedPct(v, d = 2) {
-  if (v == null) return '—'
-  const pct = v * 100
-  return `${pct >= 0 ? '+' : '−'}${Math.abs(pct).toFixed(d)}%`
+  if (v == null || !Number.isFinite(Number(v))) return '—'
+  return Number(v).toFixed(d)
 }
 
 // ── Provenance labelling ────────────────────────────────────────────────────
@@ -159,7 +159,9 @@ function boardFdrTitle(entry, fdrLevel) {
   if (entry.board_fdr_significant == null) {
     return 'Not corrected: this row has no DSR confidence for the board-level correction to act on.'
   }
-  const adjusted = entry.board_fdr_adjusted_p != null ? ` BH-adjusted p=${fmt(entry.board_fdr_adjusted_p, 3)}.` : ''
+  const adjusted = entry.board_fdr_adjusted_p != null
+    ? ` BH-adjusted p=${formatMetric('board_fdr_adjusted_p', entry.board_fdr_adjusted_p, { row: entry, digits: 3, surface: 'Leaderboard board-FDR title' }).label}.`
+    : ''
   return entry.board_fdr_significant
     ? `Clears the board-level Benjamini–Hochberg correction at ${alpha}.${adjusted} Advisory — it does not change the rigor-gate badge.`
     : `${BOARD_FDR_NOT_DISTINGUISHABLE} (Benjamini–Hochberg, ${alpha}).${adjusted} This does not mean the strategy is unsound — the rigor gate answers that separately.`
@@ -177,7 +179,7 @@ function BoardFdrCell({ entry, fdrLevel }) {
         : <span className="tag-muted">Not distinguishable</span>}
       {entry.board_fdr_adjusted_p != null && (
         <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>
-          adj p {fmt(entry.board_fdr_adjusted_p, 3)}
+          adj p <MetricValue metric="board_fdr_adjusted_p" value={entry.board_fdr_adjusted_p} row={entry} digits={3} surface="Leaderboard board-FDR" />
         </div>
       )}
     </span>
@@ -672,29 +674,49 @@ export default function Leaderboard() {
                     </div>
                   </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
-                    <div style={{ fontWeight: 600, color: 'var(--accent)' }}>{fmt(e.conviction_score, 1)}</div>
+                    <div style={{ fontWeight: 600, color: 'var(--accent)' }}>
+                      <MetricValue metric="conviction_score" value={e.conviction_score} row={e} surface="Leaderboard" />
+                    </div>
                     <ScoreBar components={e.score_components} weights={engine?.weights} />
                   </td>
-                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmt(e.sharpe_ratio)}</td>
-                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmtPct(e.cagr)}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    <MetricValue metric="sharpe_ratio" value={e.sharpe_ratio} row={e} surface="Leaderboard" />
+                  </td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    <MetricValue metric="cagr" value={e.cagr} row={e} surface="Leaderboard" />
+                  </td>
+                  {/* The Math.abs() that used to sit here was a second way to
+                      render an impossible drawdown: a SIGNED value of −0.20 —
+                      the wire contract says positive fraction — came out as
+                      "−20.0%", a plausible-looking number manufactured from a
+                      contract violation. MetricValue clamps it to the 0 bound
+                      and says the reported figure was out of range (#1651). */}
                   <td style={{ padding: '10px', whiteSpace: 'nowrap', color: 'var(--negative)' }}>
-                    {e.max_drawdown != null ? `−${fmtPct(Math.abs(e.max_drawdown))}` : '—'}
+                    <MetricValue metric="max_drawdown" value={e.max_drawdown} row={e} surface="Leaderboard" />
                   </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     {rigorBadge(e)}
                     {(e.dsr_p_value != null || e.pbo_score != null || e.out_of_sample_sharpe != null) && (
                       <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }} title="DSR confidence (0–1, higher is better): probability the Sharpe survives deflation/multiple-testing. Not a classical p-value. OOS = out-of-sample Sharpe.">
                         {[
-                          e.dsr_p_value != null && `DSR conf=${fmt(e.dsr_p_value)}`,
-                          e.pbo_score != null && `PBO ${fmt(e.pbo_score)}`,
-                          e.out_of_sample_sharpe != null && `OOS ${fmt(e.out_of_sample_sharpe)}`,
+                          e.dsr_p_value != null && (
+                            <span key="dsr">DSR conf=<MetricValue metric="dsr_p_value" value={e.dsr_p_value} row={e} surface="Leaderboard" /></span>
+                          ),
+                          e.pbo_score != null && (
+                            <span key="pbo">PBO <MetricValue metric="pbo_score" value={e.pbo_score} row={e} surface="Leaderboard" /></span>
+                          ),
+                          e.out_of_sample_sharpe != null && (
+                            <span key="oos">OOS <MetricValue metric="out_of_sample_sharpe" value={e.out_of_sample_sharpe} row={e} surface="Leaderboard" /></span>
+                          ),
                         ]
                           .filter(Boolean)
-                          .join(' · ')}
+                          .flatMap((node, i) => (i === 0 ? [node] : [<span key={`sep-${i}`}> · </span>, node]))}
                       </div>
                     )}
                   </td>
-                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>{fmt(e.deflated_sharpe_ratio)}</td>
+                  <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
+                    <MetricValue metric="deflated_sharpe_ratio" value={e.deflated_sharpe_ratio} row={e} surface="Leaderboard" />
+                  </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     <BoardFdrCell entry={e} fdrLevel={boardFdr?.fdr_level} />
                   </td>
@@ -810,7 +832,7 @@ export default function Leaderboard() {
                   </td>
                   <td style={{ padding: '10px', whiteSpace: 'nowrap' }}>
                     <div style={{ fontWeight: 600, color: row.cumulative_return >= 0 ? 'var(--accent)' : 'var(--negative)' }}>
-                      {fmtSignedPct(row.cumulative_return)}
+                      <MetricValue metric="cumulative_return" value={row.cumulative_return} row={row} surface="Leaderboard live" />
                     </div>
                     <div style={{ fontSize: 11, color: 'var(--text-3)' }}>realised, not annualised</div>
                   </td>

--- a/ui/src/components/MetricValue.jsx
+++ b/ui/src/components/MetricValue.jsx
@@ -1,0 +1,53 @@
+/** MetricValue — the one place a backtest metric becomes pixels (#1651).
+ *
+ * `metricDomain.formatMetric` decides WHAT to render; this decides HOW, and it
+ * exists so that the "what" cannot be partly ignored. A clamped value comes
+ * back as `{ label: "−100.0%", note: "reported −130.3% — outside the possible
+ * range" }`, and a caller free to render `label` while dropping `note` would
+ * turn an honest clamp back into a silent one — which is the anti-goal the
+ * issue names. Routing all four surfaces (Library table, Library card,
+ * Passport, Leaderboard, Publish table) through this component makes the
+ * annotation structural rather than a convention every future cell has to
+ * remember.
+ *
+ * Markup notes:
+ *  - The wrapper is a `<span>`, not a `<div>`, so the same component is valid
+ *    inside a `<td>`, a card `<div>` and the Passport's `Metric` value slot.
+ *  - The annotation carries a visible glyph AND a text sentence AND an sr-only
+ *    expansion: colour alone has never been an acceptable signal here (1.4.1),
+ *    and a tooltip alone is invisible on touch.
+ */
+import { formatMetric } from '../metricDomain.js'
+
+export default function MetricValue({
+  metric,
+  value,
+  row = null,
+  format,
+  digits,
+  surface = '',
+  className = '',
+  style,
+}) {
+  const m = formatMetric(metric, value, { row, format, digits, surface })
+  return (
+    <span className={className} style={style} title={m.title || undefined}>
+      {m.label}
+      {m.note && (
+        <span
+          className="metric-annotation"
+          style={{
+            display: 'block',
+            fontSize: '0.68rem',
+            fontWeight: 400,
+            color: 'var(--negative)',
+          }}
+        >
+          <span aria-hidden="true">⚠ </span>
+          {m.note}
+          <span className="sr-only"> — {m.title}</span>
+        </span>
+      )}
+    </span>
+  )
+}

--- a/ui/src/components/PublishStrategyTable.jsx
+++ b/ui/src/components/PublishStrategyTable.jsx
@@ -8,15 +8,8 @@
  * to pick and publish a strategy.
  */
 import { useState } from 'react'
+import MetricValue from './MetricValue'
 
-function fmt(v, decimals = 2) {
-  if (v == null || !Number.isFinite(v)) return '—'
-  return v.toFixed(decimals)
-}
-function fmtPct(v) {
-  if (v == null || !Number.isFinite(v)) return '—'
-  return `${(v * 100).toFixed(1)}%`
-}
 function fmtUsd(n, fractionDigits = 0) {
   if (n == null || !Number.isFinite(n)) return '—'
   return `$${n.toLocaleString(undefined, { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits })}`
@@ -85,14 +78,20 @@ function StrategyRow({ s, onSelect }) {
         <td>
           <span className="tag tag-muted">{statusLabel(s.status)}</span>
         </td>
-        <td className="mono" style={{ textAlign: 'right' }}>{fmt(s.sharpe_ratio)}</td>
-        {/* Color/class checks use Number.isFinite to match what fmtPct/fmtUsd
-            actually render — a NaN/Infinity CAGR renders "—" and must not
-            carry a positive/negative color (review). Math.abs on drawdown
-            avoids a double negative when the backend ships it signed. */}
-        <td className={`mono ${!Number.isFinite(s.cagr) ? '' : s.cagr >= 0 ? 'positive' : 'negative'}`} style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
+        <td className="mono" style={{ textAlign: 'right' }}>
+          <MetricValue metric="sharpe_ratio" value={s.sharpe_ratio} row={s} surface="Publish table" />
+        </td>
+        {/* Color/class checks use Number.isFinite to match what MetricValue
+            actually renders — a NaN/Infinity CAGR renders "—" and must not
+            carry a positive/negative color (review). The Math.abs that used to
+            sit on the drawdown cell is gone: it turned a contract-violating
+            SIGNED drawdown into a plausible-looking positive one instead of
+            reporting that the value was outside its domain (#1651). */}
+        <td className={`mono ${!Number.isFinite(s.cagr) ? '' : s.cagr >= 0 ? 'positive' : 'negative'}`} style={{ textAlign: 'right' }}>
+          <MetricValue metric="cagr" value={s.cagr} row={s} surface="Publish table" />
+        </td>
         <td className="mono negative" style={{ textAlign: 'right' }}>
-          {s.max_drawdown != null ? `−${fmtPct(Math.abs(s.max_drawdown))}` : '—'}
+          <MetricValue metric="max_drawdown" value={s.max_drawdown} row={s} surface="Publish table" />
         </td>
         <td className="mono" style={{ textAlign: 'right', color: !Number.isFinite(s.cagr) ? 'var(--text-3)' : s.cagr >= 0 ? 'var(--positive)' : 'var(--negative)' }}>{fmtUsd(endValue)}</td>
         <td style={{ textAlign: 'right', padding: '6px 10px' }}>

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -9,6 +9,7 @@ import { ROADMAP_SURFACES_ENABLED } from '../featureFlags.js'
 
 import { apiGet, apiPost, apiDelete } from '../api'
 import { compactCostCell } from '../generationCost.js'
+import MetricValue from './MetricValue'
 import {
   isUnknownRigorGateStatus,
   warnUnknownRigorGateStatus,
@@ -110,12 +111,12 @@ function statusLabel(status, passesRigor) {
   return status.charAt(0).toUpperCase() + status.slice(1)
 }
 
-function fmt(v, decimals = 2) {
-  return v != null ? v.toFixed(decimals) : '—'
-}
-function fmtPct(v) {
-  return v != null ? `${(v * 100).toFixed(1)}%` : '—'
-}
+// No local number formatter lives here any more. Every metric this file renders
+// goes through MetricValue / metricDomain.js (#1651): the old `fmt`/`fmtPct`
+// pair had no idea what quantity it was formatting, which is precisely how a
+// stored max_drawdown of 1.303 became a displayed "−130.3%". Re-adding one
+// would give the next cell a way around the domain check —
+// ui/test/metric-domain.test.js fails if either name comes back.
 
 // "2002-01-01" -> Date; null on bad input
 function isoToDate(iso) {
@@ -294,26 +295,31 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
           </div>
         </td>
         <td className="mono" style={{ textAlign: 'right' }}>
-          {fmt(s.sharpe_ratio)}
+          {/* Every measured number in this row goes through MetricValue, which
+              is the only formatter that knows each metric's domain and cannot
+              render a value outside it without saying so (#1651). */}
+          <MetricValue metric="sharpe_ratio" value={s.sharpe_ratio} row={s} surface="Library table" />
           {sharpeCI && (
             <div style={{ fontSize: '0.68rem', color: 'var(--text-4)' }}>
-              [{fmt(sharpeCI[0])}, {fmt(sharpeCI[1])}]
+              [<MetricValue metric="sharpe_ci_lower" value={sharpeCI[0]} row={s} surface="Library table" />, <MetricValue metric="sharpe_ci_upper" value={sharpeCI[1]} row={s} surface="Library table" />]
             </div>
           )}
           {s.dsr_p_value != null && (
             <div style={{ fontSize: '0.68rem', color: 'var(--text-4)' }}>
-              (DSR conf={s.dsr_p_value.toFixed(2)})
+              (DSR conf=<MetricValue metric="dsr_p_value" value={s.dsr_p_value} row={s} surface="Library table" />)
             </div>
           )}
         </td>
-        <td className={`mono ${signClass(s.cagr)}`} style={{ textAlign: 'right' }}>{fmtPct(s.cagr)}</td>
+        <td className={`mono ${signClass(s.cagr)}`} style={{ textAlign: 'right' }}>
+          <MetricValue metric="cagr" value={s.cagr} row={s} surface="Library table" />
+        </td>
         <td className="mono negative" style={{ textAlign: 'right' }}>
-          {s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}
+          <MetricValue metric="max_drawdown" value={s.max_drawdown} row={s} surface="Library table" />
           {/* Same defect: crossing the 0.5 overfitting threshold was signalled
               only by the colour swap to --negative (1.4.1). */}
           {s.pbo_score != null && (
             <div style={{ fontSize: '0.68rem', color: s.pbo_score > 0.5 ? 'var(--negative)' : 'var(--text-4)' }}>
-              (PBO {s.pbo_score.toFixed(2)}{s.pbo_score > 0.5 && <span aria-hidden="true"> ⚠</span>})
+              (PBO <MetricValue metric="pbo_score" value={s.pbo_score} row={s} surface="Library table" />{s.pbo_score > 0.5 && <span aria-hidden="true"> ⚠</span>})
               {s.pbo_score > 0.5 && (
                 <span className="sr-only"> — above the 0.50 overfitting threshold</span>
               )}
@@ -431,13 +437,17 @@ function StrategyDetailContent({ s, onOpenRigorExplainer, onOpenPassport, extraA
             )}
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10 }}>
-            <div><div className="caption">DSR</div><div className="mono" style={{ fontWeight: 700 }}>{fmt(s.deflated_sharpe_ratio)}</div></div>
-            <div><div className="caption">PBO</div><div className="mono" style={{ fontWeight: 700 }}>{fmtPct(s.pbo_score)}</div></div>
-            <div><div className="caption">OOS Sharpe</div><div className="mono" style={{ fontWeight: 700 }}>{fmt(s.out_of_sample_sharpe)}</div></div>
+            <div><div className="caption">DSR</div><div className="mono" style={{ fontWeight: 700 }}><MetricValue metric="deflated_sharpe_ratio" value={s.deflated_sharpe_ratio} row={s} surface="Library detail" /></div></div>
+            {/* PBO is a probability in [0,1] and this cell renders it as a
+                percentage — the DOMAIN is keyed off the metric, the format is
+                the cell's choice, so the table's "0.62" and this "62.0%" stay
+                two renderings of one bounded quantity. */}
+            <div><div className="caption">PBO</div><div className="mono" style={{ fontWeight: 700 }}><MetricValue metric="pbo_score" value={s.pbo_score} row={s} format="pct" surface="Library detail" /></div></div>
+            <div><div className="caption">OOS Sharpe</div><div className="mono" style={{ fontWeight: 700 }}><MetricValue metric="out_of_sample_sharpe" value={s.out_of_sample_sharpe} row={s} surface="Library detail" /></div></div>
           </div>
           {s.paper_claimed_sharpe != null && (
             <div className="caption mt-2">
-              Paper claim: <strong>{fmt(s.paper_claimed_sharpe)}</strong> · Backtest: <strong>{fmt(s.sharpe_ratio)}</strong>
+              Paper claim: <strong><MetricValue metric="paper_claimed_sharpe" value={s.paper_claimed_sharpe} row={s} surface="Library detail" /></strong> · Backtest: <strong><MetricValue metric="sharpe_ratio" value={s.sharpe_ratio} row={s} surface="Library detail" /></strong>
               {/* The pass/fail judgement against the 50% replication threshold
                   used to live in the green/red class alone — "(43%)" and
                   "(97%)" rendered identically to a colourblind reader (1.4.1).
@@ -563,9 +573,9 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
         <DeployabilityChip deploy={deploy} level={level} />
       </div>
       <div className="lib-card-stats">
-        <div><div className="caption">Sharpe</div><div className="mono">{fmt(s.sharpe_ratio)}</div></div>
-        <div><div className="caption">CAGR</div><div className={`mono ${signClass(s.cagr)}`}>{fmtPct(s.cagr)}</div></div>
-        <div><div className="caption">Max DD</div><div className="mono negative">{s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : '—'}</div></div>
+        <div><div className="caption">Sharpe</div><div className="mono"><MetricValue metric="sharpe_ratio" value={s.sharpe_ratio} row={s} surface="Library card" /></div></div>
+        <div><div className="caption">CAGR</div><div className={`mono ${signClass(s.cagr)}`}><MetricValue metric="cagr" value={s.cagr} row={s} surface="Library card" /></div></div>
+        <div><div className="caption">Max DD</div><div className="mono negative"><MetricValue metric="max_drawdown" value={s.max_drawdown} row={s} surface="Library card" /></div></div>
         <div title={genCost.title}><div className="caption">Gen tokens</div><div className={genCost.measured ? 'mono' : 'caption'}>{genCost.label}</div></div>
       </div>
       {open && (

--- a/ui/src/components/StrategyPassport.jsx
+++ b/ui/src/components/StrategyPassport.jsx
@@ -5,6 +5,7 @@ import { passportBackPage, passportBackLabel } from "../routes.js";
 import RigorStrictnessControl, { levelLabel } from "./RigorStrictnessControl";
 import { apiGet, apiPostWithMeta } from "../api";
 import StrategyReasoning from "./StrategyReasoning";
+import MetricValue from "./MetricValue";
 import { useRigorStrictness, BADGE_LEVEL } from "../hooks/useRigorStrictness";
 import {
 	NOT_MEASURED,
@@ -35,15 +36,9 @@ const API_BASE = import.meta.env.VITE_API_BASE ?? "";
 // Reachable from: Library row title click (deep-link), Reasoning trace
 // "→ Strategy in Library" follow-back, FusionResult "Open in Library →" CTA.
 
-function fmt(v, digits = 2) {
-	if (v == null || !Number.isFinite(v)) return "—";
-	return Number(v).toFixed(digits);
-}
-
-function fmtPct(v) {
-	if (v == null || !Number.isFinite(v)) return "—";
-	return `${(Number(v) * 100).toFixed(1)}%`;
-}
+// No local number formatter lives here any more. Every metric this file renders
+// goes through MetricValue / metricDomain.js (#1651) — see the note in
+// Strategies.jsx; ui/test/metric-domain.test.js fails if `fmt`/`fmtPct` return.
 
 function statusTag(status, passesRigor) {
 	// A "live" admin status combined with a failed rigor verdict shouldn't
@@ -529,7 +524,14 @@ export default function StrategyPassport({
 										<div className="caption text-[var(--text-4)]">
 											Kelly fraction
 										</div>
-										<div className="body mono">{fmt(s.kelly_fraction)}</div>
+										<div className="body mono">
+											<MetricValue
+												metric="kelly_fraction"
+												value={s.kelly_fraction}
+												row={s}
+												surface="Passport"
+											/>
+										</div>
 									</div>
 								)}
 							</div>
@@ -641,30 +643,119 @@ export default function StrategyPassport({
 							</div>
 						)}
 						<div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+							{/* Every cell below goes through MetricValue so the passport
+							    cannot render a number outside its metric's domain without
+							    saying so, and an empty cell carries a reason rather than a
+							    bare em-dash (#1651). */}
 							<Metric
 								label="Sharpe"
-								value={fmt(s.sharpe_ratio)}
+								value={
+									<MetricValue
+										metric="sharpe_ratio"
+										value={s.sharpe_ratio}
+										row={s}
+										surface="Passport"
+									/>
+								}
 								hint={
-									s.sharpe_ci_lower != null && s.sharpe_ci_upper != null
-										? `[${fmt(s.sharpe_ci_lower)}, ${fmt(s.sharpe_ci_upper)}]`
-										: null
+									s.sharpe_ci_lower != null && s.sharpe_ci_upper != null ? (
+										<>
+											[
+											<MetricValue
+												metric="sharpe_ci_lower"
+												value={s.sharpe_ci_lower}
+												row={s}
+												surface="Passport"
+											/>
+											,{" "}
+											<MetricValue
+												metric="sharpe_ci_upper"
+												value={s.sharpe_ci_upper}
+												row={s}
+												surface="Passport"
+											/>
+											]
+										</>
+									) : null
 								}
 							/>
-							<Metric label="CAGR" value={fmtPct(s.cagr)} />
+							<Metric
+								label="CAGR"
+								value={
+									<MetricValue
+										metric="cagr"
+										value={s.cagr}
+										row={s}
+										surface="Passport"
+									/>
+								}
+							/>
 							<Metric
 								label="Max DD"
 								value={
-									s.max_drawdown != null ? `−${fmtPct(s.max_drawdown)}` : "—"
+									<MetricValue
+										metric="max_drawdown"
+										value={s.max_drawdown}
+										row={s}
+										surface="Passport"
+									/>
 								}
 							/>
-							<Metric label="Calmar" value={fmt(s.calmar_ratio)} />
-							<Metric label="Sortino" value={fmt(s.sortino_ratio)} />
-							<Metric label="Win rate" value={fmtPct(s.win_rate)} />
+							<Metric
+								label="Calmar"
+								value={
+									<MetricValue
+										metric="calmar_ratio"
+										value={s.calmar_ratio}
+										row={s}
+										surface="Passport"
+									/>
+								}
+							/>
+							<Metric
+								label="Sortino"
+								value={
+									<MetricValue
+										metric="sortino_ratio"
+										value={s.sortino_ratio}
+										row={s}
+										surface="Passport"
+									/>
+								}
+							/>
+							<Metric
+								label="Win rate"
+								value={
+									<MetricValue
+										metric="win_rate"
+										value={s.win_rate}
+										row={s}
+										surface="Passport"
+									/>
+								}
+							/>
 							<Metric
 								label="Trades"
-								value={s.total_trades != null ? s.total_trades : "—"}
+								value={
+									<MetricValue
+										metric="total_trades"
+										value={s.total_trades}
+										row={s}
+										surface="Passport"
+									/>
+								}
 							/>
-							<Metric label="ρ to SPY" value={fmt(s.correlation_to_spy)} />
+							<Metric
+								label="ρ to SPY"
+								value={
+									<MetricValue
+										metric="correlation_to_spy"
+										value={s.correlation_to_spy}
+										row={s}
+										surface="Passport"
+									/>
+								}
+							/>
 						</div>
 						{(s.backtest_start || s.backtest_end) && (
 							<div className="caption mt-3 text-[var(--text-3)]">
@@ -678,8 +769,23 @@ export default function StrategyPassport({
 						{s.paper_claimed_sharpe != null && (
 							<div className="caption mt-2">
 								Paper-claimed Sharpe:{" "}
-								<strong>{fmt(s.paper_claimed_sharpe)}</strong> · realized:{" "}
-								<strong>{fmt(s.sharpe_ratio)}</strong>{" "}
+								<strong>
+									<MetricValue
+										metric="paper_claimed_sharpe"
+										value={s.paper_claimed_sharpe}
+										row={s}
+										surface="Passport"
+									/>
+								</strong>{" "}
+								· realized:{" "}
+								<strong>
+									<MetricValue
+										metric="sharpe_ratio"
+										value={s.sharpe_ratio}
+										row={s}
+										surface="Passport"
+									/>
+								</strong>{" "}
 								{s.sharpe_ratio != null &&
 									(() => {
 										const ratio =
@@ -761,16 +867,32 @@ export default function StrategyPassport({
 						<div className="grid grid-cols-2 md:grid-cols-4 gap-3">
 							<Metric
 								label="DSR"
-								value={fmt(s.deflated_sharpe_ratio)}
+								value={
+									<MetricValue
+										metric="deflated_sharpe_ratio"
+										value={s.deflated_sharpe_ratio}
+										row={s}
+										surface="Passport rigor"
+									/>
+								}
 								hint={
 									// Despite the wire field's legacy name (dsr_p_value), higher
 									// is better here — a confidence, not a classical significance
 									// statistic where lower is better (leaderboard_schemas.py).
 									// "p = 0.93" reads as catastrophic to a reader expecting the
 									// classical convention; it is in fact the passing case (#1358).
-									s.dsr_p_value != null
-										? `confidence = ${fmt(s.dsr_p_value, 3)}`
-										: null
+									s.dsr_p_value != null ? (
+										<>
+											confidence ={" "}
+											<MetricValue
+												metric="dsr_p_value"
+												value={s.dsr_p_value}
+												row={s}
+												digits={3}
+												surface="Passport rigor"
+											/>
+										</>
+									) : null
 								}
 							/>
 							{/* PBO of exactly 0 paired with missing DSR/OOS is almost always a
@@ -779,19 +901,47 @@ export default function StrategyPassport({
 							<Metric
 								label="PBO"
 								value={
-									s.pbo_score == null ||
-									(s.pbo_score === 0 &&
-										s.deflated_sharpe_ratio == null &&
-										s.out_of_sample_sharpe == null)
-										? "—"
-										: fmtPct(s.pbo_score)
+									<MetricValue
+										metric="pbo_score"
+										// The placeholder case above is expressed by handing
+										// MetricValue a null, so the cell picks up the SAME
+										// pending/degenerate reason every other empty cell on
+										// this page gets instead of a bare em-dash (#1651).
+										value={
+											s.pbo_score === 0 &&
+											s.deflated_sharpe_ratio == null &&
+											s.out_of_sample_sharpe == null
+												? null
+												: s.pbo_score
+										}
+										row={s}
+										format="pct"
+										surface="Passport rigor"
+									/>
 								}
 								hint="lower = less overfit"
 							/>
-							<Metric label="OOS Sharpe" value={fmt(s.out_of_sample_sharpe)} />
+							<Metric
+								label="OOS Sharpe"
+								value={
+									<MetricValue
+										metric="out_of_sample_sharpe"
+										value={s.out_of_sample_sharpe}
+										row={s}
+										surface="Passport rigor"
+									/>
+								}
+							/>
 							<Metric
 								label="Trades"
-								value={s.total_trades != null ? s.total_trades : "—"}
+								value={
+									<MetricValue
+										metric="total_trades"
+										value={s.total_trades}
+										row={s}
+										surface="Passport rigor"
+									/>
+								}
 								hint="executed in backtest"
 							/>
 						</div>

--- a/ui/src/metricDomain.js
+++ b/ui/src/metricDomain.js
@@ -1,0 +1,449 @@
+// metricDomain.js — the mathematical domain of every metric the Library, the
+// Passport and the Leaderboard render, and the only formatter allowed to turn
+// one of those numbers into display text (#1651).
+//
+// ── Why this file exists ────────────────────────────────────────────────────
+//
+// A real library row (`avellaneda_lee_2010_pca_statarb`, audited in
+// docs/audits/2026-07-09-curated-consolidation.md §2.4) persisted
+// `max_drawdown = 1.303`, and every surface rendered it verbatim as
+// "−130.3%". A drawdown is a fraction of a PEAK: an account cannot lose more
+// than the whole peak without its equity going negative, so −130.3% is not a
+// bad result, it is an arithmetically impossible one, and a reader who sees it
+// learns that our numbers are wrong rather than that the strategy is bad.
+//
+// The COMPUTATION that produced it is already fixed upstream, at the engine's
+// data boundary: `normalize_ohlcv` now refuses non-positive price bars (CL=F
+// settled at −$37.63 on 2020-04-20, and a long position marked at a negative
+// price drags portfolio value through zero), and
+// analytics-engine/tests/test_drawdown_invariant.py pins
+// `max_drawdown_pct < 100 <=> the reported equity curve stayed positive`.
+//
+// What that fix does NOT do is change history. The persisted row still holds
+// 1.303 and — per the append-only ledger rule — must keep holding it. So the
+// display layer needs its own discipline, and this is it:
+//
+//   1. Every metric these surfaces render has a declared domain, in the units
+//      the API serves it in. The declaration is the enumeration the tests
+//      quantify over; a metric with no entry here is a metric nobody bounded.
+//   2. A value outside its domain is rendered AT THE BOUND and carries a
+//      visible annotation naming the value that was actually reported. It is
+//      never silently clamped and never silently dropped — a clamp the reader
+//      cannot see is the same lie in the other direction.
+//   3. A value that is absent gets a REASON, drawn from the four-state
+//      pass/fail/pending/degenerate vocabulary the rigor gate already speaks
+//      (rigorGateStatus.js). A bare em-dash with no tooltip is indistinguishable
+//      from a rendering bug.
+//
+// Nothing here recomputes, corrects or writes back a stored number. `reported`
+// travels with every clamped result precisely so the display can keep saying
+// what the ledger says while refusing to draw it as if it were possible.
+
+import {
+	UNKNOWN_RIGOR_TITLE,
+	isUnknownRigorGateStatus,
+} from "./rigorGateStatus.js";
+
+/** The glyph for a value nothing measured.
+ *
+ * Deliberately equal to `generationCost.NOT_MEASURED` and
+ * `rigorGateStatus.UNKNOWN_RIGOR_LABEL` — this codebase has exactly one mark
+ * for "no number here" (#1326) and three modules agreeing by accident is one
+ * refactor away from two of them disagreeing. `metric-domain.test.js` asserts
+ * the three are the same character.
+ */
+export const ABSENT_LABEL = "—";
+
+/** How a metric's absence is explained, in the rigor gate's own vocabulary. */
+export const ABSENCE_STATES = Object.freeze([
+	"pending",
+	"degenerate",
+	"not_measured",
+	"unknown",
+]);
+
+/** What `formatMetric` can conclude about a value. */
+export const METRIC_STATES = Object.freeze([
+	// A number inside its declared domain, rendered as-is.
+	"measured",
+	// A number OUTSIDE its declared domain: rendered at the bound, annotated
+	// with what was actually reported.
+	"clamped",
+	// Present but not a finite number (NaN, ±Infinity, a string, an object).
+	// There is no bound to clamp such a value to, so the honest render is the
+	// absence glyph plus a note saying the API sent something unreadable.
+	"unreadable",
+	...ABSENCE_STATES,
+]);
+
+// ── The enumeration ─────────────────────────────────────────────────────────
+//
+// `min`/`max` are stated in the units the API serves, NOT in the units the cell
+// displays: `max_drawdown` arrives as a POSITIVE fraction of the peak (0.15 =
+// a 15% drawdown) and the surfaces prepend the minus sign themselves, which is
+// exactly how a served 1.303 became a displayed "−130.3%".
+//
+// `why` is the one-sentence justification for the bound and is shown to the
+// reader when a clamp fires. A bound with no `why` is a threshold somebody
+// picked; a bound with one is a fact about the quantity.
+export const METRIC_DOMAINS = Object.freeze({
+	max_drawdown: Object.freeze({
+		label: "Max drawdown",
+		min: 0,
+		max: 1,
+		format: "negpct",
+		why: "A drawdown is a fraction of the peak equity it is measured from, so it runs from 0% (no fall) to 100% (the whole peak). Above 100% means the equity curve went negative — a ruined account, not a survivable loss.",
+	}),
+	cagr: Object.freeze({
+		label: "CAGR",
+		min: -1,
+		max: Number.POSITIVE_INFINITY,
+		format: "pct",
+		why: "A compound growth rate cannot be below −100% per year: that is losing the entire stake, and there is nothing left to lose twice.",
+	}),
+	win_rate: Object.freeze({
+		label: "Win rate",
+		min: 0,
+		max: 1,
+		format: "pct",
+		why: "A share of trades that won, so between none of them and all of them.",
+	}),
+	pbo_score: Object.freeze({
+		label: "PBO",
+		min: 0,
+		max: 1,
+		format: "ratio",
+		why: "The probability of backtest overfitting is a probability.",
+	}),
+	dsr_p_value: Object.freeze({
+		label: "DSR confidence",
+		min: 0,
+		max: 1,
+		format: "ratio",
+		why: "Despite the legacy `p_value` name this is a confidence — the probability the Sharpe survives deflation — and probabilities live in [0, 1].",
+	}),
+	correlation_to_spy: Object.freeze({
+		label: "ρ to SPY",
+		min: -1,
+		max: 1,
+		format: "ratio",
+		why: "A Pearson correlation coefficient is bounded by ±1 (Cauchy–Schwarz).",
+	}),
+	correlation_to_btc: Object.freeze({
+		label: "ρ to BTC",
+		min: -1,
+		max: 1,
+		format: "ratio",
+		why: "A Pearson correlation coefficient is bounded by ±1 (Cauchy–Schwarz).",
+	}),
+	cumulative_return: Object.freeze({
+		label: "Realised return",
+		min: -1,
+		max: Number.POSITIVE_INFINITY,
+		format: "signedpct",
+		why: "A cumulative simple return compounded from an append-only ledger cannot be below −100%: that is the whole stake gone.",
+	}),
+	board_fdr_adjusted_p: Object.freeze({
+		label: "BH-adjusted p",
+		min: 0,
+		max: 1,
+		format: "ratio",
+		why: "A Benjamini–Hochberg adjusted p-value is a probability.",
+	}),
+	conviction_score: Object.freeze({
+		label: "Conviction",
+		min: 0,
+		max: 100,
+		format: "score",
+		why: "The leaderboard's conviction score is defined on a 0–100 scale.",
+	}),
+	total_trades: Object.freeze({
+		label: "Trades",
+		min: 0,
+		max: Number.POSITIVE_INFINITY,
+		format: "count",
+		why: "A count of trades cannot be negative.",
+	}),
+	// ── Unbounded by construction ───────────────────────────────────────────
+	// A Sharpe-family ratio has no bound this layer can justify: the real one,
+	// |SR_annualised| <= sqrt(252 * (n - 1)), needs the sample size `n`, and no
+	// Library, Passport or Leaderboard payload carries it (see the issue's
+	// "Sharpe on <4 bars"). Rather than invent a threshold, these declare the
+	// only thing that IS certain — the value has to be a finite number — and
+	// `formatMetric` enforces that for every entry alike. Stating the absence
+	// of a bound explicitly is the point: it keeps the enumeration exhaustive,
+	// so `metric-domain.test.js` can require every rendered metric to appear
+	// here without the sharpe family quietly falling through an `undefined`.
+	sharpe_ratio: Object.freeze({
+		label: "Sharpe",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "A Sharpe ratio has no bound that can be checked without the sample size, which this payload does not carry; only finiteness is enforced.",
+	}),
+	sortino_ratio: Object.freeze({
+		label: "Sortino",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "A Sortino ratio has no bound that can be checked without the sample size, which this payload does not carry; only finiteness is enforced.",
+	}),
+	calmar_ratio: Object.freeze({
+		label: "Calmar",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "Calmar is CAGR over max drawdown; both signs are reachable and it is unbounded as the drawdown shrinks.",
+	}),
+	deflated_sharpe_ratio: Object.freeze({
+		label: "DSR",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "A deflated Sharpe is a Sharpe; only finiteness is enforced.",
+	}),
+	out_of_sample_sharpe: Object.freeze({
+		label: "OOS Sharpe",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "An out-of-sample Sharpe is a Sharpe; only finiteness is enforced.",
+	}),
+	paper_claimed_sharpe: Object.freeze({
+		label: "Paper-claimed Sharpe",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "A number transcribed from a paper, not measured here; only finiteness is enforced.",
+	}),
+	kelly_fraction: Object.freeze({
+		label: "Kelly fraction",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "A Kelly fraction is a stored sizing figure that can legitimately be negative (a short) or above 1 (levered); nothing at this layer justifies a tighter bound than finiteness.",
+	}),
+	sharpe_ci_lower: Object.freeze({
+		label: "Sharpe CI lower",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "A confidence bound on a Sharpe is a Sharpe; only finiteness is enforced.",
+	}),
+	sharpe_ci_upper: Object.freeze({
+		label: "Sharpe CI upper",
+		min: Number.NEGATIVE_INFINITY,
+		max: Number.POSITIVE_INFINITY,
+		format: "ratio",
+		why: "A confidence bound on a Sharpe is a Sharpe; only finiteness is enforced.",
+	}),
+});
+
+/** Default decimal places per format. A caller may override per cell. */
+const DEFAULT_DIGITS = Object.freeze({
+	negpct: 1,
+	pct: 1,
+	signedpct: 2,
+	ratio: 2,
+	score: 1,
+	count: 0,
+});
+
+// ── Absence, with a reason ──────────────────────────────────────────────────
+
+export const PENDING_METRIC_TITLE =
+	"PENDING — no backtest has run on this strategy yet, so nothing has measured this metric. Not a zero and not a failure.";
+
+export const DEGENERATE_METRIC_TITLE =
+	"DEGENERATE — the persisted return series is zero-variance (broken data or a zero-trade backtest), not a real evaluation, so this metric is undefined for it.";
+
+export const NOT_MEASURED_METRIC_TITLE =
+	"Not measured — no value was recorded for this metric on this row.";
+
+/**
+ * Why a metric cell is empty, in the rigor gate's four-state vocabulary.
+ *
+ * The branch ORDER mirrors Strategies.jsx's rigor badge exactly (unknown →
+ * degenerate → pending → the rest) and for the same reason it was fixed there
+ * in #1358: every UNEVALUABLE state has to be ruled out before a row is
+ * described in terms that imply it was evaluated. "degenerate" deliberately
+ * does not borrow "pending"'s sentence — a degenerate row HAS persisted
+ * returns, they are just flat, so "no backtest has run" would be a fresh lie.
+ *
+ * @param {object|null|undefined} row — the strategy / leaderboard row
+ * @returns {{state: string, title: string}}
+ */
+export function absenceReason(row) {
+	if (row == null || typeof row !== "object") {
+		return { state: "not_measured", title: NOT_MEASURED_METRIC_TITLE };
+	}
+	const status = row.rigor_gate_status;
+	if (isUnknownRigorGateStatus(status)) {
+		return { state: "unknown", title: UNKNOWN_RIGOR_TITLE };
+	}
+	if (status === "degenerate") {
+		return { state: "degenerate", title: DEGENERATE_METRIC_TITLE };
+	}
+	// `is_backtest_placeholder` is the pre-backtest hypothesis flag the
+	// generated-strategies feed sets; a PRESENT-but-null `passes_rigor_gate` is
+	// the same "no verdict yet" case for rows that never carried
+	// rigor_gate_status at all (Strategies.jsx's coerceGenerated sets the key
+	// explicitly to null).
+	//
+	// The `in` check is load-bearing, not defensive tidiness. A live-paper row
+	// carries neither field, so a bare `row.passes_rigor_gate == null` would be
+	// true for it and every empty cell on the forward board would claim "no
+	// backtest has run" — a sentence about the wrong kind of evidence entirely,
+	// on the one board whose numbers are deliberately NOT backtests.
+	if (
+		status === "pending" ||
+		row.is_backtest_placeholder === true ||
+		row.status === "pending_backtest" ||
+		("passes_rigor_gate" in row && row.passes_rigor_gate == null)
+	) {
+		return { state: "pending", title: PENDING_METRIC_TITLE };
+	}
+	return { state: "not_measured", title: NOT_MEASURED_METRIC_TITLE };
+}
+
+// ── Formatting ──────────────────────────────────────────────────────────────
+
+function formatValue(format, value, digits) {
+	if (format === "count") return Number(value).toLocaleString("en-US");
+	if (format === "negpct") {
+		// The served field is a positive fraction and the cell shows the LOSS, so
+		// the sign flip happens HERE rather than in each caller — the duplicated
+		// `−${fmtPct(v)}` across four components is what let two of them also
+		// apply Math.abs(), silently turning a contract-violating negative
+		// drawdown into an ordinary-looking loss. Flipping properly means a
+		// negative served value renders with a visible "+", which is exactly
+		// what a drawdown must never be, so the annotation has something to
+		// point at instead of a plausible lie.
+		const shown = -(value * 100);
+		const rounded = Number(shown.toFixed(digits));
+		if (rounded === 0) return `${(0).toFixed(digits)}%`;
+		const magnitude = Math.abs(shown).toFixed(digits);
+		return rounded < 0 ? `−${magnitude}%` : `+${magnitude}%`;
+	}
+	if (format === "pct") return `${(value * 100).toFixed(digits)}%`;
+	if (format === "signedpct") {
+		// Always signed, so a forward return never reads as a bare magnitude.
+		const pct = value * 100;
+		return `${pct >= 0 ? "+" : "−"}${Math.abs(pct).toFixed(digits)}%`;
+	}
+	return Number(value).toFixed(digits);
+}
+
+/** Human-readable domain, in display units, for the clamp annotation. */
+export function domainLabel(key, digits) {
+	const domain = METRIC_DOMAINS[key];
+	if (!domain) return null;
+	const dp = digits ?? DEFAULT_DIGITS[domain.format] ?? 2;
+	const lo = Number.isFinite(domain.min)
+		? formatValue(domain.format, domain.min, dp)
+		: "−∞";
+	const hi = Number.isFinite(domain.max)
+		? formatValue(domain.format, domain.max, dp)
+		: "+∞";
+	// `negpct` flips the order — a larger stored drawdown displays as a MORE
+	// negative percentage — so the interval is printed in display order.
+	return domain.format === "negpct" ? `[${hi}, ${lo}]` : `[${lo}, ${hi}]`;
+}
+
+/**
+ * Dev-time alarm for a metric rendered through this module with no declared
+ * domain. Silent in a production build (same pattern as
+ * `warnUnknownRigorGateStatus`) because the user-visible behaviour is already
+ * correct — the value is finiteness-checked and rendered — while the thing a
+ * developer must not miss is that the enumeration the tests quantify over has
+ * a hole in it.
+ */
+export function warnUndeclaredMetric(key, surface) {
+	if (import.meta.env?.PROD === true) return;
+	console.warn(
+		`[metrics] ${surface || "unknown surface"}: no domain declared for metric ` +
+			`${JSON.stringify(key)} in metricDomain.js. It is rendered with a ` +
+			"finiteness check only, and no test bounds it.",
+	);
+}
+
+/**
+ * Turn one served metric value into display text that cannot be impossible.
+ *
+ * @param {string} key — a key of METRIC_DOMAINS
+ * @param {number|null|undefined} value — as the API serves it
+ * @param {object} [options]
+ * @param {object} [options.row] — the row, used only to explain an absence
+ * @param {string} [options.format] — override the display format
+ * @param {number} [options.digits] — override the decimal places
+ * @param {string} [options.surface] — for the dev warning only
+ * @returns {{state: string, label: string, note: string|null, title: string|null,
+ *            impossible: boolean, reported: number|null}}
+ *   `label` is always safe to render. `note` is the VISIBLE annotation and is
+ *   non-null exactly when the displayed number is not the reported one — the
+ *   caller is not free to drop it, which is why `MetricValue.jsx` exists and
+ *   every surface goes through it.
+ */
+export function formatMetric(key, value, options = {}) {
+	const { row = null, format, digits, surface = "" } = options;
+	const domain = METRIC_DOMAINS[key];
+	if (!domain) warnUndeclaredMetric(key, surface);
+	const fmt = format ?? domain?.format ?? "ratio";
+	const dp = digits ?? DEFAULT_DIGITS[fmt] ?? 2;
+
+	if (value == null) {
+		const absence = absenceReason(row);
+		return {
+			state: absence.state,
+			label: ABSENT_LABEL,
+			note: null,
+			title: absence.title,
+			impossible: false,
+			reported: null,
+		};
+	}
+
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		// No bound to clamp to: NaN is not "too big" and a string is not a
+		// number at all. The absence glyph is the only honest label, and the
+		// note says why it is there so it cannot be read as "not measured".
+		return {
+			state: "unreadable",
+			label: ABSENT_LABEL,
+			note: "unreadable value",
+			title:
+				`${domain?.label ?? key}: the API returned ${JSON.stringify(value)}, ` +
+				"which is not a finite number. Shown as unmeasured rather than drawn as a value.",
+			impossible: true,
+			reported: null,
+		};
+	}
+
+	const min = domain?.min ?? Number.NEGATIVE_INFINITY;
+	const max = domain?.max ?? Number.POSITIVE_INFINITY;
+	if (value < min || value > max) {
+		const bound = value < min ? min : max;
+		const reportedText = formatValue(fmt, value, dp);
+		return {
+			state: "clamped",
+			label: formatValue(fmt, bound, dp),
+			note: `reported ${reportedText} — outside the possible range`,
+			title:
+				`${domain?.label ?? key} was recorded as ${reportedText}, outside the ` +
+				`possible range ${domainLabel(key, dp) ?? "for this metric"}. ` +
+				`${domain?.why ?? ""} ` +
+				"Displayed at the bound; the recorded value is unchanged.",
+			impossible: true,
+			reported: value,
+		};
+	}
+
+	return {
+		state: "measured",
+		label: formatValue(fmt, value, dp),
+		note: null,
+		title: null,
+		impossible: false,
+		reported: value,
+	};
+}

--- a/ui/test/app-visuals.test.js
+++ b/ui/test/app-visuals.test.js
@@ -242,16 +242,19 @@ test("leaderboard renders every field it sorts by, and no constant forward colum
 	assert.match(leaderboard, /fixed at generation time/);
 	const block = leaderboard.match(/const SORT_OPTIONS = \[([\s\S]*?)\]/)[1];
 	for (const [, id] of block.matchAll(/id: '([a-z_]+)'/g)) {
-		// A RENDER site is fmt(...)/fmtPct(...)-wrapped output — a bare e.<id>
-		// also matches null-CHECKS inside a render gate, which is exactly the
-		// defect this test exists to reject (a field sorted but never shown).
+		// A RENDER site is a value handed to a formatter — a bare e.<id> also
+		// matches null-CHECKS inside a render gate, which is exactly the defect
+		// this test exists to reject (a field sorted but never shown). Since
+		// #1651 the formatter is <MetricValue metric="…" value={e.<id>} />
+		// rather than the file's own fmt()/fmtPct(); both shapes count as a
+		// render, neither of them matches a bare null-check.
 		assert.match(
 			leaderboard,
-			new RegExp(`fmt(?:Pct)?\\(\\s*e\\.${id}\\b`),
-			`sort option ${id} has no fmt-rendered value`,
+			new RegExp(`(?:fmt(?:Pct)?\\(\\s*e\\.${id}\\b|value=\\{e\\.${id}\\})`),
+			`sort option ${id} has no rendered value`,
 		);
 	}
-	assert.match(leaderboard, /fmt\(\s*e\.out_of_sample_sharpe\b/);
+	assert.match(leaderboard, /value=\{e\.out_of_sample_sharpe\}/);
 	assert.doesNotMatch(leaderboard, /SB pending/);
 	assert.doesNotMatch(leaderboard, /P&L pending/);
 });

--- a/ui/test/metric-domain.test.js
+++ b/ui/test/metric-domain.test.js
@@ -1,0 +1,561 @@
+// #1651 — no metric the Library, the Passport or the Leaderboard renders may
+// leave its mathematical domain.
+//
+// The defect: `avellaneda_lee_2010_pca_statarb` persisted
+// `max_drawdown = 1.303` and every surface rendered "−130.3%". A drawdown is a
+// fraction of a peak — above 100% means the equity curve went NEGATIVE — so
+// that figure is not a bad result, it is an impossible one, and it is the most
+// falsifiable "your numbers are wrong" claim on the product.
+//
+// The engine-side computation is already fixed and pinned upstream
+// (analytics-engine/tests/test_drawdown_invariant.py: `max_drawdown_pct < 100
+// <=> the reported equity curve stayed positive`, held by a non-positive-price
+// guard in `normalize_ohlcv`). This file guards the OTHER half, which that fix
+// deliberately does not touch: the persisted 1.303 is still in the ledger and
+// stays there (append-only), so the DISPLAY layer has to refuse to draw it as
+// if it were possible — visibly, never silently.
+//
+// Source-text assertions follow ui/test/app-visuals.test.js and
+// ui/test/rigor-tristate.test.js (no jsdom/vitest, per CLAUDE.md's ui/ testing
+// convention); the property tests import the real module and run it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+	ABSENT_LABEL,
+	DEGENERATE_METRIC_TITLE,
+	METRIC_DOMAINS,
+	METRIC_STATES,
+	NOT_MEASURED_METRIC_TITLE,
+	PENDING_METRIC_TITLE,
+	absenceReason,
+	domainLabel,
+	formatMetric,
+} from "../src/metricDomain.js";
+import { NOT_MEASURED } from "../src/generationCost.js";
+import { UNKNOWN_RIGOR_LABEL, UNKNOWN_RIGOR_TITLE } from "../src/rigorGateStatus.js";
+import { equityFromReturns, maxDrawdown } from "../src/utils/riskMath.js";
+
+const read = (rel) => readFileSync(new URL(rel, import.meta.url), "utf8");
+const SURFACES = {
+	"Library (Strategies.jsx)": read("../src/components/Strategies.jsx"),
+	"Passport (StrategyPassport.jsx)": read("../src/components/StrategyPassport.jsx"),
+	"Leaderboard (Leaderboard.jsx)": read("../src/components/Leaderboard.jsx"),
+	"Publish table (PublishStrategyTable.jsx)": read(
+		"../src/components/PublishStrategyTable.jsx",
+	),
+};
+const metricValueSrc = read("../src/components/MetricValue.jsx");
+
+// ── Parsing what a cell actually shows ──────────────────────────────────────
+//
+// The tests below assert on the NUMBER A READER SEES, not on the input, which
+// is the whole point: the input is allowed to be 1.303 forever.
+
+const MINUS = "−"; // U+2212, the glyph every surface renders
+
+/** "−130.3%" -> -130.3 ; "12.0%" -> 12 ; "—" -> null. */
+function renderedPercent(label) {
+	if (label === ABSENT_LABEL) return null;
+	const m = label.match(/^([+−-]?)([\d,]+(?:\.\d+)?)%$/);
+	assert.ok(m, `label ${JSON.stringify(label)} is not a percentage`);
+	const magnitude = Number(m[2].replace(/,/g, ""));
+	return m[1] === MINUS || m[1] === "-" ? -magnitude : magnitude;
+}
+
+/** A deterministic PRNG so the property runs are hermetic and reproducible. */
+function rng(seed) {
+	let s = seed >>> 0 || 1;
+	return () => {
+		// xorshift32
+		s ^= s << 13;
+		s >>>= 0;
+		s ^= s >> 17;
+		s ^= s << 5;
+		s >>>= 0;
+		return s / 0x100000000;
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. THE PROPERTY: for ANY return series, the rendered max drawdown is in
+//    [−100%, 0%].
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Random simple-return series. `allowRuin` lets a bar lose more than
+ *  everything, which is the only way an equity curve reaches or crosses zero
+ *  and therefore the only way a drawdown above 100% can arise at all. */
+function randomReturns(next, { allowRuin }) {
+	const n = 2 + Math.floor(next() * 60);
+	const floor = allowRuin ? -1.9 : -0.6;
+	const out = [];
+	for (let i = 0; i < n; i++) out.push(floor + next() * (0.5 - floor));
+	return out;
+}
+
+test("property: for any return series, the rendered max drawdown lands in [−100%, 0%]", () => {
+	let ruined = 0;
+	let survived = 0;
+	let clamped = 0;
+
+	for (let seed = 1; seed <= 4000; seed++) {
+		const next = rng(seed);
+		const returns = randomReturns(next, { allowRuin: seed % 2 === 0 });
+		// The UI's own equity/drawdown math (src/utils/riskMath.js), so this is
+		// the number a chart on the page would derive from the same series.
+		const curve = equityFromReturns(returns, 100_000);
+		const dd = maxDrawdown(curve);
+
+		const shown = renderedPercent(formatMetric("max_drawdown", dd).label);
+		assert.ok(
+			shown <= 0 && shown >= -100,
+			`seed=${seed}: rendered ${shown}% from max_drawdown=${dd} — outside [−100%, 0%]`,
+		);
+
+		if (Math.min(...curve) <= 0) ruined++;
+		else survived++;
+		if (dd > 1) clamped++;
+	}
+
+	// Anti-vacuity: the sampler must actually reach the ruin regime, or the
+	// property above is only ever checked on inputs that could never have
+	// violated it. This is the guard the earlier version of this bug slipped
+	// through — a test that never generates the offending shape proves nothing.
+	assert.ok(ruined > 100, `only ${ruined} ruined curves sampled`);
+	assert.ok(survived > 100, `only ${survived} surviving curves sampled`);
+	assert.ok(
+		clamped > 100,
+		`only ${clamped} series produced a >100% drawdown — the clamp branch is barely exercised`,
+	);
+});
+
+test("property: the same bound holds for ANY raw number the API could serve", () => {
+	// The Library does not derive the drawdown from a series — it renders a
+	// persisted float. So quantify over the wire value directly, including the
+	// shapes a well-behaved backend should never emit.
+	const adversarial = [
+		0, 1, 1.303, 5, 1e6, Number.MAX_VALUE, -0.0001, -0.2, -1, -1e9,
+		0.9999999, 1.0000001,
+	];
+	for (const v of adversarial) {
+		const shown = renderedPercent(formatMetric("max_drawdown", v).label);
+		assert.ok(
+			shown <= 0 && shown >= -100,
+			`max_drawdown=${v} rendered ${shown}%, outside [−100%, 0%]`,
+		);
+	}
+	for (let seed = 1; seed <= 3000; seed++) {
+		const next = rng(seed * 7919);
+		const v = (next() - 0.5) * 20; // roughly [-10, 10]
+		const shown = renderedPercent(formatMetric("max_drawdown", v).label);
+		assert.ok(shown <= 0 && shown >= -100, `max_drawdown=${v} rendered ${shown}%`);
+	}
+});
+
+test("the exact audited −130.3% series renders a possible drawdown, and says why", () => {
+	// docs/audits/2026-07-09-curated-consolidation.md §2.4: peak 100,000 →
+	// trough −30,300 is (100000 − −30300)/100000 = 130.3%.
+	const ruinedCurve = [100_000, 80_000, 20_000, -30_300, -5_000];
+	const dd = maxDrawdown(ruinedCurve);
+	assert.ok(Math.abs(dd - 1.303) < 1e-9, `expected 1.303, got ${dd}`);
+
+	const m = formatMetric("max_drawdown", dd, { row: { passes_rigor_gate: false } });
+	assert.equal(m.label, "−100.0%");
+	assert.equal(m.state, "clamped");
+	assert.equal(m.impossible, true);
+	// Not silent: the reader is told the recorded figure, in the cell.
+	assert.match(m.note, /reported −130\.3% — outside the possible range/);
+	assert.match(m.title, /outside the possible range/);
+	assert.match(m.title, /the recorded value is unchanged/);
+	// Anti-goal: nothing here rewrites history. The reported number survives on
+	// the result object exactly as the ledger holds it.
+	assert.equal(m.reported, dd);
+});
+
+test("a negative served drawdown is reported as out-of-domain, never Math.abs()'d into a plausible one", () => {
+	// The Leaderboard and the Publish table used to render
+	// `−fmtPct(Math.abs(v))`, which turns a contract-violating −0.20 into a
+	// perfectly ordinary-looking "−20.0%" — a manufactured number, and the
+	// harder half of this bug to notice.
+	const m = formatMetric("max_drawdown", -0.2);
+	assert.equal(m.state, "clamped");
+	assert.equal(m.label, "0.0%");
+	// The sign flip is the tell: a drawdown displayed with a "+" is visibly not
+	// a loss, which is the whole point of not Math.abs()-ing it away.
+	assert.match(m.note, /reported \+20\.0%/);
+	assert.notEqual(m.label, "−20.0%");
+});
+
+// ── The real persisted row, not a hand-made one ─────────────────────────────
+
+const FIXTURES = JSON.parse(
+	read("../../backend/tests/fixtures/backtest_fixtures_snapshot.json"),
+);
+
+test("the strategy that produced the screenshot renders a possible drawdown, from its own persisted row", () => {
+	// Not a synthetic value: this is the number the repo actually stores for
+	// `avellaneda_lee_2010_pca_statarb` in
+	// backend/tests/fixtures/backtest_fixtures_snapshot.json. The append-only
+	// rule says it stays 1.3030656663525957; the display rule says the reader
+	// must never see it drawn as a survivable loss.
+	const row = FIXTURES.avellaneda_lee_2010_pca_statarb;
+	assert.ok(row, "the audited strategy is missing from the fixture snapshot");
+	assert.ok(
+		row.max_drawdown > 1,
+		"fixture no longer carries the >100% drawdown — re-point this test at whatever row does, do not delete it",
+	);
+
+	const m = formatMetric("max_drawdown", row.max_drawdown, { row });
+	const shown = renderedPercent(m.label);
+	assert.ok(shown <= 0 && shown >= -100, `rendered ${shown}%`);
+	assert.equal(m.label, "−100.0%");
+	assert.match(m.note, /reported −130\.3%/);
+	// And the stored number is untouched by having been displayed.
+	assert.equal(FIXTURES.avellaneda_lee_2010_pca_statarb.max_drawdown, row.max_drawdown);
+});
+
+test("every persisted fixture row renders every one of its metrics inside the domain", () => {
+	let checked = 0;
+	let outOfDomain = 0;
+	for (const [name, row] of Object.entries(FIXTURES)) {
+		if (!row || typeof row !== "object") continue;
+		for (const key of Object.keys(METRIC_DOMAINS)) {
+			if (!(key in row)) continue;
+			const m = formatMetric(key, row[key], { row });
+			checked++;
+			if (m.state === "clamped") {
+				outOfDomain++;
+				assert.ok(m.note, `${name}.${key}: clamped with no visible annotation`);
+			}
+			if (m.label === ABSENT_LABEL) {
+				assert.ok(m.title, `${name}.${key}: em-dash with no reason`);
+				continue;
+			}
+			const domain = METRIC_DOMAINS[key];
+			if (domain.format === "negpct") {
+				const shown = renderedPercent(m.label);
+				assert.ok(
+					shown <= 0 && shown >= -100,
+					`${name}.${key}: rendered ${shown}%`,
+				);
+			}
+		}
+	}
+	assert.ok(checked > 200, `only ${checked} fixture metrics checked`);
+	// Non-vacuity, and the reason this whole change exists: the shipped fixture
+	// set really does contain an impossible value today.
+	assert.equal(
+		outOfDomain,
+		1,
+		`expected exactly the one known out-of-domain fixture value, found ${outOfDomain}`,
+	);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. THE ENUMERATION: every metric these surfaces render is bounded here, and
+//    nothing outside its domain can be rendered.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Every `metric="…"` a surface hands to MetricValue. */
+function renderedMetrics(src) {
+	return [...src.matchAll(/metric="([a-z0-9_]+)"/g)].map((m) => m[1]);
+}
+
+test("every metric rendered on Library / Passport / Leaderboard has a declared domain", () => {
+	let total = 0;
+	for (const [surface, src] of Object.entries(SURFACES)) {
+		const metrics = renderedMetrics(src);
+		assert.ok(metrics.length > 0, `${surface} renders no metric through MetricValue`);
+		for (const key of metrics) {
+			total++;
+			assert.ok(
+				Object.hasOwn(METRIC_DOMAINS, key),
+				`${surface} renders metric ${JSON.stringify(key)} with no entry in METRIC_DOMAINS`,
+			);
+		}
+	}
+	// Guard against a vacuous pass if the regex ever stops matching.
+	assert.ok(total >= 25, `only ${total} metric render sites found`);
+});
+
+test("no declared metric can render outside its domain, for any input", () => {
+	// The enumeration, exercised. For each metric, hammer the formatter with
+	// values well outside its bounds and assert the rendered number is inside.
+	const parseNumeric = (label, format) => {
+		if (label === ABSENT_LABEL) return null;
+		// `negpct` displays the LOSS, so the served value is the negation of what
+		// the cell shows: "−100.0%" came from a stored 1.0.
+		if (format === "negpct") return -renderedPercent(label) / 100;
+		if (format === "pct" || format === "signedpct") return renderedPercent(label) / 100;
+		return Number(label.replace(/,/g, ""));
+	};
+
+	for (const [key, domain] of Object.entries(METRIC_DOMAINS)) {
+		const probes = [
+			domain.min - 1,
+			domain.min - 1e6,
+			domain.max + 1,
+			domain.max + 1e6,
+			-1e12,
+			1e12,
+			0,
+			Number.isFinite(domain.min) ? domain.min : -1e3,
+			Number.isFinite(domain.max) ? domain.max : 1e3,
+		].filter((v) => Number.isFinite(v));
+
+		for (const v of probes) {
+			const m = formatMetric(key, v);
+			assert.ok(
+				METRIC_STATES.includes(m.state),
+				`${key}: unknown state ${m.state}`,
+			);
+			const shown = parseNumeric(m.label, domain.format);
+			if (shown === null) continue;
+			// Rounding at the display precision can push a value a hair past the
+			// bound (0.99999 → "1.00"), so compare with the tolerance the format
+			// itself introduces rather than pretending the text is exact.
+			const tol = 5e-3;
+			assert.ok(
+				shown >= domain.min - tol && shown <= domain.max + tol,
+				`${key}: input ${v} rendered "${m.label}" (=${shown}), outside ${domainLabel(key)}`,
+			);
+			// A displayed number that is not the reported one must be annotated.
+			if (v < domain.min || v > domain.max) {
+				assert.equal(m.state, "clamped", `${key}: input ${v} was not flagged`);
+				assert.ok(m.note, `${key}: clamped input ${v} carries no visible note`);
+			}
+		}
+	}
+});
+
+test("a non-finite or non-numeric value renders as unmeasured, never as the text 'NaN'", () => {
+	// `Number(NaN).toFixed(2)` is the string "NaN"; the old per-component `fmt`
+	// helpers on the Library and the Leaderboard did exactly that.
+	for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, "1.303", {}, true]) {
+		const m = formatMetric("sharpe_ratio", bad);
+		assert.equal(m.state, "unreadable");
+		assert.equal(m.label, ABSENT_LABEL);
+		assert.ok(m.note, "an unreadable value must be annotated, not silently blank");
+		assert.doesNotMatch(m.label, /NaN|Infinity/);
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. BLANK DASHES GET A REASON — in the vocabulary that already exists.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("the absence glyph is the one this codebase already uses", () => {
+	assert.equal(ABSENT_LABEL, NOT_MEASURED);
+	assert.equal(ABSENT_LABEL, UNKNOWN_RIGOR_LABEL);
+});
+
+test("an empty metric cell always carries a reason, never a bare em-dash", () => {
+	const rows = [
+		{ rigor_gate_status: "pending", passes_rigor_gate: false },
+		{ is_backtest_placeholder: true, passes_rigor_gate: false },
+		{ status: "pending_backtest", passes_rigor_gate: false },
+		{ passes_rigor_gate: null },
+		{ rigor_gate_status: "degenerate", passes_rigor_gate: false },
+		{ rigor_gate_status: "pass", passes_rigor_gate: true },
+		{ rigor_gate_status: "banana", passes_rigor_gate: true },
+		{},
+		null,
+	];
+	for (const row of rows) {
+		const m = formatMetric("max_drawdown", null, { row });
+		assert.equal(m.label, ABSENT_LABEL);
+		assert.ok(
+			m.title && m.title.length > 20,
+			`row ${JSON.stringify(row)} produced a dash with no reason`,
+		);
+	}
+});
+
+test("the reason reuses the rigor gate's four-state vocabulary rather than inventing one", () => {
+	assert.deepEqual(absenceReason({ rigor_gate_status: "pending", passes_rigor_gate: false }), {
+		state: "pending",
+		title: PENDING_METRIC_TITLE,
+	});
+	assert.deepEqual(absenceReason({ rigor_gate_status: "degenerate", passes_rigor_gate: false }), {
+		state: "degenerate",
+		title: DEGENERATE_METRIC_TITLE,
+	});
+	assert.deepEqual(absenceReason({ rigor_gate_status: "pass", passes_rigor_gate: true }), {
+		state: "not_measured",
+		title: NOT_MEASURED_METRIC_TITLE,
+	});
+	// A fifth state the API might grow is not silently mapped onto a known one —
+	// it reuses rigorGateStatus.js's own unknown wording (#1358).
+	assert.deepEqual(absenceReason({ rigor_gate_status: "banana", passes_rigor_gate: true }), {
+		state: "unknown",
+		title: UNKNOWN_RIGOR_TITLE,
+	});
+
+	// The three sentences must stay distinct: "degenerate" must never borrow
+	// pending's "no backtest has run", because a degenerate row HAS returns.
+	assert.doesNotMatch(DEGENERATE_METRIC_TITLE, /no backtest has run/);
+	assert.match(PENDING_METRIC_TITLE, /no backtest has run/);
+	assert.notEqual(PENDING_METRIC_TITLE, NOT_MEASURED_METRIC_TITLE);
+});
+
+test("a live-paper row's empty cell does not claim a backtest is pending", () => {
+	// The forward board's rows carry neither `rigor_gate_status` nor
+	// `passes_rigor_gate`. Reading a missing key as "no verdict yet" would put
+	// "no backtest has run on this strategy yet" under a column whose numbers
+	// are explicitly not backtests — the one board built to keep the two kinds
+	// of evidence apart.
+	const liveRow = {
+		deployment_id: "d-1",
+		name: "x",
+		performance_basis: "live_paper",
+		days_live: 12,
+	};
+	const reason = absenceReason(liveRow);
+	assert.equal(reason.state, "not_measured");
+	assert.doesNotMatch(reason.title, /backtest/i);
+	// ...while a strategy row that explicitly carries a null verdict still reads
+	// as pending, which is the case Strategies.jsx's coerceGenerated relies on.
+	assert.equal(absenceReason({ passes_rigor_gate: null }).state, "pending");
+});
+
+test("the unevaluable states are ruled out before the row is described as measured-but-empty", () => {
+	// Same branch order the rigor badge was fixed into in #1358: a degenerate
+	// row that also carries passes_rigor_gate === null must read as degenerate,
+	// not pending.
+	assert.equal(
+		absenceReason({ rigor_gate_status: "degenerate", passes_rigor_gate: null }).state,
+		"degenerate",
+	);
+	assert.equal(
+		absenceReason({ rigor_gate_status: "banana", passes_rigor_gate: null }).state,
+		"unknown",
+	);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. THE CLAMP IS STRUCTURALLY VISIBLE — the surfaces cannot drop it.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("MetricValue renders the annotation whenever formatMetric produces one", () => {
+	assert.match(metricValueSrc, /\{m\.note && \(/);
+	// Visible text, not just a tooltip: a title alone is invisible on touch.
+	assert.match(metricValueSrc, /\{m\.note\}/);
+	assert.match(metricValueSrc, /className="sr-only"/);
+	assert.match(metricValueSrc, /aria-hidden="true"/);
+	assert.match(metricValueSrc, /title=\{m\.title \|\| undefined\}/);
+});
+
+test("no surface formats a metric behind MetricValue's back", () => {
+	// The old per-component `fmt`/`fmtPct` helpers are what made four
+	// independent, domain-blind renderings of the same field possible — one of
+	// them even Math.abs()'d the drawdown. Re-declaring either name in these
+	// files is the regression this asserts against.
+	for (const [surface, src] of Object.entries(SURFACES)) {
+		assert.doesNotMatch(
+			src,
+			/function fmtPct\s*\(/,
+			`${surface} re-declared a local percent formatter`,
+		);
+		// Direct `−${...}%` drawdown construction — the literal shape of the bug.
+		assert.doesNotMatch(
+			src,
+			/−\$\{fmtPct/,
+			`${surface} still builds a drawdown string by hand`,
+		);
+		assert.doesNotMatch(
+			src,
+			/Math\.abs\(\s*\w+\.max_drawdown/,
+			`${surface} still Math.abs()es a drawdown into plausibility`,
+		);
+	}
+	// Strategies.jsx and StrategyPassport.jsx keep no numeric formatter at all.
+	assert.doesNotMatch(SURFACES["Library (Strategies.jsx)"], /function fmt\s*\(/);
+	assert.doesNotMatch(SURFACES["Passport (StrategyPassport.jsx)"], /function fmt\s*\(/);
+	// The one that survives (Leaderboard's StockBench sentence) must at least
+	// refuse to print "NaN".
+	assert.match(
+		SURFACES["Leaderboard (Leaderboard.jsx)"],
+		/function fmt\([\s\S]{0,200}Number\.isFinite/,
+	);
+});
+
+test("every surface imports the shared renderer", () => {
+	for (const [surface, src] of Object.entries(SURFACES)) {
+		assert.match(
+			src,
+			/import MetricValue from ["']\.\/MetricValue["']/,
+			`${surface} does not import MetricValue`,
+		);
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. IN-DOMAIN VALUES ARE UNTOUCHED (anti-goal: no threshold loosening, no
+//    cosmetic rewriting of honest numbers).
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("a possible value renders exactly as before, with no annotation", () => {
+	const cases = [
+		["max_drawdown", 0.153, "−15.3%"],
+		["max_drawdown", 0, "0.0%"],
+		["max_drawdown", 1, "−100.0%"],
+		["cagr", 0.1234, "12.3%"],
+		// ASCII hyphen, deliberately: this is byte-for-byte what the previous
+		// per-component `fmtPct` rendered for a losing CAGR. The clamp discipline
+		// must not quietly restyle honest numbers.
+		["cagr", -0.42, "-42.0%"],
+		["sharpe_ratio", 1.4567, "1.46"],
+		["sharpe_ratio", -0.5, "-0.50"],
+		["pbo_score", 0.62, "0.62"],
+		["win_rate", 0.5, "50.0%"],
+		["correlation_to_spy", -1, "-1.00"],
+		["conviction_score", 82.51, "82.5"],
+		["total_trades", 1234, "1,234"],
+		["cumulative_return", 0.0731, "+7.31%"],
+		["cumulative_return", -0.0731, "−7.31%"],
+	];
+	for (const [key, value, expected] of cases) {
+		const m = formatMetric(key, value);
+		assert.equal(m.label, expected, `${key}(${value})`);
+		assert.equal(m.state, "measured");
+		assert.equal(m.note, null);
+		assert.equal(m.title, null);
+	}
+});
+
+test("a metric with NO declared domain still renders safely, and warns a developer", () => {
+	// The enumeration test above is a source-text check, so it can only see
+	// metrics rendered through the `metric="…"` prop. This is the runtime half:
+	// an unlisted key must not crash the page and must not be silently trusted
+	// either — the same dev-warn / prod-silent shape as
+	// rigorGateStatus.warnUnknownRigorGateStatus.
+	const warnings = [];
+	const original = console.warn;
+	console.warn = (...args) => warnings.push(args.join(" "));
+	try {
+		const ok = formatMetric("vibes_index", 3.14159, { surface: "test" });
+		assert.equal(ok.state, "measured");
+		assert.equal(ok.label, "3.14");
+		const bad = formatMetric("vibes_index", Number.NaN, { surface: "test" });
+		assert.equal(bad.state, "unreadable");
+		assert.equal(bad.label, ABSENT_LABEL);
+	} finally {
+		console.warn = original;
+	}
+	assert.equal(warnings.length, 2);
+	assert.match(warnings[0], /no domain declared for metric "vibes_index"/);
+	assert.match(warnings[0], /no test bounds it/);
+	assert.equal(domainLabel("vibes_index"), null);
+});
+
+test("the domain table states a reason for every bound it asserts", () => {
+	for (const [key, domain] of Object.entries(METRIC_DOMAINS)) {
+		assert.ok(domain.label, `${key} has no display label`);
+		assert.ok(
+			typeof domain.why === "string" && domain.why.length > 30,
+			`${key} declares a bound with no justification — a threshold somebody picked`,
+		);
+		assert.ok(domain.min <= domain.max, `${key} has an inverted domain`);
+	}
+});


### PR DESCRIPTION
## What this is

`avellaneda_lee_2010_pca_statarb` persists `max_drawdown = 1.3030656663525957`, and the Library, the Passport, the Leaderboard and the Publish table each rendered it as **"−130.3%"**. A drawdown is a fraction of a peak: above 100% means the equity curve went *negative*. That figure is not a bad result, it is an arithmetically impossible one — Javi's most falsifiable "your numbers are wrong" claim.

This PR makes it structurally impossible for any of those surfaces to draw a number outside its metric's mathematical domain, and gives every blank cell a reason.

---

## I verified the suspected mechanics before fixing (the issue asked)

### (a) "2.0x-vs-1.0x leverage split between graded and displayed paths" — **not the cause; no split exists**

`dsl_to_backtrader.py:222` is inside the `realized_vol` indicator's `next()` — nothing to do with leverage. The `2.0` is `_VOL_SCALE_CAP` at line 30, and it caps the vol *scale* before the slot multiply, which is precisely what makes per-name exposure identical however the universe split is expressed:

```
$ /opt/homebrew/.../envs/archimedes/bin/python  (backend/, realized_vol=0.05, reference=0.15)
=== A. leverage-split hypothesis ===
_VOL_SCALE_CAP = 2.0
  slots=1 slot=1.0000 weight=2.000000 account_exposure=2.000000
  slots=2 slot=0.5000 weight=1.000000 account_exposure=2.000000
  slots=4 slot=0.2500 weight=0.500000 account_exposure=2.000000
  -> per-name exposure identical across slot expressions: True

=== B. one implementation, both paths ===
  live evaluator imports the backtest sizing primitives: True
  live evaluator defines its own copy: False
```

`strategy_signal_evaluator` imports `slot_weight` / `sizing_realized_vol` / `inverse_vol_weight` from `dsl_to_backtrader` rather than reimplementing them, so the graded and live paths are the same arithmetic by construction.

### (b) "unclamped DD formula" — **already fixed in the engine; the residual is the display layer**

`analytics-engine` already derives the drawdown from the reported equity curve and already refuses the input that produced ruin (`normalize_ohlcv` drops non-positive price bars — `CL=F` settled at **−$37.63 on 2020-04-20**, and a long position marked there drags portfolio value through zero). `tests/test_drawdown_invariant.py` pins `max_drawdown_pct < 100 <=> the reported equity curve stayed positive`, 233 cases green.

What that cannot do is change history. The persisted `1.303` is still in the ledger and — per this issue's append-only anti-goal — **must stay there**. So the display layer needed its own discipline. That is what this PR is.

### (c) "null-metric rows serving as em-dashes without a reason" — **confirmed**

`Strategies.jsx`'s generated-row coercion sets `sharpe_ratio / cagr / max_drawdown: null` and every cell rendered a bare `'—'` with no `title`, indistinguishable from a rendering bug — while the row's own `rigor_gate_status` already carried the reason.

### Two extra render paths found while enumerating

- `Leaderboard.jsx` and `PublishStrategyTable.jsx` rendered `−${fmtPct(Math.abs(v))}`. `Math.abs` turns a contract-violating **signed** `−0.20` into a perfectly ordinary-looking `−20.0%` — a manufactured number, and the harder half of the bug to notice.
- `Leaderboard.jsx`'s and `Strategies.jsx`'s local `fmt()` did `Number(v).toFixed(d)` with no finiteness guard, so a NaN Sharpe rendered the literal string **`NaN`**.

---

## The change (one logical change)

**`ui/src/metricDomain.js`** — the enumeration. Every metric these surfaces render gets `{min, max, format, why}` *in the units the API serves* (`max_drawdown` arrives as a positive fraction; the surfaces add the minus, which is exactly how `1.303` became `−130.3%`). `formatMetric()` returns `{state, label, note, title, impossible, reported}`:

- in-domain → rendered byte-for-byte as before, `note: null`;
- out-of-domain → rendered **at the bound** with a **visible** note naming the recorded figure (`"reported −130.3% — outside the possible range"`) and a tooltip that says the recorded value is unchanged. `reported` carries the original through, so nothing here rewrites a stored number;
- non-finite / non-numeric → the em-dash plus "unreadable value", because NaN has no bound to clamp to;
- absent → the em-dash plus a reason from the rigor gate's existing `pass`/`fail`/`pending`/`degenerate` vocabulary (`rigorGateStatus.js`), in the same branch order #1358 fixed the badge into.

Bounds are only asserted where they are *facts*. The Sharpe family declares `±∞` with an explicit note that the real bound needs the sample size and no payload carries it — stating the absence of a bound keeps the enumeration exhaustive instead of letting those metrics fall through an `undefined`.

**`ui/src/components/MetricValue.jsx`** — the single renderer. It exists so the annotation is *structural*: a caller free to render `label` while dropping `note` would turn an honest clamp back into a silent one, which is the issue's anti-goal.

**Wired through** `Strategies.jsx` (table, mobile card, detail), `StrategyPassport.jsx` (backtest + rigor grids), `Leaderboard.jsx` (research + live-paper boards, board-FDR cell) and `PublishStrategyTable.jsx`. The now-dead local `fmt`/`fmtPct`/`fmtSignedPct` helpers are deleted — leaving them would give the next cell a way around the domain check. Only Leaderboard keeps one `fmt()`, for the StockBench benchmark *sentence* (not a strategy metric), and it now has a finiteness guard.

---

## Evidence

### `cd ui && npm test`

```
ℹ tests 700
ℹ suites 0
ℹ pass 700
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```

(680 on `main` → 700; 20 new in `ui/test/metric-domain.test.js`, and `ui/test/app-visuals.test.js`'s leaderboard sort-render check updated to recognise `<MetricValue value={e.<id>} />` as a render site — its intent, "a field sorted must be shown", is unchanged.)

```
✔ property: for any return series, the rendered max drawdown lands in [−100%, 0%]
✔ property: the same bound holds for ANY raw number the API could serve
✔ the exact audited −130.3% series renders a possible drawdown, and says why
✔ a negative served drawdown is reported as out-of-domain, never Math.abs()'d into a plausible one
✔ the strategy that produced the screenshot renders a possible drawdown, from its own persisted row
✔ every persisted fixture row renders every one of its metrics inside the domain
✔ every metric rendered on Library / Passport / Leaderboard has a declared domain
✔ no declared metric can render outside its domain, for any input
✔ a non-finite or non-numeric value renders as unmeasured, never as the text 'NaN'
✔ the absence glyph is the one this codebase already uses
✔ an empty metric cell always carries a reason, never a bare em-dash
✔ the reason reuses the rigor gate's four-state vocabulary rather than inventing one
✔ a live-paper row's empty cell does not claim a backtest is pending
✔ the unevaluable states are ruled out before the row is described as measured-but-empty
✔ MetricValue renders the annotation whenever formatMetric produces one
✔ no surface formats a metric behind MetricValue's back
✔ every surface imports the shared renderer
✔ a possible value renders exactly as before, with no annotation
✔ a metric with NO declared domain still renders safely, and warns a developer
✔ the domain table states a reason for every bound it asserts
```

### `pytest -k "drawdown or metrics"` (repo root, env's pytest) — green, untouched

```
============== 114 passed, 4928 deselected, 26 warnings in 50.06s ==============
```

### `analytics-engine` — green, untouched

```
$ python -m pytest tests/test_drawdown_invariant.py -q
233 passed in 2.06s
$ python -m pytest -k "drawdown or metrics" -q
239 passed, 243 deselected in 5.96s
```

### `cd ui && npm run lint` — clean; `npm run build` — `✓ built in 15.90s`

### Re-verified against **current** `main`, not the base it was branched from

CLAUDE.md rules 1 and 2. The first push was based on `b359f324`; `Backend — unit tests` went red on
`test_cloudwatch_alarms.py::TestAntiGoals::test_the_oracle_stale_alarm_is_untouched` (`assert 3 == 1`) —
a pre-existing `main` breakage from the #1601 alarm retune, since fixed on `main` by #1673 (`fe9f4b4a`),
and untouchable by this branch, whose diff is eight `ui/` files and zero Python:

```
$ git diff --name-only origin/main...HEAD
ui/src/components/Leaderboard.jsx
ui/src/components/MetricValue.jsx
ui/src/components/PublishStrategyTable.jsx
ui/src/components/Strategies.jsx
ui/src/components/StrategyPassport.jsx
ui/src/metricDomain.js
ui/test/app-visuals.test.js
ui/test/metric-domain.test.js
```

Rebased onto `848673e0` and force-pushed. GitHub's test-merge ref therefore ran the union of this branch
and current `main`, and **all 14 checks pass**, `Backend — unit tests` included (18m12s). `npm test` and
`npm run lint` were re-run on the rebased tree: 700 pass, 0 fail, lint clean.


---

## Revert-demos and guard rejections

Every regression test was shown failing against the unfixed code, and every guard was shown rejecting an input it is supposed to reject. All patches reverted afterwards; the suite is green as committed.

### Revert-demo — remove the clamp branch (`if (false && (value < min || value > max))`)

```
CLAMP REVERTED -> label="−130.3%" note=null state="measured"
CLAMP RESTORED -> label="−100.0%" note="reported −130.3% — outside the possible range" state="clamped"
```

```
✖ property: for any return series, the rendered max drawdown lands in [−100%, 0%]
  AssertionError: seed=2: rendered -182.5% from max_drawdown=1.8249799717217683 — outside [−100%, 0%]
✖ property: the same bound holds for ANY raw number the API could serve
✖ the exact audited −130.3% series renders a possible drawdown, and says why
✖ a negative served drawdown is reported as out-of-domain, never Math.abs()'d into a plausible one
✖ no declared metric can render outside its domain, for any input
```

…and against the **real persisted fixture row**:

```
### DEMO A2 — clamp reverted, real persisted fixture row
  AssertionError: rendered -130.3%
  AssertionError: avellaneda_lee_2010_pca_statarb.max_drawdown: rendered -130.3%
```

### Guards, each shown rejecting

```
### GUARD 1 — undeclared metric reaches a surface   (metric="conviction_score" → metric="vibes_index")
  AssertionError: Leaderboard (Leaderboard.jsx) renders metric "vibes_index" with no entry in METRIC_DOMAINS

### GUARD 2a — Math.abs() put back on the drawdown cell
  AssertionError: Leaderboard (Leaderboard.jsx) still Math.abs()es a drawdown into plausibility

### GUARD 2b — a local percent formatter comes back
  AssertionError: Leaderboard (Leaderboard.jsx) re-declared a local percent formatter

### GUARD 3 — the visible annotation is dropped from MetricValue  ({m.note} deleted)
  AssertionError: The input did not match the regular expression /\{m\.note\}/

### GUARD 4 — 'degenerate' collapsed into the 'pending' sentence
  AssertionError: Expected values to be strictly deep-equal

### GUARD 5 — the live-paper `in` check removed
  AssertionError: 'pending' !== 'not_measured'
```

### Anti-vacuity, inside the property test itself

The sampler is asserted to actually reach the ruin regime — a property test that never generates the offending shape proves nothing:

```js
assert.ok(ruined > 100, ...);    // curves that touch or cross zero
assert.ok(survived > 100, ...);  // curves that never do
assert.ok(clamped > 100, ...);   // series whose drawdown exceeds 100%
```

and the real-data sweep asserts the fixture set contains **exactly one** out-of-domain value today, so it cannot silently become a no-op.

---

## Anti-goals, checked

| Anti-goal | Status |
|---|---|
| No threshold loosening | No threshold moved. `a possible value renders exactly as before, with no annotation` pins 14 in-domain renders byte-for-byte, including the ASCII-hyphen CAGR the previous `fmtPct` emitted. |
| No recomputing historical persisted series | Nothing writes. `formatMetric` is pure; `reported` carries the ledger value through untouched, and the fixture test re-asserts the stored number after rendering. Zero backend/engine/migration files in the diff. |
| Display-layer clamps visibly annotated, never silent | Clamped cells render `⚠ reported … — outside the possible range` as visible text (not colour, not tooltip-only), plus a `title` and an `sr-only` expansion. GUARD 3 shows the test rejecting a build that drops it. |

---

## Honest not-done list — why this says `Refs`, not `Closes`

1. **"Sharpe on <4 bars" is not implemented, and cannot be at this layer today.** The real bound is `|SR_ann| ≤ √(252·(n−1))`, which needs the sample size. No `StrategyResponse` or `LeaderboardEntry` carries `n_obs` (the fixture snapshot does — `n_obs_daily` — but the API never serves it). Rather than invent a threshold, `sharpe_ratio` / `sortino_ratio` / `calmar_ratio` / `deflated_sharpe_ratio` / `out_of_sample_sharpe` declare `±∞` with the reason written into the domain table, and enforce finiteness only. **Next step:** serve `n_obs` on those two schemas, then add the bound here — a backend change, deliberately not smuggled into this PR.
2. **`pytest -k "drawdown or metrics"` is green but does not contain the new property test.** The defect is a rendering defect, so the property test lives in `ui/test/` per CLAUDE.md's ui/ testing convention (`node --test`, no jsdom). The named pytest selector passes untouched; the property test is real and green, just in the other runner.
3. **Acceptance criterion 1 is verified against the repo's persisted row, not against prod.** `backend/tests/fixtures/backtest_fixtures_snapshot.json` carries the audited `1.3030656663525957` for `avellaneda_lee_2010_pca_statarb`, and the test drives that exact value; I have no prod DB access to confirm what the live row holds today. The clamp holds for any value, so the criterion is met for whatever it holds — but the check is against the fixture, not the live database.
4. **Two Leaderboard sites are still outside the domain module,** both prose rather than strategy metrics: the StockBench benchmark sentence (`Sortino …, return {sb.return_pct}%`) and `ScoreBar`'s per-component tooltip, which also defaults a missing component to `0` — a fabricated zero worth its own issue.
5. **Nothing was verified in a browser.** `npm run build` compiles and the suite is green; the visual weight of the `⚠ reported …` sub-line under a table cell has not been eyeballed on a real page.
6. **The backend still serves out-of-domain values,** by design (append-only). Any non-UI consumer of `/api/strategies` — the CSV/JSON export in `Strategies.jsx` included — still receives `1.303` raw. That is the correct behaviour for a ledger, but it does mean this fix protects the rendered surfaces only.

Refs #1651
