### PR TITLE
[backend] Bound the backtest fan-out; choose the process-wide executor explicitly

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -37,6 +37,8 @@ import hashlib
 import json
 import logging
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 # Imported at module top: generation_pipeline does NOT import this module at top
@@ -87,6 +89,60 @@ _CONFORMANT_INDICATORS = set(SUPPORTED_INDICATORS)
 
 # DSL price operands (not indicator aliases) — excluded from the conformance scan.
 _PRICE_OPERANDS = {"close", "open", "high", "low", "volume"}
+
+# ── Backtest fan-out pool (bounded, dedicated) ────────────────────────────────
+#
+# C-rigor backtests EVERY pooled survivor, so the fan-out is up to `_pool_max()`
+# (default 10) concurrent `cerebro.run()` calls. backtrader is pure Python and
+# therefore GIL-bound: those are not "waiting on IO" threads, they are N runnable
+# CPU threads contending with the uvicorn event loop's own thread on a task that
+# has 1-2 vCPU. Ten of them do not make the cohort ~10x faster; they make every
+# concurrently-served request wait behind GIL handoffs.
+#
+# They also used to run on the *default* executor (`asyncio.to_thread`), which is
+# the same pool `asset_market_service`, `traces_routes`, `chat_routes`,
+# `portfolio_routes` and `strategies_routes` block on. A pool whose CPython
+# default width is `min(32, os.cpu_count() + 4)` — 5 or 6 on the prod task — was
+# fully occupied by one generation's backtests, so unrelated routes queued behind
+# them. `GENERATION_MAX_CONCURRENT` (generate_routes.py) caps *pipelines*, not
+# *threads*, so it never bounded this.
+#
+# A dedicated, named, small pool fixes both halves: the CPU-bound work is capped
+# independently of how wide the pool is, and it can no longer starve the default
+# pool that serving depends on. Same motivation as the `torch.set_num_threads(1)`
+# guardrail in services/paper_rag.py (2026-07-04 reranker-starvation incident).
+_BACKTEST_POOL_HARD_MAX = 2
+_backtest_executor_lock = threading.Lock()
+_backtest_executor_instance: ThreadPoolExecutor | None = None
+
+
+def _backtest_max_workers() -> int:
+    """``DEBATE_BACKTEST_WORKERS`` clamped to ``[1, 2]`` (default 2).
+
+    The clamp is the point: the knob can make the pool narrower, never wider.
+    Widening it is what the GIL contention above forbids, so an operator typo
+    (or a well-meant "just bump it") cannot reintroduce the fan-out.
+    """
+    try:
+        requested = int(os.getenv("DEBATE_BACKTEST_WORKERS", str(_BACKTEST_POOL_HARD_MAX)))
+    except ValueError:
+        requested = _BACKTEST_POOL_HARD_MAX
+    return max(1, min(_BACKTEST_POOL_HARD_MAX, requested))
+
+
+def _backtest_executor() -> ThreadPoolExecutor:
+    """The process-wide, lazily-built backtest pool (never the default executor)."""
+    global _backtest_executor_instance
+    with _backtest_executor_lock:
+        if _backtest_executor_instance is None:
+            width = _backtest_max_workers()
+            _backtest_executor_instance = ThreadPoolExecutor(
+                max_workers=width,
+                thread_name_prefix="debate-backtest",
+            )
+            logger.info("debate C-rigor: backtest pool created (max_workers=%d, GIL-bound work)", width)
+        return _backtest_executor_instance
+
 
 # C-null passive-null bar (V_check min_cost_benefit_bps = 5 bps): a survivor must
 # beat buy-and-hold net of cost by at least this. Phase-1 proxy uses the
