### PR TITLE
[infra] Stop the RPC-throttle kill-loop: /health from cache, 429-aware backoff

### DIFF
--- a/backend/archimedes/chain/client.py
+++ b/backend/archimedes/chain/client.py
@@ -6,15 +6,17 @@ All contract calls route through this client.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from aiohttp import ClientError, ClientTimeout
+from aiohttp import ClientError, ClientResponseError, ClientTimeout
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from pydantic import field_validator, model_validator
@@ -24,6 +26,14 @@ from web3.middleware import ExtraDataToPOAMiddleware
 from web3.providers import AsyncHTTPProvider
 from web3.providers.rpc.utils import ExceptionRetryConfiguration
 
+from archimedes.chain.rate_limit import (
+    DEFAULT_BASE_BACKOFF_SECONDS,
+    DEFAULT_MAX_BACKOFF_SECONDS,
+    HTTP_TOO_MANY_REQUESTS,
+    RateLimitBackoff,
+    RpcRateLimited,
+    retry_after_seconds,
+)
 from archimedes.deadline import run_with_deadline
 
 logger = logging.getLogger(__name__)
@@ -162,6 +172,15 @@ class ChainSettings(BaseSettings):
     # blip while leaving each attempt ~1.4s, roughly 9x the live Arc round trip.
     # ARC_RPC_RETRIES overrides.
     rpc_retries: int = 2
+    # 429 backoff knobs (#1594). The Arc RPC rate-limits our egress IP, and
+    # every ECS task shares ONE of those (the NAT gateway), so its per-IP limit
+    # is a FLEET-wide budget — task churn multiplies RPC pressure on itself.
+    # These two are env-overridable (ARC_RPC_RATE_LIMIT_BASE_BACKOFF_SECONDS /
+    # ARC_RPC_RATE_LIMIT_MAX_BACKOFF_SECONDS) specifically so the numbers can be
+    # tuned during an incident without a code change; the semantics — doubling
+    # window, full jitter, Retry-After as a floor — live in chain/rate_limit.py.
+    rpc_rate_limit_base_backoff_seconds: float = DEFAULT_BASE_BACKOFF_SECONDS
+    rpc_rate_limit_max_backoff_seconds: float = DEFAULT_MAX_BACKOFF_SECONDS
 
     # ── Two-chain split (#1240) ────────────────────────────────────────────
     # Payments (USDC / x402 / Gateway / PaymentSplitter) and execution (vault,
@@ -402,25 +421,115 @@ class BoundedAsyncHTTPProvider(AsyncHTTPProvider):
     read — ``ChainClient.is_connected`` maps it to ``False``, ``oracle_health``
     records it as a read error. No caller learns a *different* answer than it
     would have; it just learns one in bounded time.
+
+    **It is also 429-aware (#1594).** ``raise_for_status=True`` on web3's session
+    turns Arc's throttle into a ``ClientResponseError`` that is a subclass of
+    ``ClientError`` — which is in this client's retry set — so web3 already
+    retried a "you are sending too much" response, immediately, on a fixed
+    unjittered schedule, adding to the burst that caused it. Two behaviours are
+    layered on top here, both outside web3's retry loop:
+
+    * **Backoff with full jitter before a retry**, spent from THIS call's
+      remaining budget so the documented total is still the total.
+    * **A cooldown that fails the next request fast** rather than sending it.
+      During the incident every ECS task shared one NAT egress IP, so Arc's
+      per-IP limit was a fleet-wide budget and each cold start's RPC burst
+      throttled the fleet it was joining. A request skipped during a cooldown
+      fails as :class:`RpcRateLimited` — an honest, named error, never a
+      fabricated success — and costs the fleet nothing.
+
+    See chain/rate_limit.py for why a throttle is not just another transport
+    error and why the jitter is load-bearing rather than cosmetic.
     """
 
-    def __init__(self, *args: Any, total_budget_seconds: float, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        total_budget_seconds: float,
+        rate_limit_backoff: RateLimitBackoff | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._total_budget_seconds = total_budget_seconds
+        self._rate_limit = rate_limit_backoff or RateLimitBackoff()
 
     async def make_request(self, method: Any, params: Any) -> Any:
-        return await run_with_deadline(
-            super().make_request(method, params),
-            self._total_budget_seconds,
+        inner = super().make_request
+        return await self._request_backing_off_on_429(
+            lambda: inner(method, params),
             label=f"eth-rpc {method}",
         )
 
     async def make_batch_request(self, batch_requests: Any) -> Any:
-        return await run_with_deadline(
-            super().make_batch_request(batch_requests),
-            self._total_budget_seconds,
+        inner = super().make_batch_request
+        return await self._request_backing_off_on_429(
+            lambda: inner(batch_requests),
             label=f"eth-rpc batch({len(batch_requests)})",
         )
+
+    async def _request_backing_off_on_429(self, call: Any, *, label: str) -> Any:
+        """Run ``call()`` under the total budget, backing off on HTTP 429.
+
+        ``call`` is a zero-argument callable returning a fresh awaitable —
+        callable rather than awaitable because a retry needs a *new* request,
+        and because nothing should be constructed before the deadline is armed
+        (same contract as ``HealthProbeCache.probe``).
+
+        The budget is spent, never extended: every attempt and every backoff
+        sleep comes out of the same ``total_budget_seconds`` deadline, so a
+        throttled endpoint can make this call *fail sooner* but never make it
+        take longer than the number ``rpc_timeout_seconds`` documents. That
+        matters because /health's probe budgets are sized against it.
+        """
+        deadline = time.monotonic() + self._total_budget_seconds
+
+        cooling = self._rate_limit.remaining()
+        if cooling > 0:
+            # Loud, greppable literal for a CloudWatch metric filter, matching
+            # the HEALTH_CHAIN_DISCONNECTED / HEALTH_ORACLE_STALE convention.
+            logger.warning(
+                "RPC_RATE_LIMIT_COOLDOWN: %s not sent — endpoint asked for %.2fs more backoff (consecutive_429=%d)",
+                label,
+                cooling,
+                self._rate_limit.consecutive,
+            )
+            raise RpcRateLimited(
+                f"{label} skipped: Arc RPC returned 429 and asked for {cooling:.2f}s more backoff "
+                f"(consecutive_429={self._rate_limit.consecutive})"
+            )
+
+        while True:
+            remaining = deadline - time.monotonic()
+            try:
+                result = await run_with_deadline(call(), max(0.0, remaining), label=label)
+            except ClientResponseError as exc:
+                if exc.status != HTTP_TOO_MANY_REQUESTS:
+                    raise
+                delay = self._rate_limit.note_rate_limited(retry_after_seconds(exc.headers))
+                budget_left = deadline - time.monotonic()
+                logger.warning(
+                    "RPC_RATE_LIMITED: %s got HTTP 429 (consecutive_429=%d) — backing off %.2fs "
+                    "with %.2fs of budget left",
+                    label,
+                    self._rate_limit.consecutive,
+                    delay,
+                    budget_left,
+                )
+                if delay >= budget_left:
+                    # No honest way to retry inside the promise this call made.
+                    # Re-raise the endpoint's own answer rather than blowing the
+                    # budget or inventing a value; the cooldown set above is
+                    # what protects the NEXT caller.
+                    raise
+                await asyncio.sleep(delay)
+                continue
+
+            # Only a completed response clears the backoff. A timeout or a
+            # connection error propagates from run_with_deadline untouched and
+            # leaves the consecutive count alone — neither is evidence that the
+            # endpoint has stopped throttling us.
+            self._rate_limit.note_success()
+            return result
 
 
 class ChainClient:
@@ -442,6 +551,14 @@ class ChainClient:
             BoundedAsyncHTTPProvider(
                 self.settings.arc_rpc_url,
                 total_budget_seconds=self.settings.rpc_timeout_seconds,
+                # 429-aware backoff (#1594). web3's own retry set already
+                # contains ClientResponseError, so without this a throttle was
+                # retried like a connection reset — immediately, unjittered,
+                # by every task behind the shared NAT IP at once.
+                rate_limit_backoff=RateLimitBackoff(
+                    base_seconds=self.settings.rpc_rate_limit_base_backoff_seconds,
+                    max_seconds=self.settings.rpc_rate_limit_max_backoff_seconds,
+                ),
                 request_kwargs={"timeout": ClientTimeout(total=per_attempt)},
                 # Passed explicitly, never left to default: web3's default is five
                 # attempts, which multiplies rpc_timeout_seconds by five and breaks

--- a/backend/archimedes/chain/rate_limit.py
+++ b/backend/archimedes/chain/rate_limit.py
@@ -55,6 +55,7 @@ fleet from retrying on the same schedule.
 from __future__ import annotations
 
 import logging
+import math
 import random
 import time
 from collections.abc import Callable, Mapping
@@ -79,6 +80,19 @@ DEFAULT_BASE_BACKOFF_SECONDS = 0.25
 # would only ever be spent failing fast in the cooldown check rather than
 # actually waiting — the cap keeps the number meaningful.
 DEFAULT_MAX_BACKOFF_SECONDS = 4.0
+
+# Floor on any returned delay. A full-jitter draw near zero is a legitimate
+# outcome of the policy and an illegitimate thing to do to a throttled endpoint:
+# it is an immediate retry wearing a backoff's name. 10ms is far below anything
+# a caller notices and far above zero.
+MIN_BACKOFF_SECONDS = 0.01
+
+# Cap on the doubling exponent, applied before the multiply. Purely defensive
+# arithmetic: the window is capped at ``max_seconds`` anyway, but computing
+# ``base * 2**consecutive`` first would raise OverflowError once ``consecutive``
+# passes ~1024, and ``consecutive`` is unbounded during a long outage because
+# only a completed response resets it.
+_MAX_DOUBLINGS = 32
 
 
 class RpcRateLimited(ClientError):
@@ -113,9 +127,15 @@ def retry_after_seconds(headers: Mapping[str, Any] | None, *, now: float | None 
         return None
     text = str(raw).strip()
     try:
-        return max(0.0, float(text))
+        seconds = float(text)
     except ValueError:
-        pass
+        seconds = None
+    if seconds is not None:
+        # ``inf`` and ``nan`` parse as floats and are not delays. An infinite
+        # value would set a cooldown that never expires, and every RPC in this
+        # process would fail fast forever off one malformed header — a
+        # permanent self-inflicted outage from a byte we do not control.
+        return max(0.0, seconds) if math.isfinite(seconds) else None
     try:
         when = parsedate_to_datetime(text)
     except (TypeError, ValueError):
@@ -173,12 +193,25 @@ class RateLimitBackoff:
         jittered increment, so we never come back earlier than we were told and
         never come back at the same instant as every other task that was told
         the same thing.
+
+        The returned delay is never below :data:`MIN_BACKOFF_SECONDS`. A full
+        jitter draw can legitimately land near zero, and a near-zero backoff on
+        a throttled endpoint is an immediate retry — the amplification this
+        module exists to remove. The floor also makes a misconfigured
+        ``base_seconds=0`` degrade to "slow" rather than to "hammer".
         """
         self._consecutive += 1
-        window = min(self._max_seconds, self._base_seconds * (2 ** (self._consecutive - 1)))
-        delay = self._jitter() * window
         if retry_after is not None:
             delay = retry_after + self._jitter() * self._base_seconds
+        else:
+            # The exponent is clamped before it reaches float arithmetic.
+            # ``consecutive`` only resets on a completed response, so a long
+            # throttling window drives it into the thousands, and
+            # ``base * 2**1024`` raises OverflowError rather than returning a
+            # large float — the backoff would crash the very call it protects.
+            window = min(self._max_seconds, self._base_seconds * (2 ** min(self._consecutive - 1, _MAX_DOUBLINGS)))
+            delay = self._jitter() * window
+        delay = max(MIN_BACKOFF_SECONDS, delay)
         self._cooldown_until = self._clock() + delay
         return delay
 

--- a/backend/archimedes/chain/rate_limit.py
+++ b/backend/archimedes/chain/rate_limit.py
@@ -1,0 +1,192 @@
+"""429-aware backoff for the Arc RPC client (#1594).
+
+INCIDENT 2026-08-31, root cause. Live ``/archimedes/app`` logs during the
+outage carried repeated ``aiohttp.client_exceptions.ClientResponseError: 429,
+message='Too Many Requests', url='https://rpc.testnet.arc.network'``. Everything
+the incident issue tracked was downstream of that one fact: the "VPC→RPC
+intermittent latency" was 429s plus client retries, not a slow network path.
+
+**Why a 429 is not just another transport error.** ``web3`` 7.16 opens its
+session with ``raise_for_status=True``, so a throttled response surfaces as
+``ClientResponseError`` — a subclass of ``ClientError``, which is in this
+client's retry set. web3 therefore already retries a 429, immediately, with a
+fixed ``backoff_factor * 2**i`` sleep and **no jitter**. Two consequences, both
+live in the incident:
+
+1. Retrying a throttle *adds* to the burst that caused it. A connection reset
+   deserves a retry; "you are sending too much" deserves the opposite.
+2. A fixed backoff re-synchronises the fleet. Every ECS task shares ONE egress
+   IP (the NAT gateway), so Arc's per-IP limit is a **fleet-wide budget** — and
+   with identical sleeps, tasks that get throttled together retry together, in
+   lockstep, forever. During the incident every cold start burst RPC through
+   that shared IP, got 429s, blew the ALB health budget, got killed, and
+   restarted: a self-sustaining storm.
+
+This module holds the state that fixes both, and nothing else — it is pure and
+clock-injectable so the policy can be tested without a network:
+
+* **Full jitter.** The backoff window doubles per consecutive 429 and the actual
+  sleep is drawn uniformly from ``[0, window]``. Two tasks throttled in the same
+  millisecond come back at different times. This is the standard
+  exponential-backoff-with-full-jitter result, and de-synchronisation is the
+  entire reason for the random draw — not politeness.
+* **``Retry-After`` is a floor, never the whole answer.** When the server names
+  a delay we never sleep less than it asked, and we add a jittered increment on
+  top, because a fleet that honours the same ``Retry-After`` to the millisecond
+  is a fleet that retries in lockstep — the very thing jitter exists to prevent.
+* **A cooldown other callers can see.** After a 429 the endpoint has told us to
+  stop; a concurrent caller that has not yet sent its request should not send
+  it. :meth:`RateLimitBackoff.remaining` lets the caller fail that request FAST
+  and loudly instead of adding to the pressure. Failing fast is not a
+  degradation here — under sustained throttling the request was going to fail
+  anyway, and this way it fails without costing the fleet another 429.
+
+**Only a completed response clears the state.** A timeout or a connection error
+leaves the consecutive count where it was: neither is evidence that the
+endpoint has stopped throttling us, and treating them as evidence would reset
+the backoff exactly when the endpoint is least able to serve us.
+
+Process-local by design, same as ``services/health_cache.py``: one instance per
+provider, so each process backs off on what IT observed. It cannot coordinate
+the fleet, and does not claim to — what it can do is stop every task in the
+fleet from retrying on the same schedule.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from collections.abc import Callable, Mapping
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+from aiohttp import ClientError
+
+logger = logging.getLogger(__name__)
+
+HTTP_TOO_MANY_REQUESTS = 429
+
+# First backoff window. Doubles per CONSECUTIVE 429; the actual sleep is drawn
+# uniformly from [0, window] (full jitter). 0.25s is chosen against the live Arc
+# RPC's ~0.1s round trip — long enough to be a real pause, short enough that a
+# single throttled call still fits inside chain client's 3s total budget with
+# room for the retry.
+DEFAULT_BASE_BACKOFF_SECONDS = 0.25
+
+# Ceiling on the window. Past this the doubling stops and the draw stays in
+# [0, 4s]: a bigger window would exceed any caller's per-call budget, so it
+# would only ever be spent failing fast in the cooldown check rather than
+# actually waiting — the cap keeps the number meaningful.
+DEFAULT_MAX_BACKOFF_SECONDS = 4.0
+
+
+class RpcRateLimited(ClientError):
+    """The endpoint is throttling us and we chose not to send this request.
+
+    Deliberately an ``aiohttp.ClientError``: every caller in this repo already
+    treats that class as "the read failed" — ``ChainClient.is_connected`` maps
+    it to ``False``, ``oracle_health`` records it as a read error — so nothing
+    learns a *different* answer than it would have learned from the 429 itself.
+    What changes is that it learns it without spending another request on an
+    endpoint that just told us to stop.
+
+    NOT a ``TimeoutError``. services/health_cache.py keeps errors and timeouts
+    apart on purpose: collapsing them lets a throttled endpoint hide behind "the
+    network was slow", which is precisely the misdiagnosis that cost this
+    incident its first several hours.
+    """
+
+
+def retry_after_seconds(headers: Mapping[str, Any] | None, *, now: float | None = None) -> float | None:
+    """Parse an HTTP ``Retry-After`` header into seconds, or ``None``.
+
+    Both RFC 9110 forms are accepted: delay-seconds (``Retry-After: 5``) and
+    HTTP-date (``Retry-After: Wed, 21 Oct 2026 07:28:00 GMT``). Anything
+    unparseable, negative, or absent returns ``None`` — the caller then falls
+    back to its own jittered window rather than inventing a server instruction.
+    """
+    if not headers:
+        return None
+    raw = headers.get("Retry-After") or headers.get("retry-after")
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    try:
+        return max(0.0, float(text))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    reference = time.time() if now is None else now
+    return max(0.0, when.timestamp() - reference)
+
+
+class RateLimitBackoff:
+    """Consecutive-429 counter plus the cooldown window it implies.
+
+    Pure and clock-injectable. ``clock`` must be monotonic in production (wall
+    time can step backwards under NTP correction and would shorten or extend a
+    cooldown for reasons that have nothing to do with the endpoint); ``jitter``
+    returns a float in ``[0, 1)`` and exists so a test can pin the draw and
+    assert the window arithmetic instead of asserting a random number.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_seconds: float = DEFAULT_BASE_BACKOFF_SECONDS,
+        max_seconds: float = DEFAULT_MAX_BACKOFF_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+        jitter: Callable[[], float] = random.random,
+    ) -> None:
+        self._base_seconds = base_seconds
+        self._max_seconds = max_seconds
+        self._clock = clock
+        self._jitter = jitter
+        self._consecutive = 0
+        self._cooldown_until = 0.0
+
+    @property
+    def consecutive(self) -> int:
+        """How many 429s in a row, with no completed response in between."""
+        return self._consecutive
+
+    def remaining(self) -> float:
+        """Seconds left before this process should send another request.
+
+        ``0.0`` means "go ahead". A positive number is the endpoint's own
+        instruction, not a guess: it exists only because a 429 was observed.
+        """
+        return max(0.0, self._cooldown_until - self._clock())
+
+    def note_rate_limited(self, retry_after: float | None = None) -> float:
+        """Record a 429 and return the delay to wait before retrying.
+
+        The window doubles per consecutive 429 up to ``max_seconds`` and the
+        delay is drawn uniformly from ``[0, window]`` (full jitter). A server
+        ``retry_after`` is a FLOOR: the returned delay is ``retry_after`` plus a
+        jittered increment, so we never come back earlier than we were told and
+        never come back at the same instant as every other task that was told
+        the same thing.
+        """
+        self._consecutive += 1
+        window = min(self._max_seconds, self._base_seconds * (2 ** (self._consecutive - 1)))
+        delay = self._jitter() * window
+        if retry_after is not None:
+            delay = retry_after + self._jitter() * self._base_seconds
+        self._cooldown_until = self._clock() + delay
+        return delay
+
+    def note_success(self) -> None:
+        """Clear the backoff — a completed response is the only evidence that clears it."""
+        self._consecutive = 0
+        self._cooldown_until = 0.0
+
+    def reset(self) -> None:
+        """Drop all state (test hygiene; production clears via :meth:`note_success`)."""
+        self.note_success()

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -20,6 +20,7 @@ faulthandler.enable()
 # Load .env into os.environ at import time for modules that use os.getenv()
 # (circle_signer, oracle_updater) — pydantic ChainSettings handles ARC_ vars itself.
 from collections.abc import AsyncGenerator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
