### PR TITLE
[backend] cancel_job works across tasks — durable Redis flag, polled at pipeline stage boundaries

### DIFF
--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -730,6 +730,38 @@ class _Emitter:
         return await self.store.push_event(self.job_id, body)
 
 
+async def _abort_if_cancel_requested(store: JobStore, job_id: str, stage: str) -> None:
+    """Stage-boundary poll of the shared cancellation flag (#1667).
+
+    The Cancel button writes a Redis flag (``JobStore.request_cancel``) rather
+    than reaching for an in-process task handle, because the task serving the
+    POST is usually NOT the task running this pipeline. This is the other half
+    of that contract: between stages — i.e. before each block of real LLM /
+    backtest spend — the runner asks the shared store whether the user has
+    cancelled, and raises ``CancelledError`` if so. ``run_generation``'s
+    existing ``except asyncio.CancelledError`` branch then emits the terminal
+    event and records the status, exactly as for a locally-cancelled task.
+
+    Fail-soft on a read error: an unreachable Redis must not crash the run into
+    PIPELINE_CRASH, and the flag is durable, so the next stage boundary retries.
+    A store that predates this surface (a test double) is skipped the same way.
+    """
+    checker = getattr(store, "is_cancel_requested", None)
+    if checker is None:
+        logger.debug("cancel-poll skipped at %s — store exposes no cancel surface", stage)
+        return
+    try:
+        requested = await checker(job_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning("cancel-poll failed at stage boundary %s for job %s — retrying next boundary", stage, job_id)
+        return
+    if requested:
+        logger.info("job %s: cancel flag observed at stage boundary %s — stopping the pipeline", job_id, stage)
+        raise asyncio.CancelledError(f"cancelled by user before stage {stage}")
+
+
 # ── Fixture path (deterministic; used in tests + when LLM unavailable) ────
 
 
@@ -1079,10 +1111,17 @@ async def run_generation(
     # cancelled paths too — every path where a strategy row already exists.
     strategy_ids: dict[str, str] = {}  # candidate_id → strategy_id
 
-    await store.update_status(job_id, "running")
-    await emit.emit("job_queued", brief=brief.model_dump())
-
     try:
+        # Stage boundary 0 (#1667): a job cancelled while it waited behind the
+        # admission gate must not be promoted back to `running` and start
+        # spending. The flag landed before this task ever woke up, so this is
+        # the boundary that catches it — inside the try, so the CancelledError
+        # branch below records the terminal state and the meter unbinds.
+        await _abort_if_cancel_requested(store, job_id, "start")
+
+        await store.update_status(job_id, "running")
+        await emit.emit("job_queued", brief=brief.model_dump())
+
         # Real LLM validation step (live path only). The fixture path skips
         # the validator so tests stay hermetic.
         with meter.stage("brief_validation"):
@@ -1167,6 +1206,7 @@ async def run_generation(
         fixture_mode = os.getenv("GENERATION_PIPELINE_FIXTURE", "").lower() in ("1", "true") or (
             not use_live and os.getenv("TESTING")
         )
+        await _abort_if_cancel_requested(store, job_id, "pipeline_select")
         with meter.stage("pipeline_select"):
             debate_can_run = use_live and await asyncio.to_thread(_debate_can_run, brief)
         if debate_can_run:
@@ -1240,6 +1280,10 @@ async def run_generation(
         candidates: list[_CandidateResult] = []
         for i, regime in enumerate(regimes):
             candidate_id = f"cand_{regime}" if dual_regime else f"cand_{i + 1}"
+            # The token-burn boundary: each pass through this loop is a full
+            # debate (sequential adversarial LLM turns + per-proposal
+            # backtests). Never start another one after a cancel.
+            await _abort_if_cancel_requested(store, job_id, f"candidate_generation:{candidate_id}")
             try:
                 # The society's own sub-phases (corpus load, proposal fan-out,
                 # adversarial transcript, per-proposal backtests) are timed
@@ -1320,6 +1364,8 @@ async def run_generation(
             meter.set_meta("outcome", "no_candidates")
             await store.update_status(job_id, "error", error="no candidates generated")
             return
+
+        await _abort_if_cancel_requested(store, job_id, "rigor_gate")
 
         # Patch PBO across the candidate set (library-level metric — Bailey
         # et al. CSCV needs N≥2 to be meaningful; the helper handles N<2
@@ -1431,6 +1477,7 @@ async def run_generation(
         # emit a DSL spec (weights={}) scored by evaluate_fusion_spec, or are a
         # populated ABSTAIN — so they skip the static backtester too (T1.1).
         _static_skip = ("fusion", "debate", "debate_abstain")
+        await _abort_if_cancel_requested(store, job_id, "backtest_persist")
         with meter.stage("backtest_persist"):
             await asyncio.gather(
                 *[

--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -105,9 +105,11 @@ _STALLED_AFTER_SECONDS = 300
 # this bound.
 _DEFAULT_GENERATION_TIMEOUT_SECONDS = 600
 
-# Live registry of in-flight asyncio tasks per job. Lets cancel_job actually
-# stop the work — without this, /cancel only flips Redis status while the
-# agent keeps burning LLM tokens to completion.
+# Registry of the in-flight asyncio tasks THIS process is running, for local
+# liveness/diagnostics only. It is deliberately NOT the cancellation
+# mechanism (#1667): a process-local dict cannot see a job started by another
+# task, so cancel_job goes through the shared Redis flag
+# (`JobStore.request_cancel`) that the pipeline polls at its stage boundaries.
 _RUNNING_TASKS: dict[str, asyncio.Task] = {}
 
 
@@ -932,15 +934,23 @@ async def cancel_job(
 ) -> dict[str, str]:
     """Cancel a running job. Idempotent.
 
-    Hard cancellation: looks up the asyncio.Task driving the job and calls
-    ``task.cancel()`` on it. The pipeline's ``except CancelledError`` branch
-    emits the synthetic error event + flips Redis status to ``cancelled``.
+    Cancellation is a **durable Redis flag**, not a local task handle (#1667).
+    The pipeline polls that flag at its stage boundaries and stops from
+    whichever task is actually running it. This is the only shape that works
+    once the service runs more than one task: ``_RUNNING_TASKS`` is
+    process-local, so at ``MinCapacity=2`` this POST landed on the task that
+    started the job barely half the time — and every other time the old code
+    returned ``{"status": "cancelled"}`` while the pipeline kept running and
+    burning LLM tokens. A worker/offload lane has no task registry at all.
 
-    Caveat: if the agent is mid-``asyncio.to_thread(llm_call)``, the OS
-    thread itself isn't cancellable (Python doesn't expose that). The
-    awaiter unblocks immediately, the in-flight LLM call burns to
-    completion but its result is discarded — no events emitted after the
-    cancellation, no strategy persisted.
+    The flag is written and read back BEFORE the job is reported cancelled;
+    if that write cannot be confirmed we return 503 rather than claim a
+    cancellation that never happened.
+
+    Caveat (unchanged): if the agent is mid-``asyncio.to_thread(llm_call)``,
+    that OS thread isn't cancellable, so the in-flight call finishes and its
+    result is discarded at the next stage boundary — no events emitted after
+    the cancellation, no strategy persisted.
     """
     store = get_job_store()
     job = await store.get(job_id)
@@ -952,8 +962,25 @@ async def cancel_job(
     if job["status"] in ("done", "error", "cancelled"):
         return {"job_id": job_id, "status": job["status"]}
 
-    # Flip status first so observers see "cancelled" even if the cancel
-    # callback hasn't fully propagated yet.
+    # Durably request the cancel FIRST — this is what actually stops the
+    # pipeline, from any task. Nothing below may claim "cancelled" until this
+    # write is confirmed.
+    try:
+        requested = await store.request_cancel(job_id)
+    except Exception:
+        logger.exception("cancel: flag write failed for job %s", sanitize_log_value(job_id))
+        requested = False
+    if not requested:
+        # Honest failure: the job IS still running. Reporting "cancelled" here
+        # is the claims-truth violation this endpoint used to commit every time
+        # the POST landed on a task that didn't own the job.
+        raise HTTPException(
+            status_code=503,
+            detail=f"cancellation for job {job_id} could not be recorded — the job is still running; retry",
+        )
+
+    # Now the flag is durable, the status may be flipped and the terminal
+    # event pushed: observers see "cancelled" and the claim is backed.
     await store.update_status(job_id, "cancelled", error="cancelled by user")
     await store.push_event(
         job_id,
@@ -962,14 +989,6 @@ async def cancel_job(
             "data": {"job_id": job_id, "message": "cancelled by user", "recoverable": False, "code": "CANCELLED"},
         },
     )
-
-    # Hard-cancel the task itself if we're still holding a reference.
-    task = _RUNNING_TASKS.get(job_id)
-    if task is not None and not task.done():
-        task.cancel()
-        logger.info("hard-cancelled job %s", sanitize_log_value(job_id))
-    else:
-        logger.info("cancel for %s: no live task (already finished or restart)", sanitize_log_value(job_id))
 
     return {"job_id": job_id, "status": "cancelled"}
 

--- a/backend/archimedes/services/job_queue.py
+++ b/backend/archimedes/services/job_queue.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 KEY_PREFIX = "archimedes:job:"
 EVENT_LOG_SUFFIX = ":events"
+# Cross-process cancellation flag (#1667). Redis is the ONLY surface every
+# task/worker shares, so a cancel request has to live here rather than in a
+# process-local dict — with MinCapacity=2 the POST lands on the task that
+# started the job barely half the time, and any offload lane has no in-process
+# task registry at all.
+CANCEL_SUFFIX = ":cancel"
 JOB_TTL = 3600  # 1 hour
 EVENT_LOG_TTL = 900  # 15 minutes after terminal state — spec 0.5 § Reconnection
 
@@ -162,6 +168,45 @@ class JobStore:
         await r.hset(key, "heartbeat_at", now)
         await r.expire(key, JOB_TTL)
         return True
+
+    # ── Cross-process cancellation (#1667) ────────────────────────────────
+
+    async def request_cancel(self, job_id: str) -> bool:
+        """Durably record a cancellation request. Returns True only if CONFIRMED.
+
+        The flag is a separate key (`archimedes:job:{id}:cancel`) rather than a
+        field on the job hash so it survives independently of the status write
+        and can be set on a job whose hash is being rewritten concurrently by
+        the running pipeline.
+
+        The write is read back before returning: a caller may only tell a user
+        "cancelled" once the request is provably visible to whichever task is
+        actually running the pipeline. An unconfirmed write returns False —
+        never "assume it landed" (`runner_lease.py`'s fail-closed discipline).
+        Redis errors propagate; the caller decides what to report.
+        """
+        r = await self._get_redis()
+        key = f"{KEY_PREFIX}{job_id}{CANCEL_SUFFIX}"
+        await r.set(key, datetime.now(UTC).isoformat(), ex=JOB_TTL)
+        confirmed = bool(await r.exists(key))
+        if confirmed:
+            logger.info("job: cancel requested for %s", sanitize_log_value(job_id))
+        else:
+            logger.error(
+                "job: cancel flag for %s did not survive read-back — NOT reporting cancelled",
+                sanitize_log_value(job_id),
+            )
+        return confirmed
+
+    async def is_cancel_requested(self, job_id: str) -> bool:
+        """True once a cancel has been durably requested for this job.
+
+        Polled by the pipeline at its stage boundaries, from whatever task
+        happens to be running it — that is the whole point: the request is
+        shared state, not a reference held by one process.
+        """
+        r = await self._get_redis()
+        return bool(await r.exists(f"{KEY_PREFIX}{job_id}{CANCEL_SUFFIX}"))
 
     async def update_terminal_status(
         self,

--- a/backend/tests/test_generate_cancel_cross_process.py
+++ b/backend/tests/test_generate_cancel_cross_process.py
@@ -1,0 +1,258 @@
+"""Cross-process cancellation for POST /api/generate/jobs/{id}/cancel (#1667).
+
+The defect: `_RUNNING_TASKS` in `generate_routes.py` is a process-local dict,
+so `cancel_job` only ever hard-cancelled a job whose `/start` happened to land
+on the SAME task. At `MinCapacity=2` that is a coin flip; on every other
+request the endpoint logged "no live task" and returned
+`{"status": "cancelled"}` while the pipeline kept running and burning LLM
+tokens — a false claim returned to a paying user.
+
+The fix: cancellation is a durable Redis flag the pipeline polls at its stage
+boundaries. These tests pin both halves of that contract:
+
+  C1  a cancel served by a DIFFERENT process (a second `JobStore` on a second
+      Redis client over one shared fake server, with an EMPTY `_RUNNING_TASKS`
+      — precisely the task that did not start the job) stops the pipeline at
+      the next stage boundary: the second candidate never runs, the job ends
+      `cancelled`, and no `done` event is ever emitted.
+  C2  `cancel_job` does NOT report `cancelled` when the flag write fails
+      (Redis raises) or is not confirmed by read-back (the write silently did
+      not land) — it 503s instead, because the job really is still running.
+  C3  store-level unit checks on the flag itself (set + TTL, absent by
+      default, idempotent).
+
+Hermetic: `fakeredis.FakeAsyncRedis` over a shared `FakeServer` for the two
+"processes" (`test_generate_job_liveness.py` precedent), the real FastAPI app
+driven through `httpx.ASGITransport` with dependency-overridden auth, the
+fixture generation path (no LLM), and `_persist_candidate` stubbed. No live
+Redis/DB/LLM/network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, patch
+
+import fakeredis
+import pytest
+from archimedes.agents import generation_pipeline
+from archimedes.agents.generation_pipeline import run_generation
+from archimedes.api.account_auth import CurrentUser, require_current_user
+from archimedes.api.generate_schemas import GenerateBrief
+from archimedes.services.job_queue import CANCEL_SUFFIX, JOB_TTL, KEY_PREFIX, JobStore
+from httpx import ASGITransport, AsyncClient
+
+_USER_ID = "user-cancel-xproc"
+
+
+@pytest.fixture(autouse=True)
+def _authenticated_account():
+    from archimedes.main import app
+
+    app.dependency_overrides[require_current_user] = lambda: CurrentUser(
+        _USER_ID, "Cancel Test", "cancel@example.com", True
+    )
+    yield
+    app.dependency_overrides.pop(require_current_user, None)
+
+
+@pytest.fixture(autouse=True)
+def _force_fixture_path(monkeypatch):
+    monkeypatch.setenv("GENERATION_PIPELINE_FIXTURE", "1")
+
+
+def _two_processes() -> tuple[JobStore, JobStore]:
+    """Two JobStores, two Redis clients, ONE shared Redis — i.e. two tasks.
+
+    Sharing a `FakeServer` rather than a client object is the point: nothing
+    in-process is shared between the pipeline side and the API side, exactly
+    as when the ALB routes /start and /cancel to different Fargate tasks.
+    """
+    server = fakeredis.FakeServer()
+    pipeline_store = JobStore(url="redis://unused")
+    pipeline_store._redis = fakeredis.FakeAsyncRedis(server=server, decode_responses=True)
+    api_store = JobStore(url="redis://unused")
+    api_store._redis = fakeredis.FakeAsyncRedis(server=server, decode_responses=True)
+    return pipeline_store, api_store
+
+
+async def _post_cancel(job_id: str, api_store: JobStore):
+    """Serve the cancel from the process that did NOT start the job.
+
+    `_RUNNING_TASKS` is patched to `{}` to make that literal: this task holds
+    no handle on the running pipeline, which is the condition under which the
+    old code silently did nothing and lied about it.
+    """
+    from archimedes.main import app
+
+    with (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=api_store),
+        patch("archimedes.api.generate_routes._RUNNING_TASKS", {}),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            return await client.post(f"/api/generate/jobs/{job_id}/cancel")
+
+
+# ── C1: a cancel from another process actually stops the pipeline ─────────
+
+
+async def test_cancel_from_another_process_stops_the_pipeline():
+    """The input that SHOULD fail against pre-fix code: the cancel is served by
+    a task with an EMPTY `_RUNNING_TASKS`. Pre-fix that took the
+    "no live task (already finished or restart)" branch, returned
+    `{"status": "cancelled"}`, and the pipeline ran the second candidate to
+    completion and reported `done` — the exact false claim in #1667.
+    """
+    pipeline_store, api_store = _two_processes()
+    job_id = await pipeline_store.enqueue(
+        job_type="generate",
+        payload={"owner_user_id": _USER_ID, "brief": {"intent": "cross-process cancel repro"}, "n_candidates": 1},
+    )
+
+    calls: list[str] = []
+    first_candidate_started = asyncio.Event()
+    release_first_candidate = asyncio.Event()
+    real_runner = generation_pipeline._run_fixture_candidate
+
+    async def _gated_runner(**kwargs):
+        """Hold the FIRST candidate open so the cancel lands mid-stage — the
+        realistic case (nobody clicks Cancel between two stages)."""
+        calls.append(kwargs["candidate_id"])
+        if len(calls) == 1:
+            first_candidate_started.set()
+            await release_first_candidate.wait()
+        return await real_runner(**kwargs)
+
+    brief = GenerateBrief(intent="cross-process cancel repro", risk_appetite="conservative")
+
+    with (
+        patch("archimedes.agents.generation_pipeline._llm_available", return_value=False),
+        patch("archimedes.agents.generation_pipeline._run_fixture_candidate", new=_gated_runner),
+        patch(
+            "archimedes.agents.generation_pipeline._persist_candidate",
+            new=AsyncMock(return_value=("strat_xproc_001", "0xdeadbeef")),
+        ),
+    ):
+        task = asyncio.create_task(
+            run_generation(job_id=job_id, brief=brief, n_candidates=1, store=pipeline_store),
+        )
+        try:
+            await asyncio.wait_for(first_candidate_started.wait(), timeout=10)
+
+            resp = await _post_cancel(job_id, api_store)
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "cancelled"
+
+            release_first_candidate.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=10)
+        finally:
+            task.cancel()
+
+    # The pipeline stopped at the next stage boundary: candidate 2 never ran.
+    assert calls == ["cand_bull"], f"pipeline kept generating after the cancel: {calls}"
+    assert task.cancelled(), "the run must end cancelled, not complete normally"
+
+    job = await pipeline_store.get(job_id)
+    assert job["status"] == "cancelled"
+
+    events = await pipeline_store.list_events(job_id)
+    names = [e["event"] for e in events]
+    assert "done" not in names, f"a cancelled job must never report done: {names}"
+    assert "persisted" not in names, f"a cancelled job must not persist a strategy: {names}"
+    # The flag is what carried the cancel across the process boundary.
+    assert await pipeline_store.is_cancel_requested(job_id) is True
+
+
+async def test_uncancelled_job_runs_to_completion():
+    """Sanity check on the other side of the guard: the stage-boundary poll
+    must stop a cancelled run, not every run."""
+    pipeline_store, _api_store = _two_processes()
+    job_id = await pipeline_store.enqueue(job_type="generate", payload={"owner_user_id": _USER_ID})
+    brief = GenerateBrief(intent="uncancelled control run", risk_appetite="conservative")
+
+    with (
+        patch("archimedes.agents.generation_pipeline._llm_available", return_value=False),
+        patch(
+            "archimedes.agents.generation_pipeline._persist_candidate",
+            new=AsyncMock(return_value=("strat_xproc_002", "0xfeedface")),
+        ),
+    ):
+        await run_generation(job_id=job_id, brief=brief, n_candidates=1, store=pipeline_store)
+
+    names = [e["event"] for e in await pipeline_store.list_events(job_id)]
+    assert names[-1] == "done"
+    assert (await pipeline_store.get(job_id))["status"] == "done"
+
+
+# ── C2: no "cancelled" claim on an unconfirmed flag write ─────────────────
+
+
+async def test_cancel_does_not_claim_cancelled_when_the_flag_write_raises():
+    """Redis down at the flag write. The job IS still running, so the endpoint
+    must say so (503) instead of returning `{"status": "cancelled"}`."""
+    pipeline_store, api_store = _two_processes()
+    job_id = await pipeline_store.enqueue(job_type="generate", payload={"owner_user_id": _USER_ID})
+
+    with patch.object(api_store._redis, "set", new=AsyncMock(side_effect=ConnectionError("redis down"))):
+        resp = await _post_cancel(job_id, api_store)
+
+    assert resp.status_code == 503, resp.text
+    assert resp.json().get("status") != "cancelled"
+    # …and the job record is untouched: still runnable, honestly reported.
+    assert (await pipeline_store.get(job_id))["status"] == "queued"
+    assert await pipeline_store.is_cancel_requested(job_id) is False
+
+
+async def test_cancel_does_not_claim_cancelled_when_the_flag_is_not_confirmed():
+    """The subtler failure: the write "succeeds" but the key is not there on
+    read-back (an eviction/silent loss). An unconfirmed cancel is not a
+    cancel — never assume it landed."""
+    pipeline_store, api_store = _two_processes()
+    job_id = await pipeline_store.enqueue(job_type="generate", payload={"owner_user_id": _USER_ID})
+
+    with patch.object(api_store._redis, "exists", new=AsyncMock(return_value=0)):
+        resp = await _post_cancel(job_id, api_store)
+
+    assert resp.status_code == 503, resp.text
+    assert resp.json().get("status") != "cancelled"
+    assert (await pipeline_store.get(job_id))["status"] == "queued"
+
+
+async def test_cancel_reports_cancelled_once_the_flag_is_durable():
+    """Sanity check on the other side of C2: a confirmed write still returns
+    `cancelled`, and the flag is visible to the OTHER process."""
+    pipeline_store, api_store = _two_processes()
+    job_id = await pipeline_store.enqueue(job_type="generate", payload={"owner_user_id": _USER_ID})
+
+    resp = await _post_cancel(job_id, api_store)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "cancelled"
+    assert await pipeline_store.is_cancel_requested(job_id) is True
+    assert (await pipeline_store.get(job_id))["status"] == "cancelled"
+
+
+# ── C3: the flag itself ───────────────────────────────────────────────────
+
+
+async def test_request_cancel_sets_a_ttld_flag_visible_to_other_stores():
+    pipeline_store, api_store = _two_processes()
+    job_id = await pipeline_store.enqueue(job_type="generate", payload={})
+
+    assert await pipeline_store.is_cancel_requested(job_id) is False
+    assert await api_store.request_cancel(job_id) is True
+    assert await pipeline_store.is_cancel_requested(job_id) is True
+
+    ttl = await pipeline_store._redis.ttl(f"{KEY_PREFIX}{job_id}{CANCEL_SUFFIX}")
+    assert 0 < ttl <= JOB_TTL, "the cancel flag must expire with the job, never leak forever"
+
+
+async def test_request_cancel_is_idempotent():
+    _pipeline_store, api_store = _two_processes()
+    job_id = await api_store.enqueue(job_type="generate", payload={})
+
+    assert await api_store.request_cancel(job_id) is True
+    assert await api_store.request_cancel(job_id) is True
+    assert await api_store.is_cancel_requested(job_id) is True

--- a/backend/tests/test_generate_cancel_scoping.py
+++ b/backend/tests/test_generate_cancel_scoping.py
@@ -43,6 +43,10 @@ def _mock_store(owner_wallet: str | None):
     )
     store.update_status = AsyncMock()
     store.push_event = AsyncMock()
+    # The durable cross-process cancel flag (#1667) — cancel_job now refuses to
+    # report "cancelled" until this write is confirmed. Behaviour when it is
+    # NOT confirmed is covered in test_generate_cancel_cross_process.py.
+    store.request_cancel = AsyncMock(return_value=True)
     return store
 
 


### PR DESCRIPTION
## What

Cancellation moves from a **process-local `asyncio.Task` handle** to a **durable Redis flag the pipeline polls at its stage boundaries**.

- `JobStore.request_cancel(job_id)` writes `archimedes:job:{id}:cancel` (TTL = `JOB_TTL`) and **reads it back**; it returns `True` only when the flag is provably there.
- `JobStore.is_cancel_requested(job_id)` is the shared read the runner polls.
- `cancel_job` sets the flag **first** and only then flips status / pushes the terminal event and answers `{"status": "cancelled"}`. If the flag write raises or is not confirmed, it returns **503** instead of claiming a cancellation that did not happen.
- `run_generation` calls `_abort_if_cancel_requested(...)` at five stage boundaries — `start` (before a queued job is promoted to `running`), `pipeline_select`, **before each candidate** (the token-burn boundary), `rigor_gate`, and `backtest_persist` — raising `CancelledError` into the existing `except asyncio.CancelledError` branch, which already emits the terminal event and records `cancelled`.

`_RUNNING_TASKS` stays as a local in-flight registry for liveness/diagnostics, and **no longer appears anywhere in `cancel_job`**:

```
$ grep -n "_RUNNING_TASKS" backend/archimedes/api/generate_routes.py
113:_RUNNING_TASKS: dict[str, asyncio.Task] = {}
117:    _RUNNING_TASKS[job_id] = task
118:    task.add_done_callback(lambda _t, jid=job_id: _RUNNING_TASKS.pop(jid, None))
940:    once the service runs more than one task: ``_RUNNING_TASKS`` is
```

(113/117/118 = the registry + `_register_task`; 940 = a line of `cancel_job`'s docstring explaining why it is *not* used there. No occurrence in the function body.)

## Why

`_RUNNING_TASKS` is process-local, so `cancel_job` only ever hard-cancelled a job whose `/start` had landed on the *same* task — a coin flip at `MinCapacity=2`, and impossible for any offload lane (a worker has no task registry at all). Every other time it took the `else` branch, logged "no live task (already finished or restart)", and returned `{"status": "cancelled"}` **while the pipeline kept running and burning LLM tokens**. That is a false claim returned to a paying user, not a latency defect.

Precedent for the shared-state shape: `services/runner_lease.py` (single owner across processes, fail-closed — never "assume it landed").

## Issues

Closes #1667

## Verification

Environment: `/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest`, run from the worktree root.

### Acceptance 1 — `-k "cancel"` → 0 failed

```
$ <env>/pytest backend/tests/ -k "cancel" -q
18 passed, 5031 deselected, 4 warnings in 5.58s
```

(7 new in `test_generate_cancel_cross_process.py`; the pre-existing `test_generate_cancel_scoping.py` still passes — its boundary mock gained `request_cancel`.)

### Acceptance 2 (adversarial) — cross-process cancel, with the fix reverted

`test_cancel_from_another_process_stops_the_pipeline` runs the pipeline on one `JobStore`/Redis client and serves the cancel from a **second** `JobStore` on a **second** client over one shared `fakeredis.FakeServer`, with `_RUNNING_TASKS` patched to `{}` — literally the task that did not start the job. The cancel lands *mid*-first-candidate; the assertion is that the **second candidate never runs**.

Reverting `generate_routes.py` + `generation_pipeline.py` to `origin/main` (i.e. back to `_RUNNING_TASKS`, no stage-boundary poll) and re-running:

```
$ git stash push backend/archimedes/api/generate_routes.py backend/archimedes/agents/generation_pipeline.py
$ grep -c "_abort_if_cancel_requested" backend/archimedes/agents/generation_pipeline.py
0
$ sed -n '/# Hard-cancel the task itself/,/return {"job_id": job_id, "status": "cancelled"}/p' backend/archimedes/api/generate_routes.py
    # Hard-cancel the task itself if we're still holding a reference.
    task = _RUNNING_TASKS.get(job_id)
    if task is not None and not task.done():
        task.cancel()
        logger.info("hard-cancelled job %s", sanitize_log_value(job_id))
    else:
        logger.info("cancel for %s: no live task (already finished or restart)", sanitize_log_value(job_id))

    return {"job_id": job_id, "status": "cancelled"}

# (1) the whole new file, one line per failure
$ <env>/pytest backend/tests/test_generate_cancel_cross_process.py -q -p no:randomly --tb=line
FAILED test_cancel_from_another_process_stops_the_pipeline - AssertionError: pipeline kept generating after the cancel: ['cand_bull', 'c...
FAILED test_cancel_does_not_claim_cancelled_when_the_flag_write_raises - AssertionError: {"job_id":"c1af4c7fd37e4048","status":"cancelled"}
FAILED test_cancel_does_not_claim_cancelled_when_the_flag_is_not_confirmed - AssertionError: {"job_id":"1964fa418ea64474","status":"cancelled"}
FAILED test_cancel_reports_cancelled_once_the_flag_is_durable - assert False is True
4 failed, 3 passed

# (2) the cross-process case with a full traceback
$ <env>/pytest backend/tests/test_generate_cancel_cross_process.py::test_cancel_from_another_process_stops_the_pipeline -q -p no:randomly --tb=short
_____________ test_cancel_from_another_process_stops_the_pipeline ______________
backend/tests/test_generate_cancel_cross_process.py:154: in test_cancel_from_another_process_stops_the_pipeline
    assert calls == ["cand_bull"], f"pipeline kept generating after the cancel: {calls}"
E   AssertionError: pipeline kept generating after the cancel: ['cand_bull', 'cand_bear']
E   assert ['cand_bull', 'cand_bear'] == ['cand_bull']
E     Left contains one more item: 'cand_bear'

$ git stash pop      # fix restored
```

The old endpoint answers `{"status":"cancelled"}` in the two failure-mode tests **while the flag write is broken** — that response body *is* the bug, printed by the assertion. With the fix restored, all 7 pass (see Acceptance 1 above).

### Acceptance 3 (guard) — no "cancelled" claim on an unconfirmed flag write

Two inputs built to fail the guard, both driving the real route through `httpx.ASGITransport` with the flag write broken at the Redis client boundary (`test_api_routes.py::TestAgentRoutes::test_agent_status_redis_down_defaults` precedent):

| input | expected | got |
| --- | --- | --- |
| `redis.set` raises `ConnectionError` | not `cancelled` | `503`, job still `queued`, no flag |
| `redis.set` "succeeds", read-back `exists` → 0 | not `cancelled` | `503`, job still `queued` |
| control: write confirmed | `cancelled` | `200 {"status":"cancelled"}`, flag visible to the *other* store |

### Full unit suite + lint

```
$ <env>/pytest -m "not integration" -q -p no:randomly     # branch rebased onto 848673e0
1 failed, 5043 passed, 3 skipped, 2 deselected, 297 warnings in 1848.54s (0:30:48)

$ <env>/ruff format --check <5 touched files>
5 files already formatted
$ <env>/ruff check generate_routes.py job_queue.py test_generate_cancel_cross_process.py test_generate_cancel_scoping.py
All checks passed!
```

**The 1 failure is not from this diff** — it is `test_health_always_answers.py::…::test_health_answers_within_budget_when_the_chain_client_hangs_forever`, a wall-clock budget assertion (`/health took 2.36s`), and this box is currently running ~10 concurrent pytest suites from other sessions. Reproduced on a **clean detached worktree at `origin/main` (848673e0)** with none of this diff present:

```
$ git worktree add ../wt-perf-cancel-basecheck --detach origin/main
$ <env>/pytest backend/tests/test_health_always_answers.py -q -p no:randomly
FAILED …::test_health_answers_within_budget_when_the_chain_client_hangs_forever - AssertionError: /health took 4.91s with a hanging chain client — the ALB cu...
FAILED …::test_a_timed_out_probe_serves_the_last_known_value_with_its_age - assert 2.0053354166448116 < 2.0
2 failed, 15 passed
```

(Worse on the clean base than on this branch — it is load, not code. Nothing in this diff touches `/health` or the chain client.) An earlier full run on the pre-rebase base also failed `test_cloudwatch_alarms.py::TestAntiGoals::test_the_oracle_stale_alarm_is_untouched`; that was a stale base — #1673 landed the matching pin and it passes after the rebase.

`ruff check` on `generation_pipeline.py` reports 2 `SIM905` hits — both pre-existing on `origin/main` (the `_COMMON_WORDS` / `_FINANCE_WORDS` frozensets, untouched by this diff); verified with `git show origin/main:… | ruff check --stdin-filename …` → same 2.

## What a reviewer should push back on

- **Responsiveness trade-off.** `cancel_job` no longer calls `task.cancel()` at all (issue anti-goal: the process-local path must not survive as a silent fallback in the success branch). A cancel therefore takes effect at the next stage boundary rather than instantly. In practice the delta is small — `task.cancel()` never interrupted an in-flight `asyncio.to_thread(llm_call)` either — but the *within-a-stage* window is now bounded by stage length, not by the event loop. If you want the local accelerator back, it belongs *after* the confirmed flag write, and the issue explicitly rules it out of that branch.
- **Boundary placement.** Five boundaries; the expensive ones are per-candidate and `backtest_persist`. A cancel arriving mid-`candidate_generation` still pays for that candidate.
- **Fail-soft poll.** A Redis read error at a boundary logs and continues rather than crashing the run into `PIPELINE_CRASH`; the flag is durable so the next boundary retries. The claim side is still fail-closed — only `cancel_job` makes a promise, and only on a confirmed write.
- `_RUNNING_TASKS` is now write-only (registry + liveness). Deleting it is out of scope here and would collide with concurrent work in this file.
- Concurrent work: another builder is changing the generation timeout in `generate_routes.py` and another is in `debate_engine.py`. This diff touches `cancel_job`, one comment block, and five one-line calls in `run_generation`.