@@ -401,7 +457,11 @@ async def _critic_rigor(pool: list[Any], num_trials: int) -> list[tuple[Any, Any
             logger.info("debate C-rigor: dropped a candidate on backtest error: %s", exc)
             return None
 
-    results = await asyncio.gather(*(asyncio.to_thread(_backtest, p) for p in pool))
+    # Bounded + dedicated, NOT `asyncio.to_thread` (which is the default pool).
+    # See the `_backtest_executor` block above for why the fan-out is capped at 2.
+    loop = asyncio.get_running_loop()
+    executor = _backtest_executor()
+    results = await asyncio.gather(*(loop.run_in_executor(executor, _backtest, p) for p in pool))
     out: list[tuple[Any, Any]] = []
     for proposal, ev in zip(pool, results, strict=True):
         if ev is not None and ev.success and ev.rigor is not None:

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -5,6 +5,7 @@ chain services that read/write Arc smart contracts.
 """
 
 import asyncio
+import concurrent.futures
 import faulthandler
 import logging
 import os
@@ -234,12 +235,76 @@ class _MarketplaceUnavailable(Exception):
     """Sentinel: the marketplace engine did not start, so rehydration is skipped."""
 
 
+# ── Process-wide default thread pool (chosen, never inherited) ───────────────
+#
+# Every `asyncio.to_thread` / `run_in_executor(None, ...)` in the backend shares
+# ONE pool. Until now nothing called `set_default_executor`, so its width was
+# whatever CPython picked: `min(32, os.cpu_count() + 4)` — 5 on a 1-vCPU task,
+# 6 on 2. That pool is what `asset_market_service`, `traces_routes`,
+# `chat_routes`, `portfolio_routes` and `strategies_routes` block on, and it is
+# also what the debate proposer fan-out (up to DEBATE_POOL_MAX = 10 concurrent
+# LLM calls) occupies for the length of a generation. 10 > 6, so serving work
+# queued behind generation with nothing in the code choosing that trade-off.
+#
+# The proposer threads are IO-bound (blocked on an LLM socket, holding no GIL),
+# so the correct answer for them is a pool wide enough to absorb the fan-out
+# plus serving headroom. The CPU-bound half — the backtests — is NOT solved by
+# widening; it is moved off this pool entirely onto the bounded, dedicated pool
+# in agents/debate_engine.py. The two changes are complements.
+_DEFAULT_EXECUTOR_FLOOR = 16
+
+
+def _default_executor_workers() -> int:
+    """Explicit width for the process-wide default thread pool.
+
+    Floor of 16 because one generation pipeline parks up to ``DEBATE_POOL_MAX``
+    (10) IO-bound proposer threads here for minutes; anything at or below that
+    leaves zero threads for request-serving blocking calls.
+    ``SERVER_THREAD_POOL_WORKERS`` overrides for a box where that is wrong.
+    """
+    try:
+        override = int(os.getenv("SERVER_THREAD_POOL_WORKERS", "0"))
+    except ValueError:
+        override = 0
+    if override > 0:
+        return min(64, override)
+    return min(32, max(_DEFAULT_EXECUTOR_FLOOR, (os.cpu_count() or 1) * 4))
+
+
+def _install_default_executor(logger_: logging.Logger) -> concurrent.futures.ThreadPoolExecutor:
+    """Bind an explicitly-sized pool as the running loop's default executor.
+
+    Emits ONE INFO line carrying ``os.cpu_count()``, the width we chose, and the
+    width CPython would have picked. That last number is the measurement: if
+    ``cpu_count() + 4`` is at or below the 10-wide debate fan-out, executor
+    exhaustion (not just GIL contention) was live on this task size.
+    """
+    cpu_count = os.cpu_count()
+    width = _default_executor_workers()
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=width,
+        thread_name_prefix="archimedes-default",
+    )
+    asyncio.get_running_loop().set_default_executor(executor)
+    logger_.info(
+        "startup: executor os.cpu_count()=%s default_executor_max_workers=%d "
+        "(cpython_default_would_be=%d, override=SERVER_THREAD_POOL_WORKERS)",
+        cpu_count,
+        width,
+        min(32, (cpu_count or 1) + 4),
+    )
+    return executor
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """FastAPI lifespan context manager — startup before yield, shutdown after."""
     _logger = logging.getLogger("archimedes.startup")
 
     # ── STARTUP ──────────────────────────────────────────────────────────
+    # 0. Choose the process-wide default executor before anything can use it.
+    _app.state.default_executor = _install_default_executor(_logger)
+
     # 1. (removed) Rigor-gate backfill.
     #
     # This used to load every backtest_results row for every curated strategy

--- a/backend/tests/test_debate_engine_executor_bounds.py
+++ b/backend/tests/test_debate_engine_executor_bounds.py
@@ -1,0 +1,221 @@
+"""Serving-latency guard (#1666): the backtest fan-out is bounded, and the
+process-wide default executor is chosen rather than inherited.
+
+Two defects, one package:
+
+1. ``agents/debate_engine.py`` ran ``asyncio.gather(*(asyncio.to_thread(_backtest, p)
+   for p in pool))`` — up to ``DEBATE_POOL_MAX`` (10) simultaneous ``cerebro.run()``
+   calls. backtrader is pure Python and GIL-bound, so those are 10 *runnable* CPU
+   threads contending with the uvicorn event loop on a 1-2 vCPU task. Worse, they
+   ran on the **default** executor, the same pool ``asset_market_service``,
+   ``traces_routes``, ``chat_routes``, ``portfolio_routes`` and ``strategies_routes``
+   block on.
+2. ``grep -rn "set_default_executor" backend/`` returned nothing, so that shared pool's
+   width was whatever CPython picked — ``min(32, os.cpu_count() + 4)``, i.e. 5 on a
+   1-vCPU task. Ten backtest threads exhaust a 5-wide pool outright.
+
+``GENERATION_MAX_CONCURRENT`` caps *pipelines*, not *threads*, so it never bounded
+either of these.
+
+These tests are behavioural, not cosmetic: reverting either fix flips them (the
+adversarial transcript is in the PR body).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import inspect
+import logging
+import os
+from types import SimpleNamespace
+
+import archimedes.main as main_module
+import pytest
+from archimedes.agents import debate_engine as de
+
+# ── Doubles ───────────────────────────────────────────────────────────────────
+
+
+def _proposal(name: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name, strategy_spec={"name": name}, cited_paper_ids=[])
+
+
+def _ev() -> SimpleNamespace:
+    return SimpleNamespace(success=True, rigor=SimpleNamespace(passing=True), backtest=None, error=None)
+
+
+@pytest.fixture(autouse=True)
+def _hermetic(monkeypatch):
+    # real_data_enabled() is off under TESTING; belt-and-suspenders so no test
+    # here can reach yfinance even if the evaluator double is bypassed.
+    monkeypatch.setenv("TESTING", "1")
+
+
+# ── 1. The backtest pool is named and bounded ────────────────────────────────
+
+
+def test_backtest_pool_is_a_named_bounded_thread_pool() -> None:
+    ex = de._backtest_executor()
+    assert isinstance(ex, concurrent.futures.ThreadPoolExecutor)
+    assert ex._max_workers <= 2, (
+        f"backtest pool widened to {ex._max_workers}. cerebro.run() is GIL-bound; "
+        "more than 2 concurrent runs buys no throughput and starves the event loop."
+    )
+    assert ex._thread_name_prefix == "debate-backtest"
+
+
+def test_backtest_pool_is_a_singleton() -> None:
+    assert de._backtest_executor() is de._backtest_executor()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, 2),  # unset → 2
+        ("1", 1),  # narrowing is allowed
+        ("2", 2),
+        ("10", 2),  # ← the adversarial input: widening is CLAMPED, not honoured
+        ("999", 2),
+        ("0", 1),
+        ("-4", 1),
+        ("garbage", 2),  # unparseable → the safe default, never the CPython pool
+    ],
+)
+def test_backtest_worker_knob_can_narrow_but_never_widen(monkeypatch, raw, expected) -> None:
+    """``DEBATE_BACKTEST_WORKERS=10`` must NOT produce a 10-wide pool.
+
+    The clamp is the guard: re-widening the fan-out is exactly the regression
+    this issue exists to prevent, and an env knob is the likeliest way back in.
+    """
+    monkeypatch.delenv("DEBATE_BACKTEST_WORKERS", raising=False)
+    if raw is not None:
+        monkeypatch.setenv("DEBATE_BACKTEST_WORKERS", raw)
+    assert de._backtest_max_workers() == expected
+
+
+# ── 2. The fan-out actually submits there — not to the default pool ──────────
+
+
+async def test_critic_rigor_submits_to_the_bounded_pool_not_the_default(monkeypatch) -> None:
+    """Every backtest goes through the dedicated executor, and the loop's default
+    executor is left untouched.
+
+    Both halves matter. Counting submissions proves the work landed on the bounded
+    pool; asserting ``loop._default_executor`` is unchanged proves it did not *also*
+    (or instead) go to the shared pool — ``asyncio.to_thread`` lazily instantiates
+    that pool on first use, so its identity changing is a direct fingerprint of the
+    old code path.
+    """
+    monkeypatch.setattr(
+        "archimedes.services.fusion_evaluator.evaluate_fusion_spec",
+        lambda spec, **kw: _ev(),
+    )
+
+    ex = de._backtest_executor()
+    submitted: list[object] = []
+    real_submit = ex.submit
+
+    def _spy(fn, /, *args, **kwargs):
+        submitted.append(fn)
+        return real_submit(fn, *args, **kwargs)
+
+    monkeypatch.setattr(ex, "submit", _spy)
+
+    loop = asyncio.get_running_loop()
+    default_before = getattr(loop, "_default_executor", None)
+
+    pool = [_proposal(f"P{i}") for i in range(4)]
+    out = await de._critic_rigor(pool, num_trials=len(pool))
+
+    assert len(out) == 4, "the bounded pool must still run every candidate, just not all at once"
+    assert len(submitted) == 4, (
+        "backtests did not go through the dedicated pool — they fell back to "
+        "asyncio.to_thread / the shared default executor."
+    )
+    assert getattr(loop, "_default_executor", None) is default_before, (
+        "the backtest fan-out instantiated or used the loop's DEFAULT executor; "
+        "that is the pool the serving routes block on."
+    )
+
+
+async def test_critic_rigor_source_does_not_use_to_thread() -> None:
+    """Source-level backstop for the behavioural test above.
+
+    ``asyncio.to_thread`` is the one-token way to reintroduce the unbounded
+    fan-out, and it is easy to add back without noticing the executor argument
+    that disappeared.
+    """
+    src = inspect.getsource(de._critic_rigor)
+    code = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    assert "to_thread" not in code
+    assert "run_in_executor" in code
+
+
+# ── 3. main.py's lifespan chooses the default executor explicitly ────────────
+
+
+async def test_install_default_executor_binds_an_explicitly_sized_named_pool(caplog) -> None:
+    loop = asyncio.get_running_loop()
+    default_before = getattr(loop, "_default_executor", None)
+    log = logging.getLogger("archimedes.startup")
+
+    with caplog.at_level(logging.INFO, logger="archimedes.startup"):
+        ex = main_module._install_default_executor(log)
+    try:
+        assert loop._default_executor is ex, "set_default_executor was not called with our pool"
+        assert ex._thread_name_prefix == "archimedes-default"
+        assert ex._max_workers == main_module._default_executor_workers()
+        assert ex._max_workers >= main_module._DEFAULT_EXECUTOR_FLOOR, (
+            "the default pool must exceed the 10-thread debate proposer fan-out, "
+            "or serving blocking-calls queue behind a generation."
+        )
+
+        # The ONE startup INFO line the issue asks for — it carries the number
+        # that decides whether executor exhaustion (not just GIL contention) was
+        # the live term on this task size.
+        lines = [r.getMessage() for r in caplog.records if "os.cpu_count()" in r.getMessage()]
+        assert len(lines) == 1, f"expected exactly one cpu_count startup line, got {lines}"
+        assert f"os.cpu_count()={os.cpu_count()}" in lines[0]
+        assert f"default_executor_max_workers={ex._max_workers}" in lines[0]
+        assert f"cpython_default_would_be={min(32, (os.cpu_count() or 1) + 4)}" in lines[0]
+    finally:
+        ex.shutdown(wait=False)
+        loop._default_executor = default_before
+
+
+def test_lifespan_installs_the_default_executor_before_anything_else() -> None:
+    """Wiring guard: the helper above is useless if the lifespan never calls it.
+
+    Position matters too — the pool must be bound before any startup step can
+    park work on the (lazily created) inherited one.
+    """
+    fn = getattr(main_module.lifespan, "__wrapped__", main_module.lifespan)
+    body = [line.split("#", 1)[0] for line in inspect.getsource(fn).splitlines()]
+    body = [line for line in body if line.strip()]
+    calls = [i for i, line in enumerate(body) if "_install_default_executor(" in line]
+    assert calls, "lifespan no longer installs an explicit default executor"
+    first_other_startup_step = next(
+        (i for i, line in enumerate(body) if "seed_from_manifest" in line),
+        len(body),
+    )
+    assert calls[0] < first_other_startup_step
+
+
+@pytest.mark.parametrize(
+    ("override", "expect"),
+    [
+        (None, None),  # unset → the computed width
+        ("24", 24),
+        ("64", 64),
+        ("4096", 64),  # clamped: an absurd value must not spawn 4096 threads
+        ("0", None),  # 0 / garbage fall back to the computed width
+        ("garbage", None),
+    ],
+)
+def test_default_executor_width_is_explicit_and_overridable(monkeypatch, override, expect) -> None:
+    monkeypatch.delenv("SERVER_THREAD_POOL_WORKERS", raising=False)
+    computed = min(32, max(main_module._DEFAULT_EXECUTOR_FLOOR, (os.cpu_count() or 1) * 4))
+    if override is not None:
+        monkeypatch.setenv("SERVER_THREAD_POOL_WORKERS", override)
+    assert main_module._default_executor_workers() == (computed if expect is None else expect)