@@ -809,6 +810,97 @@ _ORACLE_PROBE_BUDGET_SECONDS = 1.2
 # started; probes now run concurrently, so the oracle's slice is smaller and
 # has to leave the outer backstop above room to be the backstop.
 _ORACLE_INNER_BUDGET_SECONDS = 0.9
+# Budget for the six LOCAL reads (corpus file, corpus DB rows, corpus meta,
+# paper-RAG, GMM regime, risk data). Smaller than the chain/oracle budgets
+# because none of these leaves the box: the corpus load is a file read, the two
+# corpus-meta reads are single-row queries, and the three health functions are
+# in-process state checks. Measured warm they are single-digit milliseconds.
+#
+# WHY THEY NEED A BUDGET AT ALL (#1594). "Local" is not "fast" when the box is
+# the problem: an Aurora failover parks `get_paper_count`, a cold
+# sentence-transformer import parks `paper_rag_health`, an EFS/S3-backed corpus
+# file parks `load_corpus`. Measured on the live handler, /health was p50 1.19s
+# but p95 17.03s / max 30s against an ALB check of timeout 10 x threshold 5 —
+# five consecutive misses kill the task, and over 24h HealthyHostCount averaged
+# 1.03 and touched 0. #1592 bounded the two OUTBOUND probes; these six ran
+# unbounded and synchronously afterwards, which is where the p95 lived.
+#
+# They share this budget CONCURRENTLY with the two probes above, so the bounded
+# section of this handler costs max(1.2, 0.8) = 1.2s, not the sum of eight.
+_LOCAL_PROBE_BUDGET_SECONDS = 0.8
+
+# One name per local probe, defined once because it is used three ways that MUST
+# agree: the HealthProbeCache key, the `<name>_probe_*` payload prefix, and the
+# payload field the trio describes. Drift between them would publish staleness
+# fields that label a different reading than the one they sit next to.
+_CORPUS_PROBE = "corpus"
+_CORPUS_DB_PROBE = "corpus_db"
+_CORPUS_META_PROBE = "corpus_meta"
+_PAPER_RAG_PROBE = "paper_rag"
+_REGIME_PROBE = "regime_detector"
+_RISK_DATA_PROBE = "risk_data"
+
+# The health probes get their OWN thread pool, not the loop's default executor.
+# ``asyncio.to_thread`` would have been shorter and is wrong here: the default
+# executor is also where asyncio runs ``getaddrinfo``, so abandoned health reads
+# accumulating in it would eventually make DNS — for the DB, for Redis, for the
+# RPC — queue behind a stuck corpus load. A liveness probe must not be able to
+# damage the thing it reports on.
+#
+# 12 workers = two full checks' worth of the six probes. A read abandoned at its
+# budget keeps its worker until it unwinds (see archimedes/deadline.py on the
+# cost of abandonment), so the headroom is what stops ONE permanently-stuck read
+# from starving its five healthy siblings on the very next check. If the pool
+# does fill, ``run_in_executor`` queues without blocking and the queued probes
+# report ``probe_timeout`` against their last-known values — degraded and
+# labelled, never a stalled handler.
+_HEALTH_PROBE_EXECUTOR = ThreadPoolExecutor(max_workers=12, thread_name_prefix="health-probe")
+
+
+def _bounded_local_read(fn):
+    """Adapt a BLOCKING local read into a factory ``HealthProbeCache.probe`` can bound.
+
+    A worker thread, not a bare coroutine, and that is the entire point.
+    ``asyncio.wait_for`` / ``run_with_deadline`` schedule their timeout as a
+    callback ON THE EVENT LOOP, so neither can bound work that is *itself*
+    blocking the loop — a budget denominated in loop time is not a budget when
+    the loop is what stalled. Moving the call off the loop is what makes the
+    deadline real: the loop stays free to fire the timeout and answer the ALB
+    while the stalled read is still parked.
+
+    Cost, stated plainly (mirrors archimedes/deadline.py's abandonment note): a
+    read that blows its budget is ABANDONED, and its worker thread keeps running
+    until it unwinds. That is only acceptable because every read passed here is
+    READ-ONLY. Do not route a state-changing call through this helper.
+    """
+    return lambda: asyncio.get_running_loop().run_in_executor(_HEALTH_PROBE_EXECUTOR, fn)
+
+
+def _cache_annotated(outcome, reason: str) -> str:
+    """Fold a served-from-cache label into the ``*_reason`` field operators read.
+
+    Same wording the oracle block below produces by hand: the sibling
+    ``*_probe_state`` field already says ``stale_cached``, but the human-read
+    reason string has to say it too or a past reading gets quoted as a present
+    one.
+    """
+    if outcome.state == "stale_cached":
+        return f"{outcome.reason}; last completed read {outcome.age_s}s ago: {reason}"
+    return reason
+
+
+def _probe_error_fields(prefix: str, exc: BaseException) -> dict[str, object]:
+    """Staleness trio for a probe that RAISED — an error, never a timeout.
+
+    Kept distinct from ``probe_timeout`` for the reason services/health_cache.py
+    documents: collapsing them lets a broken probe hide behind "the network was
+    slow".
+    """
+    return {
+        f"{prefix}_probe_state": "probe_error",
+        f"{prefix}_probe_age_s": None,
+        f"{prefix}_probe_reason": f"{prefix} probe_error: {exc}",
+    }
 
 
 @app.get("/health")
