### PR TITLE
[perf][explore] Read only the pushed oracles, concurrently; make the TTL outlast the rebuild

### DIFF
--- a/backend/archimedes/services/asset_market_service.py
+++ b/backend/archimedes/services/asset_market_service.py
@@ -2,10 +2,11 @@
 
 Primary price source: on-chain ``PriceOracle.getPrice(token)`` via ``chain_client``.
 Fall back to yfinance histories for change windows / vol and as a price
-fallback when the oracle is stale or unavailable.  30-second TTL cache
-(per the Phase 3a spec — page must load <1s without synchronous on-chain
-reads on cache hit). The plain-English explanations live in this module so
-the route handler stays a thin facade.
+fallback when the oracle is stale or unavailable.  Cached under
+``_CACHE_TTL_SECONDS`` (per the Phase 3a spec — page must load <1s without
+synchronous on-chain reads on cache hit); that TTL is required to exceed the
+rebuild budget, see the constant. The plain-English explanations live in this
+module so the route handler stays a thin facade.
 
 Universe (aligned 2026-07 — #759 follow-up to PR #842): the listing iterates
 the **deploy-eligible SSOT universe** (``archimedes.universe.ON_CHAIN_SYNTHS``,
@@ -22,8 +23,9 @@ follow-up requests converge to full coverage.
 
 Staleness semantics (rebuilt 2026-05-25 — see Explore page rebuild):
 The on-chain ``PriceOracle`` is only actively pushed for a small subset of
-synths (those in ``OracleUpdater.YFINANCE_MAP`` / ``CRYPTO_MAP`` — currently
-~9 symbols). The rest of the universe has an
+synths (those in ``OracleUpdater.YFINANCE_MAP`` / ``CRYPTO_MAP``, derived by
+``oracle_health._push_set_symbols`` — 2 of the 281 as of 2026-08, never
+hard-coded here). The rest of the universe has an
 oracle slot allocated but no one calls ``setPrice()`` for it. Flagging those
 assets as "STALE" when in fact the displayed price comes from yfinance is
 misleading — the *displayed* price isn't stale; an unused oracle slot is. So
@@ -50,15 +52,26 @@ from archimedes.api.explore_schemas import (
 logger = logging.getLogger(__name__)
 
 
-_CACHE_TTL_SECONDS = 30
+# Cache TTL for the composed Explore payload. It MUST stay strictly greater
+# than the worst-case rebuild cost (_ORACLE_TOTAL_BUDGET_SECONDS +
+# _HISTORY_FETCH_BUDGET_SECONDS, both below) — otherwise a cache entry is
+# already expired by the time the rebuild that produced it returns, every
+# subsequent request re-kicks a background refresh, and the refresher runs
+# essentially continuously on every task. That is what 30s-against-a-57s-budget
+# was doing in prod (#1664; the docstring below records 12.7-42.9s measured
+# rebuilds). The *invariant* is the thing under guard, not this literal — see
+# ``test_cache_ttl_exceeds_rebuild_budget``, which re-derives it from the two
+# budget constants so a future budget edit cannot silently re-open the hole.
+_CACHE_TTL_SECONDS = 120
 _HISTORY_LOOKBACK = "3mo"  # enough for 30d realized vol + change windows
 _STALE_WINDOW_SECONDS = 5 * 60  # >5 min since oracle push → "stale" (per issue #168)
 _YF_STALE_WINDOW_SECONDS = 4 * 24 * 60 * 60  # yfinance daily-close → stale if >4 days old
 _ORACLE_READ_TIMEOUT = 5  # seconds per individual chain read
-# Total budget across ALL sequential oracle reads. With the ~280-synth SSOT
-# universe, an unresponsive RPC at 5s/read would otherwise stall the request
-# for minutes; symbols past the deadline are skipped (their card falls back
-# to yfinance / "none").
+# Aggregate budget across ALL oracle reads for one rebuild. Since #1664 the
+# reads are narrowed to the pushed set and run concurrently, so this is a
+# backstop rather than the expected cost — it bounds the whole fan-out to one
+# round-trip window even if the candidate set grows. Symbols not read by the
+# deadline are skipped (their card falls back to yfinance / "none").
 _ORACLE_TOTAL_BUDGET_SECONDS = 12.0
 # yfinance history fetch: chunked batch calls under one total budget. Chunks
 # keep each yf.download() call bounded so a slow upstream loses at most one
@@ -542,7 +555,10 @@ def _ssot_display_name(synth: str, fallback: str) -> str:
 
 
 class AssetMarketService:
-    """Composes per-synth market stats from on-chain oracle + histories. 30s TTL cache."""
+    """Composes per-synth market stats from on-chain oracle + histories.
+
+    Cached for ``_CACHE_TTL_SECONDS``, stale-while-revalidate.
+    """
 
     def __init__(self) -> None:
         self._cache: ExploreAssetsResponse | None = None
@@ -561,21 +577,50 @@ class AssetMarketService:
         self,
         synth_symbols: list[str],
     ) -> dict[str, dict[str, Any]]:
-        """Read current prices from on-chain PriceOracle for each synth.
+        """Read current prices from on-chain PriceOracle for the *pushed* synths.
 
         Returns ``{symbol: {price: float, updated_at: int, stale: bool}}``.
         Symbols missing from oracle config or failing chain reads are omitted.
-        Reads run sequentially under ``_ORACLE_TOTAL_BUDGET_SECONDS``; symbols
-        past the deadline are skipped (yfinance covers their card instead).
+
+        Fan-out (#1664). This used to walk the whole ~281-symbol SSOT universe
+        serially, issuing a ``getPrice`` per symbol into Arc RPC on every
+        rebuild — for a slot that nobody calls ``setPrice()`` on, so the read
+        returns nothing usable and the card falls through to yfinance anyway
+        (see the module docstring's staleness note). At a rebuild running
+        essentially continuously that is the single largest RPC consumer in the
+        app and a candidate source of the observed ``rpc.testnet.arc.network``
+        429 wave, which in turn stalls ``oracle_health`` and gets healthy tasks
+        killed by the /health check.
+
+        So the candidate set is narrowed BEFORE any read: a symbol must be in
+        the requested universe **and** have both an oracle and a synth address
+        configured **and** be in the updater's actually-pushed set. Today that
+        resolves to ``{"sSPY", "sBTC"}`` — 2 reads, not 281. The push set is
+        *derived* on every call from ``oracle_updater``'s maps rather than
+        hard-coded, so adding a pushed symbol lands here with no edit; this
+        mirrors ``services/oracle_health.py``'s probe, which is the precedent
+        for "probe the push set, not the universe."
+
+        The survivors then run CONCURRENTLY under one aggregate deadline
+        (``_ORACLE_TOTAL_BUDGET_SECONDS``), each read still capped by
+        ``_ORACLE_READ_TIMEOUT``, so the worst case is one bounded round-trip
+        window instead of reads x timeout. Partial results are kept and served
+        honestly if the aggregate deadline does fire; unread symbols fall
+        through to yfinance exactly as before, so ``price_source`` semantics
+        are unchanged.
         """
         try:
             import json
             from pathlib import Path
 
             from archimedes.chain.client import chain_client
+            from archimedes.services.oracle_health import _push_set_symbols
 
             oracle_addrs = chain_client.settings.oracle_addresses or {}
             synth_addrs = chain_client.settings.synth_addresses or {}
+            # Read-only reuse of oracle_health's derivation so the two surfaces
+            # cannot drift to different ideas of "which oracles are live".
+            pushed = set(_push_set_symbols())
 
             # Resolve ABI path — try multiple locations (repo root, relative)
             abi_candidates = [
@@ -595,55 +640,76 @@ class AssetMarketService:
             logger.warning("explore: IPriceOracle ABI not found")
             return {}
 
+        # Narrow BEFORE reading: universe ∩ configured-addresses ∩ pushed set.
+        # getPrice takes the synth token address, called on the oracle contract,
+        # so both addresses have to resolve for a read to be possible at all.
+        candidates = [
+            symbol
+            for symbol in synth_symbols
+            if symbol in pushed and oracle_addrs.get(symbol) and synth_addrs.get(symbol)
+        ]
+        logger.debug(
+            "explore: oracle read fan-out %d/%d symbols (pushed ∩ configured)",
+            len(candidates),
+            len(synth_symbols),
+        )
+        if not candidates:
+            return {}
+
         results: dict[str, dict[str, Any]] = {}
         now_ts = time.time()
-        deadline = time.monotonic() + _ORACLE_TOTAL_BUDGET_SECONDS
 
-        for i, symbol in enumerate(synth_symbols):
-            oracle_addr = oracle_addrs.get(symbol)
-            synth_addr = synth_addrs.get(symbol)
-            # getPrice takes the synth token address, called on the oracle contract
-            if not oracle_addr or not synth_addr:
-                continue
-            if time.monotonic() > deadline:
-                logger.warning(
-                    "explore: oracle read budget exhausted after %d/%d symbols (%d priced)",
-                    i,
-                    len(synth_symbols),
-                    len(results),
-                )
-                break
+        async def _read_one(symbol: str) -> None:
+            """Read one oracle, recording into ``results`` on success.
+
+            Writes as a side effect (rather than returning) so that partial
+            coverage survives an aggregate-deadline cancellation: whatever
+            landed before the timeout is still served.
+            """
+            oracle_addr = oracle_addrs[symbol]
+            synth_addr = synth_addrs[symbol]
             try:
                 contract = chain_client.w3.eth.contract(
                     address=chain_client.to_checksum(oracle_addr),
                     abi=oracle_abi,
                 )
-                # Bound each read by BOTH the per-read cap and the remaining
-                # total budget — otherwise a read started near the deadline can
-                # overshoot the endpoint budget by up to _ORACLE_READ_TIMEOUT.
-                remaining = deadline - time.monotonic()
                 price_raw, updated_at = await asyncio.wait_for(
                     contract.functions.getPrice(chain_client.to_checksum(synth_addr)).call(),
-                    timeout=max(0.1, min(_ORACLE_READ_TIMEOUT, remaining)),
+                    timeout=_ORACLE_READ_TIMEOUT,
                 )
-                price_usd = float(price_raw) / 1e6  # 6 decimals per PriceOracle.sol
-                # A future updated_at (block time ahead of the host clock) is
-                # anomalous: normal block timestamps are ≤ wall clock, and a
-                # timestamp in the future would leave the age permanently
-                # negative — masking genuine staleness forever. Treat any
-                # future timestamp as stale rather than "fresh" (#934).
-                age = now_ts - updated_at
-                stale = age < 0 or age > _STALE_WINDOW_SECONDS
-                results[symbol] = {
-                    "price": price_usd,
-                    "updated_at": updated_at,
-                    "stale": stale,
-                    "oracle_address": oracle_addr,
-                }
             except TimeoutError:
                 logger.debug("explore: oracle read timeout for %s", symbol)
+                return
             except Exception as exc:
                 logger.debug("explore: oracle read failed for %s: %s", symbol, exc)
+                return
+            price_usd = float(price_raw) / 1e6  # 6 decimals per PriceOracle.sol
+            # A future updated_at (block time ahead of the host clock) is
+            # anomalous: normal block timestamps are ≤ wall clock, and a
+            # timestamp in the future would leave the age permanently
+            # negative — masking genuine staleness forever. Treat any
+            # future timestamp as stale rather than "fresh" (#934).
+            age = now_ts - updated_at
+            stale = age < 0 or age > _STALE_WINDOW_SECONDS
+            results[symbol] = {
+                "price": price_usd,
+                "updated_at": updated_at,
+                "stale": stale,
+                "oracle_address": oracle_addr,
+            }
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(_read_one(symbol) for symbol in candidates)),
+                timeout=_ORACLE_TOTAL_BUDGET_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "explore: oracle read budget (%.1fs) exhausted — %d/%d symbols priced",
+                _ORACLE_TOTAL_BUDGET_SECONDS,
+                len(results),
+                len(candidates),
+            )
 
         return results
 
@@ -704,16 +770,18 @@ class AssetMarketService:
         """Serve the asset list, stale-while-revalidate (#explore-latency).
 
         The old shape awaited the full oracle+yfinance rebuild inline on
-        every cache miss: whichever request landed just after the 30s TTL
+        every cache miss: whichever request landed just after the TTL
         expired paid that cost synchronously. Measured in prod (2026-08-02):
         12.7s-42.9s per rebuild. The oracle read alone accounts for up to
         ``_ORACLE_TOTAL_BUDGET_SECONDS`` of that, and it is spent whether or
-        not any price comes back: ``_read_oracle_prices`` runs its reads
-        sequentially under that budget and simply OMITS symbols that fail or
-        run past the deadline, so a fully unresponsive oracle costs the entire
-        budget and returns nothing.
+        not any price comes back: ``_read_oracle_prices`` simply OMITS symbols
+        that fail or run past the deadline, so a fully unresponsive oracle
+        costs the entire budget and returns nothing.
         That is the whole "Explore takes a long time to load" symptom for
-        an unlucky visitor.
+        an unlucky visitor. (#1664 attacked the other half of the same
+        problem: the TTL was shorter than that rebuild, so the background
+        refresher never got to rest, and the read fanned out across the whole
+        universe instead of the ~2 pushed oracles.)
 
         Fix: once a cache exists at all, NEVER block a request behind a
         rebuild. A stale cache is served immediately and a rebuild is

--- a/backend/tests/services/test_asset_market_service.py
+++ b/backend/tests/services/test_asset_market_service.py
@@ -27,6 +27,8 @@ from archimedes.services.asset_market_service import (
     _CACHE_TTL_SECONDS,
     _CRYPTO_TRADING_DAYS_PER_YEAR,
     _EQUITY_TRADING_DAYS_PER_YEAR,
+    _HISTORY_FETCH_BUDGET_SECONDS,
+    _ORACLE_TOTAL_BUDGET_SECONDS,
     AssetMarketService,
     _bar_timestamp,
     _change_window,
@@ -1242,3 +1244,152 @@ class TestServedItemCarriesItsChangeWindow:
         assert spy.change_24h_pct is not None
         assert spy.change_window_hours is None
         assert spy.change_window_label is None
+
+
+# ── #1664: oracle fan-out width + TTL-vs-rebuild invariant ────────────────
+
+
+def _wide_chain_client(symbols: list[str]):
+    """A mock chain_client with an oracle AND synth address for every symbol.
+
+    Deliberately configures *all* of them: that makes the address filter alone
+    unable to narrow anything, so a passing fan-out test can only be passing
+    because of the push-set intersection.
+    """
+    from pathlib import Path
+
+    mock_settings = MagicMock()
+    mock_settings.oracle_addresses = {s: f"0xo{i:039x}" for i, s in enumerate(symbols)}
+    mock_settings.synth_addresses = {s: f"0xs{i:039x}" for i, s in enumerate(symbols)}
+    mock_settings.abi_dir = str(Path(__file__).resolve().parents[2] / "contracts" / "abis")
+
+    mock_client = MagicMock()
+    mock_client.settings = mock_settings
+    mock_client.to_checksum = lambda addr: addr
+    return mock_client
+
+
+class TestOracleFanOut:
+    """#1664 — Explore must read the pushed oracles, not the whole universe.
+
+    The prod shape walked ~281 SSOT symbols serially on every rebuild, and the
+    rebuild ran essentially continuously because the cache TTL was shorter than
+    the rebuild budget. Both halves are pinned here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reads_only_the_pushed_intersection_not_the_universe(self):
+        """A 300-symbol universe with a 3-symbol push set → exactly 3 getPrice calls.
+
+        Adversarial check: drop the ``symbol in pushed`` clause from
+        ``_read_oracle_prices``' candidate comprehension and this reports 300.
+        """
+        universe = [f"sSYM{i:03d}" for i in range(300)]
+        pushed_equity = {"sSYM007": "SYM7", "sSYM100": "SYM100", "^GSPC": "^GSPC"}
+        pushed_crypto = {"sSYM250": "some-coin"}
+
+        service = AssetMarketService()
+        mock_contract = MagicMock()
+        mock_contract.functions.getPrice.return_value.call = AsyncMock(
+            return_value=(100_000_000, int(time.time())),
+        )
+        mock_client = _wide_chain_client(universe)
+        mock_client.w3 = MagicMock()
+        mock_client.w3.eth.contract.return_value = mock_contract
+
+        with (
+            patch("archimedes.chain.client.chain_client", mock_client),
+            patch("archimedes.chain.oracle_updater.YFINANCE_MAP", pushed_equity),
+            patch("archimedes.chain.oracle_updater.CRYPTO_MAP", pushed_crypto),
+        ):
+            result = await service._read_oracle_prices(universe)
+
+        assert mock_contract.functions.getPrice.call_count == 3, (
+            f"expected 3 chain reads (the push set), got "
+            f"{mock_contract.functions.getPrice.call_count} for a 300-symbol universe"
+        )
+        assert set(result) == {"sSYM007", "sSYM100", "sSYM250"}
+        # ^GSPC is in YFINANCE_MAP but is a regime-signal index, never a synth
+        # and never pushed on-chain — it must not become a read.
+        assert "^GSPC" not in result
+
+    @pytest.mark.asyncio
+    async def test_pushed_symbol_without_addresses_is_not_read(self):
+        """Push-set membership alone is not enough — the addresses must resolve."""
+        universe = ["sSPY", "sBTC"]
+        service = AssetMarketService()
+        mock_contract = MagicMock()
+        mock_contract.functions.getPrice.return_value.call = AsyncMock(
+            return_value=(100_000_000, int(time.time())),
+        )
+        mock_client = _wide_chain_client(universe)
+        del mock_client.settings.synth_addresses["sBTC"]  # oracle configured, synth not
+        mock_client.w3 = MagicMock()
+        mock_client.w3.eth.contract.return_value = mock_contract
+
+        with (
+            patch("archimedes.chain.client.chain_client", mock_client),
+            patch("archimedes.chain.oracle_updater.YFINANCE_MAP", {"sSPY": "SPY"}),
+            patch("archimedes.chain.oracle_updater.CRYPTO_MAP", {"sBTC": "bitcoin"}),
+        ):
+            result = await service._read_oracle_prices(universe)
+
+        assert mock_contract.functions.getPrice.call_count == 1
+        assert set(result) == {"sSPY"}
+
+    @pytest.mark.asyncio
+    async def test_reads_run_concurrently_not_serially(self):
+        """Five 0.1s reads must cost ~one round trip, not five.
+
+        Adversarial check: replace the ``asyncio.gather`` with a ``for`` loop
+        that awaits ``_read_one`` per symbol and the elapsed time crosses 0.5s.
+        """
+        universe = [f"sSYM{i:03d}" for i in range(5)]
+        read_delay = 0.1
+
+        async def _slow_read(*_args, **_kwargs):
+            await asyncio.sleep(read_delay)
+            return (100_000_000, int(time.time()))
+
+        service = AssetMarketService()
+        mock_contract = MagicMock()
+        mock_contract.functions.getPrice.return_value.call = AsyncMock(side_effect=_slow_read)
+        mock_client = _wide_chain_client(universe)
+        mock_client.w3 = MagicMock()
+        mock_client.w3.eth.contract.return_value = mock_contract
+
+        with (
+            patch("archimedes.chain.client.chain_client", mock_client),
+            patch("archimedes.chain.oracle_updater.YFINANCE_MAP", {s: s for s in universe}),
+            patch("archimedes.chain.oracle_updater.CRYPTO_MAP", {}),
+        ):
+            started = time.monotonic()
+            result = await service._read_oracle_prices(universe)
+            elapsed = time.monotonic() - started
+
+        assert len(result) == 5, "all five reads must still land"
+        serial_cost = read_delay * len(universe)
+        assert elapsed < serial_cost / 2, (
+            f"reads took {elapsed:.3f}s; serial would be ~{serial_cost:.1f}s — fan-out is not concurrent"
+        )
+
+
+class TestCacheTtlInvariant:
+    def test_cache_ttl_exceeds_rebuild_budget(self):
+        """The TTL must outlast the worst-case rebuild it caches (#1664).
+
+        Asserted as an invariant over the two budget constants, not against the
+        literal 120, so a future budget increase re-trips this instead of
+        silently restoring the always-refreshing state: a TTL shorter than the
+        rebuild means every entry is born expired, every request re-kicks a
+        background refresh, and the refresher never rests.
+        """
+        rebuild_budget = _ORACLE_TOTAL_BUDGET_SECONDS + _HISTORY_FETCH_BUDGET_SECONDS
+        # Written budget-first only to satisfy ruff's SIM300 (it reads the
+        # SCREAMING_CASE side as a literal); the invariant is unchanged —
+        # _CACHE_TTL_SECONDS > oracle budget + history budget.
+        assert rebuild_budget < _CACHE_TTL_SECONDS, (
+            f"cache TTL {_CACHE_TTL_SECONDS}s must exceed the worst-case rebuild "
+            f"budget {rebuild_budget}s (oracle {_ORACLE_TOTAL_BUDGET_SECONDS}s + "
+            f"history {_HISTORY_FETCH_BUDGET_SECONDS}s)"
+        )


### PR DESCRIPTION
## What

Two coupled changes in `backend/archimedes/services/asset_market_service.py`, nothing else:

1. `_CACHE_TTL_SECONDS` 30 → **120**, so the TTL outlasts the rebuild it caches.
2. `_read_oracle_prices` narrows its candidate set to `universe ∩ configured-addresses ∩ the updater's pushed set` **before** the loop, then runs the survivors under one `asyncio.gather` instead of awaiting them serially.

Net effect per rebuild: **~281 serial `getPrice` calls into Arc RPC → 2 concurrent ones**, and the rebuild stops running essentially continuously.

## Why

Closes #1664.

`_CACHE_TTL_SECONDS = 30` was set against a rebuild budgeted at up to **57 s** (`_ORACLE_TOTAL_BUDGET_SECONDS` 12 s + `_HISTORY_FETCH_BUDGET_SECONDS` 45 s), and the service's own docstring records **12.7–42.9 s measured per rebuild** in prod. Every cache entry was therefore born already expired: each request found a stale cache, served it, and re-kicked a background refresh — so a refresh was in flight essentially all the time, on every task.

Each of those refreshes walked the whole ~281-symbol SSOT universe **serially**, issuing one `getPrice` per symbol. The overwhelming majority of those reads are for oracle slots nobody calls `setPrice()` on (the module docstring's own staleness note), so they returned nothing usable and the card fell through to yfinance anyway — after paying for the read. That is a continuous ~281-`eth_call`-per-cycle load for a result that prices 2 assets — and `ChainSettings.rpc_retries = 2` (`backend/archimedes/chain/client.py:164`) means the wire-level worst case is up to ~562 JSON-RPC requests per rebuild, which is the arithmetic that makes the 429 hypothesis plausible in the first place.

The push set is **derived** on every call from `oracle_updater`'s maps via `oracle_health._push_set_symbols`, not hard-coded here, so adding a pushed symbol lands automatically with no edit. That reuse (rather than a second local copy of the `startswith("s")` filter) is deliberate: the two surfaces must not drift to different ideas of which oracles are live. `services/oracle_health.py:215-228` is the precedent the issue cites — probe the push set, report honestly, don't walk the universe.

**`price_source` semantics are provably unchanged**, which is the part worth checking rather than taking on trust. The merge step only labels a card `price_source="oracle"` when `oracle_fresh` holds, and that requires `oracle_updated_at > 0 and (now - oracle_updated_at) <= _STALE_WINDOW_SECONDS` (300 s) — `asset_market_service.py:904-911`. A symbol outside the push set is by definition one nobody calls `setPrice()` on, so its slot can never carry a timestamp inside a 300 s window; every symbol I stopped reading was already falling through to the `elif hist_prices:` yfinance branch, after paying for a read that returned `(0, 0)`. The only theoretical exception is a symbol removed from `YFINANCE_MAP`/`CRYPTO_MAP` within the preceding 5 minutes, which self-corrects on the next refresh.

Partial results still survive an aggregate-deadline overrun: `_read_one` records into `results` as a side effect, so a `gather` cancellation keeps whatever had already landed.

## Issues

Closes #1664

## Verification

Env: `/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin` (Python 3.12.13).

### Acceptance commands

```
$ pytest backend/tests/ -k "asset_market or explore" -q
71 passed, 4975 deselected, 2 warnings in 11.79s

$ ruff check backend/archimedes/services/asset_market_service.py backend/tests/services/test_asset_market_service.py
All checks passed!
$ ruff format --check <same two files>
2 files already formatted

$ cd ui && npm test
ℹ tests 680
ℹ pass 680
ℹ fail 0
```

`ui/test/explore-data-disclosure.test.js` is inside that 680 and still holds — no `ui/` file is touched by this PR (see anti-goals below).

**The CI gate command, `pytest -m "not integration"`, run in chunks.** Five other builder sessions were running the same full suite on this box tonight (`ps -eo pid,command | grep "[n]o:cacheprovider"` showed runs from `wt-perf-1668`, `wt-1637-assoc`, `wt-1632-abandon`, `wt-1651-metrics`, `wt-1605-timeout`), which pushed a single whole-suite run past the tool's wall-clock ceiling. I split it by path instead. All chunks were run **after** the rebase onto `848673e0`:

| chunk | result |
| --- | --- |
| `backend/tests/{api,chain,marketplace,models,scripts,services}` | 1952 passed, 2 skipped, 1 deselected (5:04) |
| top-level files 1–33 | 399 passed (7:13) |
| top-level files 34–66 | 449 passed (2:23) |
| top-level files 67–132 | 895 passed, 1 skipped, 1 deselected, **1 failed** (7:39) |
| top-level files 133–196 | 1345 passed (6:51) |
| **total** | **5040 passed, 1 failed, 3 skipped, 2 deselected = 5046 collected / 5044 selected** — the exact counts a whole-suite `pytest -m "not integration"` collects, so the chunks cover the gate with nothing dropped |

**The one failure is pre-existing on `main` and is a wall-clock flake under that load, not my diff.** It is `test_health_always_answers.py::TestTheEndpointAlwaysAnswers::test_health_answers_within_budget_when_the_chain_client_hangs_forever` — a real-time assertion against a 2.0 s budget. My diff touches neither `/health` nor `oracle_health`, and that test patches *both* probes out with `_hangs_forever`, so no code path of mine executes in it. Paired run, same machine, same minute, my branch vs. a clean detached worktree at my exact base `848673e0`:

```
### ON MY BRANCH (249dcb19, base 848673e0)
FAILED ...::test_health_answers_within_budget_when_the_chain_client_hangs_forever
        - AssertionError: /health took 2.20s with a hanging chain client
FAILED ...::test_a_timed_out_probe_serves_the_last_known_value_with_its_age - assert 2.165 < 2.0
=================== 2 failed, 15 passed, 1 warning in 22.72s ===================

### ON CLEAN origin/main (848673e0), same machine, same minute
FAILED ...::test_health_answers_within_budget_when_the_chain_client_hangs_forever
        - AssertionError: /health took 3.48s with a hanging chain client
=================== 1 failed, 16 passed, 1 warning in 27.06s ===================
```

It fails **worse** on clean `main` (3.48 s) than on this branch (2.20 s), and which of the file's three timing assertions trips varies run to run. Flagging it rather than burying it: `test_health_always_answers.py` is not load-tolerant, and on a box running six suites at once it is red on `main` too. Not this PR's to fix, but somebody's.

**Base freshness (CLAUDE.md § "a stale PR's green check describes a base that no longer exists").** I branched at `b359f324`; `main` advanced to `848673e0` mid-run with `#1673` (`test_cloudwatch_alarms.py` only — the #1601 alarm-retune pin). That commit was red against my original base and green after, which is exactly the trap that rule describes. I rebased (linear, single non-overlapping test file, zero conflicts — the mechanical test says rebase, not merge) and re-ran **every** chunk on the new base; the table above is the post-rebase run.

### Adversarial demos (each guard shown to reject)

**1. The push-set intersection — revert it and the 300-symbol test reports 300.**

Patch applied to the working tree (candidate comprehension, `_read_oracle_prices`):

```
-            if symbol in pushed and oracle_addrs.get(symbol) and synth_addrs.get(symbol)
+            if oracle_addrs.get(symbol) and synth_addrs.get(symbol)
```

```
$ pytest backend/tests/services/test_asset_market_service.py -q -k "pushed_intersection or without_addresses"
E   AssertionError: expected 3 chain reads (the push set), got 300 for a 300-symbol universe
E   assert 300 == 3
FAILED ...::TestOracleFanOut::test_reads_only_the_pushed_intersection_not_the_universe
============ 1 failed, 1 passed, 66 deselected, 1 warning in 4.85s =============
```

The test configures an oracle **and** a synth address for all 300 symbols on purpose, so the address filter alone can narrow nothing — a pass can only come from the push-set intersection. `^GSPC` is put in `YFINANCE_MAP` in the same test and asserted absent, pinning the regime-signal-index exclusion.

**2. The `asyncio.gather` — revert to a serial loop and the timing test crosses the serial cost.**

```
-            await asyncio.wait_for(
-                asyncio.gather(*(_read_one(symbol) for symbol in candidates)),
-                timeout=_ORACLE_TOTAL_BUDGET_SECONDS,
-            )
+            for _sym in candidates:  # ADVERSARIAL: serial, not gather
+                await _read_one(_sym)
```

```
$ pytest backend/tests/services/test_asset_market_service.py -q -k "concurrently"
E   AssertionError: reads took 0.516s; serial would be ~0.5s — fan-out is not concurrent
E   assert 0.5163487074896693 < (0.5 / 2)
================= 1 failed, 67 deselected, 1 warning in 3.95s ==================
```

(Five mocked reads sleeping 0.1 s each. Concurrent it measures ~0.10 s — see the durations line in the green run.)

**3. The TTL invariant — put the literal back to 30 and it fails, naming both budgets.**

```
-_CACHE_TTL_SECONDS = 120
+_CACHE_TTL_SECONDS = 30
```

```
$ pytest backend/tests/services/test_asset_market_service.py -q -k "ttl"
E   AssertionError: cache TTL 30s must exceed the worst-case rebuild budget 57.0s (oracle 12.0s + history 45.0s)
E   assert 57.0 < 30
FAILED ...::TestCacheTtlInvariant::test_cache_ttl_exceeds_rebuild_budget
============ 1 failed, 1 passed, 66 deselected, 1 warning in 4.85s =============
```

That test asserts the **invariant**, re-derived from `_ORACLE_TOTAL_BUDGET_SECONDS + _HISTORY_FETCH_BUDGET_SECONDS`, not the literal 120 — so a future budget increase re-trips it instead of silently restoring the always-refreshing state. (It is written budget-first only to satisfy ruff `SIM300`, which reads the SCREAMING_CASE side as a literal; a comment on the line says so.)

All three reverts were undone and the tree restored before committing (`git diff` shows only the intended change).

### Anti-goal checks

```
$ git diff --name-only origin/main          # origin/main = 848673e0
backend/archimedes/services/asset_market_service.py
backend/tests/services/test_asset_market_service.py

$ git diff --name-only origin/main | grep '^ui/'
(no output)

$ grep -n "rigor_cache\|SharedCodec" backend/archimedes/services/asset_market_service.py
(no output)

$ grep -n "_kick_background_refresh" backend/archimedes/services/asset_market_service.py
797:            self._kick_background_refresh()
804:    def _kick_background_refresh(self) -> None:
```

Stale-while-revalidate is untouched — only the budgets and the fan-out width changed, per the issue.

## The post-deploy measurement — and what it closes

This PR's RPC-429 delta is **the closing measurement for the "Explore's refresher is feeding the `rpc.testnet.arc.network` 429 wave" hypothesis**, which is in turn the hypothesised cause of `oracle_health` stalling and the `/health`-driven task-kill spiral (i.e. *why Library is slow*). Explore was the only continuously-running ~281-call-per-cycle RPC consumer identified in the sprint, so if the 429 rate does not move, Explore is **exonerated** and the wave has another source — and that is a result worth recording, not a failure of this PR. The latency and cost wins (2 reads instead of 281, a refresher that rests) stand either way.

Acceptance target from the issue: **429 count over the 24 h after deploy drops ≥ 50 % vs. the 24 h before.**

Exact commands a reviewer runs post-deploy (log group `/archimedes/app`, defined at `infra/cloudwatch.tf:1116`; account `037613907429` / `us-east-1`):

```bash
# Set this to the deploy time (UTC) of the merge commit for this PR.
DEPLOY=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' '2026-09-01T00:00:00Z' +%s)   # macOS
# DEPLOY=$(date -u -d '2026-09-01T00:00:00Z' +%s)                          # GNU/Linux
DAY=86400

# Pre-deploy baseline: the 24 h ending at the deploy.
aws logs filter-log-events --log-group-name /archimedes/app \
  --start-time $(( (DEPLOY - DAY) * 1000 )) --end-time $(( DEPLOY * 1000 )) \
  --filter-pattern '"Too Many Requests"' \
  --query 'length(events)' --output text

# Post-deploy: the 24 h starting at the deploy. Run it 24 h after the merge.
aws logs filter-log-events --log-group-name /archimedes/app \
  --start-time $(( DEPLOY * 1000 )) --end-time $(( (DEPLOY + DAY) * 1000 )) \
  --filter-pattern '"Too Many Requests"' \
  --query 'length(events)' --output text
```

Use the same two windows in Logs Insights to split total 429s from the ones that name the Arc RPC host, which is what actually attributes the wave:

```bash
aws logs start-query --log-group-name /archimedes/app \
  --start-time $(( DEPLOY - DAY )) --end-time $DEPLOY \
  --query-string 'filter @message like /Too Many Requests/
                  | stats count() as all_429,
                          sum(@message like /rpc.testnet.arc.network/) as arc_rpc_429,
                          sum(@message like /explore:/) as explore_429'
# then: aws logs get-query-results --query-id <id>
```

Record both numbers in the issue thread whichever way they come out. Two honesty caveats on reading them:

- `filter-log-events` with `--query 'length(events)'` counts the CLI's merged pages; on a very large window confirm with the Insights `stats count()` rather than trusting a truncated page set.
- Explore's own per-symbol RPC failure log is at **DEBUG** (unchanged by this PR, and DEBUG is not emitted in prod), so the `explore_429` column will likely read 0 even in the pre-window. The 429 lines being counted come from the web3/urllib3 layer and from `oracle_health`'s WARNings. That is exactly why the **delta** across the deploy is the measurement, and not any single line's attribution.

## What a reviewer should push back on

- **Cross-module import of a private helper.** `_read_oracle_prices` imports `oracle_health._push_set_symbols`. I chose reuse over a second local copy of the `YFINANCE_MAP`/`CRYPTO_MAP` + `startswith("s")` filter, because two copies would eventually disagree about which oracles are live and this file's whole correctness claim rests on that set. If you'd rather promote it to a public `push_set_symbols()` (or move it to `chain/oracle_updater.py`, which arguably owns it), say so — it is a rename, and I kept it out of this diff to respect the issue's "do exactly this, nothing more."
- **120 s is a floor-plus-margin, not a tuned number.** The invariant requires >57 s; 120 s gives roughly 2x headroom. If the rebuild budget grows, the test fails and forces the conversation, which is the point — but if you want the TTL derived from the budgets at import time rather than asserted against them, that is a defensible alternative I did not take (a literal is easier to reason about in an incident).
- **The aggregate-timeout path now loses less, but differently.** The old serial loop stopped at the deadline and kept everything read so far; the new one cancels the whole `gather` and keeps whatever `_read_one` had already recorded. With a ~2-symbol candidate set capped at `_ORACLE_READ_TIMEOUT` (5 s) inside a 12 s aggregate budget, the aggregate timeout is now effectively unreachable — I kept it as a backstop for a growing push set rather than deleting it.
- **Scope I deliberately left out** (both named as anti-goals in the issue): moving the cache to Redis so the two Fargate tasks don't each keep a cold cache, and anything in `ui/`.