### PR DESCRIPTION
## What

Two changes, one mechanism — the serving-latency cost of a generation:

1. **`agents/debate_engine.py` (`_critic_rigor`)** — the backtest fan-out now runs on a
   **dedicated, named, 2-wide** `ThreadPoolExecutor` (`debate-backtest`) instead of
   `asyncio.to_thread`. `DEBATE_BACKTEST_WORKERS` can make it *narrower*; the clamp makes
   widening impossible.
2. **`main.py` `lifespan`** — calls `loop.set_default_executor()` with an **explicitly
   sized, named** pool (`archimedes-default`, floor 16, `SERVER_THREAD_POOL_WORKERS`
   overrides), and emits **one startup INFO line** carrying `os.cpu_count()`, the width we
   chose, and the width CPython would have picked.

Three files: the `:404` gather region plus a helper block in `debate_engine.py`, the
lifespan wiring in `main.py`, one new test file. `backend/Dockerfile` untouched.

## Why

`_critic_rigor` backtested every pooled survivor with
`asyncio.gather(*(asyncio.to_thread(_backtest, p) for p in pool))` — up to
`DEBATE_POOL_MAX` (default **10**) simultaneous `cerebro.run()` calls. Two separate
defects rode on that one line:

- **GIL contention.** backtrader is pure Python. Those are not threads parked on a socket,
  they are 10 *runnable* CPU threads contending with the uvicorn event loop's own thread on
  a task allocated 1 vCPU (`infra/variables.tf`: `ecs_backend_cpu = "1024"`,
  `ecs_backend_memory = "3072"`). The fan-out buys ~no throughput and costs latency
  everywhere else.
