### PR TITLE
[infra] Plumb the admission-control knobs into ecs.tf

### DIFF
--- a/backend/tests/test_admission_knobs_drift.py
+++ b/backend/tests/test_admission_knobs_drift.py
@@ -1,0 +1,239 @@
+"""The admission-control knobs must reach the Fargate task, at the code's own defaults (#1668).
+
+``GENERATION_MAX_CONCURRENT``, ``GENERATION_MAX_QUEUE`` and ``DEBATE_POOL_MAX``
+are read off the process environment by code that has shipped for months
+(``api/generate_routes.py``, ``agents/debate_engine.py``) and were absent from
+``infra/ecs.tf`` — so production ran on the ``os.getenv()`` fallbacks by
+accident rather than by decision. That is the config-drift class
+``docs/adr/lambda-generation-offload.md`` recorded under § Consequences instead
+of patching, and the one the ``GENERATION_DAILY_CAP_*`` comment in ``ecs.tf``
+already warns about in prose.
+
+Two ways to get this wrong, and this file guards both:
+
+1. **Unplumbed.** The name never reaches the task definition. Silent: the task
+   boots healthy, ``/health`` passes, and the knob is simply not a knob.
+   ``terraform validate`` cannot see it — an ``environment`` block missing an
+   entry is perfectly valid HCL.
+2. **Plumbed at a different value.** Worse than unplumbed, because the file now
+   *looks* authoritative. #1668 is explicitly plumbing-only: the Terraform
+   defaults must be byte-identical to the code defaults, so applying it changes
+   nothing. Retuning is a separate change with separate review.
+
+Both sides are read here — the code default via ``ast`` (no import: hermetic,
+no env, no ``archimedes`` package, no DB) and the Terraform default via text.
+Neither is hand-copied into this file, so the pairing stays checked as either
+side moves. Only the *pairing* is pinned, never a particular number: a
+deliberate retune that changes both sides together still passes, which is
+exactly the review boundary #1668 draws.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ECS_TF = REPO_ROOT / "infra" / "ecs.tf"
+VARIABLES_TF = REPO_ROOT / "infra" / "variables.tf"
+
+# env var name → (source file holding its os.getenv default, terraform variable name)
+KNOBS: dict[str, tuple[Path, str]] = {
+    "GENERATION_MAX_CONCURRENT": (
+        REPO_ROOT / "backend" / "archimedes" / "api" / "generate_routes.py",
+        "generation_max_concurrent",
+    ),
+    "GENERATION_MAX_QUEUE": (
+        REPO_ROOT / "backend" / "archimedes" / "api" / "generate_routes.py",
+        "generation_max_queue",
+    ),
+    "DEBATE_POOL_MAX": (
+        REPO_ROOT / "backend" / "archimedes" / "agents" / "debate_engine.py",
+        "debate_pool_max",
+    ),
+}
+
+# ECS `environment` entries are string/string pairs. A terraform variable typed
+# `number` would make jsonencode emit a bare JSON number and
+# RegisterTaskDefinition rejects the whole task definition — at apply time,
+# which is the prod deploy path. Same reason ecs_backend_cpu is a string.
+REQUIRED_TF_TYPE = "string"
+
+_CONTAINER_NAME_RE = re.compile(r'^      name\s*=\s*"([^"]+)"', re.MULTILINE)
+
+# `{ name = "X", value = "literal" }` or `{ name = "X", value = var.something }`.
+# The quoted alternative tolerates interpolation (`"https://${var.domain_name}"`).
+_ENTRY_RE = re.compile(
+    r'\{\s*name\s*=\s*"([^"]+)"\s*,\s*value\s*=\s*'
+    r'(?:"((?:[^"\\]|\\.)*)"|([A-Za-z_][\w.\[\]]*))\s*,?\s*\}'
+)
+
+
+def _backend_environment() -> dict[str, tuple[str | None, str | None]]:
+    """{env name: (string literal | None, unquoted reference | None)} for the backend container.
+
+    Sliced the same way ``test_ecs_backend_secrets.py`` slices it: containers are
+    delimited by their own 6-space-indented ``name = "..."`` line, and the
+    ``environment`` list is bracket-matched rather than regex-terminated (it
+    contains nested ``[...]``, and a naive ``\\]`` would silently shrink the set
+    under test).
+    """
+    assert ECS_TF.is_file(), f"missing {ECS_TF}"
+    src = ECS_TF.read_text(encoding="utf-8")
+
+    matches = list(_CONTAINER_NAME_RE.finditer(src))
+    names = [m.group(1) for m in matches]
+    assert "backend" in names, f"no `backend` container in infra/ecs.tf; found {names}"
+    idx = names.index("backend")
+    end = matches[idx + 1].start() if idx + 1 < len(matches) else len(src)
+    container = src[matches[idx].start() : end]
+
+    opener = re.search(r"^      environment\s*=\s*(?:concat\()?\[", container, re.MULTILINE)
+    assert opener, "no `environment` block in the backend container"
+    depth, i = 0, opener.end() - 1
+    block = None
+    while i < len(container):
+        if container[i] == "[":
+            depth += 1
+        elif container[i] == "]":
+            depth -= 1
+            if depth == 0:
+                block = container[opener.start() : i + 1]
+                break
+        i += 1
+    assert block is not None, "unbalanced brackets in the `environment` block"
+
+    return {m.group(1): (m.group(2), m.group(3)) for m in _ENTRY_RE.finditer(block)}
+
+
+def _tf_variable_block(name: str) -> str:
+    """The body of ``variable "<name>" { ... }`` in infra/variables.tf, brace-matched."""
+    assert VARIABLES_TF.is_file(), f"missing {VARIABLES_TF}"
+    src = VARIABLES_TF.read_text(encoding="utf-8")
+    opener = re.search(rf'^variable\s+"{re.escape(name)}"\s*\{{', src, re.MULTILINE)
+    assert opener, f'infra/ecs.tf references var.{name} but infra/variables.tf declares no variable "{name}"'
+    depth, i = 0, opener.end() - 1
+    while i < len(src):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[opener.start() : i + 1]
+        i += 1
+    raise AssertionError(f'unbalanced braces in variable "{name}"')
+
+
+def _code_getenv_defaults(path: Path) -> dict[str, str]:
+    """{env name: default} for every ``os.getenv("NAME", "DEFAULT")`` in a module.
+
+    Parsed with ``ast`` over the whole module rather than by line number: the
+    line the ADR cites moves whenever anything above it is edited, and a guard
+    that breaks on an unrelated refactor gets deleted rather than fixed.
+    """
+    assert path.is_file(), f"missing {path}"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "getenv" or len(node.args) != 2:
+            continue
+        key, default = node.args
+        if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+            continue
+        if not (isinstance(default, ast.Constant) and isinstance(default.value, str)):
+            continue
+        previous = found.get(key.value)
+        assert previous in (None, default.value), (
+            f"{path.name} reads {key.value} with two different defaults "
+            f"({previous!r} and {default.value!r}) — this guard cannot tell which "
+            "one Terraform is supposed to mirror. Collapse them to one."
+        )
+        found[key.value] = default.value
+    return found
+
+
+@pytest.fixture(scope="module")
+def backend_environment() -> dict[str, tuple[str | None, str | None]]:
+    return _backend_environment()
+
+
+@pytest.mark.parametrize("env_name", sorted(KNOBS))
+class TestTheKnobReachesTheTask:
+    def test_it_is_declared_on_the_backend_container(
+        self, env_name: str, backend_environment: dict[str, tuple[str | None, str | None]]
+    ) -> None:
+        """Fails against `main` before #1668 — all three were absent (verified by grep)."""
+        assert env_name in backend_environment, (
+            f"{env_name} is missing from the backend container's `environment` block in "
+            "infra/ecs.tf. The task boots healthy and the knob silently has no effect: "
+            "production runs on the code's os.getenv() fallback, which is a decision "
+            "nobody made."
+        )
+
+    def test_it_is_wired_from_a_variable_not_hardcoded(
+        self, env_name: str, backend_environment: dict[str, tuple[str | None, str | None]]
+    ) -> None:
+        """A literal here would make every retune a code change plus a full apply."""
+        # `.get`, not `[...]`: an absent entry is already reported by the test
+        # above, and a bare KeyError here would bury that under a worse message.
+        literal, reference = backend_environment.get(env_name, (None, None))
+        _source, tf_var = KNOBS[env_name]
+        found = "nothing (the entry is absent)"
+        if literal is not None:
+            found = f"the literal {literal!r}"
+        elif reference is not None:
+            found = f"`{reference}`"
+        assert reference == f"var.{tf_var}", (
+            f"{env_name} should be wired from `var.{tf_var}` so it is tunable at apply "
+            f"time without a code change; infra/ecs.tf has {found}."
+        )
+
+    def test_the_variable_is_typed_string(self, env_name: str) -> None:
+        """`type = number` renders a bare JSON number and RegisterTaskDefinition 400s."""
+        _source, tf_var = KNOBS[env_name]
+        block = _tf_variable_block(tf_var)
+        match = re.search(r"^\s*type\s*=\s*(\S+)", block, re.MULTILINE)
+        assert match, f'variable "{tf_var}" declares no type'
+        assert match.group(1) == REQUIRED_TF_TYPE, (
+            f'variable "{tf_var}" is `type = {match.group(1)}`. ECS `environment` values '
+            f"must be strings — jsonencode would emit a bare JSON number and the whole "
+            "task definition is rejected at apply time, i.e. mid-deploy."
+        )
+
+    def test_terraform_default_matches_the_code_default(self, env_name: str) -> None:
+        """The byte-identical check. #1668 is plumbing; applying it must change nothing.
+
+        Both sides are derived, not hand-copied: change either one alone and this
+        fails naming the other. A deliberate retune that moves both together
+        still passes — that is the intended boundary, not a hole.
+        """
+        source, tf_var = KNOBS[env_name]
+        code_defaults = _code_getenv_defaults(source)
+        assert env_name in code_defaults, (
+            f"{source.relative_to(REPO_ROOT)} no longer reads {env_name} via "
+            "os.getenv() with a literal default — if the knob was renamed or "
+            "removed, update infra/ecs.tf and this file together."
+        )
+        code_default = code_defaults[env_name]
+
+        block = _tf_variable_block(tf_var)
+        match = re.search(r'^\s*default\s*=\s*"([^"]*)"', block, re.MULTILINE)
+        assert match, (
+            f'variable "{tf_var}" has no string `default`. An unset default makes '
+            "`terraform apply` prompt (or fail in CI) rather than reproducing today's "
+            "behaviour."
+        )
+        tf_default = match.group(1)
+
+        assert tf_default == code_default, (
+            f"{env_name} drift: infra/variables.tf defaults var.{tf_var} to "
+            f"{tf_default!r} but {source.relative_to(REPO_ROOT)} falls back to "
+            f"{code_default!r}. #1668 plumbs the knob at today's value; changing the "
+            "value is a separate change with separate review. If the retune is "
+            "deliberate, move BOTH sides in the same PR."
+        )

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -562,6 +562,20 @@ resource "aws_ecs_task_definition" "backend" {
         # Not secrets. Both layers must pass; <= 0 disables a layer.
         { name = "GENERATION_DAILY_CAP_PER_USER", value = "100" },
         { name = "GENERATION_DAILY_CAP_PER_IP", value = "200" },
+        # Admission control (#1668) — the same config-drift failure the caps
+        # above were plumbed to avoid, found again by grep: all three are read
+        # from the environment by shipped code (generate_routes.py's
+        # `_max_concurrent_generations()` / `_max_queued_generations()` and
+        # debate_engine.py's `_pool_max()`) and none of them were in this file,
+        # so prod ran on the os.getenv() fallbacks by accident. Wired from
+        # variables.tf, whose defaults are byte-identical to those fallbacks —
+        # plumbing only, no behaviour change on apply. Retuning any of them is
+        # a separate, separately-reviewed change (#1668 anti-goal).
+        # backend/tests/test_admission_knobs_drift.py reads both sides and
+        # fails if they ever diverge, in either direction.
+        { name = "GENERATION_MAX_CONCURRENT", value = var.generation_max_concurrent },
+        { name = "GENERATION_MAX_QUEUE", value = var.generation_max_queue },
+        { name = "DEBATE_POOL_MAX", value = var.debate_pool_max },
         # Generation payment gate (flip-list #834): flag stays "false" until
         # Dan flips it deliberately — and GENERATION_PAYMENT_RECIPIENT (the
         # platform wallet that receives x402 settlements) MUST be set first;

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -113,6 +113,49 @@ variable "github_oauth_enabled" {
   default     = false
 }
 
+# ── Admission-control knobs (issue #1668) ──────────────────────────────────
+# The three levers that bound how much concurrent work one Fargate task takes
+# on. All three are read from the process environment by code that already
+# ships, and all three were absent from infra/ecs.tf — so production ran on the
+# code's os.getenv() fallbacks by accident rather than by decision. That is the
+# exact config-drift class the generation-cap comment in ecs.tf already calls
+# out in prose, and the one docs/adr/lambda-generation-offload.md recorded
+# under § Consequences instead of patching.
+#
+# `type = string`, not `number`: ECS `environment` entries are string/string
+# pairs and jsonencode would emit a bare JSON number, which the
+# RegisterTaskDefinition API rejects (KeyValuePair.value is typed String). Same
+# reason ecs_backend_cpu / ecs_backend_memory are strings.
+#
+# Defaults here are byte-identical to the os.getenv() fallbacks in the code, so
+# this is pure plumbing: applying it changes no behaviour, it only makes the
+# values visible and tunable without a code deploy. Retuning them is a separate
+# change with separate review (issue #1668 anti-goal). The pairing is pinned by
+# backend/tests/test_admission_knobs_drift.py, which reads both sides — the
+# reader-facing source of each default is that test, not these comments.
+#
+# Each description names the READING FUNCTION rather than a line number: the
+# line moves whenever anything above it is edited, and a stale citation is
+# worse than none.
+
+variable "generation_max_concurrent" {
+  description = "GENERATION_MAX_CONCURRENT — how many strategy-generation pipelines may run at once inside ONE backend task. A generation averages ~65% of the task's vCPU for ~48s (measured 2026-08-20), so unbounded parallelism starves auth/SSE/the ALB health check and the task gets killed with every in-flight job. Floored at 1 by the code. Must match the os.getenv default in `_max_concurrent_generations()`, backend/archimedes/api/generate_routes.py."
+  type        = string
+  default     = "1"
+}
+
+variable "generation_max_queue" {
+  description = "GENERATION_MAX_QUEUE — how many further generations may WAIT for a slot (the job stays `queued` and its SSE stream gets a job_queued event plus heartbeats). Beyond this /start refuses 429 BEFORE the payment gate, so nobody is charged for a slot that does not exist. 0 disables queueing. Must match the os.getenv default in `_max_queued_generations()`, backend/archimedes/api/generate_routes.py."
+  type        = string
+  default     = "10"
+}
+
+variable "debate_pool_max" {
+  description = "DEBATE_POOL_MAX — how many of the regime×mechanism `_STEERS` (3 regimes × 6 mechanisms = 18 today) fan out as parallel proposer LLM calls in the multi-agent debate; the code clamps to [2, len(_STEERS)]. This is the debate's cost lever (docs/specs/multi-agent-debate-spec.md § 8): the deterministic critics and the backtests cost zero tokens, the proposer fan-out is the N× spend. Must match the os.getenv default in `_pool_max()`, backend/archimedes/agents/debate_engine.py."
+  type        = string
+  default     = "10"
+}
+
 # ── Config consolidation (issue #1039 P5) ──────────────────────────────────
 # Public wallet addresses (not secrets — no private key material), but
 # operator-specific and NOT baked into the image or a box `.env` file. Set at


### PR DESCRIPTION
## What

Adds three string-typed variables to `infra/variables.tf` — `generation_max_concurrent`, `generation_max_queue`, `debate_pool_max` — and wires them into the `backend` container's `environment` block in `infra/ecs.tf` as `GENERATION_MAX_CONCURRENT`, `GENERATION_MAX_QUEUE`, `DEBATE_POOL_MAX`.

Defaults are byte-identical to today's code defaults (`"1"`, `"10"`, `"10"`), so applying this changes **no runtime behaviour**. It only makes the values visible in IaC and tunable without a code deploy. A new hermetic guard, `backend/tests/test_admission_knobs_drift.py`, reads both sides and fails if they ever diverge.

## Why

All three knobs are read off the process environment by code that has shipped for months —

- `backend/archimedes/api/generate_routes.py:137` → `os.getenv("GENERATION_MAX_CONCURRENT", "1")`
- `backend/archimedes/api/generate_routes.py:144` → `os.getenv("GENERATION_MAX_QUEUE", "10")`
- `backend/archimedes/agents/debate_engine.py:105` → `os.getenv("DEBATE_POOL_MAX", "10")`

— and **none of them existed in `infra/ecs.tf`**. Production has been running admission control on the `os.getenv()` fallbacks by accident rather than by decision. This is exactly the config-drift class the neighbouring `GENERATION_DAILY_CAP_*` comment in `ecs.tf` already warns about in prose ("a cap that silently falls back to its code default because it was never added to the task definition is a config-drift failure this file has already had"), and the one `docs/adr/lambda-generation-offload.md` § Consequences recorded instead of patching.

It is a silent failure: the task boots healthy, `/health` passes, and the knob simply is not a knob. `terraform validate` cannot see it — an `environment` block missing an entry is perfectly valid HCL. Hence the test.

Shape follows the cited precedent, `infra/kb_runner.tf:95-136`: a container `environment` block wired from variables with the reasoning written in comments.

## Issues

Closes #1668

## Verification

Environment: `terraform` 1.15.8 (the version `infra-gate.yml` pins), `pytest` from the `archimedes` conda env (`/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest`), no AWS credentials.

### terraform fmt + validate — the two checks `infra-gate.yml` actually runs

```
$ terraform fmt -check -recursive -diff infra/
fmt exit=0                       # no output, no diff, nothing would be reformatted

$ cd infra && terraform init -backend=false -input=false -upgrade -no-color
...
Terraform has been successfully initialized!

$ terraform validate -no-color
Success! The configuration is valid.
```

### On the `terraform plan` acceptance bullet — I did not run it, deliberately

The issue's own **Verify** section says "no credentials, `-backend=false`, never reading S3 state (mirrors `infra-gate.yml`)", which is incompatible with the `plan` bullet above it. `plan` requires the S3 backend, and `infra-gate.yml`'s own header explains at length why this repo does not run it in CI: state holds a `tls_private_key`, so granting read access to catch syntax errors is a bad trade (CLAUDE.md § git safety). I honoured the Verify section:

```
$ cd infra && terraform plan -no-color -input=false
Error: Backend initialization required, please run "terraform init"
Reason: Initial configuration of the requested backend "s3"
```

Substituting offline evidence for the "**new task-definition revision and no other resource change**" claim, since I cannot paste a plan I did not run:

```
$ grep -rn 'generation_max_concurrent\|generation_max_queue\|debate_pool_max' infra/
infra/ecs.tf:576:        { name = "GENERATION_MAX_CONCURRENT", value = var.generation_max_concurrent },
infra/ecs.tf:577:        { name = "GENERATION_MAX_QUEUE", value = var.generation_max_queue },
infra/ecs.tf:578:        { name = "DEBATE_POOL_MAX", value = var.debate_pool_max },
infra/variables.tf:141:variable "generation_max_concurrent" {
infra/variables.tf:147:variable "generation_max_queue" {
infra/variables.tf:153:variable "debate_pool_max" {
```

Six references, three declarations and three uses. The only resource consuming them is `aws_ecs_task_definition.backend` (via its `container_definitions`), so the only resource whose plan can change is that one — a new revision. `aws_ecs_service.backend` keeps `lifecycle.ignore_changes = [task_definition, desired_count]` (`ecs.tf:924`), so the new revision does **not** auto-roll the live service; a human or CI still points the service at it, same as any other deploy. **A reviewer with credentials should still run `terraform plan` before applying** — this is reasoning, not a measurement, and I have labelled it as such.

### Anti-goal checks

```
$ git diff --stat origin/main
 backend/tests/test_admission_knobs_drift.py | 239 ++++++++++++++++++++++++++++
 infra/ecs.tf                                |  14 ++
 infra/variables.tf                          |  43 +++++
 3 files changed, 296 insertions(+)

$ git diff origin/main -- infra/ | grep -E '^-[^-]'         # any removed line?
(none - purely additive)

$ git diff origin/main -- infra/ | grep -E '^[-+].*(desired_count|ecs_autoscale|appautoscaling)'
(none)

$ git diff origin/main -- infra/ | grep -E '^[-+].*(ecs_backend_cpu|ecs_backend_memory)'
+# reason ecs_backend_cpu / ecs_backend_memory are strings.
```

The single `ecs_backend_cpu` hit is a *comment mention* explaining why the new variables are `type = string`; neither variable's declaration or value is touched. No default value in the repo was changed — the point of this PR is that both sides stay at today's numbers.

### The drift guard, and four adversarial demos

Baseline:

```
$ pytest backend/tests/test_admission_knobs_drift.py -q
12 passed, 1 warning in 3.70s
```

Twelve cases is four assertions × three knobs. Each of the four is shown below rejecting the input it exists to reject. Every demo was reverted with `git checkout --` before the next.

**A — delete the three `ecs.tf` entries.** This is literally the state `main` is in today, so it is also the "does this test fail against the unfixed code" check:

```
$ python3 -c "...strip the three { name = ... } lines from infra/ecs.tf..."
$ git diff --stat infra/ecs.tf
 infra/ecs.tf | 3 ---
$ pytest backend/tests/test_admission_knobs_drift.py -q -rf
FAILED ...test_it_is_declared_on_the_backend_container[DEBATE_POOL_MAX] - AssertionError: DEBATE_POOL_MAX is missing from the backend container's `en...
FAILED ...test_it_is_declared_on_the_backend_container[GENERATION_MAX_CONCURRENT] - AssertionError: GENERATION_MAX_CONCURRENT is missing from the backend conta...
FAILED ...test_it_is_declared_on_the_backend_container[GENERATION_MAX_QUEUE] - AssertionError: GENERATION_MAX_QUEUE is missing from the backend container'...
FAILED ...test_it_is_wired_from_a_variable_not_hardcoded[DEBATE_POOL_MAX] - AssertionError: DEBATE_POOL_MAX should be wired from `var.debate_pool_max` ...
FAILED ...test_it_is_wired_from_a_variable_not_hardcoded[GENERATION_MAX_CONCURRENT] - AssertionError: GENERATION_MAX_CONCURRENT should be wired from `var.generat...
FAILED ...test_it_is_wired_from_a_variable_not_hardcoded[GENERATION_MAX_QUEUE] - AssertionError: GENERATION_MAX_QUEUE should be wired from `var.generation_m...
6 failed, 6 passed, 1 warning in 3.26s
```

**B — the issue's explicit adversarial ask: change one default, confirm it fails.** Terraform side moves, code side does not:

```
$ git diff -U0 infra/variables.tf
-  default     = "10"
+  default     = "12"          # var.generation_max_queue only
$ pytest backend/tests/test_admission_knobs_drift.py -q
_ TestTheKnobReachesTheTask.test_terraform_default_matches_the_code_default[GENERATION_MAX_QUEUE] _
E   AssertionError: GENERATION_MAX_QUEUE drift: infra/variables.tf defaults var.generation_max_queue to '12' but backend/archimedes/api/generate_routes.py falls back to '10'. #1668 plumbs the knob at today's value; changing the value is a separate change with separate review. If the retune is deliberate, move BOTH sides in the same PR.
E   assert '12' == '10'
1 failed, 11 passed, 1 warning in 2.77s
```

**B' — the same check is bidirectional.** Code side moves, terraform does not. This matters because the code side is the one another builder is editing this week:

```
$ git diff -U0 backend/archimedes/agents/debate_engine.py
-        return max(2, min(len(_STEERS), int(os.getenv("DEBATE_POOL_MAX", "10"))))
+        return max(2, min(len(_STEERS), int(os.getenv("DEBATE_POOL_MAX", "14"))))
$ pytest backend/tests/test_admission_knobs_drift.py -q
_ TestTheKnobReachesTheTask.test_terraform_default_matches_the_code_default[DEBATE_POOL_MAX] _
E   AssertionError: DEBATE_POOL_MAX drift: infra/variables.tf defaults var.debate_pool_max to '10' but backend/archimedes/agents/debate_engine.py falls back to '14'. ...
E   assert '10' == '14'
1 failed, 11 passed, 1 warning in 4.32s
```

**C — hardcode the literal instead of wiring the variable.** Valid HCL, correct value, still wrong: it makes every future retune a code change plus an apply, which is the thing this PR exists to remove.

```
$ git diff -U0 infra/ecs.tf
-        { name = "GENERATION_MAX_CONCURRENT", value = var.generation_max_concurrent },
+        { name = "GENERATION_MAX_CONCURRENT", value = "1" },
$ pytest backend/tests/test_admission_knobs_drift.py -q
_ TestTheKnobReachesTheTask.test_it_is_wired_from_a_variable_not_hardcoded[GENERATION_MAX_CONCURRENT] _
E   AssertionError: GENERATION_MAX_CONCURRENT should be wired from `var.generation_max_concurrent` so it is tunable at apply time without a code change; infra/ecs.tf has the literal '1'.
1 failed, 11 passed, 1 warning in 3.12s
```

**D — retype one variable as `number`.** `terraform validate` says `Success!` either way, which is the whole reason this case is in the test file:

```
$ git diff -U0 infra/variables.tf
-  type        = string
+  type        = number        # var.debate_pool_max
$ pytest backend/tests/test_admission_knobs_drift.py -q
_ TestTheKnobReachesTheTask.test_the_variable_is_typed_string[DEBATE_POOL_MAX] _
E   AssertionError: variable "debate_pool_max" is `type = number`. ECS `environment` values must be strings — jsonencode would emit a bare JSON number and the whole task definition is rejected at apply time, i.e. mid-deploy.
1 failed, 11 passed, 1 warning in 3.12s
```

The `jsonencode` half of that message is measured, in a scratch Terraform root:

```
$ echo 'jsonencode([{ name = "DEBATE_POOL_MAX", value = 10 }, { name = "DEBATE_POOL_MAX", value = "10" }])' | terraform console
"[{\"name\":\"DEBATE_POOL_MAX\",\"value\":10},{\"name\":\"DEBATE_POOL_MAX\",\"value\":\"10\"}]"
```

A `number`-typed value renders as `"value":10`. The "AWS rejects it" half is the documented `KeyValuePair.value` type (String) in the ECS API, not something I exercised — no credentials.

### Suite + lint

Rebased onto `origin/main` at `848673e0` before this run. `main` moved under me mid-verification (#1673, `backend/tests/test_cloudwatch_alarms.py`) — zero file overlap with this branch, so the rebase was clean, and the run below is against current `main` rather than a stale test-merge ref (CLAUDE.md § "a stale PR's green check describes a base that no longer exists").

```
$ pytest -m "not integration" -q       # from the worktree root, the CI command
=== 5049 passed, 3 skipped, 2 deselected, 297 warnings in 1638.27s (0:27:18) ===
PYTEST_EXIT=0

$ ruff check backend/tests/test_admission_knobs_drift.py
All checks passed!
$ ruff format --check backend/tests/test_admission_knobs_drift.py
1 file already formatted
```

One thing worth flagging for the sibling PRs in this sprint, since it cost me a verification cycle. On my **pre-rebase** run, `backend/tests/test_health_always_answers.py` failed. It is not caused by this branch and it reproduces on **pristine `origin/main` with an empty worktree**, non-deterministically, on a loaded machine:

```
$ git worktree add --detach ../wt-perf-1668-baseline origin/main   # 848673e0, no changes
$ for i in 1 2 3; do pytest backend/tests/test_health_always_answers.py -q; done
FAILED ...test_health_answers_within_budget_when_the_chain_client_hangs_forever - /health took 2.63s ...
1 failed, 16 passed
FAILED ...test_health_answers_within_budget_when_the_chain_client_hangs_forever - /health took 2.57s ...
1 failed, 16 passed
FAILED ...test_health_answers_within_budget_when_the_chain_client_hangs_forever - /health took 4.49s ...
FAILED ...test_health_answers_within_budget_when_the_oracle_probe_hangs_forever  - /health took 2.51s ...
2 failed, 15 passed
```

A different case fails each run, which is the signature of a wall-clock budget assertion under CPU contention rather than a logic defect. It did not fire in the clean full-suite run above. Whoever owns the `/health` budget work this sprint may want to know that this guard is load-sensitive on a busy box — it is not this PR's to fix.

### Not a claim I am making

I have **not** applied this, and I have not seen these values on a live task. Everything above is static: file parsing, `terraform validate`, and a test that reads two files. The claim is "the wiring is correct and pinned", not "the knobs are now doing something in prod" — that starts at the next `terraform apply` plus a task-definition roll.

## What a reviewer should push back on

- **The plan bullet is unmet as written.** I substituted static reasoning (grep + the `ignore_changes` line) for a real `terraform plan`, because the issue's Verify section forbids reading S3 state and `infra-gate.yml` explains why. If you want the plan, run it with credentials before applying — do not take my reasoning as a measurement.
- **`type = string`, not `number`.** `number` would give free apply-time validation that the value is numeric, which `string` does not. I chose `string` because ECS `environment` values must be strings (demonstrated above) and because `ecs_backend_cpu` / `ecs_backend_memory` set that precedent in this same file. The code parses all three defensively (`except ValueError` → fall back), so a garbage value fails soft rather than crashing startup — correct for a tuning knob, but worth a second opinion.
- **No `validation` block on the new variables** and **no `DEBATE_POOL_MAX` line added to `.env.example`.** Both are defensible additions; both are outside "`infra/variables.tf` and `infra/ecs.tf`'s backend container `environment` block — Terraform only. Do exactly this, nothing more." I read that anti-goal literally. Say the word and either lands in a follow-up.
- **The test pins the *pairing*, never a particular number.** A deliberate retune that moves both sides together passes. That is the intended review boundary (#1668 anti-goal: plumbing and tuning are separate changes), not a hole — but if you want the numbers themselves pinned, that is a different test.
- **This PR changes nothing at runtime until someone applies it.** The values it plumbs are the values already in effect. The win is that the next retune is a `TF_VAR` and a task-definition revision instead of a code change, and that drift now fails a test instead of hiding.
