### PR TITLE
[chain] Bind a commit's trace id to that commit, not to vault recency

### DIFF
--- a/backend/archimedes/chain/trace_publisher.py
+++ b/backend/archimedes/chain/trace_publisher.py
@@ -16,6 +16,23 @@ from archimedes.models.trace import ReasoningTrace
 logger = logging.getLogger(__name__)
 
 
+def _normalize_tx_hash(value: object) -> str | None:
+    """Lower-cased, 0x-stripped hex for tx-hash comparison, or None.
+
+    Tx hashes reach us as ``HexBytes``, ``bytes``, or ``str`` (with or without
+    the ``0x`` prefix, in either case) depending on whether they came from a
+    receipt, a log entry, or the Circle signer. Comparing the raw values would
+    make an equality check fail on representation alone — which, on the #1604
+    lookup, would silently degrade an exact match into "no match".
+    """
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray)):
+        return value.hex().lower()
+    text = str(value).strip().lower()
+    return text.removeprefix("0x") or None
+
+
 class TracePublisher:
     """Publishes reasoning trace hashes to on-chain ReasoningTraceRegistry.
 
@@ -197,7 +214,9 @@ class TracePublisher:
                     abi_params=[vault_addr, content_hash_hex, str(claimed_execution_time), trade_id_hex, intent_hex],
                 )
                 logger.info(f"Trace committed via Circle: {tx_hash[:16]}...")
-                return await self._finalize_commit(trace, tx_hash, vault_addr)
+                return await self._finalize_commit(
+                    trace, tx_hash, vault_addr, trade_id=trade_id, content_hash=content_hash_bytes
+                )
             except Exception as e:
                 logger.error(f"Circle commit failed, falling back: {e}")
 
@@ -225,18 +244,33 @@ class TracePublisher:
             tx_hash_bytes = await chain_client.w3.eth.send_raw_transaction(signed.raw_transaction)
             tx_hash = tx_hash_bytes.hex()
             logger.info(f"Trace committed on-chain: {tx_hash[:16]}...")
-            return await self._finalize_commit(trace, tx_hash, vault_addr)
+            return await self._finalize_commit(
+                trace, tx_hash, vault_addr, trade_id=trade_id, content_hash=content_hash_bytes
+            )
         except Exception as e:
             logger.error(f"Failed to commit trace on-chain: {e}")
             return None, None, None, False
 
     async def _finalize_commit(
-        self, trace: ReasoningTrace, tx_hash: str, vault_addr: str
+        self,
+        trace: ReasoningTrace,
+        tx_hash: str,
+        vault_addr: str,
+        trade_id: bytes | None = None,
+        content_hash: bytes | None = None,
     ) -> tuple[int | None, str | None, int | None, bool]:
         """Resolve the on-chain trace_id + block from a commit tx receipt.
 