- **Executor exhaustion.** `grep -rn "set_default_executor" backend/` returned **nothing**
  before this PR, so the shared default pool's width was whatever CPython picked. Verified
  against the pinned interpreter, not assumed:

  ```
  $ grep -n "max_workers = min" .../envs/archimedes/lib/python3.12/concurrent/futures/thread.py
  146:            max_workers = min(32, (os.cpu_count() or 1) + 4)

  $ sed -n '855,868p' .../envs/archimedes/lib/python3.12/asyncio/base_events.py
          if executor is None:
              executor = self._default_executor
              ...
              if executor is None:
                  executor = concurrent.futures.ThreadPoolExecutor(thread_name_prefix='asyncio')
                  self._default_executor = executor
          return futures.wrap_future(executor.submit(func, *args), loop=self)
  ```

  So `asyncio.to_thread` lazily builds a `min(32, os.cpu_count()+4)`-wide pool and every
  `to_thread` in the backend shares it: `asset_market_service.py:680`, `traces_routes.py`,
  `chat_routes.py`, `portfolio_routes.py`, `strategies_routes.py:739` — and the debate
  proposer fan-out at `debate_engine.py:277`. Ten backtest threads exhaust a 5- or 6-wide
  pool outright; serving blocking-calls then queue behind a generation.

