### PR TITLE
[perf][corpus] Corpus search: debounce, cancel, single-pass count, trigram index

### DIFF
--- a/backend/archimedes/api/papers_routes.py
+++ b/backend/archimedes/api/papers_routes.py
@@ -6,6 +6,7 @@ import json
 import logging
 
 from fastapi import APIRouter, Query
+from sqlalchemy import func
 
 from archimedes.db import get_session
 from archimedes.services.corpus_categories import label_for as _category_label
@@ -144,8 +145,37 @@ async def list_papers(
                 predicate = predicate | PaperRecord.authors.ilike(author_pattern, escape="\\")
             query = query.filter(predicate)
 
-        total = query.count()
-        rows = query.order_by(PaperRecord.published.desc()).offset((page - 1) * page_size).limit(page_size).all()
+        # ONE pass over the predicate, not two (#1665).
+        #
+        # This used to be `total = query.count()` followed by a second,
+        # separately-planned page query over the *same* filter — so every
+        # keystroke in the catalog search box made Postgres evaluate three
+        # unanchored `ILIKE '%term%'` legs across 10 000 rows of Text abstracts
+        # twice, back to back, on the event loop. `count(*) OVER ()` is a
+        # window over the filtered result set: it carries the full match count
+        # on every returned row, so the count and the page come out of a single
+        # statement with a single scan.
+        total_column = func.count().over().label("total_matches")
+        paged = (
+            query.add_columns(total_column)
+            .order_by(PaperRecord.published.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+            .all()
+        )
+        rows = [row[0] for row in paged]
+        total = paged[0][1] if paged else 0
+
+        # The one case the window function cannot answer: an out-of-range page.
+        # `?page=500` returns no rows, and a window over zero rows reports zero
+        # — which would render "0 papers found" for a query that really has
+        # 900 matches on page 1, i.e. the UI contradicting itself depending on
+        # where you are in the pagination. A count() is correct there and only
+        # there, so the second pass is paid on a cold path instead of on every
+        # keystroke. `page == 1` with no rows is a genuine zero and needs no
+        # rescue (the unfiltered/file fallbacks below still handle an empty DB).
+        if not paged and page > 1:
+            total = query.count()
 
         papers = [_paper_row_to_dict(r) for r in rows]
 

--- a/backend/migrations/versions/c1d7f4a9b3e2_papers_trigram_search_indexes.py
+++ b/backend/migrations/versions/c1d7f4a9b3e2_papers_trigram_search_indexes.py
@@ -1,0 +1,114 @@
+"""trigram GIN indexes on papers.title / papers.abstract for catalog search
+
+Issue #1665.
+
+Catalog search is an unanchored substring match — ``title ILIKE '%momentum%'``
+OR ``abstract ILIKE '%momentum%'`` OR the author leg. A leading wildcard makes
+every B-tree index on those columns useless, and ``papers`` carried only
+``ix_papers_primary_category`` / ``ix_papers_published``, so **every search was
+a sequential scan of the whole table** — 10 000 rows with Text abstracts, on
+the request path, for each keystroke.
+
+``pg_trgm`` + a GIN index over trigrams is the fix that keeps the predicate
+honest. It indexes the three-character shingles of a string, so the planner can
+answer ``LIKE '%mom%'`` from the index instead of reading every row, and
+``gin_trgm_ops`` supports ``ILIKE`` as well as ``LIKE`` (Postgres rewrites
+``ILIKE`` through the same operator class). Nothing about the query changes:
+the same rows come back in the same order. Only the plan changes, from
+``Seq Scan`` to ``Bitmap Index Scan``.
+
+Two constraints shaped how this is written.
+
+**CONCURRENTLY, always.** A plain ``CREATE INDEX`` takes an ``ACCESS
+EXCLUSIVE`` lock on ``papers`` for the duration of the build — on a live table
+that is a hard outage of the catalog, the KB intake job, and anything else that
+touches the corpus, for as long as the build runs. ``CONCURRENTLY`` builds in
+two passes without blocking reads or writes; it cannot run inside a transaction,
+which is why both statements sit in ``autocommit_block()``. Alembic commits the
+migration's transaction on entry to that block and opens a new one on exit, so
+this revision is deliberately *not* atomic. The known consequence, stated
+rather than hidden: if a concurrent build is interrupted, Postgres leaves an
+**INVALID** index behind that is never used by the planner and is not rebuilt by
+a re-run (``IF NOT EXISTS`` sees the invalid index and skips). Recovery is
+manual and cheap —
+
+    SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+    DROP INDEX CONCURRENTLY <name>;   -- then re-run this migration
+
+— and that is the right trade against locking a live table.
+
+**Postgres only.** ``pg_trgm`` is a Postgres extension; SQLite (every test, and
+local dev via ``create_all()``) has no equivalent and no seq-scan problem at
+these row counts. The whole revision is a no-op off Postgres in both
+directions, decided from ``bind.dialect.name`` so it renders correctly in
+``--sql`` offline mode too — same idiom as
+``fb8d0bae8112_schema_relations_phase1``.
+
+The extension is created but **never dropped on downgrade**. ``pg_trgm`` is
+database-scoped and something else may since have come to depend on it;
+dropping an extension this migration did not necessarily install would take
+their indexes with it. Downgrade removes exactly what upgrade added: the two
+indexes.
+
+Revision ID: c1d7f4a9b3e2
+Revises: a7f2c93b1d64
+Create Date: 2026-08-31 18:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "c1d7f4a9b3e2"
+down_revision: str | Sequence[str] | None = "a7f2c93b1d64"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+# Both legs of the title/abstract predicate get one. Indexing only `title`
+# would leave the abstract leg — the larger column, and the expensive half of
+# the scan — unindexed, and the OR means the planner still has to read every
+# row to evaluate it, so a one-sided index buys nothing. The `authors` leg is
+# deliberately left alone: it is guarded to >= 3 characters and is a serialised
+# JSON list rather than prose, so it is a separate question from this one.
+_TRIGRAM_INDEXES: tuple[tuple[str, str], ...] = (
+    ("ix_papers_title_trgm", "title"),
+    ("ix_papers_abstract_trgm", "abstract"),
+)
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    if not _is_postgres():
+        return
+
+    # Its own statement, inside the migration's transaction: CREATE EXTENSION
+    # is transactional and must land before the autocommit block below, since
+    # `gin_trgm_ops` does not exist until it does.
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    with op.get_context().autocommit_block():
+        for index_name, column in _TRIGRAM_INDEXES:
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} ON papers USING gin ({column} gin_trgm_ops)"
+            )
+
+
+def downgrade() -> None:
+    if not _is_postgres():
+        return
+
+    # DROP INDEX CONCURRENTLY carries the same no-transaction rule as the
+    # build, and the same reason: a plain DROP takes ACCESS EXCLUSIVE on the
+    # table. Reverse order of creation, for symmetry with upgrade().
+    with op.get_context().autocommit_block():
+        for index_name, _column in reversed(_TRIGRAM_INDEXES):
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+
+    # pg_trgm itself is deliberately left installed — see the module docstring.

--- a/backend/tests/test_papers_routes.py
+++ b/backend/tests/test_papers_routes.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+from contextlib import contextmanager
 
 import pytest
 from archimedes.models.chat import Base
 from archimedes.models.corpus_store import PaperRecord
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 
@@ -463,3 +464,142 @@ class TestAuthorLegGuardIsScopedToTheAuthorLeg:
             "the structural-character guard leaked out of the author leg and broke prose search"
         )
         assert result["papers"][0]["arxiv_id"] == "2601.50003"
+
+
+class TestSearchIssuesOneQuery:
+    """The search predicate is evaluated ONCE per request, not twice (#1665).
+
+    `list_papers` used to run `query.count()` and then a separately-planned
+    page query over the same filter, so a single keystroke made the database
+    evaluate three unanchored `ILIKE '%term%'` legs across the papers table
+    twice, back to back. `count(*) OVER ()` carries the match count on every
+    returned row, so both come out of one statement and one scan.
+
+    These tests read the SQL the ORM actually emits rather than trusting the
+    source, because "one query" is exactly the kind of property that a later
+    refactor re-breaks invisibly — the results stay correct, only the cost
+    doubles.
+    """
+
+    @staticmethod
+    @contextmanager
+    def _captured_sql(session):
+        """Every statement the session's engine executes inside the block."""
+        statements: list[str] = []
+        engine = session.get_bind()
+
+        def _record(_conn, _cursor, statement, _params, _context, _executemany):
+            statements.append(statement)
+
+        event.listen(engine, "before_cursor_execute", _record)
+        try:
+            yield statements
+        finally:
+            event.remove(engine, "before_cursor_execute", _record)
+
+    @staticmethod
+    def _search_statements(statements):
+        """Statements that actually evaluate the search predicate.
+
+        SQLite renders `ilike` as `lower(x) LIKE lower(?)`, Postgres as
+        `ILIKE` — matching on `LIKE` covers both. The cheap
+        `_any_paper_processed` existence probe carries no LIKE and is
+        correctly excluded.
+        """
+        return [s for s in statements if "LIKE" in s.upper()]
+
+    def test_a_search_evaluates_the_predicate_once(self, session, monkeypatch):
+        from archimedes.api import papers_routes
+
+        for i in range(5):
+            _add_paper(session, f"2601.60{i:03d}", authors=["Ada Lovelace"], title=f"Momentum study {i}")
+        _add_paper(session, "2601.60999", authors=["Alan Turing"], title="Unrelated work")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        with self._captured_sql(session) as statements:
+            result = asyncio.run(
+                papers_routes.list_papers(page=1, page_size=20, category=None, search="momentum", processed_only=True)
+            )
+
+        # The answer must still be right — a fast wrong count is worse than a
+        # slow right one.
+        assert result["total"] == 5
+        assert len(result["papers"]) == 5
+
+        searches = self._search_statements(statements)
+        assert len(searches) == 1, (
+            f"the search predicate was evaluated {len(searches)} times, expected 1:\n" + "\n---\n".join(searches)
+        )
+        # ...and the one statement really is doing both jobs, rather than the
+        # count having been dropped.
+        only = searches[0].upper()
+        assert "OVER (" in only, f"the surviving statement carries no window function:\n{searches[0]}"
+        assert "LIMIT" in only, f"the surviving statement is not the paged query:\n{searches[0]}"
+
+    def test_the_count_is_the_full_match_count_not_the_page_size(self, session, monkeypatch):
+        """The window counts the filtered set, not the returned page.
+
+        `count(*) OVER ()` is evaluated before OFFSET/LIMIT; getting that wrong
+        would silently cap "N papers found" at page_size, which is the exact
+        bug #1451 fixed on the frontend.
+        """
+        from archimedes.api import papers_routes
+
+        for i in range(25):
+            _add_paper(session, f"2601.61{i:03d}", authors=["Ada Lovelace"], title=f"Momentum study {i}")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=1, page_size=10, category=None, search="momentum", processed_only=True)
+        )
+        assert result["total"] == 25, "the window count reported the page, not the match set"
+        assert len(result["papers"]) == 10
+
+    def test_an_out_of_range_page_still_reports_the_true_total(self, session, monkeypatch):
+        """The one case a window function cannot answer, and the fallback for it.
+
+        A window over zero returned rows reports zero. Left unhandled, `?page=9`
+        of a 25-match query would render "0 papers found" while page 1 renders
+        "25" — the UI contradicting itself depending on where you are in the
+        pagination. The count() fallback is paid here and only here.
+        """
+        from archimedes.api import papers_routes
+
+        for i in range(25):
+            _add_paper(session, f"2601.62{i:03d}", authors=["Ada Lovelace"], title=f"Momentum study {i}")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        result = asyncio.run(
+            papers_routes.list_papers(page=9, page_size=10, category=None, search="momentum", processed_only=True)
+        )
+        assert result["papers"] == []
+        assert result["total"] == 25, "an out-of-range page reported 0 matches for a query with 25"
+
+    def test_the_hot_path_pays_no_second_pass_when_the_page_is_empty_at_page_one(self, session, monkeypatch):
+        """A genuine zero-match search must NOT trigger the fallback count.
+
+        This is the every-keystroke case while a user is still typing a term
+        that matches nothing yet — the most common search of all — so paying a
+        second scan here would undo the fix on precisely the hottest path.
+        """
+        from archimedes.api import papers_routes
+
+        _add_paper(session, "2601.63001", authors=["Ada Lovelace"], title="Unrelated work")
+        session.commit()
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
+
+        with self._captured_sql(session) as statements:
+            result = asyncio.run(
+                papers_routes.list_papers(
+                    page=1, page_size=20, category=None, search="zzzznonsense", processed_only=True
+                )
+            )
+
+        assert result["total"] == 0
+        searches = self._search_statements(statements)
+        assert len(searches) == 1, (
+            f"a zero-match search on page 1 fell through to a second pass ({len(searches)} statements)"
+        )

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -19,13 +19,24 @@ function walletHeaders() {
 
 /**
  * GET a JSON endpoint. Throws a clean error on non-2xx responses.
+ *
+ * `signal` is optional and additive — every existing caller omits it and is
+ * unaffected. It exists so a caller that supersedes its own requests (the
+ * corpus catalog's debounced search, #1665) can actually *cancel* the request
+ * rather than merely ignore the answer: without the signal reaching `fetch`,
+ * an abandoned keystroke still costs a full backend table scan. An aborted
+ * request rejects with an `AbortError`; see `corpusSearch.isSupersededError`
+ * for why that must not be painted as an outage.
+ *
  * @param {string} path — API path (e.g. "/api/strategies/")
+ * @param {{signal?: AbortSignal}} [options]
  * @returns {Promise<any>} parsed JSON
  */
-export async function apiGet(path) {
+export async function apiGet(path, { signal } = {}) {
   const res = await fetch(`${API_BASE}${path}`, {
     credentials: 'include',
     headers: walletHeaders(),
+    signal,
   })
   if (!res.ok) {
     const err = new Error(`Backend returned ${res.status}`)

--- a/ui/src/components/CorpusExplorer.jsx
+++ b/ui/src/components/CorpusExplorer.jsx
@@ -4,6 +4,7 @@ import CorpusGraph from './CorpusGraph'
 import CorpusKG from './CorpusKG'
 import { cleanLatex } from '../utils/latex'
 import { apiGet } from '../api'
+import { runCatalogFetch, scheduleCatalogFetch } from '../corpusSearch'
 import { KNOWLEDGE_GRAPH_TAB_ENABLED } from '../featureFlags'
 
 // The Topic Clusters tab is filtered out at build time unless the flag is on
@@ -55,28 +56,51 @@ export default function CorpusExplorer() {
 
   useEffect(() => { fetchOverview() }, [fetchOverview])
 
-  // Fetch papers catalog
-  const fetchPapers = useCallback(async () => {
+  // Fetch papers catalog.
+  //
+  // `signal` is optional so the Retry button can still call this directly; the
+  // debounced path always supplies one. See ../corpusSearch.js for why the
+  // aborted-after-resolve check has to happen after every await.
+  const fetchPapers = useCallback(async (signal) => {
     setLoading(true)
     setCatalogError(false)
-    try {
-      const params = new URLSearchParams({ page: String(page), limit: '20' })
-      if (search) params.set('search', search)
-      if (categoryFilter) params.set('category', categoryFilter)
+    const params = new URLSearchParams({ page: String(page), limit: '20' })
+    if (search) params.set('search', search)
+    if (categoryFilter) params.set('category', categoryFilter)
+    const outcome = await runCatalogFetch(signal, {
       // Trailing slash matters: FastAPI 307-redirects /api/papers → /api/papers/,
       // and the browser silently drops the query string on the redirect, so the
       // catalog rendered "0 papers found" despite the backend having 10000.
-      const data = await apiGet(`/api/papers/?${params}`)
-      setPapers(data.papers || [])
-      setTotalPapers(data.total || 0)
-    } catch {
-      setPapers([])
-      setCatalogError(true)
-    }
-    setLoading(false)
+      fetchPage: s => apiGet(`/api/papers/?${params}`, { signal: s }),
+      onResult: data => {
+        setPapers(data.papers || [])
+        setTotalPapers(data.total || 0)
+      },
+      onError: () => {
+        setPapers([])
+        setCatalogError(true)
+      },
+    })
+    // A superseded request leaves `loading` alone on purpose: the request that
+    // replaced it is still in flight and already set it, so clearing it here
+    // would flash "not loading" mid-type. The successor owns the reset.
+    if (outcome !== 'superseded') setLoading(false)
   }, [page, search, categoryFilter])
 
-  useEffect(() => { fetchPapers() }, [fetchPapers])
+  // One AbortController and one 300 ms timer per render of this effect; the
+  // cleanup cancels both. Eight keystrokes therefore produce seven cancels and
+  // one request, instead of eight requests racing each other (#1665). Page and
+  // category changes take the same path — they are single clicks, so the 300 ms
+  // is invisible, and routing every catalog fetch through one scheduler is what
+  // makes "the newest request always wins" true rather than nearly true.
+  useEffect(() => scheduleCatalogFetch(fetchPapers), [fetchPapers])
+
+  // Wrapped, not passed bare as `onRetry={fetchPapers}`: as an onClick handler
+  // it would receive the click event in its `signal` parameter, and that event
+  // would then be handed to `fetch` as an AbortSignal. Retry is a deliberate
+  // click, so it runs immediately and without a controller rather than through
+  // the debounce.
+  const retryPapers = useCallback(() => { fetchPapers() }, [fetchPapers])
 
   // Fetch paper detail
   const openPaper = async (arxivId) => {
@@ -129,7 +153,7 @@ export default function CorpusExplorer() {
       {tab === 'catalog' && (
         <CatalogTab
           papers={papers} total={totalPapers} page={page} loading={loading}
-          catalogError={catalogError} onRetry={fetchPapers}
+          catalogError={catalogError} onRetry={retryPapers}
           search={search} setSearch={setSearch}
           categoryFilter={categoryFilter} setCategoryFilter={setCategoryFilter}
           setPage={setPage} openPaper={openPaper}

--- a/ui/src/corpusSearch.js
+++ b/ui/src/corpusSearch.js
@@ -1,0 +1,101 @@
+/**
+ * Corpus catalog search: debounce + cancel (#1665).
+ *
+ * `CorpusExplorer` fired one `/api/papers/?search=…` request per keystroke,
+ * with no debounce and no `AbortController`. That is two separate defects:
+ *
+ *   * **load** — typing an 8-character word issued 8 requests, each of which
+ *     made the backend scan the papers table for an unanchored `ILIKE`;
+ *   * **ordering** — nothing tied a response to the request that asked for it,
+ *     so a slow early response could land *after* a fast later one and repaint
+ *     the results for a prefix the user had already finished typing. That is
+ *     the failure a user actually sees: the box says "momentum", the list says
+ *     "mom".
+ *
+ * The debounce fixes the first. The `AbortController` fixes the second, and it
+ * has to fix it on *both* legs — a settled request whose controller has since
+ * been aborted must not write state either, because `abort()` cannot un-resolve
+ * a promise that already resolved.
+ *
+ * This lives in a plain module rather than inline in the JSX so the behaviour
+ * is testable: `ui/` runs tests under `node --test` with no DOM and no JSX
+ * transform, so anything left inside a `.jsx` component can only ever be
+ * checked by scanning source text. Same idiom as `rigorGateStatus.js`.
+ */
+
+/** Milliseconds of quiet before a keystroke becomes a request. */
+export const SEARCH_DEBOUNCE_MS = 300
+
+/**
+ * Schedule one debounced catalog fetch and return the cancel function.
+ *
+ * The return value is exactly what a React effect returns: calling it clears
+ * the pending timer (so a superseded keystroke never becomes a request at all)
+ * *and* aborts the controller (so one that already became a request is
+ * cancelled in flight, and its late response is marked superseded). Aborting a
+ * controller whose timer never fired is a no-op, which is why one call handles
+ * both cases.
+ *
+ * @param {(signal: AbortSignal) => void} run — runs once, after `delay` ms of quiet
+ * @param {{delay?: number}} [options]
+ * @returns {() => void} cancel — clears the timer and aborts the request
+ */
+export function scheduleCatalogFetch(run, { delay = SEARCH_DEBOUNCE_MS } = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => { run(controller.signal) }, delay)
+  return () => {
+    clearTimeout(timer)
+    controller.abort()
+  }
+}
+
+/**
+ * True when a rejection is this request being cancelled rather than failing.
+ *
+ * Cancellation is not an outage, and must never be painted as one: `fetch`
+ * rejects an aborted request with an `AbortError`, so without this check every
+ * keystroke would flash the catalog's error state.
+ *
+ * Both arms are load-bearing. `signal.aborted` catches a rejection that lost
+ * its `name` crossing a wrapper (`api.js` re-throws its own `Error` on a
+ * non-2xx), and the `AbortError` name catches the window where the abort
+ * happened but the signal object is not to hand.
+ *
+ * @param {unknown} err
+ * @param {AbortSignal} [signal]
+ */
+export function isSupersededError(err, signal) {
+  return Boolean(signal?.aborted) || err?.name === 'AbortError'
+}
+
+/**
+ * Run one catalog request and apply its result **only if it is still current**.
+ *
+ * Returns the outcome rather than throwing, so the caller can tell "this
+ * request was replaced" apart from "the backend is down" — they look identical
+ * from a `catch` and must not look identical to the user.
+ *
+ * @param {AbortSignal} signal
+ * @param {{
+ *   fetchPage: (signal: AbortSignal) => Promise<any>,
+ *   onResult: (data: any) => void,
+ *   onError: (err: unknown) => void,
+ * }} handlers
+ * @returns {Promise<'applied'|'superseded'|'failed'>}
+ */
+export async function runCatalogFetch(signal, { fetchPage, onResult, onError }) {
+  try {
+    const data = await fetchPage(signal)
+    // The ordering fix. `abort()` cannot un-resolve a promise that already
+    // resolved, so a request cancelled *after* its response arrived would
+    // otherwise still repaint the list with stale rows. Checked here, after
+    // the await, is the only place that catches it.
+    if (signal?.aborted) return 'superseded'
+    onResult(data)
+    return 'applied'
+  } catch (err) {
+    if (isSupersededError(err, signal)) return 'superseded'
+    onError(err)
+    return 'failed'
+  }
+}

--- a/ui/test/corpus-search-debounce.test.js
+++ b/ui/test/corpus-search-debounce.test.js
@@ -1,0 +1,335 @@
+// Corpus catalog search: debounce + cancel (#1665).
+//
+// The pre-fix component fired one `/api/papers/?search=…` request per
+// keystroke, with no debounce and no AbortController:
+//
+//     const fetchPapers = useCallback(async () => { … await apiGet(…) … },
+//                                     [page, search, categoryFilter])
+//     useEffect(() => { fetchPapers() }, [fetchPapers])
+//
+// Two defects in one line. Typing an 8-character word issued 8 requests, each
+// costing the backend an unanchored ILIKE scan of the papers table — and
+// nothing tied a response to the request that asked for it, so a slow early
+// response could land AFTER a fast later one and repaint the list for a prefix
+// the user had already finished typing.
+//
+// The scheduling logic lives in ../src/corpusSearch.js precisely so it can be
+// exercised here for real rather than pattern-matched: `ui/` runs under
+// `node --test` with no DOM and no JSX transform, so anything left inside the
+// .jsx component can only be checked by scanning source text. Both halves are
+// covered:
+//
+//   * behavioural — the real module, driven through React's effect lifecycle
+//     (run, cleanup-then-run, …) with mocked timers;
+//   * source-text — CorpusExplorer.jsx actually calls that module, so the
+//     behavioural tests are not passing over a component that bypasses them.
+//
+// Every guard is also run against the pre-fix behaviour it exists to reject
+// (`naiveSchedule` / `naiveApply`), so a guard that has stopped guarding fails
+// loudly instead of silently.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test, { mock } from "node:test";
+
+import {
+	SEARCH_DEBOUNCE_MS,
+	isSupersededError,
+	runCatalogFetch,
+	scheduleCatalogFetch,
+} from "../src/corpusSearch.js";
+
+const explorer = readFileSync(
+	new URL("../src/components/CorpusExplorer.jsx", import.meta.url),
+	"utf8",
+);
+const api = readFileSync(new URL("../src/api.js", import.meta.url), "utf8");
+
+const TERM = "momentum"; // 8 characters — the issue's own example
+const TYPING_GAP_MS = 20; // a fast typist, well inside the debounce window
+
+/**
+ * Drive `schedule` exactly the way React drives an effect whose dependency
+ * changes on every keystroke: run, then cleanup-then-run, then … . The final
+ * cleanup is deliberately NOT called — React only runs it on the next change
+ * or on unmount, and the surviving request is the one that must fire.
+ *
+ * Returns the fetches that actually happened and the number of aborts.
+ */
+function typeInto(schedule, term) {
+	let aborts = 0;
+	const RealAbortController = globalThis.AbortController;
+	class CountingAbortController extends RealAbortController {
+		abort(reason) {
+			aborts += 1;
+			super.abort(reason);
+		}
+	}
+	globalThis.AbortController = CountingAbortController;
+
+	const fetches = [];
+	let cleanup = null;
+	try {
+		for (let i = 1; i <= term.length; i += 1) {
+			const soFar = term.slice(0, i);
+			if (cleanup) cleanup(); // React's effect cleanup for the previous value
+			cleanup = schedule((signal) => fetches.push({ term: soFar, signal }));
+			mock.timers.tick(TYPING_GAP_MS);
+		}
+		mock.timers.tick(SEARCH_DEBOUNCE_MS + 1); // the user stops typing
+	} finally {
+		globalThis.AbortController = RealAbortController;
+	}
+	return { fetches, aborts, cleanup };
+}
+
+/** The pre-fix scheduler: fire immediately, no controller, nothing to cancel. */
+function naiveSchedule(run) {
+	run(undefined);
+	return () => {};
+}
+
+test("eight keystrokes produce exactly one request and seven aborts", () => {
+	mock.timers.enable({ apis: ["setTimeout"] });
+	try {
+		const { fetches, aborts } = typeInto(scheduleCatalogFetch, TERM);
+
+		assert.equal(
+			fetches.length,
+			1,
+			`typing ${TERM.length} characters issued ${fetches.length} requests — the debounce is not collapsing them`,
+		);
+		assert.equal(
+			fetches[0].term,
+			TERM,
+			"the surviving request must be the LAST prefix typed, not an earlier one",
+		);
+		assert.equal(
+			aborts,
+			TERM.length - 1,
+			`expected ${TERM.length - 1} aborts (one per superseded keystroke), got ${aborts}`,
+		);
+		assert.equal(
+			fetches[0].signal.aborted,
+			false,
+			"the request that actually fired must not be carrying an already-aborted signal",
+		);
+	} finally {
+		mock.timers.reset();
+	}
+});
+
+test("nothing is requested before the debounce window elapses", () => {
+	mock.timers.enable({ apis: ["setTimeout"] });
+	try {
+		const fetches = [];
+		scheduleCatalogFetch(() => fetches.push(1));
+		mock.timers.tick(SEARCH_DEBOUNCE_MS - 1);
+		assert.equal(fetches.length, 0, "a request fired before the 300 ms window closed");
+		mock.timers.tick(1);
+		assert.equal(fetches.length, 1, "the request never fired after the window closed");
+	} finally {
+		mock.timers.reset();
+	}
+});
+
+test("ADVERSARIAL: the pre-fix scheduler reports 8 requests and 0 aborts, and fails the guard", () => {
+	// Anti-vacuity. Feed the counting harness the exact behaviour the fix
+	// replaced. If this ever produced 1 request the test above would be
+	// guarding nothing.
+	mock.timers.enable({ apis: ["setTimeout"] });
+	try {
+		const { fetches, aborts } = typeInto(naiveSchedule, TERM);
+		assert.equal(fetches.length, TERM.length, "the un-debounced path should fire once per keystroke");
+		assert.equal(aborts, 0, "the un-debounced path has no controller to abort");
+		assert.throws(
+			() => assert.equal(fetches.length, 1),
+			"the 'exactly 1 request' assertion passes against the un-debounced path — it is decorative",
+		);
+	} finally {
+		mock.timers.reset();
+	}
+});
+
+// ── the ordering bug: a slow early response settling after a fast later one ──
+
+/**
+ * Two overlapping requests where the FIRST one is slower — the exact race the
+ * pre-fix code lost. R1 ("mom") is scheduled, fires, and is then superseded by
+ * R2 ("momentum"); R2's response arrives first, R1's arrives afterwards.
+ *
+ * `apply` is the strategy under test: the real `runCatalogFetch` (which checks
+ * the signal after the await) or `naiveApply` (which does not).
+ */
+async function raceOutOfOrder(apply) {
+	const painted = [];
+	const errors = [];
+
+	let resolveSlow;
+	const slow = new Promise((resolve) => {
+		resolveSlow = resolve;
+	});
+
+	const c1 = new AbortController();
+	const c2 = new AbortController();
+
+	// R1: "mom" — issued first, will settle last.
+	const r1 = apply(c1.signal, {
+		fetchPage: () => slow,
+		onResult: (d) => painted.push(d.term),
+		onError: (e) => errors.push(e),
+	});
+
+	// The user keeps typing: R1 is superseded and cancelled, R2 is issued.
+	c1.abort();
+
+	// R2: "momentum" — issued second, settles first.
+	const r2 = apply(c2.signal, {
+		fetchPage: () => Promise.resolve({ term: "momentum" }),
+		onResult: (d) => painted.push(d.term),
+		onError: (e) => errors.push(e),
+	});
+	const outcome2 = await r2;
+
+	// ...and only NOW does the slow first response come back.
+	resolveSlow({ term: "mom" });
+	const outcome1 = await r1;
+
+	return { painted, errors, outcome1, outcome2 };
+}
+
+/** The pre-fix applier: whatever settles last wins, regardless of the signal. */
+async function naiveApply(_signal, { fetchPage, onResult, onError }) {
+	try {
+		onResult(await fetchPage());
+		return "applied";
+	} catch (err) {
+		onError(err);
+		return "failed";
+	}
+}
+
+test("a superseded response never repaints the catalog, even if it settles last", async () => {
+	const { painted, errors, outcome1, outcome2 } = await raceOutOfOrder(runCatalogFetch);
+
+	assert.deepEqual(
+		painted,
+		["momentum"],
+		`the catalog was painted with ${JSON.stringify(painted)} — a stale response for an abandoned prefix reached the UI`,
+	);
+	assert.equal(painted.at(-1), "momentum", "the LAST paint must be the term the user actually typed");
+	assert.equal(outcome1, "superseded", "the abandoned request must report itself superseded, not applied");
+	assert.equal(outcome2, "applied", "the current request must be applied");
+	assert.deepEqual(errors, [], "cancelling a request must not raise an error into the UI");
+});
+
+test("ADVERSARIAL: without the post-await signal check the stale response wins", async () => {
+	// Anti-vacuity for the ordering guard. `abort()` cannot un-resolve a promise
+	// that already resolved, so an applier that only relies on fetch rejecting
+	// still paints "mom" last. This is the bug, reproduced.
+	const { painted } = await raceOutOfOrder(naiveApply);
+
+	assert.deepEqual(
+		painted,
+		["momentum", "mom"],
+		"expected the pre-fix applier to paint the stale response last",
+	);
+	assert.throws(
+		() => assert.deepEqual(painted, ["momentum"]),
+		"the ordering assertion passes against the pre-fix applier — it is guarding nothing",
+	);
+});
+
+test("an AbortError is treated as cancellation, not as an outage", async () => {
+	// A real cancelled fetch REJECTS. That rejection must not reach onError —
+	// otherwise every keystroke would flash the catalog's error state.
+	const errors = [];
+	const controller = new AbortController();
+	controller.abort();
+
+	const abortError = Object.assign(new Error("The operation was aborted."), { name: "AbortError" });
+	const outcome = await runCatalogFetch(controller.signal, {
+		fetchPage: () => Promise.reject(abortError),
+		onResult: () => assert.fail("a cancelled request must not paint results"),
+		onError: (e) => errors.push(e),
+	});
+
+	assert.equal(outcome, "superseded");
+	assert.deepEqual(errors, [], "an abort was reported to the user as a failed request");
+
+	// And a genuine backend failure must still reach onError — the check above
+	// must not have swallowed error handling wholesale.
+	const live = new AbortController();
+	const outage = new Error("Backend returned 502");
+	const failed = await runCatalogFetch(live.signal, {
+		fetchPage: () => Promise.reject(outage),
+		onResult: () => assert.fail("a failed request must not paint results"),
+		onError: (e) => errors.push(e),
+	});
+	assert.equal(failed, "failed");
+	assert.deepEqual(errors, [outage], "a real 502 must still surface as a catalog error");
+});
+
+test("isSupersededError distinguishes cancellation from failure", () => {
+	const aborted = new AbortController();
+	aborted.abort();
+	const live = new AbortController();
+
+	assert.equal(isSupersededError(new Error("Backend returned 502"), aborted.signal), true);
+	assert.equal(isSupersededError({ name: "AbortError" }, undefined), true);
+	assert.equal(isSupersededError(new Error("Backend returned 502"), live.signal), false);
+	assert.equal(isSupersededError(new Error("boom"), undefined), false);
+});
+
+// ── the component and the transport actually use all of the above ──
+
+test("CorpusExplorer.jsx routes its catalog fetch through the debounced scheduler", () => {
+	assert.match(
+		explorer,
+		/import\s*\{[^}]*scheduleCatalogFetch[^}]*\}\s*from\s*['"]\.\.\/corpusSearch['"]/,
+		"CorpusExplorer.jsx must import the scheduler these tests exercise",
+	);
+	assert.match(
+		explorer,
+		/useEffect\(\(\)\s*=>\s*scheduleCatalogFetch\(fetchPapers\),\s*\[fetchPapers\]\)/,
+		"the catalog effect must return scheduleCatalogFetch's cancel function — that return value IS the cleanup React calls",
+	);
+	assert.match(
+		explorer,
+		/runCatalogFetch\(signal,/,
+		"the fetch must go through runCatalogFetch, which is what discards a superseded response",
+	);
+	// The pre-fix wiring must be gone, not merely supplemented: an effect body
+	// that calls fetchPapers() directly would fire on every keystroke alongside
+	// the debounced one.
+	assert.doesNotMatch(
+		explorer,
+		/useEffect\(\(\)\s*=>\s*\{\s*fetchPapers\(\)\s*\},\s*\[fetchPapers\]\)/,
+		"the un-debounced effect is still present",
+	);
+});
+
+test("the AbortSignal reaches fetch, so an abandoned request is actually cancelled", () => {
+	// A controller whose signal never reaches `fetch` fixes ordering but not
+	// load: the abandoned request still runs the backend scan to completion.
+	assert.match(
+		explorer,
+		/apiGet\(`\/api\/papers\/\?\$\{params\}`,\s*\{\s*signal:\s*s\s*\}\)/,
+		"CorpusExplorer.jsx must pass the signal to apiGet",
+	);
+	assert.match(
+		api,
+		/export async function apiGet\(path,\s*\{\s*signal\s*\}\s*=\s*\{\}\)/,
+		"apiGet must accept a signal",
+	);
+	const body = api.slice(api.indexOf("export async function apiGet"));
+	assert.match(
+		body.slice(0, 400),
+		/fetch\(`\$\{API_BASE\}\$\{path\}`,\s*\{[^}]*signal,/s,
+		"apiGet must hand the signal to fetch — a signal it never forwards cancels nothing",
+	);
+});
+
+test("the debounce window is 300 ms", () => {
+	assert.equal(SEARCH_DEBOUNCE_MS, 300);
+});


### PR DESCRIPTION
Closes #1665

Corpus catalog search fired **one request per keystroke**, and each request made Postgres evaluate three unanchored `ILIKE '%term%'` legs over `papers` **twice** — once for `query.count()`, once for the page query — with **no index** either pass could use. Three changes, one per layer, exactly the three the issue scopes.

| | before | after |
|---|---|---|
| requests for typing `momentum` | 8 | **1** (+ 7 `abort()`) |
| passes over the search predicate, per request | 2 | **1** |
| plan for `title ILIKE '%momentum%'` | `Seq Scan`, 14.0 ms | **`Bitmap Index Scan`, 0.39 ms** |
| plan for the real catalog statement (title OR abstract, count + page) | `Seq Scan`, ~30 ms median | **`BitmapOr` of two trigram scans, ~0.99 ms median** |

---

## 1. Frontend — 300 ms debounce + `AbortController`

`ui/src/corpusSearch.js` (new), `ui/src/components/CorpusExplorer.jsx`, `ui/src/api.js`.

```jsx
useEffect(() => scheduleCatalogFetch(fetchPapers), [fetchPapers])
```

One controller and one 300 ms timer per effect run; the effect's cleanup clears the timer **and** aborts the controller, so a superseded keystroke either never becomes a request or is cancelled in flight.

**The ordering half is the part that is easy to get wrong.** `abort()` cannot un-resolve a promise that already resolved, so an `AbortController` alone does not fix the race the issue names — a slow early response can still land after a fast later one and repaint the list for a prefix the user has finished typing. Three things together close it:

- the signal reaches `fetch` (`apiGet` gained an optional `{ signal }`), so an abandoned request is genuinely cancelled and stops costing a backend scan — a controller whose signal never reaches `fetch` fixes ordering but not load;
- the signal is re-checked **after the await**, so a response that arrived just before its abort is discarded rather than painted;
- an `AbortError` is classified as *supersession*, not failure, so cancelling never flashes the catalog's error state — while a real 502 still does.

**Why a module and not inline JSX.** `ui/` runs under `node --test` with no DOM and no JSX transform, so anything left inside `.jsx` can only be checked by scanning source text. Putting the scheduling in a plain `.js` module (same idiom as `rigorGateStatus.js` / `freeGenerations.js`) is what makes the acceptance criterion — *8 keystrokes → 1 fetch, 7 aborts* — an actual measurement instead of a regex. The component is then pinned to that module by source-text guards, so the behavioural tests cannot pass over a component that bypasses them.

One incidental fix the signal parameter forced: `onRetry={fetchPapers}` was passed bare as an `onClick` handler, which would now hand the click event to `fetch` as an `AbortSignal`. It is wrapped.

## 2. Backend — single-pass count

`backend/archimedes/api/papers_routes.py:147-148` → `count(*) OVER ()` on the page query. Same rows, same order, one statement, one scan.

The one case a window function cannot answer is an **out-of-range page**: it counts the rows it returns, so `?page=9` of a 25-match query would report `0` while page 1 reports `25` — the UI contradicting itself depending on where you are in the pagination. That falls back to `count()`, and a test pins that the fallback fires **only** there — never on `page=1` with zero matches, which is the most common keystroke of all (a term the user has not finished typing).

## 3. Migration — `pg_trgm` + GIN trigram indexes

`backend/migrations/versions/c1d7f4a9b3e2_papers_trigram_search_indexes.py`, chained on `a7f2c93b1d64`.

Both index builds and both drops use `CREATE/DROP INDEX CONCURRENTLY` inside `op.get_context().autocommit_block()` — a plain build would take `ACCESS EXCLUSIVE` on a live `papers` for the duration, i.e. a hard outage of the catalog and the KB intake job. The revision is therefore deliberately **not atomic**, and the docstring states the consequence rather than hiding it: an interrupted concurrent build leaves an `INVALID` index that `IF NOT EXISTS` will not rebuild, with the two-line recovery written down. Postgres-only, no-op on SQLite in both directions. `pg_trgm` is created but **never dropped** on downgrade — it is database-scoped and something else may have come to depend on it.

### ⚠️ Migration-chain collision with open PR #1658

`origin/main`'s alembic head is **`a7f2c93b1d64`**, and **PR #1658 chains its `c4e17b93a2d8` on the same parent.** Whichever of the two merges second creates a **second head**, which `test_alembic_migrations.py::_expected_head_revision` fails on (`assert len(heads) == 1`). The fix is one line in the *second* PR to land: re-point its `down_revision` at the other's revision id. Flagging rather than pre-resolving, because the ordering is not mine to choose.

---

# Validation

### Full suite, from the worktree root — the command CI runs

```
$ <env>/pytest -m "not integration" -q
5041 passed, 3 skipped, 2 deselected, 297 warnings in 1580.87s (0:26:20)
```

`ruff check` + `ruff format --check` clean on all three touched Python files (the 37 `ruff check backend/` findings are pre-existing and none are in this diff). `npm run build` succeeds. Branch is level with `origin/main` (`git rev-list --count HEAD..origin/main` → 0). `ScriptDirectory.get_heads()` → `['c1d7f4a9b3e2']`, exactly one.

### Acceptance criteria

```
$ cd ui && npm test
ℹ tests 690   ℹ pass 690   ℹ fail 0

$ cd ui && npm run lint
> eslint .
(no output — 0 problems)

$ <env>/pytest backend/tests/test_papers_routes.py -q
32 passed, 1 warning in 7.31s

$ <env>/pytest backend/tests/test_alembic_migrations.py -q
27 passed, 1 warning in 309.20s
```

The 10 new UI tests:

```
✔ eight keystrokes produce exactly one request and seven aborts
✔ nothing is requested before the debounce window elapses
✔ ADVERSARIAL: the pre-fix scheduler reports 8 requests and 0 aborts, and fails the guard
✔ a superseded response never repaints the catalog, even if it settles last
✔ ADVERSARIAL: without the post-await signal check the stale response wins
✔ an AbortError is treated as cancellation, not as an outage
✔ isSupersededError distinguishes cancellation from failure
✔ CorpusExplorer.jsx routes its catalog fetch through the debounced scheduler
✔ the AbortSignal reaches fetch, so an abandoned request is actually cancelled
✔ the debounce window is 300 ms
ℹ tests 10   ℹ pass 10   ℹ fail 0
```

### Migration against a scratch Postgres 18.4

Real cluster (`initdb` + `pg_ctl`, PostgreSQL 18.4 — prod is Aurora 18.3), full chain from zero, 10 000 seeded papers with Text abstracts, 18 MB table.

```
$ alembic upgrade head
INFO  [alembic.runtime.migration] Running upgrade a7f2c93b1d64 -> c1d7f4a9b3e2,
      trigram GIN indexes on papers.title / papers.abstract for catalog search

$ psql -c '\d papers'
Indexes:
    "papers_pkey" PRIMARY KEY, btree (arxiv_id)
    "ix_papers_abstract_trgm" gin (abstract gin_trgm_ops)
    "ix_papers_primary_category" btree (primary_category)
    "ix_papers_published" btree (published)
    "ix_papers_title_trgm" gin (title gin_trgm_ops)

$ alembic downgrade -1
INFO  [alembic.runtime.migration] Running downgrade c1d7f4a9b3e2 -> a7f2c93b1d64

  indexes on papers: ix_papers_primary_category, ix_papers_published, papers_pkey
  pg_trgm:           still installed (deliberate — see the docstring)
  invalid indexes:   0

$ alembic upgrade head    # re-apply, then run a third time
0 further upgrades to run — idempotent; invalid indexes: 0
```

Offline `--sql` rendering, to confirm `autocommit_block()` puts the concurrent builds **outside** any transaction (the thing that would fail at apply time if it were wrong):

```sql
$ alembic upgrade a7f2c93b1d64:c1d7f4a9b3e2 --sql
BEGIN;
-- Running upgrade a7f2c93b1d64 -> c1d7f4a9b3e2
CREATE EXTENSION IF NOT EXISTS pg_trgm;
COMMIT;
CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_papers_title_trgm ON papers USING gin (title gin_trgm_ops);
CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_papers_abstract_trgm ON papers USING gin (abstract gin_trgm_ops);
BEGIN;
UPDATE alembic_version SET version_num='c1d7f4a9b3e2' WHERE alembic_version.version_num = 'a7f2c93b1d64';
COMMIT;
```

### `EXPLAIN (ANALYZE)` — the acceptance query

**BEFORE** (`downgrade -1` applied; 10 000 rows, 119 matches — the same 119 production reports for `search=momentum&processed_only=false`):

```
 Aggregate  (cost=959.25..959.26 rows=1 width=8) (actual time=13.961..13.961 rows=1.00 loops=1)
   Buffers: shared hit=834
   ->  Seq Scan on papers  (cost=0.00..959.00 rows=101 width=0) (actual time=0.197..13.940 rows=119.00 loops=1)
         Filter: (title ~~* '%momentum%'::text)
         Rows Removed by Filter: 9881
         Buffers: shared hit=834
 Execution Time: 14.013 ms
```

**AFTER** (`upgrade head`):

```
 Aggregate  (cost=344.61..344.62 rows=1 width=8) (actual time=0.308..0.309 rows=1.00 loops=1)
   Buffers: shared hit=132
   ->  Bitmap Heap Scan on papers  (cost=56.81..344.36 rows=101 width=0) (actual time=0.060..0.301 rows=119.00 loops=1)
         Recheck Cond: (title ~~* '%momentum%'::text)
         Heap Blocks: exact=119
         Buffers: shared hit=132
         ->  Bitmap Index Scan on ix_papers_title_trgm  (cost=0.00..56.79 rows=101 width=0) (actual time=0.042..0.042 rows=119.00 loops=1)
               Index Cond: (title ~~* '%momentum%'::text)
               Buffers: shared hit=13
 Execution Time: 0.390 ms
```

`Bitmap Index Scan`, **0.390 ms vs 14.013 ms** — 36×, and 834 → 132 buffers.

### `EXPLAIN (ANALYZE)` — the statement the route actually issues

The acceptance query is one leg. This is the real one, single-pass count and page together:

```
 Limit  (cost=595.60..595.65 rows=20 width=30) (actual time=58.353..58.356 rows=20.00 loops=1)
   ->  Sort  (Sort Key: published DESC, top-N heapsort  Memory: 26kB)
         ->  WindowAgg  (rows=281.00)          ← count(*) OVER (), same statement as the page
               ->  Bitmap Heap Scan on papers  (actual rows=281.00)
                     Recheck Cond: ((title ~~* '%momentum%') OR (abstract ~~* '%momentum%'))
                     ->  BitmapOr
                           ->  Bitmap Index Scan on ix_papers_title_trgm     (rows=119.00)
                           ->  Bitmap Index Scan on ix_papers_abstract_trgm  (rows=163.00)
```

Warm timings, 5 runs each:

| plan | runs (ms) | median |
|---|---|---|
| `Seq Scan` (`enable_bitmapscan=off`) | 118.2 · 20.7 · 262.3 · 22.8 · 30.4 | **~30 ms**, wildly variable |
| trigram `BitmapOr` | 1.06 · 0.93 · 1.11 · 1.00 · 0.93 | **~0.99 ms**, tight |

**One honest operational note discovered while measuring.** The first time round I built the index on an *empty* table and then bulk-loaded 10 000 rows: the resulting GIN was 2.5× bloated (6.3 MB vs 2.5 MB) and the planner **declined** the `BitmapOr`, costing it at 1667 against a 984 seq scan, even though forcing it ran 18.9 ms vs 110.8 ms. Built over data that already exists — which is what `CONCURRENTLY` does in prod — the index is compact and the planner picks it unprompted. Worth knowing if the corpus ever grows by a large bulk intake: `VACUUM ANALYZE papers` afterwards.

---

# Adversarial demonstrations

Per the guard rule: for each guard, the input that *should* fail it was built, run, and confirmed failing.

### A. Revert the debounce → the guard reports 8 and fails

`scheduleCatalogFetch` stripped back to the pre-fix behaviour (fire immediately, no controller):

```js
export function scheduleCatalogFetch(run, { delay = SEARCH_DEBOUNCE_MS } = {}) {
  // ADVERSARIAL: debounce + cancel removed — the pre-fix behaviour.
  void delay
  run(undefined)
  return () => {}
}
```

```
$ node --test test/corpus-search-debounce.test.js
✖ eight keystrokes produce exactly one request and seven aborts
  AssertionError [ERR_ASSERTION]: typing 8 characters issued 8 requests — the debounce is not collapsing them
    actual: 8,
    expected: 1,
    operator: 'strictEqual',

✖ nothing is requested before the debounce window elapses
  AssertionError [ERR_ASSERTION]: a request fired before the 300 ms window closed
    actual: 1,
    expected: 0,
    operator: 'strictEqual',

ℹ tests 10   ℹ pass 8   ℹ fail 2
```

**Reports 8, fails.** Restored → `ℹ pass 10   ℹ fail 0`.

### B. The out-of-order-response case — remove *only* the post-await signal check

Debounce and `AbortController` left fully intact; just the one line that discards a superseded response deleted, to prove that line is what fixes the ordering bug and not the controller on its own.

```js
export async function runCatalogFetch(signal, { fetchPage, onResult, onError }) {
  try {
    const data = await fetchPage(signal)
    onResult(data) // ADVERSARIAL: post-await signal check removed
```

The scenario: R1 (`"mom"`) is issued, aborted when the user keeps typing, R2 (`"momentum"`) is issued and **settles first**, then R1's slow response comes back.

```
$ node --test test/corpus-search-debounce.test.js
✖ a superseded response never repaints the catalog, even if it settles last
  AssertionError [ERR_ASSERTION]: the catalog was painted with ["momentum","mom"] —
    a stale response for an abandoned prefix reached the UI
    actual:   [ 'momentum', 'mom' ],
    expected: [ 'momentum' ],
    operator: 'deepStrictEqual',

ℹ tests 10   ℹ pass 9   ℹ fail 1
```

**`["momentum","mom"]`** — the box says `momentum`, the list says `mom`. That is the user-visible bug, reproduced. Restored → `ℹ pass 10   ℹ fail 0`.

### C. Revert the single-pass count → the guard reports 2 and fails

`count(*) OVER ()` reverted to `query.count()` + a separate page query. The tests read the SQL the ORM actually emits (`before_cursor_execute`), not the source.

```
$ <env>/pytest backend/tests/test_papers_routes.py -k TestSearchIssuesOneQuery -q
✖ test_a_search_evaluates_the_predicate_once
E   AssertionError: the search predicate was evaluated 2 times, expected 1:
E     SELECT count(*) AS count_1
E     FROM (SELECT papers.arxiv_id ... FROM papers
E     WHERE lower(papers.title) LIKE lower(?) OR lower(papers.abstract) LIKE lower(?)
E           OR lower(papers.authors) LIKE lower(?) ESCAPE '\') AS anon_1
E     ---
E     SELECT papers.arxiv_id ... FROM papers
E     WHERE lower(papers.title) LIKE lower(?) OR lower(papers.abstract) LIKE lower(?)
E           OR lower(papers.authors) LIKE lower(?) ESCAPE '\' ORDER BY papers.published DESC
E      LIMIT ? OFFSET ?
E   assert 2 == 1

✖ test_the_hot_path_pays_no_second_pass_when_the_page_is_empty_at_page_one
E   AssertionError: a zero-match search on page 1 fell through to a second pass (2 statements)

2 failed, 2 passed, 28 deselected
```

**Reports 2, fails.** Restored → `32 passed`.

### D. In-suite anti-vacuity

Two of the ten UI tests are permanent adversarial arms rather than one-off demos — they run the pre-fix behaviour through the same harness on every CI run and `assert.throws` that the real guard's assertion does *not* hold against it. A guard that quietly stops guarding fails loudly instead.

---

# Anti-goals — verified, not asserted

| anti-goal | check | result |
|---|---|---|
| Do **not** log the search term | `grep -n "request.query_params" backend/archimedes/api/timing_middleware.py` | no hits (0); and no new `log*(...search...)` line anywhere in this diff |
| Do **not** drop the `abstract` leg | `grep -n "PaperRecord.abstract.ilike" papers_routes.py` | `139: predicate = (PaperRecord.title.ilike(pattern)) \| (PaperRecord.abstract.ilike(pattern))` — untouched, and it now has its own index |
| Do **not** use a non-`CONCURRENTLY` build | `grep -c CONCURRENTLY <migration>` | **6** (≥ 2). Regex for `(CREATE\|DROP) INDEX(?! CONCURRENTLY)` finds exactly 1 hit — line 22, docstring prose explaining why a plain build is refused. Every executable statement is `CONCURRENTLY`. |
| Do **not** fix the `limit`/`page_size` mismatch | `grep -n "limit: '20'" CorpusExplorer.jsx` → `67`; `grep -n "page_size: int = Query" papers_routes.py` → `89` | both untouched — still a real, harmless, separate issue |

## Scope

7 files. `ui/src/corpusSearch.js` + `ui/test/corpus-search-debounce.test.js` are new; `CorpusExplorer.jsx`, `api.js` (one optional param, additive — no existing caller passes a second argument), `papers_routes.py` (the two lines the issue names), `test_papers_routes.py` (+5 tests), and the migration. Nothing else.
