### PR TITLE
[infra] Close #1044's SSM leak at the compose layer: blank the AWS_SSM_PATH_PREFIX default

### DIFF
--- a/backend/archimedes/services/secrets_service.py
+++ b/backend/archimedes/services/secrets_service.py
@@ -4,9 +4,15 @@ Production: reads all parameters under ``/archimedes/prod/*`` via boto3 SSM
 and injects them into ``os.environ`` so downstream services (LLM, Circle,
 chain client) work without any code changes.
 
-Local development: no-op when ``AWS_SSM_PATH_PREFIX`` is unset or when
+Local development: no-op when ``AWS_SSM_PATH_PREFIX`` is unset/blank or when
 boto3 cannot reach SSM (no instance profile, no credentials). Falls back
 silently to .env-based values already loaded by python-dotenv.
+
+Nothing in this module defaults the prefix to a real path. A missing prefix
+means "load nothing", never "load production" — ambient AWS credentials on a
+developer machine must not be able to promote a local run to prod-secret-backed
+(issue #1044). The caller-side half of that guard lives in ``main.py``, which
+only calls ``load_ssm_secrets()`` when ``PUBLIC_DOMAIN`` is set.
 
 Usage (in main.py, BEFORE init_db / service imports):
     from archimedes.services.secrets_service import load_ssm_secrets
@@ -27,8 +33,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Default prefix — matches infra/iam policy + .env.example documentation.
-_DEFAULT_PREFIX = "/archimedes/prod/"
+# NOTE: there is intentionally no module-level default prefix constant. The
+# production prefix is declared where production is declared — infra/ecs.tf and
+# infra/ecs_migrate.tf — never as an in-code fallback that an unset env var can
+# silently select (issue #1044).
 
 # Map SSM param names (last segment after prefix) → env var names.
 # e.g. /archimedes/prod/LLM_AUTH_TOKEN → LLM_AUTH_TOKEN
@@ -65,7 +73,9 @@ def load_ssm_secrets(
     """Load secrets from AWS SSM Parameter Store into os.environ.
 
     Args:
-        prefix: SSM path prefix (default: AWS_SSM_PATH_PREFIX env var or /archimedes/prod/)
+        prefix: SSM path prefix (default: the AWS_SSM_PATH_PREFIX env var).
+            There is deliberately NO fallback path — blank means "load
+            nothing" and returns 0 (issue #1044).
         region: AWS region (default: AWS_REGION env var or us-east-1)
         override_existing: If True, overwrite env vars that already have values.
             Default False — .env values take precedence (useful for local dev override).
@@ -137,8 +147,19 @@ def _fetch_all_parameters(client: Any, prefix: str) -> list[dict[str, Any]]:
 
 
 def list_ssm_parameters(prefix: str | None = None, region: str | None = None) -> list[str]:
-    """List parameter names (not values) under the prefix. Useful for diagnostics."""
-    prefix = prefix or os.environ.get("AWS_SSM_PATH_PREFIX", _DEFAULT_PREFIX)
+    """List parameter names (not values) under the prefix. Useful for diagnostics.
+
+    Blank prefix → ``[]``, matching :func:`load_ssm_secrets`. This helper used
+    to fall back to ``/archimedes/prod/`` when the env var was unset, which
+    made a bare ``list_ssm_parameters()`` from a developer shell with ambient
+    AWS credentials enumerate the real production parameter store — the same
+    ambient-credential promotion #1044 closed on the load path, left open on
+    the diagnostic path. The prefix must now be stated, by env var or argument.
+    """
+    prefix = (prefix or os.environ.get("AWS_SSM_PATH_PREFIX", "")).strip()
+    if not prefix:
+        logger.debug("secrets_service: AWS_SSM_PATH_PREFIX not set — skipping SSM list")
+        return []
     region = region or os.environ.get("AWS_REGION", "us-east-1")
 
     try:

--- a/backend/tests/services/test_secrets_service.py
+++ b/backend/tests/services/test_secrets_service.py
@@ -214,9 +214,10 @@ class TestListSsmParameters:
     """Tests for the diagnostic list_ssm_parameters helper."""
 
     @patch("boto3.client")
-    def test_returns_param_names(self, mock_boto3):
+    def test_returns_param_names(self, mock_boto3, monkeypatch):
         from archimedes.services.secrets_service import list_ssm_parameters
 
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
         mock_client = MagicMock()
         mock_client.get_parameters_by_path.return_value = {
             "Parameters": [
@@ -230,10 +231,11 @@ class TestListSsmParameters:
         assert names == ["/archimedes/prod/SECRET_A", "/archimedes/prod/SECRET_B"]
 
     @patch("boto3.client")
-    def test_returns_empty_on_error(self, mock_boto3):
+    def test_returns_empty_on_error(self, mock_boto3, monkeypatch):
         from archimedes.services.secrets_service import list_ssm_parameters
         from botocore.exceptions import ClientError
 
+        monkeypatch.setenv("AWS_SSM_PATH_PREFIX", "/archimedes/prod/")
         mock_boto3.return_value.get_parameters_by_path.side_effect = ClientError(
             {"Error": {"Code": "InternalError", "Message": "oops"}},
             "GetParametersByPath",
@@ -241,3 +243,21 @@ class TestListSsmParameters:
 
         names = list_ssm_parameters()
         assert names == []
+
+    @patch("boto3.client")
+    def test_blank_prefix_does_not_fall_back_to_the_production_path(self, mock_boto3):
+        """#1044, diagnostic path. This helper used to default to
+        ``_DEFAULT_PREFIX = "/archimedes/prod/"`` when AWS_SSM_PATH_PREFIX was
+        unset, so a bare ``list_ssm_parameters()`` from a developer shell with
+        ambient AWS credentials enumerated the real production parameter store
+        — the same ambient-credential promotion the load path closed, left open
+        one function below it. Both tests above passed *because* of that
+        fallback, which is what made it invisible.
+
+        Asserted on the boto3 client, not just the return value: an
+        implementation that built the client and then discarded the result
+        would still have talked to production."""
+        from archimedes.services.secrets_service import list_ssm_parameters
+
+        assert list_ssm_parameters() == []
+        mock_boto3.assert_not_called()

--- a/backend/tests/test_local_setup_contract.py
+++ b/backend/tests/test_local_setup_contract.py
@@ -45,7 +45,7 @@ def _brace_block(text: str, search_from: int) -> str:
     raise AssertionError(f"unbalanced braces starting at offset {open_idx}")
 
 
-def _compose_config(*, local: bool) -> dict:
+def _compose_config(*, local: bool, env_overrides: dict[str, str] | None = None) -> dict:
     template = (ROOT / ".env.example").read_text()
     # Full-line substitution, not a prefix replace: .env.example now ships a
     # non-empty placeholder value (PLACEHOLDER_SECRET in auth/auth.js), so a
@@ -56,6 +56,18 @@ def _compose_config(*, local: bool) -> dict:
     template = re.sub(
         r"^BETTER_AUTH_SECRET=.*$", f"BETTER_AUTH_SECRET={TEST_AUTH_SECRET}", template, count=1, flags=re.MULTILINE
     )
+    # Opt-in env deltas on top of the shipped template, applied the same
+    # full-line way as BETTER_AUTH_SECRET above. Used to exercise the
+    # "operator deliberately points a compose run at SSM" path without
+    # weakening the fresh-clone default the other tests assert on.
+    for key, value in (env_overrides or {}).items():
+        line = f"{key}={value}"
+        template, replaced = re.subn(
+            rf"^{re.escape(key)}=.*$", lambda _m, _line=line: _line, template, count=1, flags=re.MULTILINE
+        )
+        if not replaced:
+            template = f"{template.rstrip()}\n{line}\n"
+
     command = ["docker", "compose"]
     if local:
         template = template.replace("\nCOMPOSE_PROFILES=localdb\n", "\nCOMPOSE_PROFILES=localdb,runners\n", 1)
@@ -140,6 +152,123 @@ class TestLocalSetupContract(unittest.TestCase):
         )
         self.assertNotIn("migrate", self.production_config["services"])
         self.assertEqual(self.production_config["services"]["nginx"]["ports"][0]["published"], "80")
+
+    def test_fresh_clone_compose_never_resolves_the_ssm_prefix_to_a_real_path(self) -> None:
+        """#1044 leak 2, second half. `.env.example` ships
+        `AWS_SSM_PATH_PREFIX=` (blank) so that a fresh clone cannot address the
+        production parameter store — but compose's `:-` substitutes on EMPTY as
+        well as unset, so a `${AWS_SSM_PATH_PREFIX:-/archimedes/prod/}` default
+        in docker-compose.yml silently put the real prod prefix back into the
+        container and made that blank default decorative:
+
+            $ cp .env.example .env && docker compose config | grep SSM
+            AWS_SSM_PATH_PREFIX: /archimedes/prod/
+
+        That left main.py's PUBLIC_DOMAIN gate as the *only* thing between a
+        local `docker compose up` on a credentialed dev machine and real
+        production secrets. This test asserts both halves of the defence, at
+        the point where the value is actually resolved rather than at the point
+        where it is written: the template ships blank, AND nothing in the
+        compose graph re-arms it."""
+        self.assertEqual(
+            self.env.get("AWS_SSM_PATH_PREFIX"),
+            "",
+            ".env.example must ship AWS_SSM_PATH_PREFIX blank — production sets it in infra/ecs.tf, not from this file",
+        )
+        for label, config in (("local", self.config), ("production-model", self.production_config)):
+            for service_name, service in config["services"].items():
+                resolved = (service.get("environment") or {}).get("AWS_SSM_PATH_PREFIX")
+                self.assertIn(
+                    resolved,
+                    (None, ""),
+                    f"{label} compose resolves AWS_SSM_PATH_PREFIX={resolved!r} for service "
+                    f"{service_name!r} from an unmodified .env.example. A fresh clone must not "
+                    "name a real SSM path: with ambient AWS creds that is a live handle on "
+                    "production secrets, one regressed PUBLIC_DOMAIN gate away from being read "
+                    "(#1044).",
+                )
+
+    def test_exported_ssm_prefix_still_reaches_the_container(self) -> None:
+        """Over-correction guard, paired with the test above. Blanking the
+        compose default must not remove the opt-in: an operator who exports
+        AWS_SSM_PATH_PREFIX (deliberately mimicking prod locally) still gets it
+        plumbed through. A fix that made the prefix unreachable would pass the
+        previous test and break the thing it exists to allow."""
+        config = _compose_config(local=True, env_overrides={"AWS_SSM_PATH_PREFIX": "/archimedes/prod/"})
+        self.assertEqual(
+            config["services"]["backend"]["environment"]["AWS_SSM_PATH_PREFIX"],
+            "/archimedes/prod/",
+        )
+
+    def test_prod_task_definition_sets_the_env_var_the_ssm_gate_keys_on(self) -> None:
+        """The other side of #1044's gate, which no test covered.
+
+        `main.py` loads SSM secrets only when PUBLIC_DOMAIN is set. That makes
+        PUBLIC_DOMAIN — not AWS_SSM_PATH_PREFIX, not credential presence — the
+        single variable separating local from production. The failure mode this
+        guards is silent and asymmetric: dropping PUBLIC_DOMAIN from the ECS
+        task definition breaks nothing at plan/apply time and nothing at
+        container start, it just means the backend never loads its SSM secrets
+        and boots degraded (EMAIL_ENCRYPTION_KEY fail-close, DATABASE_URL
+        fallbacks) — a production outage caused by an edit to a file the
+        backend tests otherwise never read.
+
+        Pinned as a pair, in the idiom of the nginx healthCheck test above:
+        the gate's shape in main.py, and the variable's presence in the
+        `backend` container block of infra/ecs.tf specifically (a file-wide
+        grep would stay green with the backend block deleted, since `auth` and
+        `nginx` also mention the domain)."""
+        main_py = (ROOT / "backend/archimedes/main.py").read_text()
+        self.assertEqual(
+            main_py.count("load_ssm_secrets()"),
+            1,
+            "main.py must contain exactly one load_ssm_secrets() call site — a second, "
+            "ungated one would reopen #1044 while the gated one kept this test green",
+        )
+        self.assertRegex(
+            main_py,
+            r'if os\.getenv\("PUBLIC_DOMAIN"\):\n\s+load_ssm_secrets\(\)',
+            "main.py's load_ssm_secrets() call must sit directly under an "
+            '`if os.getenv("PUBLIC_DOMAIN"):` gate — ungated, ambient AWS credentials on a '
+            "developer machine pull real production secrets into a local run (#1044)",
+        )
+
+        ecs_tf = (ROOT / "infra/ecs.tf").read_text()
+        container_name_starts = [m.start() for m in re.finditer(r'^\s*name\s*=\s*"', ecs_tf, re.MULTILINE)]
+        backend_decl = re.search(r'^\s*name\s*=\s*"backend"\s*$', ecs_tf, re.MULTILINE)
+        self.assertIsNotNone(backend_decl, 'infra/ecs.tf defines no container named "backend"')
+        assert backend_decl is not None  # narrow for the type checker
+        backend_start = backend_decl.start()
+        backend_end = next((s for s in container_name_starts if s > backend_start), len(ecs_tf))
+        backend_container = ecs_tf[backend_start:backend_end]
+
+        public_domain = re.search(
+            r'\{\s*name\s*=\s*"PUBLIC_DOMAIN"\s*,\s*value\s*=\s*"([^"]+)"',
+            backend_container,
+        )
+        self.assertIsNotNone(
+            public_domain,
+            'the "backend" container in infra/ecs.tf declares no PUBLIC_DOMAIN environment '
+            "entry — main.py gates the SSM secret load on it, so without it the production "
+            "task boots with none of its SSM-backed secrets (#1044)",
+        )
+        assert public_domain is not None  # narrow for the type checker
+        self.assertTrue(
+            public_domain.group(1).startswith("https://"),
+            f"PUBLIC_DOMAIN in infra/ecs.tf is {public_domain.group(1)!r}; it must be "
+            "scheme-qualified (CORS and wallet-link bindings compare full origins)",
+        )
+
+        ssm_prefix = re.search(
+            r'\{\s*name\s*=\s*"AWS_SSM_PATH_PREFIX"\s*,\s*value\s*=\s*"([^"]+)"',
+            backend_container,
+        )
+        self.assertIsNotNone(
+            ssm_prefix,
+            'the "backend" container in infra/ecs.tf declares no AWS_SSM_PATH_PREFIX — '
+            "production names its own prefix here precisely because the compose default and "
+            "the code default are both blank (#1044)",
+        )
 
     def test_nginx_proxies_backend_docs_through_sole_ingress(self) -> None:
         nginx = (ROOT / "nginx/nginx.conf").read_text()

--- a/backend/tests/test_main_ssm_prod_gate.py
+++ b/backend/tests/test_main_ssm_prod_gate.py
@@ -131,6 +131,31 @@ def test_local_mode_never_calls_ssm_even_with_prod_shaped_prefix():
     assert _run(env) == 0
 
 
+def test_ambient_aws_credentials_do_not_promote_a_local_run():
+    """The #1044 leak exactly as onboarding produces it: a developer whose
+    shell already has working AWS credentials (our own setup docs tell people
+    to configure them) runs a plain local `docker compose up`.
+
+    Distinct from the test above, which varies only the prefix. This one adds
+    the credentials, because the tempting wrong fix is to gate on credential
+    *presence* — "no creds, no SSM" — which is exactly the gate that fails on
+    the machine it matters on. The observable must stay zero as a function of
+    PUBLIC_DOMAIN alone, with credentials in hand.
+
+    The credential values are deliberately NOT AWS-shaped: a literal matching
+    detect-secrets' access-key pattern (AKIA + 16 chars) would trip the
+    pre-commit scan for a string that is not a credential. boto3 is spied here
+    and never parses them — only their presence in the subprocess env matters.
+    The real-credential version of this run is in the PR body."""
+    env = _base_env()
+    env.pop("PUBLIC_DOMAIN", None)
+    env["AWS_SSM_PATH_PREFIX"] = "/archimedes/prod/"
+    env["AWS_REGION"] = "us-east-1"
+    env["AWS_ACCESS_KEY_ID"] = "not-a-real-access-key-id"
+    env["AWS_SECRET_ACCESS_KEY"] = "not-a-real-secret-access-key"
+    assert _run(env) == 0
+
+
 def test_production_mode_does_call_ssm():
     """PUBLIC_DOMAIN set (production mode) — the SSM load path still runs.
     Guards against the fix over-correcting into never loading secrets in prod."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -310,12 +310,27 @@ services:
       FEATURE_QUANT: ${FEATURE_QUANT:-}
       EMAIL_ENCRYPTION_KEY: ${EMAIL_ENCRYPTION_KEY:-}
       # Production secret loading: load_ssm_secrets() (main.py, at import time)
-      # reads /archimedes/prod/* from SSM via the EC2 instance role at startup
-      # and injects them into the env (e.g. EMAIL_ENCRYPTION_KEY, which prod mode
-      # fail-closes on). It is a NO-OP unless AWS_SSM_PATH_PREFIX is set, and the
-      # region must match where the params live (us-east-1). This keeps the
-      # secret out of .env and CI. Local dev has no AWS creds → it no-ops safely.
-      AWS_SSM_PATH_PREFIX: ${AWS_SSM_PATH_PREFIX:-/archimedes/prod/}
+      # reads AWS_SSM_PATH_PREFIX/* from SSM and injects the values into the
+      # env (e.g. EMAIL_ENCRYPTION_KEY, which prod mode fail-closes on). Two
+      # independent things must both be true for that fetch to happen:
+      #   1. PUBLIC_DOMAIN is set — main.py's "am I production" gate (#1044).
+      #      This is the one that actually stops the fetch, and it is why prod
+      #      sets PUBLIC_DOMAIN alongside the prefix in infra/ecs.tf:516-519.
+      #   2. AWS_SSM_PATH_PREFIX is non-empty — secrets_service returns 0 on a
+      #      blank prefix.
+      # The default below is BLANK, not /archimedes/prod/. It used to be the
+      # prod path, which silently un-did .env.example's blank default: compose
+      # `:-` substitutes on empty as well as unset, so the shipped
+      # `AWS_SSM_PATH_PREFIX=` resolved back to the real prod prefix inside the
+      # container and left the PUBLIC_DOMAIN gate as the only thing between a
+      # local `docker compose up` and production secrets. Defence in depth is
+      # the point: neither layer may quietly disarm the other.
+      # Production does NOT get this value from compose — post-Fargate, prod is
+      # an ECS task definition (infra/ecs.tf, infra/ecs_migrate.tf) that sets
+      # the prefix explicitly; compose is local-only. Exporting
+      # AWS_SSM_PATH_PREFIX (plus PUBLIC_DOMAIN) still opts a compose run in,
+      # for anyone deliberately mimicking prod.
+      AWS_SSM_PATH_PREFIX: ${AWS_SSM_PATH_PREFIX:-}
       AWS_REGION: ${AWS_REGION:-us-east-1}
     env_file:
       - .env


### PR DESCRIPTION
## What

Finishes the **second half** of #1044's leak 2 — "a local run must never silently pull prod secrets" — and pins the half that was already shipped so it cannot silently regress.

PR #1280 landed the caller-side gate (`main.py:45-46`, `if os.getenv("PUBLIC_DOMAIN"): load_ssm_secrets()`) and blanked `AWS_SSM_PATH_PREFIX` in `.env.example`. I verified both are live (evidence below). But the blank `.env.example` default **never reached the container**: `docker-compose.yml` carried `AWS_SSM_PATH_PREFIX: ${AWS_SSM_PATH_PREFIX:-/archimedes/prod/}`, and compose's `:-` substitutes on *empty* as well as unset — so the shipped `AWS_SSM_PATH_PREFIX=` resolved straight back to the real production prefix:

```
$ cp .env.example .env && docker compose config | grep AWS_SSM_PATH_PREFIX
      AWS_SSM_PATH_PREFIX: /archimedes/prod/
```

Defence in depth was therefore one layer, not two: the `PUBLIC_DOMAIN` gate was the *only* thing standing between a fresh-clone `docker compose up` on a credentialed dev machine and 21 production secrets.

Changes:

| File | Change |
|---|---|
| `docker-compose.yml` | `AWS_SSM_PATH_PREFIX` default → **blank**. Comment rewritten: it claimed "NO-OP unless `AWS_SSM_PATH_PREFIX` is set" (the very claim that line falsified), never named the real gate, and still described the retired EC2/instance-role deploy. |
| `backend/archimedes/services/secrets_service.py` | Removed `_DEFAULT_PREFIX = "/archimedes/prod/"` and the `list_ssm_parameters()` fallback that used it — a bare `list_ssm_parameters()` from a dev shell with ambient creds enumerated the real production parameter store. Fixed the `load_ssm_secrets` docstring, which still advertised an `or /archimedes/prod/` fallback the code has not had since #1280. |
| `backend/tests/test_main_ssm_prod_gate.py` | New guard: ambient AWS credentials present must not promote a local run. |
| `backend/tests/test_local_setup_contract.py` | Three new guards (fresh-clone prefix, opt-in still works, prod task definition still sets the gate variable). `_compose_config` gains an `env_overrides` kwarg. |
| `backend/tests/services/test_secrets_service.py` | New guard for the `list_ssm_parameters` blank-prefix path; two existing tests now state their prefix instead of relying on the removed fallback. |

**Not touched:** `.env.example` (already correct at `:529`, and was under contention with #1595, now merged — I assert on it read-only instead). `docker-compose.yml`'s `image:` lines are B3's; my hunk is the backend service's env block, disjoint from theirs.

## Why — which env var distinguishes production

`PUBLIC_DOMAIN`, not `AWS_SSM_PATH_PREFIX` and not credential presence.

- `backend/archimedes/main.py:45-46` — the gate.
- **`infra/ecs.tf:516-519`** — the production task definition sets **both**:
  ```hcl
  { name = "AWS_SSM_PATH_PREFIX", value = "/archimedes/prod/" },
  # PUBLIC_DOMAIN includes scheme because CORS and wallet-link URI/domain
  # bindings compare scheme-qualified origins. var.domain_name is bare host.
  { name = "PUBLIC_DOMAIN", value = "https://${var.domain_name}" },
  ```
- `infra/ecs_migrate.tf:92` sets the prefix but **not** `PUBLIC_DOMAIN` — correctly, and this PR does not change it. That task runs `alembic_migrate_preflight`, which never imports `main.py` and never calls `load_ssm_secrets()`; its `DATABASE_URL` / `REDIS_URL` / `AURORA_MASTER_PASSWORD` / `EMAIL_ENCRYPTION_KEY` arrive through the ECS-native `secrets` block (`infra/ecs_migrate.tf:102-107`), not through Python. Its `AWS_SSM_PATH_PREFIX` entry is vestigial.
- Compose is local-only post-Fargate — `grep "docker compose" .github/workflows/` finds no `up`/`pull` step anywhere, so blanking the compose default changes nothing in production. The residual EC2 runners are not on this path either: `deploy-runners.yml:192,195` drives them through systemd + `docker run --env-file /opt/archimedes-runners/runner.env`, and no oracle/agent/kb-runner service declares `AWS_SSM_PATH_PREFIX` in compose at all — the key existed only on `backend`.

Production behaviour is preserved exactly, and is now guarded in both directions: RUN 3 below loads all 21 secrets, and a new test fails if `infra/ecs.tf` ever drops `PUBLIC_DOMAIN` from the `backend` container.

---

## Adversarial guard demos

Every guard is shown rejecting a bad input first.

### 1. The live leak, with real production credentials

Not simulated — this ran against the ambient SSO session on my dev machine. Values were never printed; only names and counts.

```
$ aws sts get-caller-identity   # ambient creds on this dev machine
    "Account": "037613907429",
    "Arn": "arn:aws:sts::037613907429:assumed-role/AWSReservedSSO_AdministratorAccess_.../dan.browne"

=== RUN 1 — THE FAILURE: pre-#1280 ungated call, PUBLIC_DOMAIN unset,
             compose's old /archimedes/prod/ default ===
  call site                  : load_ssm_secrets()
  PUBLIC_DOMAIN              : '<unset>'
  AWS_SSM_PATH_PREFIX        : '/archimedes/prod/'
  AWS creds in env           : yes
  PROD SECRETS LOADED        : 21
  injected env var NAMES     : ['AGENT_DRY_RUN', 'ARC_AMM_ROUTER_ADDRESS',
    'ARC_PAYMENT_SPLITTER_ADDRESS', 'ARC_REASONING_TRACE_REGISTRY_ADDRESS',
    'ARC_STRATEGY_REGISTRY_ADDRESS', 'ARC_VAULT_FACTORY_ADDRESS',
    'AURORA_MASTER_PASSWORD', 'BETTER_AUTH_SECRET', 'CIRCLE_API_KEY',
    'CIRCLE_ENTITY_SECRET', 'DATABASE_URL', 'EMAIL_ENCRYPTION_KEY',
    'GENERATION_PAYMENT_RECIPIENT', 'GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET',
    'GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'INTERNAL_AGENT_API_KEY',
    'REDIS_URL', 'WALLET_ADDRESS', 'WALLET_ID']
```

Circle API key + entity secret, the Aurora master password, the email encryption key, both OAuth client secrets, the internal agent API key, and prod `DATABASE_URL`/`REDIS_URL` — into a "local" process, from nothing but an SSO login. This is what the issue describes, confirmed rather than assumed.

```
=== RUN 2 — shipped gate (main.py:45), SAME creds, SAME prod prefix, PUBLIC_DOMAIN unset ===
  call site                  : if PUBLIC_DOMAIN: load_ssm_secrets()
  PROD SECRETS LOADED        : 0
  injected env var NAMES     : []

=== RUN 3 — PROD PRESERVED: same gate, PUBLIC_DOMAIN set (what infra/ecs.tf:519 injects) ===
  PUBLIC_DOMAIN              : 'https://archimedes-arc.com'
  PROD SECRETS LOADED        : 21

=== RUN 4 — SECOND LAYER: gate REGRESSED (ungated), this PR's blank compose default in force ===
  call site                  : load_ssm_secrets()
  AWS_SSM_PATH_PREFIX        : ''
  PROD SECRETS LOADED        : 0
```

RUN 4 is the point of the compose change: with the old `:-/archimedes/prod/` default, RUN 4 *is* RUN 1. Restoring the blank default makes the two layers independent again — either one alone now stops the fetch.

### 2. `test_fresh_clone_compose_never_resolves_the_ssm_prefix_to_a_real_path` — against pre-fix `docker-compose.yml`

```
$ git stash push -- docker-compose.yml      # back to origin/main
$ grep -n "AWS_SSM_PATH_PREFIX:" docker-compose.yml
318:      AWS_SSM_PATH_PREFIX: ${AWS_SSM_PATH_PREFIX:-/archimedes/prod/}

$ pytest ...::test_fresh_clone_compose_never_resolves_the_ssm_prefix_to_a_real_path
E   AssertionError: '/archimedes/prod/' not found in (None, '') : local compose
    resolves AWS_SSM_PATH_PREFIX='/archimedes/prod/' for service 'backend' from an
    unmodified .env.example. A fresh clone must not name a real SSM path: with
    ambient AWS creds that is a live handle on production secrets, one regressed
    PUBLIC_DOMAIN gate away from being read (#1044).
1 failed
```

After `git stash pop`:

```
$ docker compose config | grep AWS_SSM_PATH_PREFIX
      AWS_SSM_PATH_PREFIX: ""
$ pytest ...test_fresh_clone... ...test_exported_ssm_prefix_still_reaches_the_container
2 passed
```

### 3. `test_prod_task_definition_sets_the_env_var_the_ssm_gate_keys_on` — two separate mutations

**(a) delete the gate from `main.py`:**

```
$ python -c "... replace 'if os.getenv(\"PUBLIC_DOMAIN\"):\n    load_ssm_secrets()' with 'load_ssm_secrets()' ..."
mutated main.py -> unconditional load_ssm_secrets()

$ pytest backend/tests/test_main_ssm_prod_gate.py ...::test_prod_task_definition_sets_the_env_var_the_ssm_gate_keys_on
FAILED backend/tests/test_main_ssm_prod_gate.py::test_local_mode_never_calls_ssm_even_with_prod_shaped_prefix
FAILED backend/tests/test_main_ssm_prod_gate.py::test_ambient_aws_credentials_do_not_promote_a_local_run
FAILED backend/tests/test_local_setup_contract.py::TestLocalSetupContract::test_prod_task_definition_sets_the_env_var_the_ssm_gate_keys_on
3 failed, 1 passed
```

(The one that stays green is `test_production_mode_does_call_ssm` — correct: removing the gate does not stop production from loading, which is exactly why it needed a *different* guard.)

**(b) delete `PUBLIC_DOMAIN` from the `backend` container in `infra/ecs.tf`:**

```
mutated infra/ecs.tf -> PUBLIC_DOMAIN dropped from the backend container

E   AssertionError: unexpectedly None : the "backend" container in infra/ecs.tf
    declares no PUBLIC_DOMAIN environment entry — main.py gates the SSM secret
    load on it, so without it the production task boots with none of its
    SSM-backed secrets (#1044)
1 failed
```

Both restored → `1 passed`. This is the guard that did not exist: the gate is now pinned at *both* ends, so neither "local starts loading" nor "prod stops loading" can land silently. Dropping `PUBLIC_DOMAIN` from the task definition breaks nothing at plan, apply, or container start — it just boots prod with no secrets.

### 4. `test_blank_prefix_does_not_fall_back_to_the_production_path`

Restoring the old `list_ssm_parameters` body, with boto3 spied so nothing real is contacted and the spy records the path the code *asked for*:

```
### BEFORE (pre-fix, prod-path fallback restored):
AWS_SSM_PATH_PREFIX = '<unset>'
boto3 SSM clients constructed : 1
SSM paths queried             : ['/archimedes/prod/']
returned                      : ['/archimedes/prod/EXAMPLE']

### AFTER (fix restored):
boto3 SSM clients constructed : 0
SSM paths queried             : []
returned                      : []
```

Run under pytest instead, the pre-fix code doesn't merely fail — it **hangs**, because `MagicMock().get("NextToken")` is truthy and `_fetch_all_parameters`' `while True` never terminates. Worth noting since the two pre-existing `TestListSsmParameters` tests passed *because of* the fallback, which is what kept it invisible.

### 5. Is the compose guard a *property* check or just a string check?

Adversarial pass on my own guard: fed it a bad input that is **not** the literal string it was written against, in an isolated temp tree so the running suite was undisturbed.

```
333:      AWS_SSM_PATH_PREFIX: ${AWS_SSM_PATH_PREFIX:-/archimedes/staging/}
guard verdict: REJECTS -> [('backend', '/archimedes/staging/')]
```

It asserts "resolves to nothing", not "does not equal `/archimedes/prod/`", so any real path fails it — and it iterates every service in both the local and production-model configs, so moving the leak to `oracle` or into `.env.example` is caught too (the `.env.example` half is the first assertion in the same test).

---

## Verification of the already-shipped half (#1280), not assumed

- `pytest backend/tests/test_main_ssm_prod_gate.py backend/tests/services/test_secrets_service.py` → 16 passed on `origin/main` before any change.
- `grep -n AWS_SSM_PATH_PREFIX .env.example` → single hit, `:529`, value empty.
- `main.py:45-46` gate read and confirmed to sit after both `load_dotenv` calls and before every service import.
- `secrets_service.py:90-93` early-returns 0 on a blank prefix.
- RUN 2 above re-demonstrates the gate against **live** credentials, not only spied ones.

## Tests

Rebased onto `848673e0` (current `main`). Two main-moves happened while this was in flight and both were re-checked rather than assumed:

- **#1595** rewrote `.env.example` and `main.py`. Both anchors this PR depends on survive: `.env.example:529` still ships the prefix blank, and `main.py:45-46` still carries the gate.
- **#1673** fixed `test_cloudwatch_alarms.py::TestAntiGoals::test_the_oracle_stale_alarm_is_untouched`, which had left `main` red since #1601 retuned the alarm without updating its pin. An earlier run of this branch inherited that failure; this run is on top of the fix.

```
$ pytest -m "not integration" -q          # from the worktree root
= 3 failed, 5039 passed, 3 skipped, 2 deselected, 297 warnings in 1795.94s (0:29:55) =

FAILED test_health_always_answers.py::TestTheEndpointAlwaysAnswers::test_health_answers_within_budget_when_the_chain_client_hangs_forever
FAILED test_health_always_answers.py::TestTheEndpointAlwaysAnswers::test_health_answers_within_budget_when_the_oracle_probe_hangs_forever
FAILED test_health_always_answers.py::TestStalenessFieldsAppearExactlyWhenAProbeTimedOut::test_a_timed_out_probe_serves_the_last_known_value_with_its_age
```

**Those three are wall-clock budget assertions failing under machine load, not this diff.** They are `assert elapsed < 2.0` on `/health`; the run measured 2.16-2.51s on a box with 40-145 concurrent pytest processes from other sessions. Nothing in this PR touches `/health`, `health_probe_cache`, or the chain/oracle probes.

Verified rather than asserted — the same file, run back to back on a checkout of pristine `origin/main` (848673e0) and on this branch, under the same load:

```
load: 60 pytest procs
=== origin/main (pristine, 848673e0) ===
1 failed, 16 passed, 1 warning in 28.13s
=== dbrowneup/1044-ssm-safety (this PR) ===
1 failed, 16 passed, 1 warning in 22.32s
```

Identical. Worth a separate look at whether that budget wants to be load-tolerant (it is the class of test that goes red on a busy CI runner for reasons unrelated to the change under review), but not this PR's to fix.

Everything this PR touches is green in that run: `test_main_ssm_prod_gate.py ...` (3/3), `test_local_setup_contract.py ...........` (11/11, 8 pre-existing + 3 new), `test_secrets_service.py` (17/17).

`ruff format --check backend/` clean; `ruff check` clean on all changed files.

## Merge-train note re #1671 (the #1044 doc + local-mode checker)

Checked for the pairwise collision CLAUDE.md rule 5 asks for. **No file overlap** — #1671 touches `Makefile`, `SETUP.md`, `docs/*`, `mkdocs.yml`, `scripts/check-local-mode.py`, `backend/tests/test_local_mode_contract.py`; none of my five. No semantic break either direction: its `no-prod-secrets` check resolves the **`.env` layer**, which has been blank since #1280, so it is green before and after this PR.

Two things there want a follow-up once this lands, neither blocking:

1. Its `no-prod-secrets` check reads `.env` values only, so it would stay green with the compose-level prod default still in place — the exact regression this PR closes. My `test_fresh_clone_compose_never_resolves_the_ssm_prefix_to_a_real_path` covers that layer; the two are complementary, not duplicative.
2. `docs/local-vs-prod.md` § 3 records leak 2 as **"CLOSED by #1280, in two layers"**. Accurate for the code gate, not for the second layer: the blank `.env.example` default was being overwritten inside the container until this PR. Worth a one-line correction after merge.

## Notes for the owner

- `list_ssm_parameters()` has zero callers in the tree, so tightening it changes no production behaviour. Flagging it because it is a behaviour change, not just a docstring fix.
- The `AWS_SSM_PATH_PREFIX` entry in `infra/ecs_migrate.tf:92` is dead (that task's secrets come from the ECS `secrets` block). Left alone deliberately — removing it is a separate, deploy-touching change.

Part of #1044