`#1408`'s semaphore caps **pipelines** (`GENERATION_MAX_CONCURRENT`, default 1), not
**threads**, so it never bounded either half.

The two fixes are complements, not alternatives. Widening cannot help GIL-bound work, so
the CPU-bound half is *moved off* the shared pool entirely; the IO-bound half — up to 10
proposer LLM threads that legitimately belong on the default pool for minutes — gets a pool
wide enough to absorb it plus serving headroom. That is where the floor of 16 comes from.

Precedent for the shape: `services/paper_rag.py:275-284`, the `torch.set_num_threads(1)`
guardrail with the 2026-07-04 reranker-starvation incident written into the source.

## Issues

Closes #1666

## Verification

Branch is rebased onto `origin/main` @ `848673e0`. Env is the conda `archimedes` env
(`.../envs/archimedes/bin/pytest`, Python 3.12.13) — not a bare `pytest`.

### Suites

```
$ .../bin/pytest backend/tests/test_debate_engine_executor_bounds.py -q
20 passed, 1 warning in 7.97s

$ .../bin/pytest backend/tests/ -k "debate_engine" -q
50 passed, 5012 deselected, 2 warnings in 59.51s

$ .../bin/pytest -m "not integration" -q            # repo root
5057 passed, 3 skipped, 2 deselected, 297 warnings in 1187.95s (0:19:47)

$ .../bin/ruff check backend/archimedes/main.py backend/archimedes/agents/debate_engine.py backend/tests/test_debate_engine_executor_bounds.py
All checks passed!
$ .../bin/ruff format --check <same three>
3 files already formatted
```