@@ -820,9 +912,10 @@ async def health(response: Response):
     Reports corpus state so silent degradation is visible.
 
     **This endpoint reports what we know; it does not go and find out.** Every
-    outbound probe is bounded and falls back to its last-known value, labelled
-    with age and reason (#1592). No field's MEANING changed — only how long the
-    handler is willing to wait to compute it.
+    probe is bounded and falls back to its last-known value, labelled with age
+    and reason — the two outbound ones since #1592, the six local ones since
+    #1594. No field's MEANING changed — only how long the handler is willing to
+    wait to compute it.
     """
     _no_store(response)
 
@@ -839,10 +932,45 @@ async def health(response: Response):
 
         return await _oracle_health_probe(budget_seconds=_ORACLE_INNER_BUDGET_SECONDS)
 
+    def _paper_rag_read():
+        # Imported INSIDE the worker thread, not at handler scope, so a cold
+        # sentence-transformer import is inside the budget too — the import is
+        # the slow part on a fresh task. Tests keep patching
+        # ``services.paper_rag.paper_rag_health`` exactly as they do today.
+        from archimedes.services.paper_rag import paper_rag_health as _prag_health
+
+        return _prag_health()
+
+    def _regime_read():
+        from archimedes.services.gmm_regime_detector import gmm_regime_health
+
+        return gmm_regime_health()
+
+    def _risk_data_read():
+        from archimedes.api.risk_routes import risk_data_health
+
+        return risk_data_health()
+
     # Concurrent + bounded. return_exceptions keeps one broken probe from
-    # taking the other down: a raised probe is still a health verdict, it is
+    # taking the others down: a raised probe is still a health verdict, it is
     # just a "we could not read it" one, and that is what gets reported.
-    chain_outcome, oracle_outcome = await asyncio.gather(
+    #
+    # ALL EIGHT reads live in this one gather (#1594). The six local ones used
+    # to run one after another, unbounded, below the chain/oracle block — which
+    # is why #1592 read correct and measured wrong: the outbound calls were
+    # bounded and the handler still went to 17s p95. Adding them here costs
+    # max(budget), not sum(budget), and every one of them now reports its own
+    # freshness instead of stalling the endpoint that reports everything else.
+    (
+        chain_outcome,
+        oracle_outcome,
+        corpus_outcome,
+        corpus_db_outcome,
+        corpus_meta_outcome,
+        paper_rag_outcome,
+        regime_outcome,
+        risk_data_outcome,
+    ) = await asyncio.gather(
         health_probe_cache.probe(
             "chain_connected",
             chain_client.is_connected,
@@ -853,6 +981,45 @@ async def health(response: Response):
             "oracle_health",
             _oracle_probe,
             budget_seconds=_ORACLE_PROBE_BUDGET_SECONDS,
+            absent=None,
+        ),
+        # `absent=[]` renders corpus_papers: 0 — a plausible-looking number, and
+        # the reason every one of these carries a `*_probe_state`: the state
+        # field is what separates "we read zero" from "we could not read".
+        health_probe_cache.probe(
+            _CORPUS_PROBE,
+            _bounded_local_read(load_corpus),
+            budget_seconds=_LOCAL_PROBE_BUDGET_SECONDS,
+            absent=[],
+        ),
+        health_probe_cache.probe(
+            _CORPUS_DB_PROBE,
+            _bounded_local_read(get_paper_count),
+            budget_seconds=_LOCAL_PROBE_BUDGET_SECONDS,
+            absent=0,
+        ),
+        health_probe_cache.probe(
+            _CORPUS_META_PROBE,
+            _bounded_local_read(get_corpus_meta),
+            budget_seconds=_LOCAL_PROBE_BUDGET_SECONDS,
+            absent=None,
+        ),
+        health_probe_cache.probe(
+            _PAPER_RAG_PROBE,
+            _bounded_local_read(_paper_rag_read),
+            budget_seconds=_LOCAL_PROBE_BUDGET_SECONDS,
+            absent=None,
+        ),
+        health_probe_cache.probe(
+            _REGIME_PROBE,
+            _bounded_local_read(_regime_read),
+            budget_seconds=_LOCAL_PROBE_BUDGET_SECONDS,
+            absent=None,
+        ),
+        health_probe_cache.probe(
+            _RISK_DATA_PROBE,
+            _bounded_local_read(_risk_data_read),
+            budget_seconds=_LOCAL_PROBE_BUDGET_SECONDS,
             absent=None,
         ),
         return_exceptions=True,
@@ -889,67 +1056,108 @@ async def health(response: Response):
         # metric filter on this exact string (infra/cloudwatch.tf) turns repeated
         # occurrences into a paging alarm without touching the response contract.
         logger.warning("HEALTH_CHAIN_DISCONNECTED: chain_connected=false (Arc RPC unreachable or timed out)")
-    corpus = load_corpus()
+
+    # ── corpus file load ─────────────────────────────────────────────────
+    # Previously a bare `corpus = load_corpus()`: an unbounded read whose only
+    # failure mode was a 500 from the endpoint that exists to report failures.
+    # Now bounded, and a raise is reported as `probe_error` rather than losing
+    # every other field on the page.
+    corpus_probe_fields: dict[str, object] = {}
+    if isinstance(corpus_outcome, BaseException):
+        logger.warning("corpus load raised %s — reporting 0 papers", type(corpus_outcome).__name__)
+        corpus: list = []
+        corpus_probe_fields = _probe_error_fields(_CORPUS_PROBE, corpus_outcome)
+    else:
+        corpus = corpus_outcome.value or []
+        corpus_probe_fields = corpus_outcome.payload_fields(_CORPUS_PROBE)
+
     _fusion_on = fusion_enabled()
     backend = make_llm_backend()
     llm_provider = os.getenv("LLM_PROVIDER", "auto")
     is_available = getattr(backend, "available", False)
     llm_backend = "live" if is_available else backend.model_id if hasattr(backend, "model_id") else "unavailable"
 
-    # DB-backed corpus diagnostics
+    # DB-backed corpus diagnostics. Two probes, not one try block: a paper-count
+    # query that answers and a corpus-meta query that stalls are two different
+    # facts, and folding them together lost the distinction.
     db_count = 0
+    corpus_db_probe_fields: dict[str, object] = {}
+    if isinstance(corpus_db_outcome, BaseException):
+        logger.debug("corpus paper-count read failed", exc_info=corpus_db_outcome)
+        corpus_db_probe_fields = _probe_error_fields(_CORPUS_DB_PROBE, corpus_db_outcome)
+    else:
+        db_count = corpus_db_outcome.value or 0
+        corpus_db_probe_fields = corpus_db_outcome.payload_fields(_CORPUS_DB_PROBE)
+
     corpus_source = "file"
     corpus_last_intake = None
     artifact_hash = None
-    try:
-        db_count = get_paper_count()
-        meta = get_corpus_meta()
+    corpus_meta_probe_fields: dict[str, object] = {}
+    if isinstance(corpus_meta_outcome, BaseException):
+        logger.debug("corpus meta read failed", exc_info=corpus_meta_outcome)
+        corpus_meta_probe_fields = _probe_error_fields(_CORPUS_META_PROBE, corpus_meta_outcome)
+    else:
+        meta = corpus_meta_outcome.value
+        corpus_meta_probe_fields = corpus_meta_outcome.payload_fields(_CORPUS_META_PROBE)
         if meta:
             corpus_source = meta.get("source", "unknown")
             corpus_last_intake = meta.get("last_intake_at")
             artifact_hash = meta.get("artifact_hash")
-    except Exception:
-        logger.debug("corpus meta read failed", exc_info=True)
 
-    # Paper RAG health (semantic retrieval)
+    # Paper RAG health (semantic retrieval). "unknown" is reserved for a probe
+    # that never completed — it must not collapse into "disabled", which is a
+    # real, deliberately-configured state.
     paper_rag_status = "disabled"
     paper_rag_reason = ""
-    try:
-        from archimedes.services.paper_rag import paper_rag_health as _prag_health
-
-        _diag = _prag_health()
-        paper_rag_status = _diag.status
-        paper_rag_reason = _diag.reason
-    except Exception:
+    paper_rag_probe_fields: dict[str, object] = {}
+    if isinstance(paper_rag_outcome, BaseException):
         paper_rag_reason = "import failed"
+        paper_rag_probe_fields = _probe_error_fields(_PAPER_RAG_PROBE, paper_rag_outcome)
+    else:
+        paper_rag_probe_fields = paper_rag_outcome.payload_fields(_PAPER_RAG_PROBE)
+        _diag = paper_rag_outcome.value
+        if _diag is None:
+            paper_rag_status = "unknown"
+            paper_rag_reason = paper_rag_outcome.reason
+        else:
+            paper_rag_status = _diag.status
+            paper_rag_reason = _cache_annotated(paper_rag_outcome, _diag.reason)
 
     # GMM regime-detector health (T0.5 — loud fallback telemetry).
     # "degraded" => no fitted artifact, rule-based VixRegimeDetector fallback
     # active. Surfaced so rule-based regime calls aren't presented as data-driven.
     regime_detector_status = "unknown"
     regime_detector_reason = ""
-    try:
-        from archimedes.services.gmm_regime_detector import gmm_regime_health
-
-        _gmm_diag = gmm_regime_health()
-        regime_detector_status = _gmm_diag.status
-        regime_detector_reason = _gmm_diag.reason
-    except Exception:
+    regime_detector_probe_fields: dict[str, object] = {}
+    if isinstance(regime_outcome, BaseException):
         regime_detector_reason = "import failed"
+        regime_detector_probe_fields = _probe_error_fields(_REGIME_PROBE, regime_outcome)
+    else:
+        regime_detector_probe_fields = regime_outcome.payload_fields(_REGIME_PROBE)
+        _gmm_diag = regime_outcome.value
+        if _gmm_diag is None:
+            regime_detector_reason = regime_outcome.reason
+        else:
+            regime_detector_status = _gmm_diag.status
+            regime_detector_reason = _cache_annotated(regime_outcome, _gmm_diag.reason)
 
     # Risk-analysis data health (T0.5 — loud fallback telemetry).
     # "mock" => no persisted backtest equity curves, so the Risk UI renders
     # placeholder mockReturns. Surfaced so mock tail-risk isn't presented as real.
     risk_data_status = "unknown"
     risk_data_reason = ""
-    try:
-        from archimedes.api.risk_routes import risk_data_health
-
-        _risk_diag = risk_data_health()
-        risk_data_status = _risk_diag.status
-        risk_data_reason = _risk_diag.reason
-    except Exception:
+    risk_data_probe_fields: dict[str, object] = {}
+    if isinstance(risk_data_outcome, BaseException):
         risk_data_reason = "import failed"
+        risk_data_probe_fields = _probe_error_fields(_RISK_DATA_PROBE, risk_data_outcome)
+    else:
+        risk_data_probe_fields = risk_data_outcome.payload_fields(_RISK_DATA_PROBE)
+        _risk_diag = risk_data_outcome.value
+        if _risk_diag is None:
+            risk_data_reason = risk_data_outcome.reason
+        else:
+            risk_data_status = _risk_diag.status
+            risk_data_reason = _cache_annotated(risk_data_outcome, _risk_diag.reason)
 
     # Oracle-freshness health (issue #1371 — isFresh()/lastUpdated() had zero
     # backend callers; every deployed PriceOracle has been stale since the
@@ -1207,6 +1415,14 @@ async def health(response: Response):
         "corpus_source": corpus_source,
         "corpus_last_intake": corpus_last_intake,
         "artifact_hash": artifact_hash,
+        # Bounded-probe provenance for the six LOCAL reads (#1594), same shape
+        # and same rules as the chain/oracle blocks: `*_probe_state` always
+        # present, `*_probe_age_s` + `*_probe_reason` present ONLY when the
+        # fresh read missed. Without these, `corpus_papers: 0` and
+        # `regime_detector: "unknown"` are indistinguishable from real readings.
+        **corpus_probe_fields,
+        **corpus_db_probe_fields,
+        **corpus_meta_probe_fields,
         # Claim-integrity honesty fields (issue #778). The counts above are
         # manifest-seeded *metadata records*; these say what has actually been
         # built on top of them. New keys only — existing keys are unchanged so
@@ -1229,10 +1445,13 @@ async def health(response: Response):
         "llm_has_base_url": bool(os.getenv("LLM_BASE_URL") or os.getenv("ANTHROPIC_BASE_URL")),
         "paper_rag": paper_rag_status,
         "paper_rag_reason": paper_rag_reason,
+        **paper_rag_probe_fields,
         "regime_detector": regime_detector_status,
         "regime_detector_reason": regime_detector_reason,
+        **regime_detector_probe_fields,
         "risk_data": risk_data_status,
         "risk_data_reason": risk_data_reason,
+        **risk_data_probe_fields,
         # Oracle-freshness health (issue #1371). oracle_fresh is true only when
         # EVERY probed oracle is fresh — oracle_probed_count/oracle_universe_count
         # are always both present so a fully-fresh push set is never read as

--- a/backend/tests/chain/test_rpc_rate_limit_backoff.py
+++ b/backend/tests/chain/test_rpc_rate_limit_backoff.py
@@ -53,6 +53,7 @@ import yarl
 from aiohttp import ClientResponseError, RequestInfo
 from archimedes.chain.client import BoundedAsyncHTTPProvider, chain_client
 from archimedes.chain.rate_limit import (
+    MIN_BACKOFF_SECONDS,
     RateLimitBackoff,
     RpcRateLimited,
     retry_after_seconds,
@@ -174,6 +175,39 @@ class TestTheBackoffPolicy:
         clock.advance(5.0)
         assert backoff.remaining() == 0.0
 
+    def test_a_near_zero_jitter_draw_still_pauses(self):
+        """MUTATION: drop the MIN_BACKOFF_SECONDS floor.
+
+        ``random()`` is allowed to return ~0, and a full-jitter draw of ~0 on a
+        throttled endpoint is an immediate retry wearing a backoff's name — the
+        amplification this module exists to remove. The floor also makes a
+        misconfigured ``base_seconds=0`` degrade to slow rather than to hammer.
+        """
+        broken = RateLimitBackoff(base_seconds=0.0, max_seconds=0.0, clock=_FakeClock(), jitter=lambda: 0.0)
+        assert broken.note_rate_limited() >= MIN_BACKOFF_SECONDS
+
+        drew_zero = RateLimitBackoff(base_seconds=1.0, max_seconds=4.0, clock=_FakeClock(), jitter=lambda: 0.0)
+        assert drew_zero.note_rate_limited() >= MIN_BACKOFF_SECONDS
+
+    def test_a_long_outage_does_not_overflow_the_doubling(self):
+        """ADVERSARIAL: the input that SHOULD break the exponent.
+
+        ``consecutive`` only resets on a completed RESPONSE, so a sustained
+        throttling window drives it without bound. ``base * 2**consecutive``
+        computed before the cap raises ``OverflowError: int too large to convert
+        to float`` somewhere past 1024 — the backoff crashing the very call it
+        was added to protect, and only after a long outage, which is exactly
+        when nobody wants to discover it.
+        """
+        clock = _FakeClock()
+        backoff = RateLimitBackoff(base_seconds=0.25, max_seconds=4.0, clock=clock, jitter=lambda: 1.0)
+
+        for _ in range(5_000):
+            delay = backoff.note_rate_limited()
+
+        assert backoff.consecutive == 5_000
+        assert delay == pytest.approx(4.0), "the window escaped its cap"
+
     def test_only_a_completed_response_clears_the_backoff(self):
         """MUTATION: reset on any non-429 outcome.
 
@@ -210,6 +244,18 @@ class TestRetryAfterParsing:
 
     def test_a_past_date_is_zero_never_negative(self):
         assert retry_after_seconds({"Retry-After": self._HTTP_DATE}, now=self._HTTP_DATE_EPOCH + 600) == 0.0
+
+    @pytest.mark.parametrize("raw", ["inf", "-inf", "Infinity", "nan"])
+    def test_a_non_finite_delay_is_refused(self, raw):
+        """ADVERSARIAL: the header value that SHOULD fail the parser.
+
+        ``float("inf")`` parses. Honouring it would set a cooldown that never
+        expires, and every RPC in the process would fail fast FOREVER off one
+        malformed response header — a permanent self-inflicted outage from a
+        byte we do not control. ``nan`` is refused for the same reason: it
+        compares false against everything, so it would silently become 0.
+        """
+        assert retry_after_seconds({"Retry-After": raw}) is None
 
     @pytest.mark.parametrize("headers", [None, {}, {"Retry-After": "soon"}, {"X-Other": "5"}])
     def test_unparseable_or_absent_yields_none_not_a_guess(self, headers):

--- a/backend/tests/chain/test_rpc_rate_limit_backoff.py
+++ b/backend/tests/chain/test_rpc_rate_limit_backoff.py
@@ -1,0 +1,402 @@
+"""A throttled Arc RPC must not be retried like a dropped connection (#1594).
+
+ROOT CAUSE, 2026-08-31. Live ``/archimedes/app`` logs during the outage carried
+repeated::
+
+    aiohttp.client_exceptions.ClientResponseError: 429,
+        message='Too Many Requests', url='https://rpc.testnet.arc.network'
+
+web3 7.16 builds its session with ``raise_for_status=True``, so Arc's throttle
+arrives as a ``ClientResponseError`` — a subclass of ``ClientError``, which is
+in this client's ``exception_retry_configuration``. The client therefore
+answered "you are sending too much" by sending more, immediately, on a fixed
+``backoff_factor * 2**i`` schedule with no jitter. Every ECS task shares ONE
+NAT egress IP, so Arc's per-IP limit is a fleet-wide budget: identical backoffs
+meant tasks throttled together retried together, and each cold start's RPC
+burst throttled the fleet it was joining. That storm blew /health past the ALB
+budget, the target group killed the tasks, and the deployment circuit breaker
+declared three consecutive GOOD revisions bad.
+
+Two behaviours are under test, and they are deliberately separate:
+
+1. **The POLICY** — window doubles per consecutive 429, full jitter on the
+   sleep, ``Retry-After`` as a floor rather than the whole answer, and only a
+   completed response clears the state. Pure, clock- and jitter-injected, so
+   these assert arithmetic instead of asserting a random number.
+2. **The CLIENT** — the policy actually reaches every request that leaves
+   ``BoundedAsyncHTTPProvider``: a 429 is retried once after a real sleep, a
+   non-429 is NOT, a cooldown skips the transport entirely, and none of it
+   outlasts the total budget ``rpc_timeout_seconds`` documents.
+
+**These are guards, not coverage.** Each was demonstrated to REJECT — with
+``_request_backing_off_on_429`` reduced to the pre-#1594 body (a bare
+``run_with_deadline(super().make_request(...))``) every test in
+``TestTheClientAppliesThePolicy`` fails. Evidence in the PR body.
+
+Fault injection is at the RPC boundary: ``AsyncHTTPProvider.make_request``, the
+last web3-owned frame before the socket. Nothing internal to web3 or to aiohttp
+is patched, and no test opens a socket.
+
+Run: env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
+       backend/tests/chain/test_rpc_rate_limit_backoff.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+import yarl
+from aiohttp import ClientResponseError, RequestInfo
+from archimedes.chain.client import BoundedAsyncHTTPProvider, chain_client
+from archimedes.chain.rate_limit import (
+    RateLimitBackoff,
+    RpcRateLimited,
+    retry_after_seconds,
+)
+from multidict import CIMultiDict
+from web3.providers import AsyncHTTPProvider
+
+_RPC_URL = yarl.URL("https://rpc.testnet.arc.network")
+
+
+def _throttled(retry_after: str | None = None) -> ClientResponseError:
+    """The exact exception the live incident logged, headers and all."""
+    return ClientResponseError(
+        RequestInfo(_RPC_URL, "POST", CIMultiDict(), _RPC_URL),
+        (),
+        status=429,
+        message="Too Many Requests",
+        headers=CIMultiDict({"Retry-After": retry_after}) if retry_after is not None else None,
+    )
+
+
+def _server_error() -> ClientResponseError:
+    """A 5xx — a real transport failure, and NOT a rate limit."""
+    return ClientResponseError(
+        RequestInfo(_RPC_URL, "POST", CIMultiDict(), _RPC_URL),
+        (),
+        status=500,
+        message="Internal Server Error",
+    )
+
+
+class _FakeClock:
+    """A monotonic clock the test advances by hand."""
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class TestTheBackoffPolicy:
+    """Pure arithmetic. No network, no event loop, no randomness left unpinned."""
+
+    def test_the_window_doubles_per_consecutive_429(self):
+        """MUTATION: make the window constant.
+
+        A constant window is what web3's own retry already does. If a single
+        backoff step were enough, the endpoint would not still be throttling us
+        on the second 429.
+        """
+        clock = _FakeClock()
+        backoff = RateLimitBackoff(base_seconds=0.25, max_seconds=100.0, clock=clock, jitter=lambda: 1.0)
+
+        # jitter pinned at its maximum draw, so the delay IS the window.
+        assert backoff.note_rate_limited() == pytest.approx(0.25)
+        assert backoff.note_rate_limited() == pytest.approx(0.50)
+        assert backoff.note_rate_limited() == pytest.approx(1.00)
+        assert backoff.consecutive == 3
+
+    def test_the_window_is_capped(self):
+        """Unbounded doubling would produce a delay no caller's budget can spend."""
+        clock = _FakeClock()
+        backoff = RateLimitBackoff(base_seconds=0.25, max_seconds=1.0, clock=clock, jitter=lambda: 1.0)
+
+        for _ in range(12):
+            delay = backoff.note_rate_limited()
+        assert delay == pytest.approx(1.0)
+
+    def test_the_sleep_is_drawn_from_the_whole_window_not_pinned_to_it(self):
+        """Full jitter: the delay is ``draw * window``, not ``window``."""
+        clock = _FakeClock()
+        backoff = RateLimitBackoff(base_seconds=1.0, max_seconds=10.0, clock=clock, jitter=lambda: 0.5)
+
+        assert backoff.note_rate_limited() == pytest.approx(0.5)
+
+    def test_two_instances_throttled_identically_do_not_come_back_together(self):
+        """MUTATION: drop the jitter and return the window directly.
+
+        This is the property the whole module exists for. Every task sits behind
+        ONE NAT egress IP, so a fleet that backs off by the same amount is a
+        fleet that retries in lockstep and re-creates the burst. With the jitter
+        removed this test fails: 40 identical draws.
+        """
+        delays = set()
+        for _ in range(40):
+            backoff = RateLimitBackoff(base_seconds=1.0, max_seconds=10.0, clock=_FakeClock())
+            delays.add(backoff.note_rate_limited())
+
+        assert len(delays) > 1, "every task computed the same backoff — the fleet will retry in lockstep"
+
+    def test_retry_after_is_a_floor_never_a_ceiling(self):
+        """MUTATION: return ``retry_after`` unchanged.
+
+        Honouring the server's number to the millisecond is the lockstep failure
+        again, wearing the server's authority: every throttled task is told the
+        same value at the same moment. We never come back EARLIER than asked,
+        and never at exactly the instant everyone else does.
+        """
+        clock = _FakeClock()
+        backoff = RateLimitBackoff(base_seconds=0.25, max_seconds=10.0, clock=clock, jitter=lambda: 0.4)
+
+        delay = backoff.note_rate_limited(retry_after=2.0)
+        assert delay >= 2.0
+        assert delay == pytest.approx(2.0 + 0.4 * 0.25)
+
+    def test_the_cooldown_counts_down_on_the_injected_clock(self):
+        clock = _FakeClock()
+        backoff = RateLimitBackoff(base_seconds=1.0, max_seconds=10.0, clock=clock, jitter=lambda: 1.0)
+
+        assert backoff.remaining() == 0.0
+        backoff.note_rate_limited()
+        assert backoff.remaining() == pytest.approx(1.0)
+        clock.advance(0.4)
+        assert backoff.remaining() == pytest.approx(0.6)
+        clock.advance(5.0)
+        assert backoff.remaining() == 0.0
+
+    def test_only_a_completed_response_clears_the_backoff(self):
+        """MUTATION: reset on any non-429 outcome.
+
+        A timeout is not evidence the endpoint stopped throttling us — it is the
+        endpoint being even less able to answer. Resetting on one would clear
+        the backoff at the worst possible moment.
+        """
+        clock = _FakeClock()
+        backoff = RateLimitBackoff(base_seconds=1.0, max_seconds=10.0, clock=clock, jitter=lambda: 1.0)
+
+        backoff.note_rate_limited()
+        backoff.note_rate_limited()
+        assert backoff.consecutive == 2
+
+        backoff.note_success()
+        assert backoff.consecutive == 0
+        assert backoff.remaining() == 0.0
+
+
+class TestRetryAfterParsing:
+    # Both RFC 9110 forms are legal and Arc is free to send either. The
+    # reference instant is built with `datetime`, not with the same email parser
+    # the implementation uses, so this is a check rather than a tautology.
+    _HTTP_DATE = "Wed, 21 Oct 2026 07:28:00 GMT"
+    _HTTP_DATE_EPOCH = datetime(2026, 10, 21, 7, 28, 0, tzinfo=UTC).timestamp()
+
+    def test_delay_seconds_form(self):
+        assert retry_after_seconds({"Retry-After": "5"}) == pytest.approx(5.0)
+
+    def test_http_date_form(self):
+        assert retry_after_seconds({"Retry-After": self._HTTP_DATE}, now=self._HTTP_DATE_EPOCH - 30) == pytest.approx(
+            30.0
+        )
+
+    def test_a_past_date_is_zero_never_negative(self):
+        assert retry_after_seconds({"Retry-After": self._HTTP_DATE}, now=self._HTTP_DATE_EPOCH + 600) == 0.0
+
+    @pytest.mark.parametrize("headers", [None, {}, {"Retry-After": "soon"}, {"X-Other": "5"}])
+    def test_unparseable_or_absent_yields_none_not_a_guess(self, headers):
+        """An invented server instruction is worse than none — the caller's own
+        jittered window is at least honest about being ours."""
+        assert retry_after_seconds(headers) is None
+
+
+class TestTheClientAppliesThePolicy:
+    """FIX: every request leaving BoundedAsyncHTTPProvider is 429-aware.
+
+    MUTATION for this whole class: replace ``_request_backing_off_on_429`` with
+    the pre-#1594 body — ``return await run_with_deadline(super().make_request(
+    method, params), self._total_budget_seconds, label=...)``. Every test below
+    then fails: the 429 propagates on the first attempt, no cooldown is set, and
+    the skipped-request test sends its request.
+    """
+
+    def _provider(self, *, budget: float = 3.0, base: float = 0.02) -> BoundedAsyncHTTPProvider:
+        return BoundedAsyncHTTPProvider(
+            str(_RPC_URL),
+            total_budget_seconds=budget,
+            rate_limit_backoff=RateLimitBackoff(base_seconds=base, max_seconds=base * 4),
+        )
+
+    async def test_a_429_is_retried_once_the_backoff_has_been_slept(self):
+        provider = self._provider()
+        calls: list[float] = []
+
+        async def _throttle_then_answer(*_args, **_kwargs):
+            calls.append(time.monotonic())
+            if len(calls) == 1:
+                raise _throttled()
+            return {"result": "0x1"}
+
+        with patch.object(AsyncHTTPProvider, "make_request", _throttle_then_answer):
+            result = await provider.make_request("eth_chainId", [])
+
+        assert result == {"result": "0x1"}
+        assert len(calls) == 2, "the throttled call was not retried"
+        assert calls[1] > calls[0], "the retry did not wait at all"
+        # A completed response is the evidence that clears the backoff.
+        assert provider._rate_limit.consecutive == 0
+        assert provider._rate_limit.remaining() == 0.0
+
+    async def test_a_non_429_response_error_is_not_treated_as_a_rate_limit(self):
+        """ADVERSARIAL: the input that SHOULD fail the 429 branch.
+
+        A 500 is a real transport failure and belongs to web3's own retry set,
+        not to this one. If the status check were dropped — or written as
+        ``>= 400`` — every server error would silently arm a cooldown that
+        blocks the whole process from talking to a chain that is merely
+        unhealthy, not throttling.
+        """
+        provider = self._provider()
+        calls = 0
+
+        async def _five_hundred(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            raise _server_error()
+
+        with (
+            patch.object(AsyncHTTPProvider, "make_request", _five_hundred),
+            pytest.raises(ClientResponseError) as excinfo,
+        ):
+            await provider.make_request("eth_chainId", [])
+
+        assert excinfo.value.status == 500
+        assert calls == 1, "a 500 was retried by the rate-limit path"
+        assert provider._rate_limit.consecutive == 0
+        assert provider._rate_limit.remaining() == 0.0
+
+    async def test_a_persistent_429_surfaces_the_endpoints_own_answer(self):
+        """No fabricated success, and no swallowing.
+
+        The caller must still learn the read failed — ``is_connected`` maps it
+        to False, ``oracle_health`` records a read error. What changes is that
+        the process now carries a cooldown afterwards.
+        """
+        provider = self._provider(budget=0.3)
+
+        async def _always_throttled(*_args, **_kwargs):
+            raise _throttled()
+
+        with (
+            patch.object(AsyncHTTPProvider, "make_request", _always_throttled),
+            pytest.raises(ClientResponseError) as excinfo,
+        ):
+            await provider.make_request("eth_chainId", [])
+
+        assert excinfo.value.status == 429
+        assert provider._rate_limit.consecutive >= 1
+
+    async def test_a_request_during_the_cooldown_never_reaches_the_transport(self):
+        """MUTATION: delete the cooldown check at the top of the method.
+
+        This is the fleet-wide fix. During the incident every concurrent caller
+        in the process kept sending into an endpoint that had already said stop,
+        and each send cost the shared egress IP another slice of its budget.
+        """
+        provider = self._provider(base=5.0)
+        calls = 0
+
+        async def _always_throttled(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            raise _throttled()
+
+        with patch.object(AsyncHTTPProvider, "make_request", _always_throttled):
+            with pytest.raises(ClientResponseError):
+                await provider.make_request("eth_chainId", [])
+            sent_during_first_call = calls
+
+            with pytest.raises(RpcRateLimited) as excinfo:
+                await provider.make_request("eth_blockNumber", [])
+
+        assert calls == sent_during_first_call, "a request was sent while the endpoint was cooling us down"
+        # The error names WHY, so nothing reads it as "the chain is unreachable".
+        assert "429" in str(excinfo.value)
+        assert "backoff" in str(excinfo.value)
+
+    async def test_the_total_budget_still_bounds_a_429_storm(self):
+        """The backoff is spent FROM the budget, never added to it.
+
+        /health sizes its probe budgets against ``rpc_timeout_seconds``. A
+        retry policy that can extend a call past that number would move the
+        outage from the RPC layer into the health check — which is exactly the
+        chain of events this issue exists to break.
+        """
+        budget = 0.4
+        provider = self._provider(budget=budget, base=0.05)
+
+        async def _always_throttled(*_args, **_kwargs):
+            raise _throttled()
+
+        with patch.object(AsyncHTTPProvider, "make_request", _always_throttled):
+            started = time.perf_counter()
+            with pytest.raises(ClientResponseError):
+                await asyncio.wait_for(provider.make_request("eth_chainId", []), timeout=5.0)
+            elapsed = time.perf_counter() - started
+
+        assert elapsed < budget + 0.25, f"a 429 storm took {elapsed:.2f}s against a documented {budget}s budget"
+
+    async def test_a_server_retry_after_is_honoured_as_a_minimum(self):
+        provider = self._provider(budget=3.0, base=0.01)
+        calls: list[float] = []
+
+        async def _throttle_then_answer(*_args, **_kwargs):
+            calls.append(time.perf_counter())
+            if len(calls) == 1:
+                raise _throttled(retry_after="0.15")
+            return {"result": "0x1"}
+
+        with patch.object(AsyncHTTPProvider, "make_request", _throttle_then_answer):
+            await provider.make_request("eth_chainId", [])
+
+        assert len(calls) == 2
+        assert calls[1] - calls[0] >= 0.15, "we came back sooner than the endpoint asked"
+
+    async def test_is_connected_reports_false_when_we_are_being_throttled(self):
+        """The caller contract is unchanged: a failed read is still False.
+
+        ``RpcRateLimited`` is an ``aiohttp.ClientError`` precisely so nothing
+        downstream has to learn a new exception to keep behaving correctly.
+        """
+
+        async def _always_throttled(*_args, **_kwargs):
+            raise _throttled()
+
+        provider = chain_client.w3.provider
+        assert isinstance(provider, BoundedAsyncHTTPProvider)
+        try:
+            with patch.object(AsyncHTTPProvider, "make_request", _always_throttled):
+                assert await chain_client.is_connected() is False
+                # Second call: skipped during the cooldown, and STILL False.
+                assert await chain_client.is_connected() is False
+        finally:
+            provider._rate_limit.reset()
+
+    def test_the_singleton_provider_carries_a_rate_limit_policy(self):
+        """MUTATION: construct BoundedAsyncHTTPProvider without the backoff.
+
+        Every test above builds its own provider; this is the one that proves
+        the policy reaches the client the application actually uses.
+        """
+        provider = chain_client.w3.provider
+        assert isinstance(provider._rate_limit, RateLimitBackoff)
+        assert provider._rate_limit._base_seconds == chain_client.settings.rpc_rate_limit_base_backoff_seconds
+        assert provider._rate_limit._max_seconds == chain_client.settings.rpc_rate_limit_max_backoff_seconds

--- a/backend/tests/test_health_always_answers.py
+++ b/backend/tests/test_health_always_answers.py
@@ -25,6 +25,20 @@ Two properties are under test and they are deliberately separate:
    present EXACTLY when a probe timed out, so their presence is itself the
    signal.
 
+RESIDUAL, 2026-08-31 (#1594). #1592 read correct and MEASURED WRONG: it bounded
+the two outbound probes and the handler still went to p95 17.03s / max 30s
+against an ALB check of ``timeout 10 x threshold 5``, with ``HealthyHostCount``
+averaging 1.03 over 24h and touching 0. The reason is the second half of the
+same lesson — the six LOCAL reads below the outbound block (``load_corpus``,
+``get_paper_count``, ``get_corpus_meta``, ``paper_rag_health``,
+``gmm_regime_health``, ``risk_data_health``) ran synchronously and unbounded,
+and **a budget denominated in loop time is not a budget when the loop is what
+stalled**: ``asyncio.wait_for``'s timeout is itself a loop callback, so it can
+bound an await but never a blocking call. Those six now run in worker threads,
+concurrently, under ``HealthProbeCache``. ``TestTheSixLocalReadsAreBoundedToo``
+injects a 30s stall into each in turn — the fault-injection point is the module
+boundary each read is imported from, never an internal.
+
 Hermetic: no network, no DB, no Redis, no .env. Every outbound probe is patched.
 Run: env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
        backend/tests/test_health_always_answers.py -q
@@ -33,7 +47,9 @@ Run: env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -439,3 +455,362 @@ class TestTheChainClientItselfIsBounded:
             f"is_connected() took {elapsed:.2f}s against a "
             f"{chain_client.settings.rpc_timeout_seconds}s documented total budget"
         )
+
+
+# ── #1594: the six LOCAL reads ───────────────────────────────────────────────
+
+# The stall injected into each local read. 30s is the measured `/health` max
+# from the incident, and it is deliberately far past every budget in play: the
+# ALB's 10s, the endpoint's 2s promise, the 0.8s local-probe budget. A stall
+# this size cannot be passed by accident.
+_INJECTED_STALL_SECONDS = 30.0
+
+# (fault-injection target, the payload prefix whose probe MUST report the miss).
+# Targets are the module attribute the handler imports — the boundary — so a
+# refactor that stops going through it fails these tests loudly instead of
+# silently testing nothing. Internals are never patched.
+_LOCAL_READS = [
+    ("archimedes.agents.strategy_fusion.load_corpus", "corpus"),
+    ("archimedes.services.corpus_service.get_paper_count", "corpus_db"),
+    ("archimedes.services.corpus_service.get_corpus_meta", "corpus_meta"),
+    ("archimedes.services.paper_rag.paper_rag_health", "paper_rag"),
+    ("archimedes.services.gmm_regime_detector.gmm_regime_health", "regime_detector"),
+    ("archimedes.api.risk_routes.risk_data_health", "risk_data"),
+]
+
+
+@contextmanager
+def _stalling(target: str, seconds: float = _INJECTED_STALL_SECONDS):
+    """Replace ``target`` with a read that blocks its CALLING THREAD for ``seconds``.
+
+    ``threading.Event.wait``, not ``asyncio.sleep``: the whole failure mode is a
+    read that blocks rather than awaits — an Aurora failover, a cold
+    sentence-transformer import, an S3-backed corpus file — and an awaitable
+    stand-in would leave the event loop free and prove nothing. The loop must
+    actually be at risk for the test to be a test.
+
+    The event is set on exit so the abandoned worker thread unwinds instead of
+    parking the interpreter for 30s at shutdown. It is NOT set before the
+    assertion, so the stall the handler faces is the full 30s.
+
+    Yields the list of thread names the stalled read actually ran on, so a test
+    can assert WHERE it ran and not merely that it was survived.
+    """
+    release = threading.Event()
+    ran_on: list[str] = []
+
+    def _stall(*_args, **_kwargs):
+        ran_on.append(threading.current_thread().name)
+        release.wait(seconds)
+
+    with patch(target, _stall):
+        try:
+            yield ran_on
+        finally:
+            release.set()
+
+
+@contextmanager
+def _fast_local_reads():
+    """Pin all six local reads to instant, in-range answers.
+
+    Used by the live-path tests so they assert on the probe machinery rather
+    than on how quickly this machine happens to load a corpus file.
+    """
+    from archimedes.api.risk_routes import RiskDataHealth
+    from archimedes.services.gmm_regime_detector import GmmRegimeHealth
+    from archimedes.services.paper_rag import PaperRAGHealth
+
+    with (
+        patch("archimedes.agents.strategy_fusion.load_corpus", lambda *_a, **_k: [{"id": "p1"}]),
+        patch("archimedes.services.corpus_service.get_paper_count", lambda *_a, **_k: 7),
+        patch("archimedes.services.corpus_service.get_corpus_meta", lambda *_a, **_k: {"source": "db"}),
+        patch(
+            "archimedes.services.paper_rag.paper_rag_health",
+            lambda *_a, **_k: PaperRAGHealth(status="live", reason="test"),
+        ),
+        patch(
+            "archimedes.services.gmm_regime_detector.gmm_regime_health",
+            lambda *_a, **_k: GmmRegimeHealth(status="live", reason="test"),
+        ),
+        patch(
+            "archimedes.api.risk_routes.risk_data_health",
+            lambda *_a, **_k: RiskDataHealth(status="real", reason="test"),
+        ),
+    ):
+        yield
+
+
+class TestTheSixLocalReadsAreBoundedToo:
+    """#1594: a stalled LOCAL read must not hold the endpoint either.
+
+    MUTATION for every case below: restore the plain synchronous calls
+    (``corpus = load_corpus()``, the ``try: db_count = get_paper_count()``
+    block, and the three ``*_health()`` try-blocks) under the concurrent gather.
+    Each test then blocks the event loop for the full 30s and fails on the
+    budget assertion — including the ones whose read is "just a local DB query".
+    Evidence in the PR body.
+    """
+
+    @pytest.mark.parametrize(("target", "prefix"), _LOCAL_READS, ids=[p for _, p in _LOCAL_READS])
+    async def test_a_stalled_local_read_still_answers_inside_the_budget(self, target, prefix):
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _stalling(target),
+        ):
+            body, elapsed = await _get_health()
+
+        assert elapsed < _HEALTH_BUDGET_SECONDS, (
+            f"/health took {elapsed:.2f}s with {target} stalled — the ALB kills a target after "
+            f"5 consecutive misses, which is how a good revision gets declared bad"
+        )
+        # Answering fast is half of it. The payload must say WHICH reading is
+        # missing, or a fabricated-looking default (corpus_papers: 0,
+        # regime_detector: "unknown") is indistinguishable from a real one.
+        assert body[f"{prefix}_probe_state"] == "probe_timeout"
+        assert body[f"{prefix}_probe_age_s"] is None  # nothing cached ⇒ no age to report
+        assert "probe_timeout" in body[f"{prefix}_probe_reason"]
+
+    async def test_all_six_stalling_at_once_still_answers(self):
+        """Budgets must be shared, not summed.
+
+        Six local reads at 0.8s each plus the two outbound probes would be 6.0s
+        sequentially — past the ALB's 10s only in aggregate, but well past the
+        2s this endpoint promises, and the shape that produced a 17s p95.
+        """
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _stalling(_LOCAL_READS[0][0]),
+            _stalling(_LOCAL_READS[1][0]),
+            _stalling(_LOCAL_READS[2][0]),
+            _stalling(_LOCAL_READS[3][0]),
+            _stalling(_LOCAL_READS[4][0]),
+            _stalling(_LOCAL_READS[5][0]),
+        ):
+            body, elapsed = await _get_health()
+
+        assert elapsed < _HEALTH_BUDGET_SECONDS, (
+            f"/health took {elapsed:.2f}s with all six local reads stalled — budgets are being summed"
+        )
+        for _target, prefix in _LOCAL_READS:
+            assert body[f"{prefix}_probe_state"] == "probe_timeout"
+
+    async def test_a_stalled_read_parks_a_dedicated_thread_not_the_loops_default_pool(self):
+        """MUTATION: use ``asyncio.to_thread`` instead of the dedicated executor.
+
+        ``to_thread`` runs on the loop's DEFAULT executor — which is also where
+        asyncio runs ``getaddrinfo``. Abandoned health reads accumulating there
+        would eventually make DNS for the DB, for Redis, and for the RPC queue
+        behind a stuck corpus load: a liveness probe damaging the very thing it
+        reports on. Under the mutation the thread is named ``asyncio_N`` and
+        this fails.
+        """
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _stalling(_LOCAL_READS[0][0]) as ran_on,
+        ):
+            body, elapsed = await _get_health()
+
+        assert elapsed < _HEALTH_BUDGET_SECONDS
+        assert body["corpus_probe_state"] == "probe_timeout"
+        assert ran_on, "the corpus read never ran"
+        assert all(name.startswith("health-probe") for name in ran_on), f"a health probe ran on a shared pool: {ran_on}"
+
+    async def test_the_whole_endpoint_survives_every_probe_being_dark(self):
+        """The incident's worst case: RPC throttled AND the box unresponsive."""
+        with (
+            patch.object(chain_client, "is_connected", _hangs_forever),
+            patch.object(oracle_health_mod, "oracle_health", _hangs_forever),
+            _stalling(_LOCAL_READS[0][0]),
+            _stalling(_LOCAL_READS[3][0]),
+        ):
+            body, elapsed = await _get_health()
+
+        assert elapsed < _HEALTH_BUDGET_SECONDS
+        assert body["status"] == "degraded"
+        assert body["chain_probe_state"] == "probe_timeout"
+        assert body["corpus_probe_state"] == "probe_timeout"
+        assert body["paper_rag_probe_state"] == "probe_timeout"
+
+
+class TestTheLocalProbesObeyTheSameHonestyRules:
+    """The staleness contract is identical for local reads — no second standard."""
+
+    async def test_a_live_local_read_carries_no_staleness_fields(self):
+        """MUTATION: emit the age/reason fields unconditionally.
+
+        Presence is the alarm; always-present fields train readers to skip them.
+        """
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _fast_local_reads(),
+        ):
+            body, _ = await _get_health()
+
+        for _target, prefix in _LOCAL_READS:
+            assert body[f"{prefix}_probe_state"] == "live"
+            assert f"{prefix}_probe_age_s" not in body
+            assert f"{prefix}_probe_reason" not in body
+
+    async def test_a_stalled_local_read_serves_its_last_known_value_with_the_age(self):
+        """The ALB poller gets the CACHE, not a fresh trip — labelled as cache.
+
+        This is the fix's whole point: liveness is what the poller needs, and a
+        past reading answers that question honestly as long as it says it is a
+        past reading. Serving it bare would be the plausible substitute.
+        """
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _fast_local_reads(),
+        ):
+            first, _ = await _get_health()
+        assert first["corpus_papers"] == 1
+        assert first["regime_detector"] == "live"
+
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _stalling(_LOCAL_READS[0][0]),
+            _stalling(_LOCAL_READS[4][0]),
+        ):
+            second, elapsed = await _get_health()
+
+        assert elapsed < _HEALTH_BUDGET_SECONDS
+        assert second["corpus_probe_state"] == "stale_cached"
+        assert second["corpus_papers"] == 1  # the cached reading, unaltered
+        assert second["corpus_probe_age_s"] >= 0
+        assert "probe_timeout" in second["corpus_probe_reason"]
+
+        assert second["regime_detector_probe_state"] == "stale_cached"
+        assert second["regime_detector"] == "live"
+        # The *_reason field is what an operator actually reads, so the
+        # staleness has to be visible there too, not only in the sibling field.
+        assert "probe_timeout" in second["regime_detector_reason"]
+        assert "last completed read" in second["regime_detector_reason"]
+
+    async def test_a_raising_local_read_is_an_error_not_a_timeout(self):
+        """Errors and timeouts stay different states.
+
+        Collapsing them lets a broken import hide behind "the box was busy".
+        """
+
+        def _explodes(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            patch("archimedes.services.paper_rag.paper_rag_health", _explodes),
+        ):
+            body, _ = await _get_health()
+
+        assert body["paper_rag_probe_state"] == "probe_error"
+        assert "probe_error" in body["paper_rag_probe_reason"]
+        assert body["paper_rag_reason"] == "import failed"
+
+    async def test_a_timed_out_local_read_never_reports_a_configured_state(self):
+        """ "unknown" (never read) must not collapse into "disabled" (a real setting).
+
+        `paper_rag: "disabled"` is a deliberate configuration. Reporting it for a
+        read that never completed would present an absence as a decision.
+        """
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _stalling(_LOCAL_READS[3][0]),
+        ):
+            body, _ = await _get_health()
+
+        assert body["paper_rag"] == "unknown"
+        assert body["paper_rag_probe_state"] == "probe_timeout"
+
+
+class TestNoReportedFieldWasDropped:
+    """Anti-goal guard: this change adds fields, it never removes one.
+
+    The issue's own check is `grep -c` over four field literals. That grep is a
+    PROXY for "nothing was deleted" and it moves whenever a probe *name* is
+    added, so this asserts the property directly instead: every key /health
+    published before #1594 is still published.
+    """
+
+    # Captured from origin/main's handler by AST-walking its return dict, so the
+    # list is the pre-change contract rather than someone's recollection of it.
+    _PRE_1594_KEYS = frozenset(
+        {
+            "agent_count",
+            "artifact_hash",
+            "chain_connected",
+            "corpus_artifact_present",
+            "corpus_db_count",
+            "corpus_embedded_at_rest",
+            "corpus_embedded_at_rest_reason",
+            "corpus_kg_built",
+            "corpus_kg_entities",
+            "corpus_kg_relations",
+            "corpus_last_intake",
+            "corpus_papers",
+            "corpus_source",
+            "fusion_enabled",
+            "human_count",
+            "llm_available",
+            "llm_backend",
+            "llm_has_api_key",
+            "llm_has_auth_token",
+            "llm_has_base_url",
+            "llm_model",
+            "llm_provider",
+            "oracle_fresh",
+            "oracle_oldest_age_s",
+            "oracle_probed_count",
+            "oracle_reason",
+            "oracle_universe_count",
+            "paper_rag",
+            "paper_rag_reason",
+            "paper_rerank_model_live",
+            "real_users",
+            "regime_detector",
+            "regime_detector_reason",
+            "rerank_candidate_cap",
+            "reveal_reconcile_pending",
+            "reveal_reconcile_terminal",
+            "risk_data",
+            "risk_data_reason",
+            "service",
+            "status",
+            "strategy_count",
+            "version",
+        }
+    )
+
+    async def test_every_field_published_before_1594_is_still_published(self):
+        with (
+            patch.object(chain_client, "is_connected", _returns_connected),
+            patch.object(oracle_health_mod, "oracle_health", _fast_oracle),
+            _fast_local_reads(),
+        ):
+            body, _ = await _get_health()
+
+        assert set(body) >= self._PRE_1594_KEYS, f"/health stopped reporting {sorted(self._PRE_1594_KEYS - set(body))}"
+
+    async def test_the_status_code_stays_200_while_degraded(self):
+        """Anti-goal: 200-while-degraded is deliberate.
+
+        A 503 here would let an RPC blip or a slow disk cascade the whole ECS
+        service down — the exact mechanism that took prod off the air on
+        2026-08-31. _get_health already asserts 200; this states the intent so a
+        later "make /health honest by 503ing" change trips a named test.
+        """
+        with (
+            patch.object(chain_client, "is_connected", _hangs_forever),
+            patch.object(oracle_health_mod, "oracle_health", _hangs_forever),
+            _stalling(_LOCAL_READS[0][0]),
+        ):
+            body, _ = await _get_health()  # asserts status_code == 200
+
+        assert body["status"] == "degraded"