-        Decodes the TraceCommitted event to read the auto-incremented trace_id; falls
-        back to getTracesByVault()[-1] if the event can't be decoded.
+        Decodes the TraceCommitted event in THIS tx's own receipt to read the
+        auto-incremented trace_id. Every fallback below is likewise keyed to this
+        specific commit — see ``_resolve_commit_trace_id``. **There is deliberately
+        no recency fallback.** Until #1604 an undecodable event fell back to
+        ``getTracesByVault(vault)[-1]``, "the newest trace id for the vault": with
+        two commits for the same vault in flight, that binds decision A's trace to
+        commit B's id — a silent provenance mis-attribution that reads as a
+        perfectly plausible id downstream. Per
+        ``docs/architectural-principles.md`` § fail-soft, a loud ``None`` beats a
+        plausible substitute on a surface whose whole product claim is provenance.
 
         The 4th return value, ``reverted``, is True only on a CONFIRMED revert
         (receipt.status == 0) — callers that gate further on-chain action (e.g.
@@ -291,15 +325,115 @@ class TracePublisher:
             logger.warning(f"Cannot read commit receipt: {e}")
 
         if trace_id is None:
-            # Fallback: newest trace id for the vault.
-            try:
-                ids = await registry.functions.getTracesByVault(vault_addr).call()
-                trace_id = int(ids[-1]) if ids else None
-            except Exception:
-                trace_id = None
+            trace_id = await self._resolve_commit_trace_id(tx_hash, vault_addr, block_num, trade_id, content_hash)
+
+        if trace_id is None:
+            logger.error(
+                f"Commit tx {tx_hash} left no resolvable trace id "
+                f"(vault={vault_addr}, block={block_num}): the TraceCommitted event was "
+                "undecodable and neither the single-block log re-read nor "
+                "pendingTradeCommitment() could bind this commit. Returning None — "
+                "guessing the vault's newest id would mis-attribute a concurrent "
+                "commit's trace (#1604). Reveal is skipped; reconcile from the "
+                "on-chain commitment."
+            )
 
         trace.commit_block_number = block_num
         return trace_id, tx_hash, block_num, reverted
+
+    async def _resolve_commit_trace_id(
+        self,
+        tx_hash: str,
+        vault_addr: str,
+        block_num: int | None,
+        trade_id: bytes | None,
+        content_hash: bytes | None,
+    ) -> int | None:
+        """Recover this commit's trace id when its receipt event won't decode.
+
+        Both routes are keyed to the specific commit, never to "whatever is
+        newest for this vault" (#1604):
+
+        1. **Single-block ``TraceCommitted`` re-read matched on our own tx hash.**
+           The commit block is already known from the receipt, so the log range is
+           one block — no provider rejects that for size (same bound as
+           ``find_reveal_tx``). The tx hash then picks OUR log out of the block even
+           when a sibling commit for the same vault landed in it.
+        2. **``pendingTradeCommitment(vault, tradeId)``.** The registry keys its
+           outstanding commitment by the caller's own ``tradeId`` and refuses a
+           second live commitment for the same key (``"Pending commitment exists"``,
+           #589), so this mapping read is exact — and it survives the case where
+           route 1 can't run at all (no block number, or an RPC with no log
+           filtering). The candidate is verified against ``getCommitment``'s stored
+           content hash before it is trusted, so a stale pointer can't slip through.
+
+        Returns None when neither route can bind the commit; the caller turns that
+        into a loud ERROR.
+        """
+        trace_id = await self._trace_id_from_commit_log(tx_hash, block_num, content_hash)
+        if trace_id is not None:
+            return trace_id
+        return await self._trace_id_from_pending_trade(vault_addr, trade_id, content_hash)
+
+    async def _trace_id_from_commit_log(
+        self, tx_hash: str, block_num: int | None, content_hash: bytes | None
+    ) -> int | None:
+        """Route 1: re-read TraceCommitted in the commit block, match on tx hash."""
+        want = _normalize_tx_hash(tx_hash)
+        if block_num is None or want is None:
+            return None
+
+        registry = self.loader.trace_registry
+        kwargs: dict = {"from_block": int(block_num), "to_block": int(block_num)}
+        if content_hash:
+            # contentHash is an indexed topic — narrows the block scan server-side.
+            kwargs["argument_filters"] = {"contentHash": content_hash}
+        try:
+            logs = await registry.events.TraceCommitted().get_logs(**kwargs)
+            for entry in logs or []:
+                entry_tx = (
+                    entry.get("transactionHash") if isinstance(entry, dict) else getattr(entry, "transactionHash", None)
+                )
+                if _normalize_tx_hash(entry_tx) != want:
+                    continue  # a sibling commit sharing this block — not ours
+                args = entry.get("args") if isinstance(entry, dict) else getattr(entry, "args", None)
+                raw_id = args.get("traceId") if isinstance(args, dict) else getattr(args, "traceId", None)
+                if raw_id is None:
+                    continue
+                return int(raw_id)
+        except Exception as e:
+            logger.warning(f"TraceCommitted re-read for {tx_hash} @ block {block_num} failed: {e}")
+        return None
+
+    async def _trace_id_from_pending_trade(
+        self, vault_addr: str, trade_id: bytes | None, content_hash: bytes | None
+    ) -> int | None:
+        """Route 2: the registry's own (vault, tradeId) -> traceId mapping."""
+        if not trade_id:
+            return None
+
+        registry = self.loader.trace_registry
+        try:
+            candidate = int(await registry.functions.pendingTradeCommitment(vault_addr, trade_id).call())
+        except Exception as e:
+            logger.warning(f"pendingTradeCommitment({vault_addr}, {trade_id.hex()}) unreadable: {e}")
+            return None
+        if not candidate:
+            return None
+
+        if content_hash:
+            commitment = await self.get_commitment(candidate)
+            if commitment is None:
+                logger.warning(f"Cannot verify pending trace id {candidate} — commitment unreadable")
+                return None
+            stored = commitment.get("content_hash")
+            if not isinstance(stored, (bytes, bytearray)) or bytes(stored) != content_hash:
+                logger.error(
+                    f"pendingTradeCommitment returned trace id {candidate} whose stored content "
+                    "hash is not this commit's — refusing to bind (stale or foreign commitment)"
+                )
+                return None
+        return candidate
 
     async def reveal(
         self,

--- a/backend/tests/test_trace_publisher_commit_reveal.py
+++ b/backend/tests/test_trace_publisher_commit_reveal.py
@@ -131,12 +131,14 @@ class TestCommit:
 class TestFinalizeCommitRevertHandling:
     """#714 follow-up: a reverted commit must never surface a stale trace_id.
 
-    ``getTracesByVault()[-1]`` is a reasonable last-resort guess ONLY when the
-    receipt confirms the tx succeeded but the ``TraceCommitted`` event couldn't be
-    decoded. A confirmed revert (``status == 0`` — the #1047-class failure mode:
-    the client builds a call shape the deployed bytecode doesn't expose) must
-    short-circuit straight to ``trace_id=None`` instead, or the fallback would
-    silently hand back an unrelated, already-committed trace's id.
+    A confirmed revert (``status == 0`` — the #1047-class failure mode: the client
+    builds a call shape the deployed bytecode doesn't expose) must short-circuit
+    straight to ``trace_id=None``, before any id-recovery route runs at all.
+
+    (#1604 removed the ``getTracesByVault()[-1]`` recency fallback these tests
+    originally guarded against; ``getTracesByVault`` must now never be reached from
+    the commit path under ANY receipt outcome. The assertions below keep watching
+    it, so a reintroduction fails here as well as in ``TestCommitIdIsCommitSpecific``.)
     """
 
     def test_reverted_commit_does_not_fall_back_to_stale_trace_id(self, supported_loader, caplog):
@@ -177,10 +179,15 @@ class TestFinalizeCommitRevertHandling:
             # stream would claim the commit succeeded.
             assert "reverted on-chain (status=0)" in caplog.text
 
-    def test_successful_commit_with_undecodable_event_still_uses_fallback(self, supported_loader):
-        """Regression guard: only a confirmed revert skips the fallback — a
-        genuinely successful receipt (status=1) whose event can't be decoded
-        should still use getTracesByVault() as before."""
+    def test_successful_commit_with_undecodable_event_never_guesses_newest_id(self, supported_loader, caplog):
+        """#1604: a successful receipt whose event won't decode, with every
+        commit-specific route unavailable, resolves to a loud None — NOT to the
+        vault's newest trace id.
+
+        Pre-#1604 this returned 9 (``getTracesByVault()[-1]``), which is only
+        correct by coincidence: it is whichever commit for this vault happens to
+        be newest at read time, not this one.
+        """
         with (
             patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
             patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
@@ -195,18 +202,208 @@ class TestFinalizeCommitRevertHandling:
             supported_loader.trace_registry.functions.getTracesByVault.return_value.call = AsyncMock(
                 return_value=[7, 8, 9]
             )
+            # Both commit-specific routes come up empty: no matching log in the
+            # block, and no outstanding pending commitment.
+            supported_loader.trace_registry.events.TraceCommitted.return_value.get_logs = AsyncMock(return_value=[])
+            supported_loader.trace_registry.functions.pendingTradeCommitment.return_value.call = AsyncMock(
+                return_value=0
+            )
             from archimedes.chain.trace_publisher import TracePublisher
 
             trace = _make_trace()
             trace.compute_hash()
-            trace_id, tx, block, reverted = asyncio.run(
-                TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x55" * 32)
-            )
+            with caplog.at_level(logging.ERROR, logger="archimedes.chain.trace_publisher"):
+                trace_id, tx, block, reverted = asyncio.run(
+                    TracePublisher(loader=supported_loader).commit(trace, 2_000_000_000, b"\x55" * 32)
+                )
 
-            assert trace_id == 9  # last element of the fallback lookup
+            assert trace_id is None  # NOT 9
             assert tx == "0xOK"
             assert block == 101
             assert reverted is False
+            assert "no resolvable trace id" in caplog.text
+            supported_loader.trace_registry.functions.getTracesByVault.assert_not_called()
+
+
+class TestCommitIdIsCommitSpecific:
+    """#1604 — the id a commit resolves to must be THIS commit's, never "newest".
+
+    Önder's 2026-08-20 review note (kept out of #1095's scope, forked out of
+    #714's close-out): when the receipt's ``TraceCommitted`` event can't be
+    decoded, ``_finalize_commit`` used to fall back to
+    ``getTracesByVault(vault)[-1]``. With two commits for the same vault in
+    flight and the FIRST one's event undecodable, that binds decision A's trace
+    to commit B's id — silent provenance mis-attribution, which is strictly worse
+    than a loud None on the one surface whose product claim IS provenance.
+
+    The scenario below is the mis-attribution, made hermetic: two commits land in
+    the same block for the same vault, A's receipt event is undecodable, and B is
+    the newest id for the vault.
+    """
+
+    VAULT = "0x1234567890abcdef1234567890abcdef12345678"
+    BLOCK = 500
+    TX_A = "0xaaa1"
+    TX_B = "0xbbb2"
+    TRACE_A = 101
+    TRACE_B = 102
+    TRADE_A = b"\xa1" * 32
+    TRADE_B = b"\xb2" * 32
+
+    def _racing_loader(self, hash_a: bytes, hash_b: bytes, *, logs=None):
+        """Registry double for the two-commits-in-one-block race.
+
+        ``getTracesByVault`` returns ``[A, B]`` — so the removed recency fallback
+        would answer ``B`` (102) for BOTH commits. The block-``BLOCK`` log re-read
+        returns both commits' ``TraceCommitted`` entries, deliberately WITHOUT
+        honouring ``argument_filters``: that models an RPC that ignores server-side
+        topic filtering, and forces the disambiguation to come from the tx-hash
+        match rather than from the filter.
+        """
+        loader = MagicMock()
+        loader.trace_registry = MagicMock()
+        # A's receipt event is undecodable — the defect's precondition.
+        loader.trace_registry.events.TraceCommitted.return_value.process_log.side_effect = ValueError("undecodable")
+        entries = (
+            logs
+            if logs is not None
+            else [
+                # bytes tx hash (HexBytes shape, as web3 returns it) …
+                {"transactionHash": bytes.fromhex("bbb2"), "args": {"traceId": self.TRACE_B, "contentHash": hash_b}},
+                # … and a str one, mixed-case with 0x — both must normalize.
+                {"transactionHash": "0xAAA1", "args": {"traceId": self.TRACE_A, "contentHash": hash_a}},
+            ]
+        )
+        loader.trace_registry.events.TraceCommitted.return_value.get_logs = AsyncMock(return_value=entries)
+        loader.trace_registry.functions.getTracesByVault.return_value.call = AsyncMock(
+            return_value=[self.TRACE_A, self.TRACE_B]
+        )
+        loader.trace_registry.functions.pendingTradeCommitment.return_value.call = AsyncMock(return_value=0)
+        return loader
+
+    def _run_commit_a(self, loader, trace):
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value=self.TX_A)
+            mock_client.to_checksum = lambda x: x
+            mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(
+                return_value=MagicMock(blockNumber=self.BLOCK, status=1, logs=[MagicMock()])
+            )
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            return asyncio.run(TracePublisher(loader=loader).commit(trace, 2_000_000_000, self.TRADE_A))
+
+    def test_concurrent_same_vault_commits_do_not_cross_attribute(self):
+        """The headline guard: decision A must never receive commit B's id."""
+        trace_a = _make_trace(id="decision-A", vault_address=self.VAULT)
+        hash_a = bytes.fromhex(trace_a.compute_hash().removeprefix("0x"))
+        hash_b = bytes.fromhex("cd" * 32)  # some other decision's content hash
+        loader = self._racing_loader(hash_a, hash_b)
+
+        trace_id, tx, block, reverted = self._run_commit_a(loader, trace_a)
+
+        assert trace_id == self.TRACE_A, "decision A must bind to ITS OWN commit's trace id"
+        assert trace_id != self.TRACE_B, "the newest-for-vault id belongs to commit B, not to decision A"
+        assert (tx, block, reverted) == (self.TX_A, self.BLOCK, False)
+        # The re-read is bounded to the single known commit block (the
+        # find_reveal_tx precedent) — never an open-ended range.
+        _, kwargs = loader.trace_registry.events.TraceCommitted.return_value.get_logs.call_args
+        assert kwargs["from_block"] == self.BLOCK
+        assert kwargs["to_block"] == self.BLOCK
+        assert kwargs["argument_filters"] == {"contentHash": hash_a}
+        # And the recency lookup is not merely out-ranked, it is gone.
+        loader.trace_registry.functions.getTracesByVault.assert_not_called()
+
+    def test_pending_trade_commitment_binds_when_log_reread_unavailable(self):
+        """Route 2: no usable logs, but the caller's own tradeId still binds exactly.
+
+        ``getTracesByVault`` would still answer B here; ``pendingTradeCommitment``
+        answers A, because the registry keys the outstanding commitment by the
+        tradeId the caller passed in (#589 forbids a second live commitment for
+        the same key).
+        """
+        trace_a = _make_trace(id="decision-A", vault_address=self.VAULT)
+        hash_a = bytes.fromhex(trace_a.compute_hash().removeprefix("0x"))
+        loader = self._racing_loader(hash_a, b"", logs=[])  # log re-read finds nothing
+        loader.trace_registry.functions.pendingTradeCommitment.return_value.call = AsyncMock(return_value=self.TRACE_A)
+        loader.trace_registry.functions.getCommitment.return_value.call = AsyncMock(
+            return_value=[hash_a, "0xagent", self.VAULT, self.BLOCK, 2_000_000_000, False, 0, ""]
+        )
+
+        trace_id, _, _, _ = self._run_commit_a(loader, trace_a)
+
+        assert trace_id == self.TRACE_A
+        args, _ = loader.trace_registry.functions.pendingTradeCommitment.call_args
+        assert args == (self.VAULT, self.TRADE_A), "must be keyed by THIS commit's tradeId"
+        loader.trace_registry.functions.getTracesByVault.assert_not_called()
+
+    def test_pending_pointer_with_foreign_content_hash_is_refused(self, caplog):
+        """Adversarial: a stale/foreign pending pointer must NOT be bound.
+
+        Feeds route 2 a candidate whose on-chain commitment carries someone
+        else's content hash — exactly the shape the removed fallback would have
+        swallowed. The verified route rejects it and returns a loud None.
+        """
+        trace_a = _make_trace(id="decision-A", vault_address=self.VAULT)
+        hash_a = bytes.fromhex(trace_a.compute_hash().removeprefix("0x"))
+        foreign_hash = bytes.fromhex("ef" * 32)
+        loader = self._racing_loader(hash_a, b"", logs=[])
+        loader.trace_registry.functions.pendingTradeCommitment.return_value.call = AsyncMock(return_value=self.TRACE_B)
+        loader.trace_registry.functions.getCommitment.return_value.call = AsyncMock(
+            return_value=[foreign_hash, "0xagent", self.VAULT, self.BLOCK, 2_000_000_000, False, 0, ""]
+        )
+
+        with caplog.at_level(logging.ERROR, logger="archimedes.chain.trace_publisher"):
+            trace_id, _, _, _ = self._run_commit_a(loader, trace_a)
+
+        assert trace_id is None, "a commitment whose content hash isn't ours must never be bound"
+        assert "refusing to bind" in caplog.text
+        assert "no resolvable trace id" in caplog.text
+
+    def test_log_entry_for_a_different_tx_in_the_same_block_is_skipped(self):
+        """Only B's log is present in A's commit block — resolve to None, not B."""
+        trace_a = _make_trace(id="decision-A", vault_address=self.VAULT)
+        trace_a.compute_hash()
+        loader = self._racing_loader(
+            b"",
+            b"",
+            logs=[{"transactionHash": "0xBBB2", "args": {"traceId": self.TRACE_B, "contentHash": b""}}],
+        )
+
+        trace_id, _, _, _ = self._run_commit_a(loader, trace_a)
+
+        assert trace_id is None
+        assert trace_id != self.TRACE_B
+
+    def test_unreadable_receipt_block_does_not_reopen_the_recency_guess(self, caplog):
+        """No block number => route 1 can't run; route 2 empty => loud None."""
+        trace_a = _make_trace(id="decision-A", vault_address=self.VAULT)
+        trace_a.compute_hash()
+        loader = self._racing_loader(b"", b"")
+        with (
+            patch("archimedes.chain.trace_publisher.circle_signer") as mock_signer,
+            patch("archimedes.chain.trace_publisher.chain_client") as mock_client,
+        ):
+            mock_signer.is_configured = True
+            mock_signer.execute_contract = AsyncMock(return_value=self.TX_A)
+            mock_client.to_checksum = lambda x: x
+            mock_client.settings = MagicMock(reasoning_trace_registry_address="0xregistry", chain_id=5042002)
+            mock_client.w3.eth.wait_for_transaction_receipt = AsyncMock(side_effect=Exception("RPC timeout"))
+            from archimedes.chain.trace_publisher import TracePublisher
+
+            with caplog.at_level(logging.ERROR, logger="archimedes.chain.trace_publisher"):
+                trace_id, tx, block, reverted = asyncio.run(
+                    TracePublisher(loader=loader).commit(trace_a, 2_000_000_000, self.TRADE_A)
+                )
+
+        assert (trace_id, tx, block, reverted) == (None, self.TX_A, None, False)
+        assert "no resolvable trace id" in caplog.text
+        loader.trace_registry.events.TraceCommitted.return_value.get_logs.assert_not_called()
+        loader.trace_registry.functions.getTracesByVault.assert_not_called()
 
 
 class TestReveal:


### PR DESCRIPTION
Closes #1604

## The defect

`_finalize_commit` resolved a commit's on-chain trace id from the `TraceCommitted` event in
its own receipt, but when that event could not be decoded it fell back to
`getTracesByVault(vault)[-1]` — *"the newest trace id for the vault"*
(`backend/archimedes/chain/trace_publisher.py:293-298` on `main`).

That fallback answers a different question than the one being asked. It returns whichever
commit for this vault is newest **at read time**, not the one this receipt belongs to. With
two commits for the same vault in flight and the first one's event undecodable, it binds
decision A's trace to commit B's id — a silent provenance mis-attribution which reads
downstream as a perfectly plausible integer, on the one surface whose entire product claim
*is* provenance.

Credit: **@onder-akkaya**, 2026-08-20 review note on #714. He deliberately kept it out of
#1095's scope and no issue captured it until #1604 forked it out of #714's close-out.

## The fix

The recency fallback is gone. Two replacement routes, each keyed to **this** commit:

1. **Single-block `TraceCommitted` re-read, matched on our own tx hash.** The commit block
   is already known from the receipt, so the log range is exactly one block — the same
   bound `find_reveal_tx` already relies on, which no RPC provider rejects for size. The tx
   hash then picks *our* log out of that block even when a sibling same-vault commit landed
   in it. `contentHash` is an indexed topic, so it also goes in as a server-side
   `argument_filters` narrowing — but correctness never depends on the provider honouring
   it (the test's registry double deliberately ignores the filter and returns both commits'
   logs, so the tx-hash match is what has to do the work).
2. **`pendingTradeCommitment(vault, tradeId)`.** The registry keys its outstanding
   commitment by the caller's own `tradeId` and refuses a second live commitment for the
   same key (`"Pending commitment exists"`, #589), so this mapping read is exact — and it
   still works when route 1 cannot run at all (receipt had no block number, or the RPC
   offers no log filtering). The candidate is verified against `getCommitment()`'s stored
   content hash before it is trusted, so a stale or foreign pointer cannot slip through.

When neither binds, the method returns `None` and logs an **ERROR**. Per
CLAUDE.md § fail-soft, a loud absence beats a plausible substitute for anything a claim
depends on. The consumer already handles this correctly: `agent_runner._commit_trace`
passes the id to `_reveal_trace`, and `reveal()` skips on a `None` id — the on-chain
commitment still exists and is reconcilable (#1276), it just is not guessed at.

`_normalize_tx_hash` exists because tx hashes reach this code as `HexBytes`, `bytes`, or
`str` (0x-prefixed or not, either case) depending on whether they came from a receipt, a
log entry, or the Circle signer. Without normalization an exact match would silently
degrade to "no match" on representation alone.

## No contract change

Both routes use ABI surface that is **already deployed**: `TraceCommitted` already indexes
`traceId`/`contentHash`/`committer`, and `pendingTradeCommitment(address,bytes32)` is
already a public view on the live v1.5 registry. Nothing under `contracts/` is touched.

## Anti-goals — verified

Checked mechanically rather than asserted, per CLAUDE.md's pre-close verification gate:

```
$ git diff origin/main --name-only -- contracts/ | wc -l
files under contracts/ changed: 0

$ git diff origin/main -U0 -- backend/archimedes/chain/trace_publisher.py \
    | grep -E "^[+-]" | grep -c publishTrace
diff lines mentioning publishTrace: 0

$ python  # AST-free body comparison against origin/main
publish() body identical to origin/main: True
_finalize_reveal() body identical: True
reveal() body identical: True
```

The whole diff is two files: `backend/archimedes/chain/trace_publisher.py` and
`backend/tests/test_trace_publisher_commit_reveal.py`.

## Adversarial demo (guard rule)

The guard here is "never bind a trace id that isn't this commit's". Built the input that
*should* fail it — two same-vault commits in one block, A's receipt event undecodable, B
newest for the vault — and ran it against the **unfixed** code by restoring only the
pre-#1604 fallback inside `_finalize_commit`:

```
$ python - <<'PY'   # restore ONLY the old recency fallback, nothing else
REVERTED _finalize_commit to the pre-#1604 getTracesByVault()[-1] recency fallback

$ pytest backend/tests/test_trace_publisher_commit_reveal.py -q -p no:randomly -rf
=========================== short test summary info ============================
FAILED ...::TestFinalizeCommitRevertHandling::test_successful_commit_with_undecodable_event_never_guesses_newest_id
        - assert 9 is None
FAILED ...::TestCommitIdIsCommitSpecific::test_concurrent_same_vault_commits_do_not_cross_attribute
        - AssertionError: decision A must bind to ITS OWN commit's trace id
FAILED ...::TestCommitIdIsCommitSpecific::test_pending_trade_commitment_binds_when_log_reread_unavailable
        - assert 102 == 101
FAILED ...::TestCommitIdIsCommitSpecific::test_pending_pointer_with_foreign_content_hash_is_refused
        - AssertionError: a commitment whose content hash isn't ours must never be bound
FAILED ...::TestCommitIdIsCommitSpecific::test_log_entry_for_a_different_tx_in_the_same_block_is_skipped
        - assert 102 is None
FAILED ...::TestCommitIdIsCommitSpecific::test_unreadable_receipt_block_does_not_reopen_the_recency_guess
        - AssertionError: assert (102, '0xaaa1', None, False) == (None, '0xaaa1', Non...
6 failed, 11 passed, 1 warning in 7.31s
```

The headline failure *is* the reported defect, verbatim — decision A handed commit B's id:

```
    assert trace_id == self.TRACE_A, "decision A must bind to ITS OWN commit's trace id"
E   AssertionError: decision A must bind to ITS OWN commit's trace id
E   assert 102 == 101
E    +  where 101 = <...TestCommitIdIsCommitSpecific object>.TRACE_A
```

Restoring the fix:

```
$ git checkout backend/archimedes/chain/trace_publisher.py
$ pytest backend/tests/test_trace_publisher_commit_reveal.py -q
17 passed, 1 warning in 3.59s
```

So the new tests fail against the unfixed code and pass against the fixed code — they are
regression guards, not coverage.

## Tests

New `TestCommitIdIsCommitSpecific` (hermetic — registry, chain client and Circle signer all
mocked at the boundary, per CLAUDE.md § testing conventions):

- `test_concurrent_same_vault_commits_do_not_cross_attribute` — the issue's required
  scenario. Also asserts the re-read range is `from_block == to_block == commit block`.
- `test_pending_trade_commitment_binds_when_log_reread_unavailable` — route 2 binds by the
  caller's own `tradeId` where recency would still answer B.
- `test_pending_pointer_with_foreign_content_hash_is_refused` — the content-hash
  verification rejects a stale/foreign pointer rather than binding it.
- `test_log_entry_for_a_different_tx_in_the_same_block_is_skipped` — a sibling's log alone
  in the block resolves to `None`, never to the sibling.
- `test_unreadable_receipt_block_does_not_reopen_the_recency_guess` — no block number means
  route 1 cannot run; the answer is a loud `None`, not a guess.

`test_successful_commit_with_undecodable_event_still_uses_fallback` asserted the removed
behaviour (`trace_id == 9`) and is rewritten as
`..._never_guesses_newest_id`, asserting the loud `None` instead. Every test in the file
that can reach the commit path now also asserts `getTracesByVault.assert_not_called()`, so
a reintroduction of the recency guess fails here too.

## Validation

- **CI `Backend — unit tests` (the blocking `pytest -m "not integration"` gate) → pass**,
  10m37s, on a clean runner with nothing ignored. Whole board green: `Ruff — format +
  critical lint rules`, `import-guard`, CodeQL, complexity, frontend, supply-chain.
- Locally, `pytest -m "not integration" -q` from the worktree root → `5041 passed, 3
  skipped, 1 failed`. **The one local failure is pre-existing, environmental, and
  unrelated** — it passes on the CI runner above. The wall-clock budget
  assertions in `backend/tests/test_health_always_answers.py`
  (`_HEALTH_BUDGET_SECONDS = 2.0`) flake on a loaded dev box. Verified by checking the two
  touched files back out to `origin/main` — i.e. a pristine main tree, zero diff — and
  re-running that file three times:

  ```
  $ git checkout origin/main -- backend/archimedes/chain/trace_publisher.py \
                                backend/tests/test_trace_publisher_commit_reveal.py
  $ git diff origin/main --stat        # empty — tree is pristine origin/main
  $ for i in 1 2 3; do pytest backend/tests/test_health_always_answers.py -q; done
  FAILED ...::test_health_answers_within_budget_when_the_chain_client_hangs_forever
         - AssertionError: /health took 3.61s ...
  FAILED ...  - AssertionError: /health took 3.04s ...
  FAILED ...  - AssertionError: /health took 2.90s ...
  ```

  3/3 on main with no diff applied, and a *different* test in that same file than the one
  the full run reported — a load-dependent timing flake, not a regression. This diff
  touches two files, neither of which the health tests import, and CI runs that same file
  green.
- `ruff check --select E9,F63,F7,F40` (the blocking `ruff-gate` subset) on both touched
  files → clean; `ruff format --check` → clean. Full `ruff check` reports the same 3
  pre-existing `RUF059` on an untouched test at line 509 as `origin/main` does — no new
  findings.
- No `.tf` touched.