> **Two earlier full-suite runs each had exactly one failure; neither is this diff, and
> both are accounted for.**
>
> 1. Pre-rebase (base `b359f324`): `test_cloudwatch_alarms.py::TestAntiGoals::test_the_oracle_stale_alarm_is_untouched`
>    — `assert 3 == 1` on `evaluation_periods`. Pre-existing, and already fixed on `main` by
>    #1673 (`fe9f4b4a`, "Update the oracle-stale anti-goal pin to the #1601 retune values").
>    Rebasing onto `848673e0` resolved it. This is CLAUDE.md § rule 1 in practice — the
>    stale base was testing a `main` that no longer exists.
> 2. Post-rebase: `test_security_hardening.py::test_startup_fails_without_encryption_key_in_production`
>    — `subprocess.TimeoutExpired`, not an assertion. Its budget is `timeout=30` and it
>    spawns a process that imports the whole app; this laptop was running ~7 other full
>    suites at the time (other builders on this sprint) and that run took 30 min instead of
>    the usual ~19. Three isolated runs: `1 passed in 26.55s / 31.06s / 26.18s` — i.e. the
>    import alone was consuming the test's entire 30 s budget under that load. My diff adds
>    no import-time work: the only new import is `concurrent.futures`, which `asyncio` has
>    already pulled in — `after import asyncio, concurrent.futures already loaded: True`,
>    `marginal import cost: 0.000003 s`.
>
> Run 3 above is the clean one and is what I am standing behind.

### The startup INFO line

Run against the real `main._install_default_executor` — the same call the lifespan makes
(the wiring itself is guarded by a test, and the guard is demonstrated in (c) below):

```
$ PYTHONPATH=backend .../bin/python -c '<call _install_default_executor under asyncio.run>'
INFO archimedes.startup startup: executor os.cpu_count()=10 default_executor_max_workers=32 (cpython_default_would_be=14, override=SERVER_THREAD_POOL_WORKERS)
loop._default_executor is ours: True
thread_name_prefix: archimedes-default max_workers: 32
```

That is a 10-core laptop. **The prod number is not known until this deploys** — I am not
merging or deploying, so I am not going to present a number I do not have. Post-deploy, one
line:

```
aws logs filter-log-events --log-group-name /archimedes/app \
  --filter-pattern '"startup: executor os.cpu_count()"' --limit 5
```

Read it this way: `cpython_default_would_be` is *exactly* the width the old code ran on —
same `os.cpu_count()` input, verified against the stdlib above. If it is ≤ 10, executor
exhaustion was live on this task size and not merely theoretical.

### Adversarial demos

Every behavioural claim was reverted and re-run. Transcripts, not summaries.

**(a) Revert the fan-out to `asyncio.to_thread`:**