### PR DESCRIPTION
## Issues

**Refs #1594** — deliberately not `Closes`. The issue's own acceptance list ends with a
post-deploy criterion (`HealthyHostCount` Minimum >= 2 for 6 consecutive hours, `/health`
p95 < 2 s from ALB access logs) that cannot be met before this is deployed and observed for
six hours; item 3 of its structural-fix list (fallback RPC endpoint / Arc rate-limit
arrangement, #794) is out of scope by assignment; and `MinCapacity = 2` is an owner
decision. Close it when CloudWatch says so, not when this merges.

## What

Structural fixes **1** and **2** from #1594's "Structural fixes this issue now owns": `/health` serves the #1593 last-known cache to the ALB poller instead of hard-probing per check, and the web3 client path is 429-aware. Both are application-code causes of the same kill-loop, so they ship together; splitting them on request is easy (the diffs do not overlap).

**Not in this PR, deliberately:** `MinCapacity = 2` (owner's cost-vs-resilience call), the Arc rate-limit / fallback-endpoint conversation (item 3), and `infra/alb.tf` (anti-goal — `git diff --name-only` below).

---

## The mechanism this removes

The 2026-08-31 outage was one loop with two application-code links:

```
cold task starts ─► warms against Arc RPC ─► 429 (shared NAT egress IP = fleet-wide budget)
        ▲                                              │
        │                                              ▼
   ECS restarts it ◄── target group kills it ◄── /health blows the ALB budget
```

1. **`/health` did unbounded work on the serving loop.** #1592 bounded the two *outbound* probes and the handler still measured **p50 1.19 s, p95 17.03 s, max 30 s** against `timeout 10 × threshold 5`; over 24 h `HealthyHostCount` averaged **1.03** and reached **0**, across ~155 distinct task IPs. Six *local* reads (`load_corpus`, `get_paper_count`, `get_corpus_meta`, `paper_rag_health`, `gmm_regime_health`, `risk_data_health`) still ran synchronously and unbounded below the outbound block. That is the whole reason #1592 read correct and measured wrong: **`asyncio.wait_for` cannot bound anything on a starved event loop, because the timeout callback is itself a loop callback.** A budget denominated in loop time is not a budget when the loop is what stalled.

2. **A 429 was retried like a dropped connection.** web3 7.16 builds its session with `raise_for_status=True`, so Arc's throttle arrives as `ClientResponseError` — a subclass of `ClientError`, which is already in this client's `exception_retry_configuration`. The client answered *"you are sending too much"* by sending more, immediately, on a fixed `backoff_factor * 2**i` schedule with **no jitter**. Every ECS task shares one NAT egress IP, so identical backoffs meant tasks throttled together retried together.

---

## What changed

### (a) `/health` reports, it does not go and find out — for all eight reads

All six local reads now go through `health_probe_cache.probe(...)` with `absent=` defaults, in the **same `asyncio.gather`** as `chain_connected`/`oracle_health`, so the bounded section costs `max(1.2, 0.8) = 1.2 s` rather than the sum of eight. Each gets the `<name>_probe_state` / `_probe_age_s` / `_probe_reason` trio via `ProbeOutcome.payload_fields` — present exactly when the fresh read missed, so presence is the alarm.

The one piece of machinery the spec did not name, and why it is load-bearing: `HealthProbeCache.probe` takes an **awaitable factory**, and these six are **blocking calls**. Wrapping a blocking call in `run_with_deadline` bounds nothing, for the exact reason quoted above. `_bounded_local_read` moves each read onto a worker thread so the loop stays free to fire the deadline. That pool is **dedicated, not `asyncio.to_thread`**: the loop's default executor is also where asyncio runs `getaddrinfo`, and abandoned health reads accumulating there would eventually queue DNS for the DB, Redis, and the RPC behind a stuck corpus load — a liveness probe damaging the thing it reports on. There is a test for that specifically.

Honesty rules carried over unchanged from #1592/#1593:
- `probe_timeout` with nothing cached ⇒ the caller's `absent` value plus a loud reason. `corpus_papers: 0` is never mistakable for a real reading, because `corpus_probe_state` says otherwise.
- `stale_cached` ⇒ the last real reading, and the `*_reason` field an operator actually reads says out loud that it is a past reading.
- **A timed-out `paper_rag` reports `"unknown"`, never `"disabled"`** — `disabled` is a deliberate configuration and an absence must not be dressed up as a decision.
- Errors stay distinct from timeouts (`probe_error`), so a broken import cannot hide behind "the box was busy".

### (b) 429-aware backoff + jitter in the web3 client path

New `backend/archimedes/chain/rate_limit.py` (pure, clock- and jitter-injectable) plus a wrapper inside `BoundedAsyncHTTPProvider`, **outside** web3's retry loop:

- **Full jitter.** Window doubles per consecutive 429 up to a cap; the sleep is drawn uniformly from `[0, window]`. The random draw is the point, not politeness: with one shared egress IP, a fleet that backs off by the same amount retries in lockstep and re-creates the burst.
- **`Retry-After` is a floor, never the whole answer.** We never come back earlier than asked, and never at the same instant as every other task that was told the same number.
- **A cooldown that fails the *next* request fast** (`RpcRateLimited`) instead of sending it into an endpoint that just said stop. Deliberately an `aiohttp.ClientError`, so `is_connected()` still maps it to `False` and `oracle_health` still records a read error — nothing downstream learns a *different* answer, it just learns it without costing the fleet another 429.
- **The backoff is spent FROM the total budget, never added to it.** `rpc_timeout_seconds` still bounds the call; a throttled endpoint can make a call fail *sooner*, never make it take longer. That matters because /health's probe budgets are sized against that number.
- **Only a completed response clears the state.** A timeout or connection error is not evidence the endpoint stopped throttling us.

Three edges came out of my own read-back of the policy after the first commit, each with an adversarial test demonstrated to reject the unhardened code (transcripts below). They are the same defect class as the bug being fixed — a mechanism harming the thing it protects — so they are called out rather than buried:

| edge | what it would have done |
| --- | --- |
| a full-jitter draw of ~0 | an immediate retry wearing a backoff's name — the amplification this module exists to remove. Floored at `MIN_BACKOFF_SECONDS` (10 ms), which also makes a misconfigured `base_seconds=0` degrade to *slow* rather than to *hammer*. |
| `consecutive` unbounded | `base * 2**consecutive` raises `OverflowError` past ~1024. `consecutive` only resets on a completed **response**, so this fires *only after a long outage* — precisely when nobody wants to discover it. Exponent clamped before the multiply. |
| `Retry-After: inf` | parses as a float, sets a cooldown that never expires, and every RPC in the process fails fast **forever** off one malformed response header. Non-finite values refused. |

---

## Evidence

Toolchain: `/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/{pytest,python,ruff}` (Python 3.12.13), per CLAUDE.md § Setup.

### Acceptance criteria

```
$ pytest backend/tests/test_health_always_answers.py -q
32 passed, 1 warning in 40.19s
```

```
$ pytest backend/tests/test_health_always_answers.py -q \
      -k test_a_stalled_local_read_still_answers_inside_the_budget
6 passed, 25 deselected, 1 warning in 16.08s
```

Hermetic gate (both files):

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
      backend/tests/test_health_always_answers.py -q
32 passed, 1 warning in 26.38s

$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
      backend/tests/chain/test_rpc_rate_limit_backoff.py -q
28 passed, 1 warning in 3.19s
```

```
$ pytest backend/tests/chain/test_rpc_rate_limit_backoff.py -q
28 passed, 1 warning in 11.32s
```

Adjacent suites that read this payload or this client:

```
$ pytest backend/tests/test_loud_fallback_telemetry.py \
    backend/tests/test_corpus_embedding_claims.py \
    backend/tests/test_health_is_uncacheable.py \
    backend/tests/test_cloudfront_health_uncached.py \
    backend/tests/test_oracle_health_telemetry.py \
    backend/tests/test_health_amm.py backend/tests/chain/ -q
416 passed, 2 skipped, 25 warnings in 76.34s (0:01:16)
```

Lint gate:

```
$ ruff check <the five changed files>   → All checks passed!
$ ruff format --check <same>            → 5 files already formatted
```

### Revert-demo 1 — `/health`, reverted to `origin/main` **verbatim**

`git show origin/main:backend/archimedes/main.py > backend/archimedes/main.py`, run, restore.

```
=== REVERT-DEMO 1: backend/archimedes/main.py restored to origin/main verbatim ===
FAILED ...TestTheSixLocalReadsAreBoundedToo::test_a_stalled_local_read_still_answers_inside_the_budget[corpus] - TimeoutError
FAILED ...[corpus_db] - TimeoutError
FAILED ...[corpus_meta] - TimeoutError
FAILED ...[paper_rag] - TimeoutError
FAILED ...[regime_detector] - TimeoutError
FAILED ...[risk_data] - TimeoutError
=========== 6 failed, 25 deselected, 1 warning in 190.27s (0:03:10) ============
```

Read the durations, not just the failures — each case took **~30 s** against an 8 s in-test hard stop:

```
33.59s call  ...[corpus]        31.02s call ...[paper_rag]     30.83s call ...[regime_detector]
30.35s call  ...[corpus_meta]   30.31s call ...[corpus_db]     30.29s call ...[risk_data]
```

The hard stop is `asyncio.wait_for`, and it **could not fire** until the blocking read returned. That is the issue's central claim, reproduced: a loop-scheduled timeout cannot bound a call that is blocking the loop. Against the fix the same six answer in ~1.2 s and report `probe_timeout`.

### Guard-demos — every new honesty guard shown rejecting

Each mutation applied to the source, suite re-run, source restored.

```
$ pytest backend/tests/test_health_always_answers.py -q -k 'carries_no_staleness_fields'
# MUTATION: payload_fields emits age/reason unconditionally (presence stops being the alarm)
FAILED ...TestStalenessFieldsAppearExactlyWhenAProbeTimedOut::test_a_live_probe_carries_no_staleness_fields - AssertionError: assert 'chain_probe_age_s' not in {...}
FAILED ...TestTheLocalProbesObeyTheSameHonestyRules::test_a_live_local_read_carries_no_staleness_fields - AssertionError: assert 'corpus_probe_age_s' not in {...}
2 failed, 29 deselected

$ pytest ... -k 'serves_its_last_known_value_with_the_age'
# MUTATION: _cache_annotated returns the reason unchanged (a past reading quoted as present)
FAILED ...test_a_stalled_local_read_serves_its_last_known_value_with_the_age - AssertionError: assert 'probe_timeout' in 'test'
1 failed, 30 deselected

$ pytest ... -k 'never_reports_a_configured_state'
# MUTATION: a timed-out paper_rag probe renders the configured state 'disabled'
FAILED ...test_a_timed_out_local_read_never_reports_a_configured_state - AssertionError: assert 'disabled' == 'unknown'
1 failed, 30 deselected

$ pytest ... -k 'TestNoReportedFieldWasDropped'
# MUTATION: drop one reported field (corpus_source) from the payload
FAILED ...test_every_field_published_before_1594_is_still_published - AssertionError: /health stopped reporting ['corpus_source']
1 failed, 1 passed, 29 deselected

$ pytest ... -k 'TestTheSixLocalReadsAreBoundedToo and corpus]'
# MUTATION: absent corpus reported without a probe_state trio
FAILED ...test_a_stalled_local_read_still_answers_inside_the_budget[corpus] - AssertionError: assert 'live' == 'probe_timeout'
1 failed, 30 deselected

$ pytest ... -k 'dedicated_thread'
# MUTATION: _bounded_local_read -> asyncio.to_thread (loop default executor, shared with getaddrinfo)
FAILED ...test_a_stalled_read_parks_a_dedicated_thread_not_the_loops_default_pool - AssertionError: a health probe ran on a shared pool: ['asyncio_0']
1 failed, 31 deselected
```

### Revert-demo 2 — the 429 path, reverted to its pre-#1594 body

`_request_backing_off_on_429` reduced to `return await run_with_deadline(call(), self._total_budget_seconds, label=label)` — literally the old `make_request` body.

```
$ pytest backend/tests/chain/test_rpc_rate_limit_backoff.py -q -k 'TestTheClientAppliesThePolicy'
# MUTATION: _request_backing_off_on_429 -> the pre-#1594 body (bare run_with_deadline)
FAILED ...test_a_429_is_retried_once_the_backoff_has_been_slept - ClientResponseError: 429, message='Too Many Reque...
FAILED ...test_a_persistent_429_surfaces_the_endpoints_own_answer - assert 0 >= 1
FAILED ...test_a_request_during_the_cooldown_never_reaches_the_transport - ClientResponseError: 429, message='Too Many Reque...
FAILED ...test_a_server_retry_after_is_honoured_as_a_minimum - ClientResponseError: 429, message='Too Many Reque...
============ 4 failed, 4 passed, 14 deselected, 1 warning in 3.82s =============
```

Policy guards, one mutation each:

```
# MUTATION: full jitter removed (delay = window)  ← the lockstep bug itself
FAILED ...TestTheBackoffPolicy::test_the_sleep_is_drawn_from_the_whole_window_not_pinned_to_it - assert 1.0 == 0.5 ± 5.0e-07
FAILED ...TestTheBackoffPolicy::test_two_instances_throttled_identically_do_not_come_back_together - AssertionError: every task computed the same backoff — the fleet will retry...
2 failed, 13 passed, 7 deselected

# MUTATION: 429 check widened to "any 4xx/5xx is a rate limit"
FAILED ...test_a_non_429_response_error_is_not_treated_as_a_rate_limit - AssertionError: a 500 was retried by the rate-limit path
1 failed, 7 passed, 14 deselected

# MUTATION: Retry-After returned unchanged (no jittered increment)
FAILED ...test_retry_after_is_a_floor_never_a_ceiling - assert 2.0 == 2.1 ± 2.1e-06
1 failed, 6 passed, 15 deselected

# MUTATION: cooldown pre-check deleted (send into an endpoint that said stop)
FAILED ...test_a_request_during_the_cooldown_never_reaches_the_transport - ClientResponseError: 429, message='Too Many Reque...
1 failed, 7 passed, 14 deselected
```

The three self-review edges, each shown rejecting:

```
$ pytest backend/tests/chain/test_rpc_rate_limit_backoff.py -q -k 'a_near_zero_jitter_draw_still_pauses'
# MUTATION: MIN_BACKOFF_SECONDS floor removed
FAILED ...TestTheBackoffPolicy::test_a_near_zero_jitter_draw_still_pauses - assert 0.0 >= 0.01
1 failed, 27 deselected

$ pytest ... -k 'a_long_outage_does_not_overflow_the_doubling'
# MUTATION: doubling exponent left unclamped (base * 2**consecutive)
FAILED ...TestTheBackoffPolicy::test_a_long_outage_does_not_overflow_the_doubling - OverflowError: int too large to convert to float
1 failed, 27 deselected

$ pytest ... -k 'a_non_finite_delay_is_refused'
# MUTATION: non-finite Retry-After accepted (permanent cooldown from one header)
FAILED ...TestRetryAfterParsing::test_a_non_finite_delay_is_refused[inf] - AssertionError: assert (inf is None or ...)
FAILED ...[-inf] - assert 0.0 is None
FAILED ...[Infinity] - AssertionError: assert (inf is None or ...)
FAILED ...[nan] - assert 0.0 is None
4 failed, 24 deselected
```

The 500-mutation is the adversarial pass required by CLAUDE.md § rule 4: the input that *should* fail the 429 branch. A `>= 400` check would arm a process-wide cooldown on any server error, blocking the whole process from talking to a chain that is merely unhealthy rather than throttling.

### Anti-goal verification (I-1's four, run literally)

```
$ git diff --name-only
backend/archimedes/chain/client.py
backend/archimedes/chain/rate_limit.py
backend/archimedes/main.py
backend/tests/chain/test_rpc_rate_limit_backoff.py
backend/tests/test_health_always_answers.py
                                          # infra/alb.tf: absent ✅

$ grep -c "status_code=503" backend/archimedes/main.py
3                                         # origin/main: 3 — unchanged ✅

$ grep -c '"oracle_fresh"\|"paper_rag"\|"regime_detector"\|"risk_data"' backend/archimedes/main.py
8                                         # origin/main: 5 — MOVED, see below ⚠️
```

**The `grep -c` moved 5 → 8, and I am not going to pretend it didn't.** That grep is a *proxy* for "do not delete any reported field", and it moves whenever a probe *name* is added. All five original occurrences are the payload keys and all five are intact; the three new ones are the `_PAPER_RAG_PROBE` / `_REGIME_PROBE` / `_RISK_DATA_PROBE` constants, which exist so the cache key, the payload prefix, and the field they describe cannot drift apart:

```
$ grep -n '"oracle_fresh"\|"paper_rag"\|"regime_detector"\|"risk_data"' backend/archimedes/main.py
 838:_PAPER_RAG_PROBE = "paper_rag"          ← new (probe-name constant)
 839:_REGIME_PROBE = "regime_detector"       ← new
 840:_RISK_DATA_PROBE = "risk_data"          ← new
1435:        "paper_rag": paper_rag_status,          ← original payload key
1438:        "regime_detector": regime_detector_status,
1441:        "risk_data": risk_data_status,
1449:        "oracle_fresh": oracle_fresh,
1480:        "paper_rag": diag.status,              (the /health/paper-rag route, untouched)
```

The property itself is proven directly rather than by proxy — AST-walking the handler's return dict on both revisions gives **42 keys before, 42 keys after, identical sets** — and `TestNoReportedFieldWasDropped` asserts it in CI against a key list captured from `origin/main`, with the drop-a-field mutation above showing it rejects.

Fourth anti-goal — "no fail-soft default indistinguishable from a real reading": every absent value carries a `probe_state`, `probe_timeout` age is `null` rather than a fabricated number, and `paper_rag` reports `unknown` rather than the real-looking `disabled`. Three of the guard-demos above are exactly this property.

---

## What a reviewer should push back on

1. **I-1 says "Scope: `main.py:900-955` only. Do exactly this, nothing more."** The routing is exactly as specified, but it could not be done *only* in those lines:
   - The six probes joined the **existing gather** above them. Sequential `probe()` calls would sum budgets (6 × 0.8 s), which fails the 2 s promise the spec also requires; the spec's own words are "exactly as `chain_connected`/`oracle_health` already are", and those are in the gather.
   - `probe()` wants an awaitable factory; these six are blocking. `_bounded_local_read` + the dedicated executor are the minimum machinery that makes the deadline real, for the reason the spec itself states.
   - Two small module-level helpers (`_cache_annotated`, `_probe_error_fields`) exist to avoid six copies of the same rendering.
2. **The 429 backoff is outside I-1's scope sentence** — it is item **2** of the issue's own "Structural fixes this issue now owns" list, and it is what makes item 1 more than a bandage. Say the word and I will split it into its own PR.
3. **`load_corpus` raising now returns 200 + `corpus_probe_state: "probe_error"` instead of a 500.** Previously it was the one unguarded call in the handler. This is a deliberate consequence of routing it through `probe()`, and it is aligned with the "200-while-degraded is deliberate" anti-goal rather than against it — but it *is* a behaviour change and belongs in a reviewer's head.
4. **New payload keys**, all additive: `corpus_probe_state`, `corpus_db_probe_state`, `corpus_meta_probe_state`, `paper_rag_probe_state`, `regime_detector_probe_state`, `risk_data_probe_state` (always present) plus their `_probe_age_s` / `_probe_reason` siblings (present only on a miss).
5. **`ChainSettings` gains two env-overridable fields** — `ARC_RPC_RATE_LIMIT_BASE_BACKOFF_SECONDS` (0.25) and `ARC_RPC_RATE_LIMIT_MAX_BACKOFF_SECONDS` (4.0) — specifically so the numbers are tunable during an incident without a deploy. **`.env.example` is not updated**: CLAUDE.md § "When to ask before acting" lists it as an env contract, and both defaults are safe. Say so and I will add the two documented lines.
6. **I did not touch the existing `chain`/`oracle` `probe_error` blocks** even though `_probe_error_fields("chain", …)` produces a byte-identical dict to the inline literal there. "Do exactly this, nothing more" outranks a cosmetic dedupe.

---

## Honest not-done list

- **The post-deploy acceptance criterion is unverifiable from here.** `HealthyHostCount` Minimum ≥ 2 for 6 consecutive hours and `/health` p95 < 2 s from ALB access logs both need this deployed plus a 6-hour window. That alone is why this is `Refs`, not `Closes`.
- **Item 3 of the structural-fix list is untouched** — fallback RPC endpoint / API-key arrangement with Arc (#794 stays open). Out of scope by assignment.
- **`MinCapacity = 2` is not proposed here.** Owner's cost-vs-resilience call; noted in the issue.
- **`infra/alb.tf` is deliberately untouched**, per its own `:243` comment: do not tighten `timeout`/`unhealthy_threshold` until this fix is deployed *and proven*. The proof is CloudWatch, not this PR.
- **Six reads are bounded; the handler has more.** `corpus_embedding_at_rest`, the KG entity/relation `COUNT(*)` queries, `load_manifest`, `count_strategy_files`, `TelemetryStore.get_counts`, `get_distinct_user_count`, and the reveal-reconciliation SCARDs are all still unbounded. The KG counts are two DB aggregates and are the most likely next p95. I-1 named six and said "nothing more", so they are left for a follow-up rather than smuggled in — worth its own issue.
- **`backend/archimedes/api/_erc6492.py` builds its own plain `AsyncHTTPProvider`** and therefore gets neither the total-budget ceiling nor the 429 policy. It is on a serving path (signature verification). Not in scope; flagging it because it is the same defect class.
- **The backoff is process-local.** It de-synchronises the fleet, which is what the incident needed; it cannot *coordinate* the fleet. A shared (Redis) token bucket would, and is a bigger decision than this PR.
- **Abandonment has a standing cost.** A permanently-stuck local read holds its worker thread. The pool is dedicated and sized at 12 so a single stuck read cannot starve its siblings for several checks, and a full pool degrades to `probe_timeout` + last-known rather than to a stalled handler — but a genuinely wedged dependency will eventually show all six as `probe_timeout`. That is the honest report, not a bug, and it is why the `*_probe_state` fields ship.
- **No UI change**, so `cd ui && npm test` was not run; `git diff --name-only` contains no `ui/` path.

---

### Base drift, caught and corrected (CLAUDE.md § rule 1)

The first full-suite run on this branch came back **1 failed** —
`test_cloudwatch_alarms.py::TestAntiGoals::test_the_oracle_stale_alarm_is_untouched`,
`assert 3 == 1`. It is not mine, and it is worth showing rather than quietly rebasing away,
because it is exactly the failure mode CLAUDE.md warns about: `main` had moved two commits
while I worked, and #1673 (`[test] Update the oracle-stale anti-goal pin to the #1601
retune values`) had already fixed that pin. My branch was still measuring a base that no
longer existed.

Neither drifted commit touches any file in this PR:

```
$ git log --oneline b359f324..origin/main
848673e0 Merge pull request #1673 from a-apin/dbrowneup/alarm-pin-retune
fe9f4b4a [test] Update the oracle-stale anti-goal pin to the #1601 retune values

$ git log --oneline b359f324..origin/main -- backend/archimedes/main.py \
      backend/archimedes/chain/client.py backend/tests/test_health_always_answers.py backend/tests/chain/
(nothing)
```

Linear, un-interwoven, no conflicts → rebased (not merged) onto `848673e0` and re-ran the
whole suite from scratch. The result below is that re-run, against current `main`.

---

### Full CI unit command

```
$ pytest -m "not integration" -q     # the exact quality-gate command, from the repo root
5080 passed, 3 skipped, 2 deselected, 296 warnings in 484.08s (0:08:04)
```

