### PR TITLE
[infra] Local compose must never resolve to a production image (#1044 leak 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,33 @@ COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.local.yml
 COMPOSE_PROFILES=localdb
 
+# ── Image source: local build (default) vs ECR pull ────────────────────────
+# LEAVE BOTH COMMENTED OUT. docker-compose.yml resolves every app-tier service
+# to a project-scoped, registry-less tag
+# (`${COMPOSE_PROJECT_NAME:-archimedes}-backend:local`), so the only thing that
+# can satisfy it is your own `docker compose up --build`. That is deliberate:
+# these keys used to default to the live production ECR ref, so a bare
+# `docker compose up` — no `--build` — reached the production registry and, on
+# an ECR-authenticated machine, silently ran the last image CI pushed to prod
+# instead of your working tree (#1044, leak 3). The scoping by project name
+# also stops one worktree's build from overwriting the tag every other checkout
+# on the machine resolves.
+#
+# To run prebuilt ECR images instead, opt in explicitly — name the overlay AND
+# set both variables (they are `:?`-required in the overlay, so a forgotten one
+# errors rather than silently selecting production `:latest`):
+#
+#   aws ecr get-login-password --region us-east-1 \
+#     | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+#   ECR_REGISTRY=037613907429.dkr.ecr.us-east-1.amazonaws.com IMAGE_TAG=<sha> \
+#     docker compose -f docker-compose.yml -f docker-compose.ecr.yml pull
+#
+# Neither variable affects production: since the Fargate cutover, deploy.yml
+# registers ECS task definitions with explicit image URIs and never runs
+# compose. See docker-compose.ecr.yml.
+#ECR_REGISTRY=037613907429.dkr.ecr.us-east-1.amazonaws.com
+#IMAGE_TAG=latest
+
 # Rootless Docker cannot publish privileged host ports (<1024) by default.
 # Production omits this variable and keeps docker-compose.yml's port-80 fallback.
 ARCHIMEDES_HTTP_PORT=8080

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,13 +67,17 @@
 # infra/ecr.tf — not part of this PR); build-and-push fails with a clear
 # `::error::` if a repo doesn't exist yet rather than a bare AWS API error.
 #
-# Box-side prerequisite (NOT applied by this PR — tracked in #1039 chunk 2):
-# the EC2 instance role (`archimedes-backend-role`) needs
+# HISTORICAL (superseded by the ECS Fargate cutover; corrected 2026-08-31,
+# #1044). This paragraph described a box-side `docker compose pull` deploy:
+# the EC2 instance role (`archimedes-backend-role`) needing
 # ecr:GetAuthorizationToken + ecr:BatchGetImage + ecr:GetDownloadUrl +
-# ecr:BatchCheckLayerAvailability on repository/archimedes*, and the box needs
-# `awscli` installed, so `docker compose pull` can authenticate to ECR. The
-# deploy step fails closed with an explicit error if either is missing — see
-# docs/deployment.md § "Production deploy flow".
+# ecr:BatchCheckLayerAvailability on repository/archimedes*, plus `awscli` on
+# the box. THAT PATH NO LONGER EXISTS. This workflow deploys by registering
+# ECS task definitions with explicit image URIs (see the `deploy-ecs` job) and
+# never invokes compose; `deploy-runners.yml` uses raw `docker pull`/`docker
+# tag` over SSM for the residual oracle/agent box. Nothing in CI or production
+# reads `docker-compose.yml`'s `image:` keys — it is a local-development file,
+# and #1044 made its refs registry-less so it stays that way.
 #
 # Required GitHub Variables (or hardcoded below):
 #   AWS_ROLE_ARN — arn:aws:iam::037613907429:role/archimedes-github-deploy
@@ -207,10 +211,12 @@ jobs:
         # Env-parity fix (PR #1041 correctness pass, 2026-07-07): this is NOT
         # just a boot/smoke validation image — the SAME `:ci`-tagged image
         # built here is tagged + pushed to ECR verbatim below ("Tag + push
-        # nginx image"; no separate rebuild happens for the push), and BOTH
-        # live deploy targets (the EC2 box's `docker compose pull`, #1039 P1,
-        # and the Fargate `deploy-ecs` job) serve whatever landed in ECR —
-        # never a locally-rebuilt image. Leaving VITE_* build-args at the
+        # nginx image"; no separate rebuild happens for the push), and the
+        # live deploy target (the Fargate `deploy-ecs` job below) serves
+        # whatever landed in ECR — never a locally-rebuilt image. (The second
+        # target this comment used to name, the EC2 box's `docker compose
+        # pull`, was retired by the Fargate cutover; corrected 2026-08-31,
+        # #1044.) Leaving VITE_* build-args at the
         # Dockerfile's empty defaults (the prior state of this step) means
         # the shipped JS bundle has no Circle client key baked in and the
         # wallet / passkey / Circle SDK UI breaks on every real deploy, not

--- a/backend/tests/test_compose_no_prod_image_default.py
+++ b/backend/tests/test_compose_no_prod_image_default.py
@@ -1,0 +1,360 @@
+"""A local `docker compose up` must never resolve to a production image (#1044).
+
+`docker-compose.yml` is the file a fresh clone runs. Every app-tier service in
+it carries a `build:` section, so local code is *supposed* to be authoritative.
+The leak this module guards is that those same services also carried an
+``image:`` key whose **baked-in default** was the live production ECR ref::
+
+    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+
+Neither ``ECR_REGISTRY`` nor ``IMAGE_TAG`` was defined anywhere in
+``.env.example``, so on a fresh clone the defaults always won and two distinct
+things went wrong, both silent:
+
+1. **Reaching production.** ``docker compose up`` *without* ``--build`` — and
+   ``docker compose pull`` — resolve that ref and make a real request to the
+   production registry. On a machine that is ECR-authenticated (our own
+   onboarding tells people to set that up) it succeeds, and the developer runs
+   the last image CI pushed to prod while believing they are running their
+   working tree.
+2. **Cross-checkout tag theft.** ``build:`` tags whatever ``image:`` names, and
+   that name is machine-global. Every worktree on the box therefore builds into
+   the *same* tag, so the last checkout to run ``--build`` silently owns it, and
+   a bare ``up`` in any other checkout adopts that foreign build.
+
+The fix keeps ``build:`` authoritative and makes the pull path opt-in:
+``docker-compose.yml`` resolves to a project-scoped, registry-less tag that
+cannot exist on any remote, and ``docker-compose.ecr.yml`` is a separate
+override that restores the registry-qualified refs and *requires* the two vars
+to be set explicitly.
+
+These tests read the YAML directly and do their own POSIX-subset interpolation,
+so they need no docker daemon and run in the default unit sweep.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE_COMPOSE = REPO_ROOT / "docker-compose.yml"
+ECR_COMPOSE = REPO_ROOT / "docker-compose.ecr.yml"
+PRODUCTION_COMPOSE = REPO_ROOT / "docker-compose.production.yml"
+
+# Any registry host, not just ours — a default pointing at *someone's* remote
+# registry is the defect, and hardcoding the account number would let a
+# re-tagged copy sail through.
+ECR_HOST_RE = re.compile(r"\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/")
+
+# The env a fresh clone has: `cp .env.example .env` and nothing else. Neither
+# var is defined in that template, which is the whole point.
+SCRUBBED_ENV: dict[str, str] = {}
+
+
+# ---------------------------------------------------------------------------
+# Compose variable interpolation (the POSIX subset compose implements)
+# ---------------------------------------------------------------------------
+
+
+class MissingRequiredVar(Exception):
+    """Raised for ``${VAR:?msg}`` when VAR is unset/empty — compose's own
+    fail-loud form. The tests assert on this to prove the ECR override cannot
+    silently fall back to a default."""
+
+
+_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _apply(name: str, op: str, word: str, env: dict[str, str]) -> str:
+    present = name in env
+    value = env.get(name, "")
+    non_empty = present and value != ""
+
+    if op == ":-":
+        return value if non_empty else word
+    if op == "-":
+        return value if present else word
+    if op == ":+":
+        return word if non_empty else ""
+    if op == "+":
+        return word if present else ""
+    if op == ":?":
+        if not non_empty:
+            raise MissingRequiredVar(f"{name}: {word}")
+        return value
+    if op == "?":
+        if not present:
+            raise MissingRequiredVar(f"{name}: {word}")
+        return value
+    return value
+
+
+def interpolate(template: str, env: dict[str, str]) -> str:
+    """Resolve ``$VAR`` / ``${VAR}`` / ``${VAR:-d}`` / ``${VAR:+a}`` /
+    ``${VAR:?e}`` (and the no-colon variants) the way compose does.
+
+    Handles nesting inside the default word, and ``$$`` as a literal ``$``.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(template)
+    while i < n:
+        ch = template[i]
+        if ch != "$":
+            out.append(ch)
+            i += 1
+            continue
+        if i + 1 < n and template[i + 1] == "$":
+            out.append("$")
+            i += 2
+            continue
+        if i + 1 < n and template[i + 1] == "{":
+            depth = 1
+            j = i + 2
+            while j < n and depth:
+                if template[j] == "{":
+                    depth += 1
+                elif template[j] == "}":
+                    depth -= 1
+                j += 1
+            if depth:
+                raise ValueError(f"unbalanced ${{ in {template!r}")
+            body = template[i + 2 : j - 1]
+            match = _NAME_RE.match(body)
+            if not match:
+                raise ValueError(f"unparseable substitution {body!r}")
+            name = match.group(0)
+            rest = body[match.end() :]
+            op, word = "", ""
+            for candidate in (":-", ":+", ":?", ":=", "-", "+", "?", "="):
+                if rest.startswith(candidate):
+                    op, word = candidate, rest[len(candidate) :]
+                    break
+            out.append(_apply(name, op, interpolate(word, env), env))
+            i = j
+            continue
+        match = _NAME_RE.match(template, i + 1)
+        if match:
+            out.append(env.get(match.group(0), ""))
+            i = match.end()
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _services(path: Path) -> dict[str, dict]:
+    assert path.is_file(), f"{path.relative_to(REPO_ROOT)} is missing"
+    doc = yaml.safe_load(path.read_text()) or {}
+    return doc.get("services") or {}
+
+
+def _raw_images(path: Path) -> dict[str, str]:
+    return {
+        name: svc["image"]
+        for name, svc in _services(path).items()
+        if isinstance(svc, dict) and isinstance(svc.get("image"), str)
+    }
+
+
+def _built_services(path: Path) -> set[str]:
+    """Services that build from this repo's source — the ones whose image ref
+    is a *local build tag*, not a third-party pin like ``postgres:18-alpine``."""
+    return {name for name, svc in _services(path).items() if isinstance(svc, dict) and svc.get("build")}
+
+
+def _has_registry_host(ref: str) -> bool:
+    """True when the first path segment is a registry host.
+
+    Docker's own rule: a name is registry-qualified only if the first
+    ``/``-separated component contains a ``.`` or ``:`` (or is ``localhost``).
+    ``postgres:18-alpine`` → False. ``example.com/x:1`` → True.
+    """
+    head = ref.split("/")[0]
+    return "/" in ref and ("." in head or ":" in head or head == "localhost")
+
+
+# ---------------------------------------------------------------------------
+# The guard: the fresh-clone default must not be a production image
+# ---------------------------------------------------------------------------
+
+
+def test_base_compose_never_defaults_to_a_remote_registry_image():
+    """With ECR_REGISTRY / IMAGE_TAG unset, nothing in the file a fresh clone
+    runs may resolve to an ECR ref."""
+    offenders = {name: interpolate(raw, SCRUBBED_ENV) for name, raw in _raw_images(BASE_COMPOSE).items()}
+    leaking = {name: ref for name, ref in offenders.items() if ECR_HOST_RE.search(ref)}
+    assert not leaking, (
+        "docker-compose.yml resolves to production ECR images on a fresh clone "
+        "(ECR_REGISTRY and IMAGE_TAG unset). A bare `docker compose up` — no "
+        "--build — pulls and runs the last image CI pushed to prod instead of "
+        "the developer's working tree (#1044 leak 3). Offending services:\n  "
+        + "\n  ".join(f"{k}: {v}" for k, v in sorted(leaking.items()))
+        + "\nThe ECR pull path belongs in docker-compose.ecr.yml, opt-in."
+    )
+
+
+def test_base_compose_images_are_unresolvable_on_any_registry():
+    """Stronger than the ECR check: the local default must not name *any*
+    remote host, so a mis-typed or third-party registry cannot serve it
+    either."""
+    qualified = {
+        name: ref
+        for name, ref in ((n, interpolate(raw, SCRUBBED_ENV)) for n, raw in _raw_images(BASE_COMPOSE).items())
+        if _has_registry_host(ref)
+    }
+    assert not qualified, (
+        "docker-compose.yml resolves registry-qualified images by default; "
+        "local runs must resolve to build-only tags no registry can serve:\n  "
+        + "\n  ".join(f"{k}: {v}" for k, v in sorted(qualified.items()))
+    )
+
+
+def test_locally_built_images_are_scoped_per_compose_project():
+    """`build:` tags whatever `image:` names, and image tags are machine-global.
+
+    An unscoped tag means every checkout on the machine builds into the same
+    name, so the last worktree to run `--build` owns it and a bare `up` in any
+    other checkout silently adopts that foreign build. Scoping the tag by
+    ``COMPOSE_PROJECT_NAME`` (which compose derives from the directory) gives
+    each worktree its own tag.
+    """
+    unscoped = {
+        name: raw
+        for name, raw in _raw_images(BASE_COMPOSE).items()
+        if name in _built_services(BASE_COMPOSE) and "COMPOSE_PROJECT_NAME" not in raw
+    }
+    assert not unscoped, (
+        "these built services use a machine-global image tag, so a build in "
+        "one worktree overwrites the tag every other checkout resolves "
+        "(#1044). Scope it with ${COMPOSE_PROJECT_NAME:-archimedes} or drop "
+        "the `image:` key so compose names it per project:\n  "
+        + "\n  ".join(f"{k}: {v}" for k, v in sorted(unscoped.items()))
+    )
+
+
+def test_production_compose_never_defaults_to_a_remote_registry_image():
+    """`docker-compose.production.yml` documents a `--build` workflow, so it
+    carries the same fresh-clone hazard and gets the same treatment."""
+    if not PRODUCTION_COMPOSE.is_file():
+        pytest.skip("docker-compose.production.yml has been removed")
+    leaking = {
+        name: ref
+        for name, ref in ((n, interpolate(raw, SCRUBBED_ENV)) for n, raw in _raw_images(PRODUCTION_COMPOSE).items())
+        if ECR_HOST_RE.search(ref)
+    }
+    assert not leaking, (
+        "docker-compose.production.yml bakes the prod registry in as a default; "
+        "the registry prefix must appear only when ECR_REGISTRY is explicitly "
+        "exported:\n  " + "\n  ".join(f"{k}: {v}" for k, v in sorted(leaking.items()))
+    )
+
+
+# ---------------------------------------------------------------------------
+# The inverse: the pull path must still exist, behind explicit intent
+# ---------------------------------------------------------------------------
+
+
+def test_ecr_override_restores_registry_qualified_refs():
+    """Opting in must actually give back a pullable ref for every service the
+    base file builds — otherwise this change just breaks `docker compose pull`
+    instead of gating it."""
+    env = {
+        "ECR_REGISTRY": "037613907429.dkr.ecr.us-east-1.amazonaws.com",
+        "IMAGE_TAG": "deadbeef",
+    }
+    override = _raw_images(ECR_COMPOSE)
+    missing = sorted(_built_services(BASE_COMPOSE) - set(override))
+    assert not missing, (
+        "docker-compose.ecr.yml does not cover every buildable service in "
+        f"docker-compose.yml; `docker compose pull` would silently no-op for {missing}"
+    )
+    for name, raw in override.items():
+        resolved = interpolate(raw, env)
+        assert ECR_HOST_RE.search(resolved), (
+            f"{name}: opting into the ECR override still did not produce a registry-qualified ref (got {resolved!r})"
+        )
+        assert resolved.endswith(":deadbeef"), f"{name}: IMAGE_TAG must select the tag (got {resolved!r})"
+
+
+def test_ecr_override_fails_loudly_when_any_single_var_is_unset():
+    """No defaults in the override: an operator who forgets **either** var gets
+    an error, never a surprise `:latest` from production.
+
+    Checking only "unset everything → raises" is too weak, and the adversarial
+    pass caught it: swapping `${ECR_REGISTRY:?…}` back to
+    `${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}` still
+    raised — because the *other* variable, IMAGE_TAG, was still required. The
+    guard would have gone green on a file that had silently re-armed the
+    production registry default. So each referenced variable is withheld on its
+    own, with every sibling supplied.
+    """
+    for service, raw in _raw_images(ECR_COMPOSE).items():
+        referenced = sorted(set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)", raw)))
+        assert referenced, f"{service}: image ref interpolates nothing"
+        for withheld in referenced:
+            env = {name: "placeholder" for name in referenced if name != withheld}
+            with pytest.raises(MissingRequiredVar):
+                resolved = interpolate(raw, env)
+                pytest.fail(
+                    f"{service}: {withheld} is unset yet the image ref still "
+                    f"resolved, to {resolved!r}. Every variable in the ECR "
+                    f"overlay must use the `:?` (required) form — a `:-` "
+                    f"default here is how a forgotten variable turns into a "
+                    f"silent production pull."
+                )
+
+
+def test_env_example_documents_the_opt_in_but_does_not_arm_it():
+    """`.env.example` must explain ECR_REGISTRY / IMAGE_TAG, and must leave
+    both commented out — a template that ships them set would re-arm exactly
+    the leak this guards."""
+    lines = (REPO_ROOT / ".env.example").read_text().splitlines()
+    for var in ("ECR_REGISTRY", "IMAGE_TAG"):
+        mentioned = [ln for ln in lines if var in ln]
+        assert mentioned, f".env.example never mentions {var}"
+        armed = [ln for ln in mentioned if re.match(rf"\s*{var}\s*=", ln)]
+        assert not armed, (
+            f".env.example sets {var} for real; it must stay commented out so "
+            f"a `cp .env.example .env` cannot turn on the registry pull path:\n  " + "\n  ".join(armed)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Interpolator self-checks — a guard whose engine is wrong proves nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("template", "env", "expected"),
+    [
+        ("${A:-d}", {}, "d"),
+        ("${A:-d}", {"A": ""}, "d"),
+        ("${A:-d}", {"A": "v"}, "v"),
+        ("${A-d}", {"A": ""}, ""),
+        ("${A:+p}", {}, ""),
+        ("${A:+p}", {"A": "v"}, "p"),
+        ("${A:+${A}/}x", {"A": "reg"}, "reg/x"),
+        ("${A:+${A}/}x", {}, "x"),
+        ("$A-b", {"A": "v"}, "v-b"),
+        ("$$A", {"A": "v"}, "$A"),
+    ],
+)
+def test_interpolate_matches_compose_semantics(template, env, expected):
+    assert interpolate(template, env) == expected
+
+
+def test_interpolate_raises_on_required_var():
+    with pytest.raises(MissingRequiredVar):
+        interpolate("${A:?set it}", {})
+    assert interpolate("${A:?set it}", {"A": "v"}) == "v"

--- a/docker-compose.ecr.yml
+++ b/docker-compose.ecr.yml
@@ -1,0 +1,63 @@
+# Archimedes — OPT-IN overlay: run the app tier from ECR images instead of a
+# local build (issue #1044, leak 3).
+#
+# `docker-compose.yml` deliberately resolves to project-scoped, registry-less
+# tags (`${COMPOSE_PROJECT_NAME:-archimedes}-backend:local`) so that a fresh
+# clone can only ever run code it built itself. That is the safe default, and
+# it removed the footgun where a bare `docker compose up` — no `--build` —
+# quietly pulled and ran the last image CI pushed to production.
+#
+# This file puts the registry back, behind two explicit gates:
+#
+#   1. You have to name the file. It is NOT in `.env.example`'s COMPOSE_FILE.
+#   2. You have to set BOTH variables. They use `:?` (required), not `:-`
+#      (default), so a forgotten variable is a hard error — never a surprise
+#      production `:latest`.
+#
+#   ECR_REGISTRY=037613907429.dkr.ecr.us-east-1.amazonaws.com \
+#   IMAGE_TAG=<commit-sha> \
+#     docker compose -f docker-compose.yml -f docker-compose.ecr.yml pull
+#
+# `aws ecr get-login-password --region us-east-1 | docker login --username AWS \
+#   --password-stdin "$ECR_REGISTRY"` first; the repos are Terraformed in
+# infra/ecr.tf.
+#
+# `pull_policy: always` is deliberate: the base file leaves `build:` in place
+# (compose merge cannot remove it), and without this an unreachable registry
+# would silently fall back to a local build — the same silent substitution,
+# pointing the other way. With it, opting in either pulls or fails loudly.
+#
+# NOT a deploy mechanism. Since the Fargate cutover, production rollout is
+# `.github/workflows/deploy.yml` registering ECS task definitions with explicit
+# image URIs, plus `deploy-runners.yml` doing raw `docker pull` over SSM.
+# Nothing in CI or on any box reads this file; it exists for an operator who
+# wants to run the built artifacts locally without rebuilding them.
+
+services:
+  migrate:
+    image: ${ECR_REGISTRY:?set ECR_REGISTRY to use the ECR overlay}/archimedes-backend:${IMAGE_TAG:?set IMAGE_TAG (a commit SHA) to use the ECR overlay}
+    pull_policy: always
+
+  nginx:
+    image: ${ECR_REGISTRY:?set ECR_REGISTRY to use the ECR overlay}/archimedes-nginx:${IMAGE_TAG:?set IMAGE_TAG (a commit SHA) to use the ECR overlay}
+    pull_policy: always
+
+  auth:
+    image: ${ECR_REGISTRY:?set ECR_REGISTRY to use the ECR overlay}/archimedes-auth:${IMAGE_TAG:?set IMAGE_TAG (a commit SHA) to use the ECR overlay}
+    pull_policy: always
+
+  backend:
+    image: ${ECR_REGISTRY:?set ECR_REGISTRY to use the ECR overlay}/archimedes-backend:${IMAGE_TAG:?set IMAGE_TAG (a commit SHA) to use the ECR overlay}
+    pull_policy: always
+
+  oracle:
+    image: ${ECR_REGISTRY:?set ECR_REGISTRY to use the ECR overlay}/archimedes-backend:${IMAGE_TAG:?set IMAGE_TAG (a commit SHA) to use the ECR overlay}
+    pull_policy: always
+
+  agent:
+    image: ${ECR_REGISTRY:?set ECR_REGISTRY to use the ECR overlay}/archimedes-backend:${IMAGE_TAG:?set IMAGE_TAG (a commit SHA) to use the ECR overlay}
+    pull_policy: always
+
+  kb-runner:
+    image: ${ECR_REGISTRY:?set ECR_REGISTRY to use the ECR overlay}/archimedes-backend:${IMAGE_TAG:?set IMAGE_TAG (a commit SHA) to use the ECR overlay}
+    pull_policy: always

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -23,14 +23,24 @@
 #   DATABASE_URL=postgresql://archimedes:<pw>@<aurora-endpoint>:5432/archimedes
 #   REDIS_URL=rediss://<elasticache-endpoint>:6379/0
 #
-# Image refs (config consolidation, issue #1039 P5): services below now
-# carry an explicit `image:` (ECR-hosted) alongside `build:`, mirroring the
-# same addition already made to docker-compose.yml (issue #1039 P1) — so
-# `docker compose pull` has something to pull instead of always needing
-# `--build` on this tier's instances too. `build:` stays so the documented
-# `--build` usage above (and any local exercising of this file) is
-# unaffected. ECR_REGISTRY / IMAGE_TAG read from `.env` / the shell env, same
-# defaults as docker-compose.yml — see docs/deployment.md.
+# Image refs (issue #1044, leak 3 — was #1039 P5): services below carry an
+# explicit `image:` alongside `build:` so `docker compose pull` has something
+# to pull, but the ECR registry prefix is now `${ECR_REGISTRY:+…}` — `:+`, not
+# `:-`. The prefix appears ONLY when ECR_REGISTRY is explicitly exported.
+#
+# It used to default to the live production registry, which meant anyone
+# exercising this file — including on a laptop — resolved to
+# `037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest` and,
+# if ECR-authenticated, silently ran the last image CI pushed to prod instead
+# of their own build. Unset, these now resolve to `archimedes-backend:local`,
+# which no registry can serve, so only a local `--build` satisfies them and the
+# documented `--build` usage above is unaffected.
+#
+# THIS FILE IS CURRENTLY UNUSED — nothing in the pipeline references it (see
+# Dan's 2026-07-07 comment on #1044); the ASG tier it was written for was
+# superseded by the ECS Fargate cutover. It is left in place rather than
+# deleted because docs link to it and the adopt-or-delete call is the owner's.
+# Guarded by backend/tests/test_compose_no_prod_image_default.py.
 
 services:
   # ---------- Reverse proxy + Frontend ----------
@@ -38,7 +48,7 @@ services:
   # terminates TLS and forwards plain HTTP to the instance on port 80 → 8080.
   # nginx does NOT terminate TLS in this tier (the ALB does).
   nginx:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-nginx:${IMAGE_TAG:-latest}
+    image: ${ECR_REGISTRY:+${ECR_REGISTRY}/}archimedes-nginx:${IMAGE_TAG:-local}
     build:
       context: .
       dockerfile: nginx/Dockerfile
@@ -66,7 +76,7 @@ services:
 
   # ---------- Better Auth ----------
   auth:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-auth:${IMAGE_TAG:-latest}
+    image: ${ECR_REGISTRY:+${ECR_REGISTRY}/}archimedes-auth:${IMAGE_TAG:-local}
     build:
       context: ./auth
     restart: unless-stopped
@@ -90,7 +100,7 @@ services:
 
   # ---------- Backend API ----------
   backend:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+    image: ${ECR_REGISTRY:+${ECR_REGISTRY}/}archimedes-backend:${IMAGE_TAG:-local}
     build:
       context: .
       dockerfile: backend/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,47 @@
-# Archimedes — Docker Compose for production deployment on EC2
+# Archimedes — Docker Compose for LOCAL development
 # Usage: docker compose up --build -d
 #
-# Image refs (issue #1039, P1 — "stop the bleeding"): the app-tier services
-# below (nginx, backend, oracle, agent, kb-runner) now carry an explicit
-# `image:` in addition to `build:`. This is what lets `docker compose pull`
-# do something useful — without an `image:` key, compose has nothing to pull
-# and a bare `docker compose pull && up -d` would silently no-op, still
-# forcing a local `--build` (the exact OOM-on-serving-host failure mode this
-# issue exists to kill; see #1001). `build:` is left in place on purpose so
-# local dev (`docker compose up --build -d`) is completely unaffected — it
-# builds fresh from the Dockerfile and tags the image with the same name the
-# `image:` key declares, purely a local tag, no registry push happens unless
-# you explicitly run `docker compose push`.
+# ── Image refs: local-only by construction (issue #1044, leak 3) ───────────
+# `build:` is authoritative here. Every app-tier service resolves to a
+# project-scoped, registry-less tag:
 #
-# ECR_REGISTRY / IMAGE_TAG are read from `.env` (or the shell env); the
-# defaults below point at the live account/region and `:latest`. CI
-# (.github/workflows/deploy.yml, `build-and-push` job) builds + validates +
-# pushes both `archimedes-backend` and `archimedes-nginx` to ECR tagged by
-# commit SHA *and* `latest`; the box's deploy step sets IMAGE_TAG to the
-# deployed commit SHA before `docker compose pull`, so `latest` is a fallback
-# for anyone pulling by hand. See docs/deployment.md § "Production deploy
-# flow" and infra/README.md for the ECR repos (Terraform, issue #1039 chunk 2).
+#     image: ${COMPOSE_PROJECT_NAME:-archimedes}-backend:local
+#
+# Two failure modes made that shape necessary, and both were live:
+#
+#  1. REACHING PRODUCTION. These keys used to default to
+#     `${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/…:${IMAGE_TAG:-latest}`,
+#     and neither variable was defined anywhere in `.env.example` — so on a
+#     fresh clone the defaults always won. `docker compose up` WITHOUT
+#     `--build` (and `docker compose pull`) then made a real request to the
+#     production registry; on an ECR-authenticated machine it succeeds and the
+#     developer runs the last image CI pushed to prod while believing they are
+#     running their working tree. Nothing warns. A registry-less name cannot
+#     resolve anywhere, so the only thing that can satisfy it is a local build.
+#
+#  2. CROSS-CHECKOUT TAG THEFT. `build:` tags the image with whatever `image:`
+#     names, and image tags are machine-global while compose projects are not.
+#     Every worktree on the box therefore built into the SAME tag, so the last
+#     checkout to run `--build` silently owned it and a bare `up` in any other
+#     checkout adopted that foreign build. `COMPOSE_PROJECT_NAME` (which
+#     compose derives from the directory, or `-p`) scopes the tag per checkout;
+#     the `:-archimedes` fallback keeps the historical name for the canonical
+#     clone. `migrate`/`oracle`/`agent`/`kb-runner` deliberately share the
+#     `-backend:local` tag with `backend` so the image is still built once.
+#
+# THE ECR PULL PATH STILL EXISTS — it is now opt-in. `docker-compose.ecr.yml`
+# restores the registry-qualified refs and REQUIRES `ECR_REGISTRY` and
+# `IMAGE_TAG` to be set (no defaults, so a forgotten variable errors instead of
+# silently selecting production `:latest`):
+#
+#     ECR_REGISTRY=… IMAGE_TAG=<sha> \
+#       docker compose -f docker-compose.yml -f docker-compose.ecr.yml pull
+#
+# Note that nothing in CI or production consumes these keys today: since the
+# Fargate cutover, `.github/workflows/deploy.yml` registers ECS task
+# definitions with explicit image URIs and `deploy-runners.yml` uses raw
+# `docker pull`/`docker tag` over SSM. Compose is a local-development tool.
+# Guarded by backend/tests/test_compose_no_prod_image_default.py.
 #
 # ── Compose profiles in this file (two independent gates) ──────────────────
 #   `localdb` — postgres + redis, LOCAL DEV ONLY (see the "Data stores" note
@@ -106,7 +127,7 @@ services:
   # never creates PostgreSQL tables. Base-file dependencies stay optional so
   # production can omit localdb; docker-compose.local.yml makes them strict.
   migrate:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+    image: ${COMPOSE_PROJECT_NAME:-archimedes}-backend:local
     profiles: ["localdb"]
     build:
       context: .
@@ -120,7 +141,7 @@ services:
 
   # ---------- Reverse proxy + Frontend ----------
   nginx:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-nginx:${IMAGE_TAG:-latest}
+    image: ${COMPOSE_PROJECT_NAME:-archimedes}-nginx:local
     build:
       context: .
       dockerfile: nginx/Dockerfile
@@ -155,7 +176,7 @@ services:
 
   # ---------- Better Auth ----------
   auth:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-auth:${IMAGE_TAG:-latest}
+    image: ${COMPOSE_PROJECT_NAME:-archimedes}-auth:local
     build:
       context: ./auth
     restart: unless-stopped
@@ -186,7 +207,7 @@ services:
 
   # ---------- Oracle (price feeder) ----------
   oracle:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+    image: ${COMPOSE_PROJECT_NAME:-archimedes}-backend:local
     build:
       context: .
       dockerfile: backend/Dockerfile
@@ -231,7 +252,7 @@ services:
 
   # ---------- Strategy Agent (autonomous portfolio runner) ----------
   agent:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+    image: ${COMPOSE_PROJECT_NAME:-archimedes}-backend:local
     build:
       context: .
       dockerfile: backend/Dockerfile
@@ -278,7 +299,7 @@ services:
 
   # ---------- Backend API ----------
   backend:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+    image: ${COMPOSE_PROJECT_NAME:-archimedes}-backend:local
     build:
       context: .
       dockerfile: backend/Dockerfile
@@ -358,7 +379,7 @@ services:
   #
   # #1043 — gated behind the `runners` profile; see the file-header note.
   kb-runner:
-    image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+    image: ${COMPOSE_PROJECT_NAME:-archimedes}-backend:local
     profiles: ["runners"]
     build:
       context: .


### PR DESCRIPTION
## What

A fresh-clone `docker compose up` can no longer resolve to a production image. Every app-tier service in `docker-compose.yml` now resolves to a **project-scoped, registry-less** tag; the ECR pull path moves to a new opt-in overlay, `docker-compose.ecr.yml`, that **requires** `ECR_REGISTRY` and `IMAGE_TAG` to be set explicitly.

```diff
- image: ${ECR_REGISTRY:-037613907429.dkr.ecr.us-east-1.amazonaws.com}/archimedes-backend:${IMAGE_TAG:-latest}
+ image: ${COMPOSE_PROJECT_NAME:-archimedes}-backend:local
```

`build:` stays authoritative locally. This is leak 3 of #1044.

## Why — two live failure modes, both reproduced on a real machine, not simulated

Neither `ECR_REGISTRY` nor `IMAGE_TAG` was defined anywhere in `.env.example`, so the baked-in defaults always won on a fresh clone.

**1. A local run reached the production registry.** Reproduced from a clean worktree, `cp .env.example .env` and nothing else:

```
$ env | grep -E "^(ECR_REGISTRY|IMAGE_TAG)=" ; echo "(none set)"
(none set)

$ docker compose config --images
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
redis:7-alpine
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-nginx:latest
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-auth:latest
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
postgres:18-alpine

$ docker compose pull auth
 Image 037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-auth:latest Pulling
 ... unexpected status from HEAD request to
     https://037613907429.dkr.ecr.us-east-1.amazonaws.com/v2/archimedes-auth/manifests/latest: 403 Forbidden
```

That is a **real network request to the production registry from a local dev run**. It 403s only because this machine happens not to be ECR-authenticated right now. An authenticated machine — which our own onboarding tells people to set up — gets a 200 and runs the last image CI pushed to prod.

**2. Cross-checkout tag theft — worse than the issue describes, and happening on this machine today.** `build:` tags the image with whatever `image:` names, and image tags are machine-global while compose projects are not. Every worktree therefore built into the *same* tag, so the last checkout to run `--build` silently owned it.

Demonstrated by running a bare `docker compose create` — **no `--build`** — from this branch's worktree:

```
$ git rev-parse --abbrev-ref HEAD
dbrowneup/1044-b3-image-guard

$ docker compose create backend          # bare, NO --build
 Container wt-1044-b3-image-backend-1 Creating
 Container wt-1044-b3-image-backend-1 Created     # <- note: no "Building" step

### what my worktree just created:
container image     = sha256:c56ab2f1097845cc42d2eaa01bf4a23ed1dd90dcc3eed08402ba7f12b9a1cb8b
image ref           = 037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest

### who actually BUILT that image:
built by project    = wt-int2-1626
```

Compose did not build. It silently adopted an image built minutes earlier by **a different PR's worktree** (`wt-int2-1626`, PR #1626) and created a container on it. No ECR auth, no network, no warning — the operator believes they are running their own branch. During this session the tag changed owners twice in ~15 minutes as sibling worktrees rebuilt.

The mechanism, isolated:

```
===== PRE-FIX (origin/main), same file, two different projects =====
wt-alice   -> 037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
wt-bob     -> 037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest

===== POST-FIX (this branch), two different projects =====
wt-alice   -> wt-alice-backend:local
wt-bob     -> wt-bob-backend:local
```

## Why removing the registry default is now free

The `image:` keys have **no consumer in CI or production**. Since the Fargate cutover:

- `deploy.yml` registers ECS task definitions with explicit image URIs (`jq --arg backend_image "$ECR_REGISTRY/$BACKEND_ECR_REPO:${{ github.sha }}"`) and sets its own workflow-level `ECR_REGISTRY`. It never invokes compose.
- `deploy-runners.yml` uses raw `docker pull` / `docker tag` / `systemctl restart` over SSM.
- `docker compose up|pull` appears in **zero** workflow steps. The only remaining mentions in `deploy.yml` were two stale comments describing the retired EC2 path — corrected here (comment-only).

## Post-fix behaviour, verified with real compose

```
$ docker compose config --images                       # local default
wt-1044-b3-image-auth:local
wt-1044-b3-image-backend:local
...

$ docker compose pull auth                             # can it still reach ECR?
 Image wt-1044-b3-image-auth:local Pulling
 Image wt-1044-b3-image-auth:local pull access denied for wt-1044-b3-image-auth,
   repository does not exist or may require 'docker login'
 WARNING: Some service image(s) must be built from source by running:
     docker compose build auth
```

No ECR host is contacted at all. And the required behaviour — **bare up now builds locally instead of pulling**:

```
$ docker compose create auth          # bare, NO --build (post-fix)
 Image wt-1044-b3-image-auth:local Pulling
 Image wt-1044-b3-image-auth:local pull access denied ...
 Image wt-1044-b3-image-auth:local Building
 Image wt-1044-b3-image-auth:local Built
 Container wt-1044-b3-image-auth-1 Created

### the container my worktree created:
image ref = wt-1044-b3-image-auth:local
### that image was built by:
project   = wt-1044-b3-image        <- this worktree, not a sibling
### the prod tag is untouched and unreferenced:
prod tag  = sha256:15d9574492fa... (created 2026-08-24)
```

The pull path survives, behind two gates (name the overlay **and** set both vars):

```
$ COMPOSE_FILE=docker-compose.yml:docker-compose.ecr.yml docker compose config --images   # vars UNSET
error while interpolating services.oracle.image: required variable ECR_REGISTRY is
  missing a value: set ECR_REGISTRY to use the ECR overlay

$ ECR_REGISTRY=037613907429.dkr.ecr.us-east-1.amazonaws.com IMAGE_TAG=873fa26b  <same command>
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-auth:873fa26b
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:873fa26b
037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-nginx:873fa26b
```

## Adversarial guard demo — every guard shown REJECTING a bad input

New guard: `backend/tests/test_compose_no_prod_image_default.py`. Pure YAML + a POSIX-subset interpolator, **no docker daemon**, so it runs in the default unit sweep.

### Step 1 — written first, run against unmodified `origin/main`. It must fail, and it does, naming all seven services.

```
$ pytest backend/tests/test_compose_no_prod_image_default.py -q     # on origin/main
E   AssertionError: docker-compose.yml resolves to production ECR images on a fresh clone
    (ECR_REGISTRY and IMAGE_TAG unset). A bare `docker compose up` — no --build — pulls and
    runs the last image CI pushed to prod instead of the developer's working tree
    (#1044 leak 3). Offending services:
E       agent:     037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
E       auth:      037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-auth:latest
E       backend:   037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
E       kb-runner: 037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
E       migrate:   037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest
E       nginx:     037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-nginx:latest
E       oracle:    037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:latest

E   AssertionError: these built services use a machine-global image tag, so a build in one
    worktree overwrites the tag every other checkout resolves (#1044).
E       [same seven services]

E   AssertionError: docker-compose.production.yml bakes the prod registry in as a default
E       auth / backend / nginx

7 failed, 11 passed
```

### Step 2 — each guard shown rejecting a purpose-built bad input, after the fix

**Mutation 1 — drop the project scoping (re-introduce a machine-global tag):**
```
E   AssertionError: these built services use a machine-global image tag, so a build in one
    worktree overwrites the tag every other checkout resolves (#1044). Scope it with
    ${COMPOSE_PROJECT_NAME:-archimedes} or drop the `image:` key:
E       agent: archimedes-backend:local
E       auth:  archimedes-auth:local
E       ... (6 services)
FAILED test_locally_built_images_are_scoped_per_compose_project
```

**Mutation 2 — put a registry back, disguised as a *different* AWS account** (proves the guard is not just grepping our account number):
```
E   AssertionError: docker-compose.yml resolves to production ECR images on a fresh clone ...
E       backend: 999999999999.dkr.ecr.eu-west-2.amazonaws.com/archimedes-backend:latest
FAILED test_base_compose_never_defaults_to_a_remote_registry_image
FAILED test_base_compose_images_are_unresolvable_on_any_registry
```

**Mutation 3 — give the ECR overlay a silent default instead of `:?`. THIS ONE CAUGHT A HOLE IN MY OWN GUARD.**

First run: the mutation **passed** — 18/18 green on a file that had just re-armed the production registry default. The test asserted "unset everything → raises", which still raised because the *other* variable (`IMAGE_TAG`) was still `:?`-required. Classic weak guard: it proved *something* was required, not that *each* variable was.

Strengthened to withhold each referenced variable individually with every sibling supplied, then re-run:
```
E   Failed: migrate: ECR_REGISTRY is unset yet the image ref still resolved, to
    '037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:placeholder'.
    Every variable in the ECR overlay must use the `:?` (required) form — a `:-` default
    here is how a forgotten variable turns into a silent production pull.
FAILED test_ecr_override_fails_loudly_when_any_single_var_is_unset
```

**Mutation 4 — arm `ECR_REGISTRY` in `.env.example` (uncomment it):**
```
E   AssertionError: .env.example sets ECR_REGISTRY for real; it must stay commented out so a
    `cp .env.example .env` cannot turn on the registry pull path
FAILED test_env_example_documents_the_opt_in_but_does_not_arm_it
```

**Mutation 5 — drop `kb-runner` from the ECR overlay** (the over-correction guard: opting in must not silently no-op for a service):
```
E   AssertionError: docker-compose.ecr.yml does not cover every buildable service in
    docker-compose.yml; `docker compose pull` would silently no-op for ['kb-runner']
FAILED test_ecr_override_restores_registry_qualified_refs
```

**Restored → `18 passed`.** The interpolator itself has 11 self-check cases (`${A:-d}`, `${A:+p}`, `${A-d}`, `$$A`, nesting, `:?`), because a guard whose engine is wrong proves nothing.

## Files

| File | Change |
|---|---|
| `docker-compose.yml` | 7 `image:` lines → `${COMPOSE_PROJECT_NAME:-archimedes}-<svc>:local`; header comment rewritten (its claims about `docker compose pull` and "deploy.yml runs `docker compose up -d` against it" were false post-Fargate) |
| `docker-compose.ecr.yml` | **new** — opt-in ECR overlay, `:?`-required vars, `pull_policy: always` so an unreachable registry fails loudly instead of silently falling back to a local build |
| `docker-compose.production.yml` | 3 `image:` lines → `${ECR_REGISTRY:+${ECR_REGISTRY}/}archimedes-<svc>:${IMAGE_TAG:-local}` (`:+`, so the prefix appears only on explicit intent); comment records that the file is unused |
| `.env.example` | **+27 lines, 0 deletions** — new `ECR_REGISTRY`/`IMAGE_TAG` block, both **commented out**, inserted immediately after `COMPOSE_PROFILES=localdb` (line 42) per the agreed shared-file protocol; no reflow, no other hunk |
| `.github/workflows/deploy.yml` | **comment-only.** Two stale comments asserting a compose-based deploy target that no longer exists |
| `backend/tests/test_compose_no_prod_image_default.py` | **new** — the guard above |

## Owner decisions — flagged, not silently taken

1. **Shape.** The issue prescribed `image: ${ECR_REGISTRY:+${ECR_REGISTRY}/}archimedes-backend:${IMAGE_TAG:-local}`. That kills leak (1) but **not** leak (2) — it still leaves one shared tag per machine, so the cross-worktree theft reproduced above survives it. I went further in `docker-compose.yml`: registry-less **and** project-scoped, which kills both, and is free because nothing in CI or prod consumes these keys. I applied the issue's original `:+` shape to `docker-compose.production.yml`, where it fits. **Veto the base-file scoping and I'll fall back to the narrower `:+` shape there too.**
2. **`docker-compose.production.yml` — adopt or delete.** Still unused (your 2026-07-07 comment). The scout brief recommended deleting it. **I did not**, because `docs/operations/feature-flag-fliplist.md:38`, `docs/database-architecture.md:275`, and `docs/runbooks/t3.2-contract-redeploy.md` all link to it, and deleting would break the docs link check — that call belongs with the doc work, not here. It is neutered against the leak either way. Your call.
3. **`.env.example` and CI wiring** are both "ask before acting" surfaces in CLAUDE.md. The edits here are prescribed by this issue (owner-promoted), the `.env.example` change is a pure insertion in the block the shared-file protocol assigns to B3, and the `deploy.yml` change is comment-only. Flagging rather than assuming.

## Not in scope

Leaks 1 (ollama honesty), 2 (SSM prefix), and 4 (the local-vs-prod doc) are separate branches on this issue. No anvil / local-chain work. Nothing merged.

## Tests

Rebased onto current `main` (`848673e0`) before running — the original base, `873fa26b`, predates #1673.

```
$ pytest -m "not integration" -q          # from the worktree root
1 failed, 5054 passed, 3 skipped, 2 deselected, 297 warnings in 1668.80s (0:27:48)

FAILED backend/tests/test_health_always_answers.py::TestTheEndpointAlwaysAnswers
       ::test_health_answers_within_budget_when_the_oracle_probe_hangs_forever
       - AssertionError: /health took 2.09s with a hanging oracle probe
```

**That failure is pre-existing on `main` and is not caused by this branch.** This diff contains **zero Python runtime code** — compose YAML, `.env.example`, two `deploy.yml` comments, and one new test file — so it cannot affect `/health` latency. Verified rather than asserted, by running the same test in a **separate pristine `origin/main` worktree with my changes absent**:

```
$ cd wt-1044-b3-baseline && git status --short && git log --oneline -1
848673e0 Merge pull request #1673 from a-apin/dbrowneup/alarm-pin-retune     # clean tree

$ pytest "…::test_health_answers_within_budget_when_the_oracle_probe_hangs_forever" -q
FAILED … - AssertionError: /health took 3.02s with a hanging oracle probe
1 failed
```

It fails on unmodified `main`, and *worse* there (3.02s vs 2.09s). It is a wall-clock budget assertion and this box was at **load average ~120-145** from parallel sessions throughout, so some of it is contention — but it also matches the residual the #1044 scout identified for the ollama branch: `/health`'s LLM probe is an unbounded synchronous `httpx.get` inside an `async def`, outside `health_probe_cache`, contradicting the handler's own docstring at `main.py:818-826`. That fix belongs to the B1 branch on this issue, not here.

An earlier full run on the pre-rebase base also flagged `test_cloudwatch_alarms.py::TestAntiGoals::test_the_oracle_stale_alarm_is_untouched`; that one was fixed by #1673 and passes after the rebase.

Part of #1044