```
-    loop = asyncio.get_running_loop()
-    executor = _backtest_executor()
-    results = await asyncio.gather(*(loop.run_in_executor(executor, _backtest, p) for p in pool))
+    results = await asyncio.gather(*(asyncio.to_thread(_backtest, p) for p in pool))
```
```
FAILED test_critic_rigor_submits_to_the_bounded_pool_not_the_default
E   AssertionError: backtests did not go through the dedicated pool — they fell back to
E   asyncio.to_thread / the shared default executor.
E   assert 0 == 4
E    +  where 0 = len([])
FAILED test_critic_rigor_source_does_not_use_to_thread
E   AssertionError: assert 'to_thread' not in 'async def _...  return out'
E     'to_thread' is contained here:
E       *(asyncio.to_thread(_backtest, p) for p in pool))
2 failed, 18 deselected
```

**(b) Remove the width clamp** (`max(1, min(_BACKTEST_POOL_HARD_MAX, requested))` →
`max(1, requested)`) — i.e. build the input that *should* be rejected,
`DEBATE_BACKTEST_WORKERS=10`, and confirm the guard is what rejects it:

```
FAILED test_backtest_worker_knob_can_narrow_but_never_widen[10-2]  - assert 10 == 2
FAILED test_backtest_worker_knob_can_narrow_but_never_widen[999-2] - assert 999 == 2
2 failed, 6 passed, 12 deselected
```

With the clamp in place the same inputs clamp to 2, and the narrowing inputs (`1`, `0`,
`-4`, `garbage`) all resolve inside `[1, 2]` — 8 parametrised cases, all passing.

**(c) Unwire the lifespan** (delete the `_install_default_executor(_logger)` call):

```
FAILED test_lifespan_installs_the_default_executor_before_anything_else
E   AssertionError: lifespan no longer installs an explicit default executor
E   assert []
```

**(d) Build the pool but never bind it** (drop the `set_default_executor(...)` line):

```
FAILED test_install_default_executor_binds_an_explicitly_sized_named_pool
E   AssertionError: set_default_executor was not called with our pool
E   assert None is <concurrent.futures.thread.ThreadPoolExecutor object at 0x1487da2a0>
E    +  where None = <_UnixSelectorEventLoop running=True closed=False>._default_executor
------------------------------ Captured log call -------------------------------
INFO archimedes.startup startup: executor os.cpu_count()=10 default_executor_max_workers=32 ...
```

Note the INFO line still fires in (d). That is the point of asserting the *binding*
separately from the *logging* — a PR that only checked for the log line would have passed
here while shipping a pool bound to nothing.

**(e) Drop `os.cpu_count()` from the INFO line:**

```
FAILED test_install_default_executor_binds_an_explicitly_sized_named_pool
E   AssertionError: expected exactly one cpu_count startup line, got []
E   assert 0 == 1
------------------------------ Captured log call -------------------------------
INFO archimedes.startup startup: default executor ready
```

All five reverts were rolled back before committing; the suites above ran against the
committed tree.

### Mechanism measurement — NOT the §2.2 phase-3 load test

The controlled prod load test needs the live stack and a deploy; this PR is not merged and
I am not deploying it, so that acceptance box is **not** ticked. Rather than leave it
silently empty, here is the mechanism reproduced in isolation so a reviewer can see what
changes and what it costs. 10 backtests of a **fixed amount** of pure-Python (GIL-holding)
work — work-bounded, not wall-clock-bounded, or it would model IO instead of backtrader — a
request arriving 50 ms into the generation, and arm A's default pool pinned to 5 to model
`min(32, 1+4)` on a 1-vCPU task.

```
python=3.12.13  os.cpu_count()=10
fanout=10 backtests x ~400 ms of GIL-bound work (6466767 iters each)

A pre  (to_thread, pool=5)   route_thread_wait= 3684.3 ms   loop_lag p50= 49.7 p95=140.9 max=275.4 ms   fanout_wall= 4.07 s
B post (bounded=2, pool=16)  route_thread_wait=   15.3 ms   loop_lag p50= 26.0 p95= 33.6 max= 51.2 ms   fanout_wall= 4.02 s

A pre  (to_thread, pool=5)   route_thread_wait= 4158.4 ms   loop_lag p50= 39.8 p95=119.4 max=153.5 ms   fanout_wall= 4.40 s
B post (bounded=2, pool=16)  route_thread_wait=    0.1 ms   loop_lag p50= 24.2 p95= 31.5 max= 40.8 ms   fanout_wall= 4.10 s

A pre  (to_thread, pool=5)   route_thread_wait= 3878.0 ms   loop_lag p50= 60.6 p95=139.9 max=230.3 ms   fanout_wall= 4.14 s
B post (bounded=2, pool=16)  route_thread_wait=    0.1 ms   loop_lag p50= 25.1 p95= 31.5 max= 42.7 ms   fanout_wall= 4.14 s
```

Read honestly:

- **`route_thread_wait` is the finding** — seconds → ~0 ms. That is executor exhaustion,
  and it is the term this change actually removes.
- **`loop_lag p95` roughly halves.** Real, smaller, noisier.
- **`fanout_wall` is ~flat.** That is the GIL claim being true: 10 concurrent GIL-bound
  backtests are not meaningfully faster than 2, so bounding the pool costs ~nothing in
  cohort time. On a genuinely parallel box the picture would differ — see push-back.

Three consecutive runs on a comparatively quiet box; `route_thread_wait` is 3.7-4.2 s
before and 0.1-15 ms after, `loop_lag p95` 119-141 ms before and 31-34 ms after, and
`fanout_wall` is flat to within noise (4.07/4.40/4.14 s vs 4.02/4.10/4.14 s).

## What a reviewer should push back on

- **`os.cpu_count()` in a container reports the host's cores, not the task's cgroup CPU
  quota**, so the logged number can overstate what the task can actually *run*. I still
  logged exactly `os.cpu_count()` because it is the precise input CPython uses to size the
  default pool (verified against the stdlib above) — it answers the *exhaustion* question
  exactly. It does **not** answer the *GIL contention* question; the number for that is the
  1024 CPU units in `infra/variables.tf`. Worth knowing before anyone reasons from the
  logged value.
- **The floor of 16 is a judgement call, not a measurement.** It comes from "one generation
  parks up to `DEBATE_POOL_MAX` = 10 IO-bound proposer threads on this pool for minutes, so
  the pool must exceed 10." If `DEBATE_POOL_MAX` is ever raised, this floor has to move with
  it and nothing enforces that coupling. I deliberately did not import `_pool_max()` into
  `main.py` to create it — that is scope the issue did not ask for.
- **Widening the default pool costs RSS**, against a 3072 MiB task that already peaks near
  866 MB. I judged 16-32 threads immaterial (and a ThreadPoolExecutor spawns threads lazily,
  on submit, so an idle process pays nothing). If measurement disagrees,
  `SERVER_THREAD_POOL_WORKERS` narrows it without a code deploy.
- **A 2-wide backtest pool serialises the cohort on a genuinely multi-core box.** The bench
  shows ~flat wall time because the GIL already serialises it — true on the 1-vCPU prod
  task, and it would stop being true if the task were given real parallelism *and*
  backtrader released the GIL. `DEBATE_BACKTEST_WORKERS` cannot widen past 2 by design; if
  that ever needs to change, change `_BACKTEST_POOL_HARD_MAX` deliberately, in a PR, with
  the measurement.
- **Deliberately out of scope, per the issue's anti-goals:** `GENERATION_MAX_CONCURRENT`
  untouched; `torch.set_num_threads(1)` untouched; `backend/Dockerfile` untouched
  (`git diff origin/main -- backend/Dockerfile` is empty — no `--workers`); the proposer
  fan-out at `debate_engine.py:277` left on the default pool, because those threads are
  IO-bound and widening the pool is the right fix for them. No `ProcessPoolExecutor`, so the
  picklability question does not arise.
- **Known concurrent work.** Another builder is in `debate_engine.py` (papers-into-the-debate)
  and another in `generate_routes.py` (generation timeout). This diff touches neither region
  — `_critic_rigor`'s gather line plus a new helper block above `MIN_COST_BENEFIT` — but per
  CLAUDE.md § rule 5 it should be union-tested pairwise against the other `debate_engine.py`
  branch before both land in one train.
