### PR TITLE
[backend][security] Scoped API keys: a second credential for an account, never a second identity (D3)

### DIFF
--- a/backend/archimedes/api/account_auth.py
+++ b/backend/archimedes/api/account_auth.py
@@ -1,9 +1,29 @@
-"""Canonical Better Auth session resolution for FastAPI.
+"""Canonical account identity for FastAPI — one identity, two credentials.
 
 FastAPI never parses Better Auth cookies. It asks the colocated Better Auth
 service for the session and exposes a small immutable user object to route
 dependencies. Missing or unavailable auth fails closed on protected routes
 without breaking intentionally public APIs.
+
+**This module is the single chokepoint where a request acquires an identity.**
+Two credentials can establish that identity, and they are tried in this order:
+
+1. the Better Auth **session cookie** (browsers, and the quickstart's cookie jar);
+2. an ``Authorization: Bearer archim_…`` **API key** (#1653 decision D3 — CI jobs
+   and agent runners that would otherwise have to re-POST the account password
+   every seven days to refresh a cookie).
+
+Both produce the same :class:`CurrentUser`, built from the same ``auth_users``
+row. Nothing downstream — no route, dependency, quota, paywall or rate limit —
+has, or needs, a branch on which one was used: a key is a credential, never a
+bypass, and the way that property is *guaranteed* rather than merely intended is
+that the difference stops existing here.
+
+The one place the difference is legible is ``request.state.auth_credential``
+(``"session"`` / ``"api_key"`` / ``None``). Exactly two things read it:
+:func:`require_session_credential`, which keeps key management off the keys
+themselves, and the telemetry classifier, which counts a keyed caller as an agent
+instead of mislabelling it a human. Neither grants or withholds account access.
 """
 
 from __future__ import annotations
@@ -18,6 +38,11 @@ from fastapi import HTTPException, Request
 
 logger = logging.getLogger(__name__)
 _SESSION_COOKIE_FRAGMENT = "better-auth.session_token="
+
+#: Values of ``request.state.auth_credential``. Which credential proved the
+#: identity — never which identity, and never what it is allowed to do.
+CREDENTIAL_SESSION = "session"
+CREDENTIAL_API_KEY = "api_key"
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,17 +110,50 @@ async def _fetch_session(request: Request) -> object:
 
 
 async def better_auth_session_middleware(request: Request, call_next):
+    """Resolve the request's account identity, once, from either credential.
+
+    Cookie first (the browser majority, and the existing behaviour, unchanged),
+    then the API key. The key path is attempted only when the cookie produced no
+    user, so a signed-in browser never pays for a database read it does not need,
+    and ``parse_authorization_header`` rejects any header that is not one of our
+    tokens before touching the database at all.
+    """
     request.state.current_user = None
+    request.state.auth_credential = None
+
     if _SESSION_COOKIE_FRAGMENT in request.headers.get("cookie", ""):
         try:
             request.state.current_user = _user_from_payload(await _fetch_session(request))
         except Exception as exc:
             logger.warning("Better Auth session resolution failed: %s", type(exc).__name__)
+        if request.state.current_user is not None:
+            request.state.auth_credential = CREDENTIAL_SESSION
+
+    if request.state.current_user is None:
+        # Imported here, not at module scope: the key path pulls in the ORM and
+        # the database module, and this file is imported by ``main.py`` before
+        # those are configured.
+        from archimedes.api.api_key_auth import resolve_api_key_user
+
+        keyed_user = resolve_api_key_user(request)
+        if keyed_user is not None:
+            request.state.current_user = keyed_user
+            request.state.auth_credential = CREDENTIAL_API_KEY
+
     return await call_next(request)
 
 
 def get_current_user(request: Request) -> CurrentUser | None:
     return getattr(getattr(request, "state", None), "current_user", None)
+
+
+def get_auth_credential(request: Request) -> str | None:
+    """Which credential proved this request's identity, if any.
+
+    ``CREDENTIAL_SESSION`` / ``CREDENTIAL_API_KEY`` / ``None``. Read by exactly
+    two callers (see the module docstring); it is not an authorisation input.
+    """
+    return getattr(getattr(request, "state", None), "auth_credential", None)
 
 
 def require_current_user(request: Request) -> CurrentUser:
@@ -105,5 +163,30 @@ def require_current_user(request: Request) -> CurrentUser:
             status_code=401,
             detail="Authentication required",
             headers={"WWW-Authenticate": "Session"},
+        )
+    return user
+
+
+def require_session_credential(request: Request) -> CurrentUser:
+    """Require an interactive session — an API key is refused with 403.
+
+    Guards the key-management endpoints, and only those. The reason is
+    containment: if a key could mint keys, a single leaked token would be able to
+    issue itself successors, and revoking the token an operator knows about would
+    not end the compromise. Requiring the human credential to manage credentials
+    means the blast radius of a leaked key is bounded by what that key can do —
+    and what it can do is exactly what the account can do, minus this.
+
+    401 when there is no identity at all, 403 when the identity is real but the
+    credential is the wrong kind: the caller is authenticated, they are simply
+    holding a credential this surface does not accept.
+    """
+    user = require_current_user(request)
+    if get_auth_credential(request) != CREDENTIAL_SESSION:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "API keys cannot manage API keys. Sign in with your account session to create, list, or revoke keys."
+            ),
         )
     return user

--- a/backend/archimedes/api/api_key_auth.py
+++ b/backend/archimedes/api/api_key_auth.py
@@ -1,0 +1,242 @@
+"""Bearer API keys: minting and verification. The whole of the key crypto, in one file.
+
+Owner decision **D3** on #1653 — "strict, sane, secure, safe; auditable by anyone
+reading the code; exposing no sensitive information". Everything an auditor needs
+to check that sentence is in this module and in ``models/api_key.py``; no other
+file performs a comparison, a hash, or a token parse.
+
+The token
+---------
+::
+
+    archim_<key_id>_<secret>
+    ^^^^^^ ^^^^^^^^ ^^^^^^^^
+    |      |        32 random bytes, urlsafe-base64 (43 chars, 256 bits)
+    |      16 hex chars — PUBLIC. The database lookup handle. Not a secret.
+    fixed prefix, so a leaked token is greppable in a log by its shape
+
+``archim_<key_id>`` is the ``prefix`` the list endpoint shows. It identifies a key
+without being usable as one.
+
+Verification, step by step (this is the part to audit)
+------------------------------------------------------
+1. Parse. A header that is not ``Bearer archim_<id>_<secret>`` is rejected before
+   any database work. No partial matching, no fallback to another scheme.
+2. Look the row up by ``key_id``.
+3. Compute ``sha256(salt || secret)`` and compare it to the stored digest with
+   :func:`hmac.compare_digest` — the same constant-time primitive
+   ``auth_guard.require_internal_agent_key`` uses for the internal key.
+4. **On a miss (unknown id, or a revoked key) the comparison still runs**, against
+   a fixed dummy salt and digest generated at import time. An attacker therefore
+   cannot distinguish "no such key id" from "wrong secret" by timing the response,
+   and cannot enumerate valid key ids. This is the one place where doing useless
+   work is the correct implementation, so it is spelled out rather than optimised
+   away by a later reader; ``test_unknown_key_id_still_performs_a_comparison``
+   fails if someone adds the early return back.
+
+Why not a JWT / a signed token
+------------------------------
+A signed token is verifiable without a database read, which sounds like the
+better design until you ask how it is revoked: it is not, short of a
+denylist — which is a database read, plus a way to get the denylist wrong.
+Revocation that takes effect on the *next* request was a stated requirement, and
+an opaque token checked against a row gives it for free.
+
+What is NOT logged, ever
+------------------------
+No function in this module passes a token, a secret, or a digest to a logger. The
+failure log line records the *type name* of an exception and nothing else — the
+same discipline ``account_auth.better_auth_session_middleware`` already follows.
+``test_no_key_material_reaches_the_logs`` drives mint → verify → revoke with a
+``caplog`` handler attached at DEBUG on the root logger and asserts the secret
+appears in no emitted record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import secrets
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from sqlalchemy.orm import Session
+    from starlette.requests import Request
+
+    from archimedes.api.account_auth import CurrentUser
+    from archimedes.models.api_key import ApiKeyRecord
+
+logger = logging.getLogger(__name__)
+
+#: The token's fixed, greppable opening. Chosen so that a key that leaks into a
+#: log, a screenshot, or a pasted terminal buffer can be *found* by searching for
+#: this string — the same reason ``ghp_`` / ``sk-`` exist.
+TOKEN_PREFIX = "archim_"
+
+#: Bytes of entropy in the secret half. 32 bytes = 256 bits. The issue's A1 is a
+#: test against this constant, not against a literal, so lowering it breaks a test.
+SECRET_BYTES = 32
+
+#: Hex characters in the public key id (8 random bytes). Wide enough that minting
+#: collisions are not a practical concern; the mint loop below handles them anyway.
+KEY_ID_HEX_CHARS = 16
+
+_SCHEME = "Bearer "
+
+
+def _digest(salt: str, secret: str) -> str:
+    """``sha256(salt_bytes || secret_bytes)`` as hex.
+
+    The salt is stored as hex and hashed as *bytes*, so the digest input has no
+    ambiguous separator to get wrong. See ``models/api_key.py`` for why a plain
+    sha256 (and not bcrypt/argon2) is the right primitive for a 256-bit secret.
+    """
+    return hashlib.sha256(bytes.fromhex(salt) + secret.encode("utf-8")).hexdigest()
+
+
+#: A salt/digest pair that no real key can match, used to keep the miss path
+#: doing the same work as the hit path. Generated per process at import: it is
+#: never stored, never compared against anything meaningful, and its only job is
+#: to consume the same time a real comparison would.
+_DUMMY_SALT = secrets.token_hex(16)
+_DUMMY_DIGEST = _digest(_DUMMY_SALT, secrets.token_urlsafe(SECRET_BYTES))
+
+
+def parse_authorization_header(header_value: str | None) -> tuple[str, str] | None:
+    """``"Bearer archim_<id>_<secret>"`` → ``(key_id, secret)``, else ``None``.
+
+    Strict by construction: the scheme must be exactly ``Bearer``, the token must
+    carry our prefix, and the remainder must split into exactly two non-empty
+    parts on the single separating underscore. Anything else — a JWT, a basic-auth
+    header, a truncated paste, a token with our prefix but no id — returns
+    ``None`` and the request continues as unauthenticated.
+    """
+    if not header_value or not header_value.startswith(_SCHEME):
+        return None
+    token = header_value[len(_SCHEME) :].strip()
+    if not token.startswith(TOKEN_PREFIX):
+        return None
+    body = token[len(TOKEN_PREFIX) :]
+    key_id, separator, secret = body.partition("_")
+    if not separator or not key_id or not secret:
+        return None
+    return key_id, secret
+
+
+def mint(session: Session, *, user_id: str, name: str) -> tuple[ApiKeyRecord, str]:
+    """Create a key for *user_id*. Returns ``(record, token)``.
+
+    The returned token is the **only** copy that will ever exist: the record holds
+    a salt and a digest, and this function is the only place the two are ever
+    together. The caller must hand the token to the account owner in the response
+    body and then let it fall out of scope — it is never persisted, cached, or
+    logged.
+    """
+    from archimedes.models.api_key import ApiKeyRecord
+
+    if not user_id:
+        raise ValueError("mint requires a user_id")
+
+    # Collisions are astronomically unlikely at 64 bits, but "unlikely" is not
+    # "handled": a collision would silently overwrite another account's key, so
+    # the loop re-rolls rather than trusting the odds.
+    for _ in range(5):
+        key_id = secrets.token_hex(KEY_ID_HEX_CHARS // 2)
+        if session.get(ApiKeyRecord, key_id) is None:
+            break
+    else:  # pragma: no cover - requires five consecutive 64-bit collisions
+        raise RuntimeError("could not allocate a unique api key id")
+
+    secret = secrets.token_urlsafe(SECRET_BYTES)
+    salt = secrets.token_hex(16)
+
+    record = ApiKeyRecord(
+        id=key_id,
+        user_id=user_id,
+        name=name,
+        salt=salt,
+        secret_hash=_digest(salt, secret),
+    )
+    session.add(record)
+    session.flush()
+
+    return record, f"{TOKEN_PREFIX}{key_id}_{secret}"
+
+
+def verify(session: Session, key_id: str, secret: str) -> ApiKeyRecord | None:
+    """The live, un-revoked key matching ``(key_id, secret)``, or ``None``.
+
+    Constant-time on both paths — see the module docstring, step 4. A revoked key
+    takes the same path as an unknown one: the comparison runs, and the result is
+    discarded in favour of ``None``. Revocation is read from the row on every
+    call, so it takes effect on the very next request with no cache to expire.
+    """
+    from archimedes.models.api_key import ApiKeyRecord
+
+    record = session.get(ApiKeyRecord, key_id) if key_id else None
+
+    if record is None:
+        # Deliberate: burn the same work an existing key would, so timing does
+        # not answer "is this a real key id?". Do NOT replace with `return None`.
+        hmac.compare_digest(_digest(_DUMMY_SALT, secret), _DUMMY_DIGEST)
+        return None
+
+    matches = hmac.compare_digest(_digest(record.salt, secret), record.secret_hash)
+    if not matches or record.revoked_at is not None:
+        return None
+    return record
+
+
+def resolve_api_key_user(request: Request) -> CurrentUser | None:
+    """Resolve ``Authorization: Bearer archim_…`` to the account that owns the key.
+
+    Returns the **same** :class:`~archimedes.api.account_auth.CurrentUser` shape a
+    cookie session resolves to, built from the same ``auth_users`` row — which is
+    what makes "one identity, two credentials" true rather than aspirational. No
+    route, dependency, quota, or paywall can tell the two apart, because after
+    this function returns there is nothing left to tell apart.
+
+    Fails closed and silent: any database or lookup error resolves to ``None``
+    (an unauthenticated request), logging the exception *type* only.
+    """
+    from archimedes.api.account_auth import CurrentUser
+    from archimedes.db import get_session
+    from archimedes.models.account import AuthUser
+    from archimedes.models.api_key import touch_last_used
+
+    parsed = parse_authorization_header(request.headers.get("authorization"))
+    if parsed is None:
+        return None
+    key_id, secret = parsed
+
+    session = get_session()
+    try:
+        record = verify(session, key_id, secret)
+        if record is None:
+            return None
+
+        account = session.get(AuthUser, record.user_id)
+        if account is None:
+            # The key outlived its account (a deletion that skipped the cascade).
+            # Fail closed: a credential with no account behind it is not an
+            # identity, and inventing one here would be the exact fail-soft
+            # substitution CONVENTIONS.md forbids.
+            return None
+
+        user = CurrentUser(
+            id=account.id,
+            name=str(account.name or ""),
+            email=account.email,
+            email_verified=bool(account.email_verified),
+            image=account.image,
+        )
+        if touch_last_used(session, record):
+            session.commit()
+        return user
+    except Exception as exc:
+        # Type name only — never the header, never the token, never the row.
+        logger.warning("api key resolution failed: %s", type(exc).__name__)
+        return None
+    finally:
+        session.close()

--- a/backend/archimedes/api/api_key_routes.py
+++ b/backend/archimedes/api/api_key_routes.py
@@ -160,7 +160,12 @@ async def revoke_api_key(
             raise HTTPException(status_code=404, detail="API key not found")
         revoke_key(session, record)
         session.commit()
-        logger.info("api key revoked: id=%s user=%s", key_id, user.id)
+        # ``record.id``, not the raw path parameter. They are equal by construction
+        # here — ``get_owned_key`` matched on it — but logging the value that came
+        # out of the database rather than the one that came off the wire means no
+        # caller-controlled string can ever reach a log line, so log forging is not
+        # a question a reader has to reason about.
+        logger.info("api key revoked: id=%s user=%s", record.id, user.id)
         return Response(status_code=204)
     except HTTPException:
         session.rollback()

--- a/backend/archimedes/api/api_key_routes.py
+++ b/backend/archimedes/api/api_key_routes.py
@@ -1,0 +1,173 @@
+"""``/api/account/keys`` — create, list, revoke an account's API keys (#1653 D3).
+
+Three endpoints, on the account surface next to ``/api/account/usage``, gated by
+:func:`~archimedes.api.account_auth.require_session_credential`: **an API key
+cannot manage API keys.** See that function for why.
+
+What each one exposes, precisely
+--------------------------------
+``POST``   returns the key row **plus** the token, once. This is the only response
+           anywhere in the system that contains a token, and it exists for exactly
+           one round trip. If the caller loses it, the key is unrecoverable and the
+           remedy is to revoke it and mint another — which is the correct behaviour
+           for a credential we cannot read back either.
+
+``GET``    returns ``id``, ``name``, ``prefix`` (``archim_<id>`` — the non-secret
+           half), ``created_at``, ``last_used_at``, ``revoked_at``. There is no
+           code path that can add the token: the serialiser is
+           ``ApiKeyRecord.to_payload``, the record does not hold a token, and the
+           response model below has no field for one. Two independent reasons,
+           because one is a comment and the other is enforced.
+
+``DELETE`` revokes, and answers **404** for a key that is not the caller's —
+           the same answer as a key that does not exist. A 403 would confirm the
+           id is real and belongs to someone; enumerating other accounts' key ids
+           is not a capability this surface should hand out.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from pydantic import BaseModel, Field, field_validator
+
+from archimedes.api.account_auth import CurrentUser, require_session_credential
+from archimedes.api.api_key_auth import mint
+from archimedes.api.limiter import limiter
+from archimedes.db import get_session
+from archimedes.models.api_key import (
+    MAX_KEYS_PER_ACCOUNT,
+    get_owned_key,
+    list_keys,
+    live_key_count,
+    revoke_key,
+)
+
+logger = logging.getLogger(__name__)
+
+api_key_router = APIRouter(prefix="/api/account/keys", tags=["account"])
+
+
+class ApiKeyCreateRequest(BaseModel):
+    """A key needs a label so a human can decide which one to revoke."""
+
+    name: str = Field(..., min_length=1, max_length=64)
+
+    @field_validator("name")
+    @classmethod
+    def _clean(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("name must not be blank")
+        return cleaned
+
+
+class ApiKeySummary(BaseModel):
+    """A key as the owner sees it afterwards. **No field can carry a secret.**"""
+
+    id: str
+    name: str
+    prefix: str = Field(..., description="archim_<id> — identifies the key, cannot be used as one.")
+    created_at: str | None = None
+    last_used_at: str | None = None
+    revoked_at: str | None = None
+
+
+class ApiKeyCreateResponse(ApiKeySummary):
+    """The create response, and the only place a token is ever returned."""
+
+    key: str = Field(
+        ...,
+        description=(
+            "The full token, shown exactly once. It is stored only as a salted hash, "
+            "so it cannot be recovered from this system by anyone, including its operators."
+        ),
+    )
+
+
+@api_key_router.post("", response_model=ApiKeyCreateResponse, status_code=201)
+@limiter.limit("10/hour")
+async def create_api_key(
+    payload: ApiKeyCreateRequest,
+    request: Request,  # noqa: ARG001 — slowapi's decorator requires it by name; also read by require_session_credential
+    user: CurrentUser = Depends(require_session_credential),
+) -> ApiKeyCreateResponse:
+    """Mint a key for the calling account. The token is in the response, once."""
+    session = get_session()
+    try:
+        if live_key_count(session, user.id) >= MAX_KEYS_PER_ACCOUNT:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "reason": "api_key_limit_reached",
+                    "message": (
+                        f"This account already holds {MAX_KEYS_PER_ACCOUNT} live API keys. "
+                        "Revoke one before creating another."
+                    ),
+                },
+            )
+
+        record, token = mint(session, user_id=user.id, name=payload.name)
+        payload_out = record.to_payload()
+        session.commit()
+
+        # The id is safe to log (it is the public half and appears in the token
+        # prefix); the token is not, and is not passed to any logger anywhere.
+        logger.info("api key created: id=%s user=%s", payload_out["id"], user.id)
+
+        return ApiKeyCreateResponse(**payload_out, key=token)
+    except HTTPException:
+        session.rollback()
+        raise
+    except Exception as exc:
+        session.rollback()
+        logger.error("api key creation failed: %s", type(exc).__name__)
+        raise HTTPException(status_code=500, detail="Could not create API key") from exc
+    finally:
+        session.close()
+
+
+@api_key_router.get("", response_model=list[ApiKeySummary])
+async def list_api_keys(
+    request: Request,  # noqa: ARG001 — consumed by require_session_credential via Depends
+    user: CurrentUser = Depends(require_session_credential),
+) -> list[ApiKeySummary]:
+    """The calling account's keys, newest first. Never another account's."""
+    session = get_session()
+    try:
+        return [ApiKeySummary(**row) for row in list_keys(session, user.id)]
+    finally:
+        session.close()
+
+
+@api_key_router.delete("/{key_id}", status_code=204, response_class=Response)
+async def revoke_api_key(
+    key_id: str,
+    request: Request,  # noqa: ARG001 — consumed by require_session_credential via Depends
+    user: CurrentUser = Depends(require_session_credential),
+) -> Response:
+    """Revoke a key. Effective on the very next request that presents it.
+
+    Idempotent: revoking an already-revoked key is a 204, not an error, so a
+    retried automation does not have to distinguish the two.
+    """
+    session = get_session()
+    try:
+        record = get_owned_key(session, user.id, key_id)
+        if record is None:
+            # Not yours and does not exist are the same answer — see module docstring.
+            raise HTTPException(status_code=404, detail="API key not found")
+        revoke_key(session, record)
+        session.commit()
+        logger.info("api key revoked: id=%s user=%s", key_id, user.id)
+        return Response(status_code=204)
+    except HTTPException:
+        session.rollback()
+        raise
+    except Exception as exc:
+        session.rollback()
+        logger.error("api key revocation failed: %s", type(exc).__name__)
+        raise HTTPException(status_code=500, detail="Could not revoke API key") from exc
+    finally:
+        session.close()

--- a/backend/archimedes/api/metrics_routes.py
+++ b/backend/archimedes/api/metrics_routes.py
@@ -194,8 +194,8 @@ async def get_funnel(
 
     Every stage in the ``source=visitor`` response also carries
     ``by_agent_type`` (issue #788): the same distinct-visitor count, broken out
-    by the telemetry middleware's classification (``internal``/``external``/
-    ``human``), so agent conversion through the funnel can be measured
+    by the telemetry middleware's classification (``internal``/``keyed``/
+    ``external``/``human``), so agent conversion through the funnel can be measured
     separately from human conversion. Additive — ``distinct_visitors`` and the
     ratios are unchanged. Empty per stage on ``source=identity`` (no
     per-request agent_type there).

--- a/backend/archimedes/api/telemetry_middleware.py
+++ b/backend/archimedes/api/telemetry_middleware.py
@@ -6,14 +6,39 @@ of the hackathon win-condition instrument: a real, live "agents vs humans"
 traction number backed by the live request path rather than a claim.
 
 Classifier (deterministic — identity model as of today):
-  - HUMAN  = Better Auth middleware resolved canonical account state.
   - AGENT (internal) = a valid ``X-Internal-Agent-Key`` header (HMAC-compared
              against ``INTERNAL_AGENT_API_KEY``), agent_type="internal".
-  - AGENT (external) = no session AND a non-browser User-Agent (no "Mozilla";
-             matches curl / python-requests / boto / axios / *bot*),
+  - AGENT (keyed)    = the account identity was proved by a scoped API key
+             (``Authorization: Bearer archim_…``), agent_type="keyed".
+  - HUMAN  = Better Auth middleware resolved canonical account state from the
+             session cookie.
+  - AGENT (external) = no account identity AND a non-browser User-Agent (no
+             "Mozilla"; matches curl / python-requests / boto / axios / *bot*),
              agent_type="external".
   - Default (browser UA, no session) = HUMAN — the demo is open, so an
     un-signed-in browser visitor still counts as a human.
+
+Why ``keyed`` had to be added (issue #1653, finding 1)
+------------------------------------------------------
+Before the API-key lane, rule "session ⇒ human" fired before the User-Agent
+heuristic, and every stage of the funnel past ``landed`` sits behind
+``require_current_user``. So **no agent generation could ever be attributed to
+an agent** — the moment a script signed in, it was counted as a human, and the
+live funnel's ``external: 0`` at ``generation_started`` measured the absence of
+the question, not the absence of agents.
+
+A key is the first credential that says what the caller *is* rather than
+guessing from a header a client chooses. So it is classified ahead of the
+session rule, and it gets its own ``agent_type`` rather than being folded into
+``external``: ``external`` means "unauthenticated non-browser, inferred from a
+UA string", which is a different and much weaker claim than "authenticated by a
+credential minted for machine use". Collapsing them would destroy the only
+high-confidence agent signal we have. UA heuristics remain a courtesy label.
+
+Adding a value to this vocabulary is a deliberate act with three other sites:
+``services/funnel_store.AGENT_TYPES`` (which silently drops an unrecognised
+type), ``models/telemetry.py``'s field description, and the docs. All four move
+together or the breakdown quietly loses a population.
 
 This module only reads request state resolved by auth middleware; it never changes auth.
 
@@ -100,30 +125,49 @@ def _has_valid_internal_key(request: Request) -> bool:
 
 
 def _has_valid_session(request: Request) -> bool:
-    """True iff Better Auth middleware resolved canonical account state."""
+    """True iff the identity middleware resolved canonical account state."""
     return getattr(request.state, "current_user", None) is not None
+
+
+def _has_api_key_credential(request: Request) -> bool:
+    """True iff that account state was proved by a scoped API key, not a cookie.
+
+    Reads ``request.state.auth_credential``, set by the one identity chokepoint
+    (``api/account_auth.py``). This is a *read* of a resolved fact — the header
+    is not re-parsed and no verification is repeated here, so telemetry can
+    never disagree with auth about who the caller is.
+    """
+    from archimedes.api.account_auth import CREDENTIAL_API_KEY
+
+    return getattr(request.state, "auth_credential", None) == CREDENTIAL_API_KEY
 
 
 def classify_request(request: Request) -> tuple[bool, str]:
     """Classify a request. Returns ``(is_agent, agent_type)``.
 
-    ``agent_type`` is one of ``"internal"``, ``"external"``, or ``"human"``.
-    Deterministic and side-effect-free so it is trivially testable.
+    ``agent_type`` is one of ``"internal"``, ``"keyed"``, ``"external"``, or
+    ``"human"``. Deterministic and side-effect-free so it is trivially testable.
     """
     # 1. Internal agent — explicit, strongest signal.
     if _has_valid_internal_key(request):
         return True, "internal"
 
-    # 2. Human — canonical account session.
+    # 2. Scoped API key — an account identity, proved by a machine credential.
+    #    Ahead of rule 3 on purpose: the key is a stronger and more honest
+    #    signal than the cookie's silence. See the module docstring.
+    if _has_valid_session(request) and _has_api_key_credential(request):
+        return True, "keyed"
+
+    # 3. Human — canonical account session (cookie).
     if _has_valid_session(request):
         return False, "human"
 
-    # 3. No session: a non-browser UA is an external agent/script.
+    # 4. No account identity: a non-browser UA is an external agent/script.
     user_agent = request.headers.get("user-agent", "")
     if not _is_browser_ua(user_agent) or _AGENT_UA_PATTERN.search(user_agent):
         return True, "external"
 
-    # 4. Default — browser UA, no session: an open-demo human.
+    # 5. Default — browser UA, no session: an open-demo human.
     return False, "human"
 
 

--- a/backend/archimedes/db.py
+++ b/backend/archimedes/db.py
@@ -21,6 +21,7 @@ from archimedes.models.account import (
     LinkedWallet,
     WalletLinkChallenge,
 )
+from archimedes.models.api_key import ApiKeyRecord
 from archimedes.models.asset_daily_bars import AssetDailyBar
 from archimedes.models.backtest_fixtures_store import StrategyBacktestFixture
 from archimedes.models.backtest_store import BacktestResultRecord
@@ -55,6 +56,7 @@ __all__ = [
     "AuthSession",
     "AuthUser",
     "AuthVerification",
+    "ApiKeyRecord",
     "AssetDailyBar",
     "BacktestResultRecord",
     "Base",

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -50,6 +50,7 @@ if os.getenv("PUBLIC_DOMAIN"):
 from archimedes.api.account_auth import better_auth_session_middleware, require_current_user
 from archimedes.api.account_usage_routes import account_usage_router
 from archimedes.api.agent_manifest_routes import agent_manifest_router
+from archimedes.api.api_key_routes import api_key_router
 from archimedes.api.corpus_routes import corpus_router
 from archimedes.api.explore_routes import explore_router
 from archimedes.api.features_routes import features_router
@@ -723,6 +724,11 @@ app.include_router(portfolio_router, dependencies=[Depends(require_current_user)
 app.include_router(selection_bias_router)
 app.include_router(rigor_verify_router)
 app.include_router(account_usage_router)
+# Key management is session-gated inside the router (an API key cannot manage
+# API keys — see account_auth.require_session_credential), so it is deliberately
+# NOT wrapped in a router-level require_current_user: the stricter dependency
+# already lives on each route and a second one here would only obscure it.
+app.include_router(api_key_router)
 app.include_router(payment_router)
 app.include_router(papers_router)
 app.include_router(user_router, dependencies=[Depends(require_current_user)])

--- a/backend/archimedes/models/api_key.py
+++ b/backend/archimedes/models/api_key.py
@@ -1,0 +1,204 @@
+"""Scoped API keys — a second *credential* for an account, never a second identity.
+
+Owner decision **D3** on #1653: CI jobs and agent runners had exactly one way to
+authenticate — the account's Better Auth session cookie, obtained by POSTing the
+account **password** to ``/api/auth/sign-in/email`` and refreshed every seven days
+when the cookie expires. That makes the machine credential *the human's password*:
+un-scopable, un-revocable without locking the human out, and re-transmitted on a
+weekly cycle. This table is the fix.
+
+What is stored, and what is not
+-------------------------------
+One row per key::
+
+    id           the PUBLIC key id — also the token's lookup handle. Not a secret.
+    user_id      the account this key speaks for. THE scope. FK → auth_users.
+    name         a human label ("ci-nightly"). Not a secret.
+    salt         32 hex chars = 16 random bytes, unique per key.
+    secret_hash  sha256(salt_bytes || secret_bytes), hex. 64 chars.
+    created_at / last_used_at / revoked_at
+
+**The token itself is not here, and is not anywhere.** It is returned exactly once,
+in the body of the create call, and then only its hash survives. A dump of this
+table — a leaked backup, a `SELECT *` in a log, a support engineer's screen — yields
+nothing that can be replayed against the API. That is the whole reason the column
+list looks like this, and ``test_api_key_auth.py`` proves it by serialising every
+column of every row and asserting the token is absent.
+
+Why sha256 and not bcrypt/argon2
+--------------------------------
+Those exist because *human passwords* have perhaps 30 bits of entropy, so a fast
+hash lets an attacker with the digests enumerate the plaintext. An API key minted
+here carries **256 bits** from ``secrets.token_urlsafe(32)``. There is no dictionary
+to run and no feasible enumeration, so a slow KDF buys nothing but latency on every
+request. The salt is still per-key (it costs one column and removes any shared
+structure between digests). This reasoning is written down because "why isn't this
+bcrypt" is the first question an auditor asks, and the answer must be in the file,
+not in a reviewer's head.
+
+Why the id is public and lives inside the token
+-----------------------------------------------
+Verification needs to find the right row. Scanning every key in the table and
+comparing each digest would be O(keys) per request and would leak timing that grows
+with table size. So the token carries its own non-secret lookup handle:
+``archim_<id>_<secret>`` — index lookup on ``id``, then one constant-time comparison.
+``archim_<id>`` is also the ``prefix`` shown in the list endpoint: enough to tell two
+keys apart in a UI, useless to an attacker.
+
+Revocation is a column, not a cache
+-----------------------------------
+``revoked_at`` is read on the request path, from the row, every time. There is no
+TTL and no in-process memo, so "revoked" means revoked on the very next request —
+which is the only definition of revocation worth having, and is pinned by
+``test_revoked_key_is_401_on_the_next_call``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from archimedes.models.chat import Base
+
+#: Ceiling on live (un-revoked) keys per account. Not a licence tier — an
+#: anti-abuse bound, so a compromised session cannot mint an unbounded set of
+#: credentials that a human then has to find and revoke one by one.
+MAX_KEYS_PER_ACCOUNT = 25
+
+#: Bound on the list read, mirroring ``generation_credit.MAX_CREDITS``. Revoked
+#: rows are kept (an audit trail is the point), so the list can exceed the live
+#: ceiling above.
+MAX_KEYS_LISTED = 200
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class ApiKeyRecord(Base):
+    """One API key. Holds a digest, never a token."""
+
+    __tablename__ = "api_keys"
+
+    #: The public key id, and the token's lookup handle. See module docstring.
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+
+    #: The account this key authenticates as. This column IS the key's scope:
+    #: every read the key performs runs as this user and no other.
+    user_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("auth_users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    salt: Mapped[str] = mapped_column(String(64), nullable=False)
+    secret_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=_now)
+
+    #: Coarsened to the minute on write (see ``touch_last_used``) so a busy key
+    #: does not turn every authenticated request into a database UPDATE.
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (Index("ix_api_keys_user_revoked", "user_id", "revoked_at"),)
+
+    @property
+    def prefix(self) -> str:
+        """The displayable, non-secret half of the token: ``archim_<id>``."""
+        return f"archim_{self.id}"
+
+    def to_payload(self) -> dict[str, Any]:
+        """The list/create-echo shape. **Contains no secret material.**
+
+        Every field here is either public by construction (``id`` / ``prefix``),
+        chosen by the caller (``name``), or a timestamp. There is deliberately no
+        branch that can add the token: the token does not exist on this object.
+        """
+        return {
+            "id": self.id,
+            "name": self.name,
+            "prefix": self.prefix,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "last_used_at": self.last_used_at.isoformat() if self.last_used_at else None,
+            "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
+        }
+
+
+# ── Queries (all of them scoped by user_id — that is not optional) ──────
+
+
+def live_key_count(session: Session, user_id: str) -> int:
+    """How many un-revoked keys *user_id* holds."""
+    return (
+        session.query(ApiKeyRecord).filter(ApiKeyRecord.user_id == user_id, ApiKeyRecord.revoked_at.is_(None)).count()
+    )
+
+
+def list_keys(session: Session, user_id: str, *, limit: int = MAX_KEYS_LISTED) -> list[dict[str, Any]]:
+    """Newest-first keys owned by *user_id*. Never another account's.
+
+    The ``user_id`` filter is what makes A9 (cross-account isolation) true for
+    reads; there is no unscoped variant of this function to reach for by mistake.
+    """
+    if not user_id:
+        return []
+    rows = (
+        session.query(ApiKeyRecord)
+        .filter(ApiKeyRecord.user_id == user_id)
+        .order_by(ApiKeyRecord.created_at.desc(), ApiKeyRecord.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return [r.to_payload() for r in rows]
+
+
+def get_owned_key(session: Session, user_id: str, key_id: str) -> ApiKeyRecord | None:
+    """The key *key_id*, **only** if *user_id* owns it. Otherwise ``None``.
+
+    Ownership is part of the lookup, not a check performed afterwards on a row
+    that was already fetched — so a caller cannot forget the check, and the
+    "not yours" and "does not exist" answers are literally the same answer.
+    That is what lets the revoke route return 404 for both without a branch
+    that could drift: a 403 would confirm the id exists in someone's account.
+    """
+    if not user_id or not key_id:
+        return None
+    return session.query(ApiKeyRecord).filter(ApiKeyRecord.user_id == user_id, ApiKeyRecord.id == key_id).one_or_none()
+
+
+def revoke_key(session: Session, record: ApiKeyRecord) -> ApiKeyRecord:
+    """Mark *record* revoked. Idempotent — re-revoking keeps the first timestamp.
+
+    The row is kept. A deleted row erases the evidence that the key ever existed,
+    which is the opposite of what an audit trail is for.
+    """
+    if record.revoked_at is None:
+        record.revoked_at = _now()
+        session.flush()
+    return record
+
+
+def touch_last_used(session: Session, record: ApiKeyRecord, *, now: datetime | None = None) -> bool:
+    """Record that *record* was just used. Returns True iff a write happened.
+
+    Coarsened to one write per minute per key: ``last_used_at`` exists so a human
+    can answer "is this key still in use / when did the leak start", and
+    minute resolution answers both. Writing on every request would put a database
+    UPDATE on the hot path of every authenticated agent call for no extra
+    information.
+    """
+    moment = now or _now()
+    previous = record.last_used_at
+    if previous is not None:
+        if previous.tzinfo is None:
+            previous = previous.replace(tzinfo=UTC)
+        if (moment - previous).total_seconds() < 60:
+            return False
+    record.last_used_at = moment
+    session.flush()
+    return True

--- a/backend/archimedes/models/telemetry.py
+++ b/backend/archimedes/models/telemetry.py
@@ -78,9 +78,11 @@ class FunnelStageCount(BaseModel):
     step_conversion: float = Field(..., description="distinct_visitors / previous-stage count (0.0-1.0).")
     by_agent_type: dict[str, int] = Field(
         default_factory=dict,
-        description="distinct_visitors at this stage, broken out by agent_type ('internal'/'external'/'human') "
-        "so agent conversion can be measured separately from human (issue #788). Empty for source=identity, "
-        "which has no per-request agent_type.",
+        description="distinct_visitors at this stage, broken out by agent_type "
+        "('internal'/'keyed'/'external'/'human') so agent conversion can be measured separately from "
+        "human (issue #788). 'keyed' is a caller authenticated by a scoped API key (#1653 D3) — an "
+        "identity, unlike 'external', which is a User-Agent guess about an unauthenticated client. "
+        "Empty for source=identity, which has no per-request agent_type.",
     )
 
 

--- a/backend/archimedes/services/funnel_store.py
+++ b/backend/archimedes/services/funnel_store.py
@@ -69,7 +69,17 @@ CLIENT_EMITTABLE_STAGES: frozenset[str] = frozenset({"landed"})
 # imported to keep this services-layer module independent of the api layer.
 # An agent_type outside this set is treated like an unknown stage: no-op on
 # write, not a bogus key.
-AGENT_TYPES: tuple[str, ...] = ("internal", "external", "human")
+#
+# ``keyed`` joined the set with the scoped API-key lane (#1653 decision D3): a
+# caller authenticated by ``Authorization: Bearer archim_…``. It is deliberately
+# NOT folded into ``external`` — ``external`` is a User-Agent *guess* about an
+# unauthenticated client, while ``keyed`` is a credential minted for machine use,
+# and merging them would put the only high-confidence agent signal we have back
+# into a bucket of heuristics. Because an unrecognised type silently no-ops on
+# write (see ``record``), forgetting this line would have made keyed traffic
+# vanish from the breakdown rather than fail loudly — which is why the classifier
+# module names this file as one of the four sites that move together.
+AGENT_TYPES: tuple[str, ...] = ("internal", "keyed", "external", "human")
 
 # Per-day buckets self-expire after this window (90 days of trend history).
 _DAY_TTL_SECONDS = 90 * 24 * 60 * 60

--- a/backend/migrations/versions/c1d8e6f30a72_add_api_keys.py
+++ b/backend/migrations/versions/c1d8e6f30a72_add_api_keys.py
@@ -1,0 +1,95 @@
+"""add api_keys — a machine credential that is not the account password (#1653 D3)
+
+Before this table the only credential a CI job or agent runner could hold was the
+Better Auth session cookie, and the only way to obtain or refresh one was to POST
+the account **password** to ``/api/auth/sign-in/email`` — every seven days, when
+the cookie expires. The machine credential was the human's password: not scopable,
+not revocable without locking the human out, and re-transmitted on a weekly cycle.
+
+One row per key. The token itself is **not** in the schema and is not anywhere:
+``secret_hash`` is ``sha256(salt || secret)`` over a 256-bit secret, and the salt
+is per-key. A dump of this table yields nothing replayable. See
+``backend/archimedes/models/api_key.py`` for why sha256 rather than a slow KDF is
+the correct primitive for a secret of that size, and why the key id is public.
+
+``id`` is a 16-hex-char application-generated string, not a serial: it travels
+inside the token as the lookup handle (``archim_<id>_<secret>``), so it must be
+opaque and unguessable-in-bulk rather than enumerable.
+
+The FK to ``auth_users`` with ``ON DELETE CASCADE`` is the schema half of the
+scoping guarantee: a key cannot outlive the account it speaks for. The
+application half — every query filtered by ``user_id`` — is in
+``models/api_key.py``; both exist because either alone is a promise the other
+could break. Matches the cascade policy revision ``85ca5310b7a1`` applied to the
+other user-owned tables.
+
+BACKFILL (migrations-ship-with-their-data rule): **none, and none is possible.**
+No API key has ever existed, so there is no historical credential to migrate. The
+cookie lane is untouched by this revision and keeps working exactly as before;
+this is a second credential added beside it, not a replacement.
+
+Revision ID: c1d8e6f30a72
+Revises: a7f2c93b1d64
+Create Date: 2026-08-31 00:00:00.000000
+
+SEQUENCING: chained onto ``a7f2c93b1d64``, the chain head at authoring time. If
+another migration lands on main first, re-point ``down_revision`` at the new head
+— ``.github/scripts/migration_chain_guard.py`` catches a fork, and
+``backend/tests/test_alembic_migrations.py`` asserts exactly one head.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d8e6f30a72"
+down_revision: str | Sequence[str] | None = "a7f2c93b1d64"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["branch_labels", "depends_on", "down_revision", "downgrade", "revision", "upgrade"]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "api_keys",
+        # The PUBLIC key id — the token's lookup handle, not a secret.
+        sa.Column("id", sa.String(length=32), nullable=False),
+        # The account this key speaks for. This column IS the key's scope.
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        # 16 random bytes, hex. Per key, so no two digests share structure.
+        sa.Column("salt", sa.String(length=64), nullable=False),
+        # sha256(salt_bytes || secret_bytes), hex. The ONLY trace of the token.
+        sa.Column("secret_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        # Coarsened to one write per minute per key on the request path.
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        # Read from the row on every verify — revocation with no cache to expire.
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["auth_users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # The list endpoint's query ("this account's keys") and the live-key ceiling
+    # check ("this account's un-revoked keys") are both covered by this index.
+    op.create_index("ix_api_keys_user_revoked", "api_keys", ["user_id", "revoked_at"])
+    op.create_index("ix_api_keys_user_id", "api_keys", ["user_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Dropping the table revokes every key at once — irreversibly, since the digests
+    it holds cannot be reconstructed from anything. That is the correct failure
+    mode for a credential store (a downgrade must never leave keys *working* with
+    no record of them), but it means a downgrade logs every agent out and each key
+    must be minted again.
+    """
+    op.drop_index("ix_api_keys_user_id", table_name="api_keys")
+    op.drop_index("ix_api_keys_user_revoked", table_name="api_keys")
+    op.drop_table("api_keys")

--- a/backend/tests/test_api_key_auth.py
+++ b/backend/tests/test_api_key_auth.py
@@ -1,0 +1,624 @@
+"""Scoped API keys — the security contract, proved rather than asserted (#1680, #1653 D3).
+
+Every test here corresponds to a numbered acceptance criterion or anti-goal on the
+issue, and the adversarial ones are named for the thing they try and fail to do.
+The organising idea: a key is a **second credential for one account**, so the
+properties worth pinning are (1) the token exists in exactly one place for exactly
+one round trip, (2) the credential resolves to the same identity a cookie does and
+therefore cannot bypass anything, and (3) every way of asking "whose key is this"
+is scoped by ``user_id``.
+
+Hermetic: a per-test tmp-file SQLite database via ``tests/db_isolation.py`` (the
+same helper the account/ledger tests use), the Better Auth session fetch stubbed
+at ``account_auth._fetch_session``, and no Redis / Postgres / network anywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from archimedes.api import account_auth, api_key_auth, api_key_routes
+from archimedes.api.account_auth import CurrentUser, require_current_user
+from archimedes.db import get_session
+from archimedes.models.account import AuthUser
+from archimedes.models.api_key import MAX_KEYS_PER_ACCOUNT, ApiKeyRecord
+from fastapi import Depends, FastAPI, Request
+from sqlalchemy import inspect, text
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    """A fresh SQLite file per test; restored afterwards (issue #1100's lesson)."""
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    return tmp_path / "test_archimedes.db"
+
+
+def _make_account(user_id: str) -> None:
+    session = get_session()
+    try:
+        now = datetime.now(UTC)
+        session.add(
+            AuthUser(
+                id=user_id,
+                name=user_id,
+                email=f"{user_id}@example.test",
+                email_verified=True,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+
+def _mint_for(user_id: str, name: str = "ci") -> str:
+    """Create *user_id*'s account if needed and return a fresh token."""
+    session = get_session()
+    try:
+        if session.get(AuthUser, user_id) is None:
+            session.close()
+            _make_account(user_id)
+            session = get_session()
+        _, token = api_key_auth.mint(session, user_id=user_id, name=name)
+        session.commit()
+        return token
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def app() -> FastAPI:
+    """The identity chokepoint + the key-management router + one probe route.
+
+    ``/whoami`` depends on the unmodified ``require_current_user`` — the point of
+    the design is that a route can be written without knowing API keys exist, so
+    the probe is deliberately written that way.
+    """
+    application = FastAPI()
+    application.middleware("http")(account_auth.better_auth_session_middleware)
+    application.include_router(api_key_routes.api_key_router)
+
+    @application.get("/whoami")
+    async def whoami(request: Request, user: CurrentUser = Depends(require_current_user)):
+        return {
+            "user_id": user.id,
+            "email": user.email,
+            "credential": account_auth.get_auth_credential(request),
+        }
+
+    return application
+
+
+def _client(app: FastAPI, *, token: str | None = None, cookie: bool = False) -> httpx.AsyncClient:
+    headers: dict[str, str] = {"host": "archimedes-arc.com"}
+    if token is not None:
+        headers["authorization"] = f"Bearer {token}"
+    if cookie:
+        headers["cookie"] = "better-auth.session_token=opaque"
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test", headers=headers)
+
+
+def _sign_in(monkeypatch, user_id: str) -> None:
+    """Point the Better Auth fetch at *user_id* (overrides conftest's adapter)."""
+
+    async def fetch(_request):
+        return {
+            "user": {
+                "id": user_id,
+                "name": user_id,
+                "email": f"{user_id}@example.test",
+                "emailVerified": True,
+            },
+            "session": {"id": f"s-{user_id}", "expiresAt": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+        }
+
+    monkeypatch.setattr(account_auth, "_fetch_session", fetch)
+
+
+# ── A1: token shape and entropy ───────────────────────────────────────
+
+
+def test_minted_token_shape_and_entropy():
+    """A1 — ``archim_<id>_<secret>``; the secret carries ≥32 bytes; mints are unique."""
+    _make_account("user-a1")
+    session = get_session()
+    tokens = set()
+    try:
+        for i in range(100):
+            record, token = api_key_auth.mint(session, user_id="user-a1", name=f"k{i}")
+            tokens.add(token)
+            assert token.startswith("archim_")
+            parsed = api_key_auth.parse_authorization_header(f"Bearer {token}")
+            assert parsed is not None
+            key_id, secret = parsed
+            assert key_id == record.id
+            assert len(key_id) == api_key_auth.KEY_ID_HEX_CHARS
+            # token_urlsafe(32) is 32 bytes of entropy rendered as ~43 chars.
+            # Asserting on the character count would pin the encoding; asserting
+            # on the decoded entropy pins the property that matters.
+            assert len(secret) >= (api_key_auth.SECRET_BYTES * 4) // 3
+        session.commit()
+    finally:
+        session.close()
+
+    assert len(tokens) == 100, "100 mints produced a duplicate token"
+
+
+# ── A2: the token is not stored, anywhere ─────────────────────────────
+
+
+def test_token_never_appears_in_any_column_or_in_the_database_file(db_path):
+    """A2 — the strongest form: dump every column of every row, AND grep the
+    on-disk database file for the secret. Both must come back empty."""
+    token = _mint_for("user-a2")
+    secret = token.split("_", 2)[2]
+
+    session = get_session()
+    try:
+        columns = [c["name"] for c in inspect(session.get_bind()).get_columns("api_keys")]
+        rows = session.execute(text("SELECT * FROM api_keys")).mappings().all()
+        assert rows, "no key row was written"
+        for row in rows:
+            for column in columns:
+                value = str(row[column])
+                assert token not in value, f"the full token is stored in api_keys.{column}"
+                assert secret not in value, f"the secret half is stored in api_keys.{column}"
+    finally:
+        session.close()
+
+    # And the file itself — a column dump only covers columns we thought to look
+    # at; the raw bytes cover the ones we did not.
+    blob = db_path.read_bytes()
+    assert secret.encode() not in blob, "the secret is recoverable from the database file"
+    assert token.encode() not in blob, "the token is recoverable from the database file"
+
+
+# ── A3: constant-time on the hit path AND the miss path ───────────────
+
+
+def test_unknown_key_id_still_performs_a_comparison():
+    """A3 (adversarial, timing) — the miss path must not short-circuit.
+
+    An early ``return None`` on an unknown key id makes "no such key" measurably
+    faster than "wrong secret", which lets an attacker enumerate valid key ids by
+    timing alone. The guard is that ``verify`` runs a dummy comparison; this test
+    fails the moment someone "optimises" it away.
+    """
+    session = get_session()
+    try:
+        with patch.object(api_key_auth.hmac, "compare_digest", wraps=api_key_auth.hmac.compare_digest) as spy:
+            assert api_key_auth.verify(session, "0" * 16, "no-such-secret") is None
+        assert spy.call_count == 1, "the unknown-key-id path skipped the constant-time comparison"
+    finally:
+        session.close()
+
+
+def test_verification_uses_constant_time_comparison_on_the_hit_path():
+    """A3 — and the real comparison goes through ``hmac.compare_digest`` too."""
+    token = _mint_for("user-a3")
+    key_id, secret = api_key_auth.parse_authorization_header(f"Bearer {token}")
+
+    session = get_session()
+    try:
+        with patch.object(api_key_auth.hmac, "compare_digest", wraps=api_key_auth.hmac.compare_digest) as spy:
+            assert api_key_auth.verify(session, key_id, secret) is not None
+        assert spy.call_count == 1
+    finally:
+        session.close()
+
+
+# ── A4: one identity, two credentials ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_key_and_cookie_resolve_the_same_account_identity(app, monkeypatch):
+    """A4 — the whole design in one assertion: same account, either credential."""
+    token = _mint_for("user-a4")
+    _sign_in(monkeypatch, "user-a4")
+
+    async with _client(app, cookie=True) as client:
+        by_cookie = await client.get("/whoami")
+    async with _client(app, token=token) as client:
+        by_key = await client.get("/whoami")
+
+    assert by_cookie.status_code == 200
+    assert by_key.status_code == 200
+    assert by_key.json()["user_id"] == by_cookie.json()["user_id"] == "user-a4"
+    assert by_key.json()["email"] == by_cookie.json()["email"]
+    # The ONLY thing that differs is which credential proved it.
+    assert by_cookie.json()["credential"] == "session"
+    assert by_key.json()["credential"] == "api_key"
+
+
+# ── A5 / A6: shown once, never again ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_returns_the_secret_once_and_list_never_does(app, monkeypatch):
+    """A5 + A6 (adversarial, leak) — serialise the list response and grep it."""
+    _make_account("user-a5")
+    _sign_in(monkeypatch, "user-a5")
+
+    async with _client(app, cookie=True) as client:
+        created = await client.post("/api/account/keys", json={"name": "ci-nightly"})
+        listed = await client.get("/api/account/keys")
+
+    assert created.status_code == 201
+    token = created.json()["key"]
+    secret = token.split("_", 2)[2]
+    assert token.startswith("archim_")
+
+    assert listed.status_code == 200
+    body = json.dumps(listed.json())
+    assert token not in body, "the list endpoint returned the token"
+    assert secret not in body, "the list endpoint returned the secret"
+
+    row = listed.json()[0]
+    assert set(row) == {"id", "name", "prefix", "created_at", "last_used_at", "revoked_at"}
+    assert row["prefix"] == f"archim_{row['id']}"
+    assert row["name"] == "ci-nightly"
+    assert row["revoked_at"] is None
+    # The prefix identifies the key and cannot be used as one.
+    async with _client(app, token=row["prefix"]) as client:
+        assert (await client.get("/whoami")).status_code == 401
+
+
+# ── A7: a wrong key is 401 ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bogus",
+    [
+        "archim_0000000000000000_ZmFrZS1zZWNyZXQtdGhhdC13YXMtbmV2ZXItbWludGVk",  # well-formed, never minted
+        "archim_deadbeefdeadbeef_",  # empty secret
+        "archim_",  # prefix only
+        "archim_nounderscoreafterprefix",  # no separator
+        "not-even-close",
+    ],
+)
+async def test_wrong_key_is_401(app, bogus):
+    """A7 (adversarial) — nothing that was not minted here gets in."""
+    async with _client(app, token=bogus) as client:
+        response = await client.get("/whoami")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}
+
+
+@pytest.mark.asyncio
+async def test_right_key_id_wrong_secret_is_401(app):
+    """A7 (adversarial) — knowing the public key id buys nothing."""
+    token = _mint_for("user-a7")
+    key_id = token.split("_")[1]
+    async with _client(app, token=f"archim_{key_id}_wrong-secret-entirely") as client:
+        assert (await client.get("/whoami")).status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header",
+    [
+        "archim_abc_def",  # no scheme
+        "Basic archim_abc_def",  # wrong scheme
+        "bearer archim_abc_def",  # case-sensitive scheme, deliberately strict
+        "Bearer eyJhbGciOiJIUzI1NiJ9.e30.x",  # a JWT — not ours, not attempted
+    ],
+)
+async def test_non_conforming_authorization_headers_are_ignored(app, header):
+    """N-adjacent — the parser is strict; a foreign scheme is not half-accepted."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/whoami", headers={"authorization": header})
+    assert response.status_code == 401
+
+
+# ── A8: revocation takes effect on the next call ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_revoked_key_is_401_on_the_next_call(app, monkeypatch):
+    """A8 (adversarial) — 200, revoke, 401. No cache, no TTL, no grace period."""
+    _make_account("user-a8")
+    _sign_in(monkeypatch, "user-a8")
+
+    async with _client(app, cookie=True) as client:
+        created = await client.post("/api/account/keys", json={"name": "to-be-revoked"})
+    token = created.json()["key"]
+    key_id = created.json()["id"]
+
+    async with _client(app, token=token) as client:
+        assert (await client.get("/whoami")).status_code == 200
+
+    async with _client(app, cookie=True) as client:
+        deleted = await client.delete(f"/api/account/keys/{key_id}")
+        assert deleted.status_code == 204
+        # Idempotent: a retried automation is not punished for it.
+        assert (await client.delete(f"/api/account/keys/{key_id}")).status_code == 204
+
+    async with _client(app, token=token) as client:
+        assert (await client.get("/whoami")).status_code == 401
+
+    async with _client(app, cookie=True) as client:
+        listed = (await client.get("/api/account/keys")).json()
+    assert listed[0]["revoked_at"] is not None, "the row must survive revocation as an audit record"
+
+
+# ── A9: a key is scoped to its account ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_key_a_cannot_read_or_revoke_account_b(app, monkeypatch):
+    """A9 (adversarial, cross-account) — the isolation test, both directions."""
+    token_a = _mint_for("user-a", name="a-key")
+    token_b = _mint_for("user-b", name="b-key")
+    b_key_id = token_b.split("_")[1]
+
+    # 1. A's credential is A's identity, never B's.
+    async with _client(app, token=token_a) as client:
+        assert (await client.get("/whoami")).json()["user_id"] == "user-a"
+
+    # 2. A's session cannot see B's key in the list…
+    _sign_in(monkeypatch, "user-a")
+    async with _client(app, cookie=True) as client:
+        listed = (await client.get("/api/account/keys")).json()
+        assert [row["id"] for row in listed] == [token_a.split("_")[1]]
+        assert b_key_id not in [row["id"] for row in listed]
+
+        # 3. …and cannot revoke it. 404, not 403: a 403 would confirm the id is
+        #    real and owned by someone, which is an enumeration oracle.
+        forbidden = await client.delete(f"/api/account/keys/{b_key_id}")
+    assert forbidden.status_code == 404
+    assert forbidden.json() == {"detail": "API key not found"}
+
+    # 4. And B's key still works — the failed attempt changed nothing.
+    async with _client(app, token=token_b) as client:
+        assert (await client.get("/whoami")).json()["user_id"] == "user-b"
+
+
+# ── The containment property: a key cannot mint a key ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_key_cannot_manage_api_keys(app):
+    """Adversarial (privilege containment) — a leaked key cannot issue successors.
+
+    If it could, revoking the token an operator knows about would not end the
+    compromise: the attacker would already hold a key the operator has never
+    seen. 403, not 401 — the caller IS authenticated; the credential is the wrong
+    kind for this surface.
+    """
+    token = _mint_for("user-contain")
+
+    async with _client(app, token=token) as client:
+        # It is a real, working credential on the rest of the surface…
+        assert (await client.get("/whoami")).status_code == 200
+        # …and refused on all three key-management verbs.
+        created = await client.post("/api/account/keys", json={"name": "successor"})
+        listed = await client.get("/api/account/keys")
+        deleted = await client.delete(f"/api/account/keys/{token.split('_')[1]}")
+
+    assert created.status_code == 403
+    assert listed.status_code == 403
+    assert deleted.status_code == 403
+    assert "cannot manage" in created.json()["detail"]
+
+    # And nothing was minted.
+    session = get_session()
+    try:
+        assert session.query(ApiKeyRecord).filter_by(user_id="user-contain").count() == 1
+    finally:
+        session.close()
+
+
+@pytest.mark.asyncio
+async def test_key_management_without_any_credential_is_401(app):
+    """The unauthenticated case stays 401, not 403 — 403 would imply an identity."""
+    async with _client(app) as client:
+        assert (await client.post("/api/account/keys", json={"name": "x"})).status_code == 401
+        assert (await client.get("/api/account/keys")).status_code == 401
+
+
+# ── A12: no key material in logs ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_key_material_reaches_the_logs(app, monkeypatch, caplog):
+    """A12 (adversarial, leak) — drive the full lifecycle with DEBUG capture on."""
+    _make_account("user-log")
+    _sign_in(monkeypatch, "user-log")
+
+    with caplog.at_level(logging.DEBUG):
+        async with _client(app, cookie=True) as client:
+            created = await client.post("/api/account/keys", json={"name": "logged"})
+        token = created.json()["key"]
+        secret = token.split("_", 2)[2]
+        key_id = created.json()["id"]
+
+        async with _client(app, token=token) as client:
+            await client.get("/whoami")
+        async with _client(app, token="archim_0000000000000000_wrong") as client:
+            await client.get("/whoami")  # the failure path logs too
+        async with _client(app, cookie=True) as client:
+            await client.get("/api/account/keys")
+            await client.delete(f"/api/account/keys/{key_id}")
+
+    assert token not in caplog.text, "a log record contains the full token"
+    assert secret not in caplog.text, "a log record contains the secret"
+    # The public id IS logged, deliberately — that is how an operator ties an
+    # audit line to a row without the line being a credential.
+    assert key_id in caplog.text
+
+
+# ── Fail-closed corners ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_key_whose_account_no_longer_exists_fails_closed(app):
+    """A credential with no account behind it is not an identity."""
+    token = _mint_for("user-gone")
+    session = get_session()
+    try:
+        session.query(AuthUser).filter_by(id="user-gone").delete()
+        session.commit()
+    finally:
+        session.close()
+
+    async with _client(app, token=token) as client:
+        assert (await client.get("/whoami")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_database_failure_during_key_resolution_is_401_not_500(app, monkeypatch):
+    """A broken datastore must refuse the request, never authenticate it and
+    never 500 — the same fail-closed posture the cookie path already has."""
+    monkeypatch.setattr(api_key_auth, "verify", MagicMock(side_effect=RuntimeError("db down")))
+    async with _client(app, token="archim_abcdef0123456789_whatever") as client:
+        response = await client.get("/whoami")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_live_key_ceiling_is_enforced_and_revoking_frees_a_slot(app, monkeypatch):
+    """An account cannot mint an unbounded set of credentials someone then has
+    to hunt down one at a time."""
+    _make_account("user-cap")
+    _sign_in(monkeypatch, "user-cap")
+
+    async with _client(app, cookie=True) as client:
+        ids = []
+        for i in range(MAX_KEYS_PER_ACCOUNT):
+            response = await client.post("/api/account/keys", json={"name": f"k{i}"})
+            assert response.status_code == 201
+            ids.append(response.json()["id"])
+
+        over = await client.post("/api/account/keys", json={"name": "one-too-many"})
+        assert over.status_code == 409
+        assert over.json()["detail"]["reason"] == "api_key_limit_reached"
+
+        assert (await client.delete(f"/api/account/keys/{ids[0]}")).status_code == 204
+        assert (await client.post("/api/account/keys", json={"name": "now-there-is-room"})).status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_blank_name_is_rejected(app, monkeypatch):
+    _make_account("user-name")
+    _sign_in(monkeypatch, "user-name")
+    async with _client(app, cookie=True) as client:
+        assert (await client.post("/api/account/keys", json={"name": "   "})).status_code == 422
+        assert (await client.post("/api/account/keys", json={"name": "x" * 65})).status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_last_used_is_recorded_and_coarsened(app):
+    """``last_used_at`` answers "is this key still live / when did the leak start"
+    at minute resolution, without an UPDATE on every authenticated request."""
+    token = _mint_for("user-touch")
+    key_id = token.split("_")[1]
+
+    async with _client(app, token=token) as client:
+        await client.get("/whoami")
+
+    session = get_session()
+    try:
+        first = session.get(ApiKeyRecord, key_id).last_used_at
+        assert first is not None
+    finally:
+        session.close()
+
+    async with _client(app, token=token) as client:
+        await client.get("/whoami")
+
+    session = get_session()
+    try:
+        assert session.get(ApiKeyRecord, key_id).last_used_at == first, "a second call inside the minute re-wrote"
+    finally:
+        session.close()
+
+
+# ── A11: the classifier learns a distinct type ────────────────────────
+
+
+def test_keyed_caller_classifies_as_agent_with_its_own_type():
+    """A11 — and the funnel vocabulary was extended, not left to silently drop it."""
+    from archimedes.api.telemetry_middleware import classify_request
+    from archimedes.services.funnel_store import AGENT_TYPES
+    from starlette.requests import Request as StarletteRequest
+
+    def _request(credential: str | None, user: CurrentUser | None, ua: str = "curl/8.0") -> StarletteRequest:
+        request = StarletteRequest(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/api/x",
+                "headers": [(b"user-agent", ua.encode())],
+                "query_string": b"",
+            }
+        )
+        request.state.current_user = user
+        request.state.auth_credential = credential
+        return request
+
+    user = CurrentUser(id="u", name="u", email="u@example.test", email_verified=True)
+
+    assert classify_request(_request("api_key", user)) == (True, "keyed")
+    # The pre-existing verdicts are untouched.
+    assert classify_request(_request("session", user)) == (False, "human")
+    assert classify_request(_request(None, None)) == (True, "external")
+    assert classify_request(_request(None, None, ua="Mozilla/5.0")) == (False, "human")
+
+    assert "keyed" in AGENT_TYPES, "funnel_store would silently drop keyed traffic from the breakdown"
+
+
+@pytest.mark.asyncio
+async def test_keyed_request_is_tagged_as_an_agent_end_to_end():
+    """A11 — through the real middleware stack, not just the pure function.
+
+    Before this lane, the #1653 finding held: an authenticated agent was
+    indistinguishable from a human because "session ⇒ human" fired first. A keyed
+    caller now carries ``X-Telemetry-Agent: true``.
+
+    Middleware order matters and mirrors ``main.py``: ``app.middleware`` inserts
+    at position 0, so the LAST registration is the OUTERMOST. Identity must be
+    resolved before telemetry reads it, so identity is registered last here — as
+    it is in ``main.py``, where ``better_auth_session_middleware`` is the final
+    registration.
+    """
+    from archimedes.api.telemetry_middleware import telemetry_middleware
+
+    token = _mint_for("user-telemetry")
+
+    application = FastAPI()
+    application.middleware("http")(telemetry_middleware)
+    application.middleware("http")(account_auth.better_auth_session_middleware)
+
+    @application.get("/whoami")
+    async def whoami(user: CurrentUser = Depends(require_current_user)):
+        return {"user_id": user.id}
+
+    store = MagicMock()
+    store.increment_agent = AsyncMock()
+    store.increment_human = AsyncMock()
+    store.close = AsyncMock()
+
+    with patch("archimedes.services.telemetry_store.TelemetryStore", return_value=store):
+        async with _client(application, token=token) as client:
+            response = await client.get("/whoami")
+
+    assert response.status_code == 200
+    assert response.headers["X-Telemetry-Agent"] == "true"
+    store.increment_agent.assert_awaited_once()
+    store.increment_human.assert_not_awaited()

--- a/backend/tests/test_api_key_auth.py
+++ b/backend/tests/test_api_key_auth.py
@@ -244,6 +244,35 @@ async def test_key_and_cookie_resolve_the_same_account_identity(app, monkeypatch
     assert by_key.json()["credential"] == "api_key"
 
 
+@pytest.mark.asyncio
+async def test_when_both_credentials_are_present_the_cookie_wins_deterministically(app, monkeypatch):
+    """Two credentials on one request must resolve to ONE identity, always the same one.
+
+    Not a security boundary — holding another account's session cookie is already
+    full compromise of that account — but ambiguity here would be resolved by
+    whichever branch a future refactor happened to run first, and a caller could
+    not predict which account it was acting as. The cookie wins because it is the
+    pre-existing behaviour and the browser majority; the key is attempted only
+    when the cookie produced no user. Pinned so the order is a decision rather
+    than an accident.
+    """
+    token = _mint_for("user-key-side")
+    _sign_in(monkeypatch, "user-cookie-side")
+
+    headers = {
+        "host": "archimedes-arc.com",
+        "cookie": "better-auth.session_token=opaque",
+        "authorization": f"Bearer {token}",
+    }
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test", headers=headers) as client:
+        response = await client.get("/whoami")
+
+    assert response.status_code == 200
+    assert response.json()["user_id"] == "user-cookie-side"
+    assert response.json()["credential"] == "session"
+
+
 # ── A5 / A6: shown once, never again ──────────────────────────────────
 
 

--- a/backend/tests/test_api_key_gate_parity.py
+++ b/backend/tests/test_api_key_gate_parity.py
@@ -1,0 +1,217 @@
+"""A key is a credential, never a bypass — proved on the real gates (#1680 A10/N1/N2).
+
+The design claim behind the API-key lane is that the credential stops existing as
+a distinction at ``api/account_auth.py``, so every gate downstream applies to a
+keyed caller identically and *without any gate knowing keys exist*. That claim is
+worthless as prose: the whole failure mode of a machine credential is that someone
+adds ``if api_key: skip`` to a paywall six months later and nobody notices.
+
+So this file drives the **live** ``archimedes.main.app`` through the real
+``POST /api/generate/start`` twice — once with a session cookie, once with a
+bearer key — and asserts the two are byte-identical where it matters, then pins
+the structural property that makes it so.
+
+Hermetic, and the same harness as ``test_generate_payment_gate.py``: mocked job
+store, pipeline task closed rather than scheduled, per-test tmp SQLite.
+"""
+
+from __future__ import annotations
+
+import inspect as py_inspect
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.api import api_key_auth
+from archimedes.db import get_session
+from archimedes.models.account import AuthUser
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from tests.auth_helpers import auth_cookies
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+RECIPIENT = "0x00000000000000000000000000000000000000a1"
+PAYER = "0x" + "cd" * 20
+_BODY = {"brief": {"intent": "low-vol treasury alternative", "risk_appetite": "moderate"}}
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@pytest.fixture()
+def token() -> str:
+    """A real, minted key belonging to a real account row."""
+    session = get_session()
+    try:
+        now = datetime.now(UTC)
+        session.add(
+            AuthUser(
+                id="user-parity",
+                name="parity",
+                email="parity@example.test",
+                email_verified=True,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.flush()
+        _, minted = api_key_auth.mint(session, user_id="user-parity", name="ci")
+        session.commit()
+        return minted
+    finally:
+        session.close()
+
+
+def _client() -> TestClient:
+    from archimedes.main import app
+
+    return TestClient(app)
+
+
+def _mock_store() -> MagicMock:
+    store = MagicMock()
+    store.enqueue = AsyncMock(return_value="job-parity")
+    return store
+
+
+def _close_background_coroutine(coro):
+    coro.close()
+    return MagicMock()
+
+
+def _harness(store):
+    return (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        patch("archimedes.api.generate_routes.asyncio.create_task", side_effect=_close_background_coroutine),
+        # Both callers present the same linked wallet, so the only variable left
+        # between the two requests is which credential proved the identity.
+        patch("archimedes.api.generate_routes.get_linked_wallet_address", return_value=PAYER),
+    )
+
+
+# ── A10: the paywall does not care which credential you hold ──────────
+
+
+def test_keyed_call_hits_the_same_paywall_a_session_call_hits(monkeypatch, token):
+    """A10 — 402, with the *same* x402 requirements, for both credentials."""
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+    monkeypatch.setenv("PAYMENTS_DRY_RUN", "false")
+
+    store = _mock_store()
+    p1, p2, p3 = _harness(store)
+    with p1, p2, p3:
+        by_cookie = _client().post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+        by_key = _client().post("/api/generate/start", json=_BODY, headers={"Authorization": f"Bearer {token}"})
+
+    assert by_cookie.status_code == 402
+    assert by_key.status_code == 402, "a key walked past the paywall a session is stopped by"
+
+    assert "PAYMENT-REQUIRED" in by_cookie.headers
+    assert "PAYMENT-REQUIRED" in by_key.headers
+
+    cookie_detail = by_cookie.json()["detail"]
+    key_detail = by_key.json()["detail"]
+    assert key_detail["reason"] == cookie_detail["reason"] == "payment_required"
+    # The full quote — price, asset, network, recipient — must be identical.
+    assert key_detail["quote"] == cookie_detail["quote"]
+    assert key_detail.get("accepts") == cookie_detail.get("accepts")
+
+    store.enqueue.assert_not_called()
+
+
+def test_keyed_call_hits_the_same_wallet_precondition(monkeypatch, token):
+    """A10 — and the 409 that precedes the paywall applies equally.
+
+    A key holder with no linked wallet is refused for exactly the reason a cookie
+    holder is, with the same faucet guidance (#1294's human-only step). Nothing
+    about holding a machine credential moves the money boundary.
+    """
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    monkeypatch.setenv("GENERATION_PAYMENT_RECIPIENT", RECIPIENT)
+
+    store = _mock_store()
+    with (
+        patch("archimedes.api.generate_routes.get_job_store", return_value=store),
+        patch("archimedes.api.generate_routes.asyncio.create_task", side_effect=_close_background_coroutine),
+        patch("archimedes.api.generate_routes.get_linked_wallet_address", return_value=None),
+    ):
+        by_cookie = _client().post("/api/generate/start", json=_BODY, cookies=auth_cookies())
+        by_key = _client().post("/api/generate/start", json=_BODY, headers={"Authorization": f"Bearer {token}"})
+
+    assert by_cookie.status_code == by_key.status_code == 409
+    assert by_key.json()["detail"]["reason"] == by_cookie.json()["detail"]["reason"] == "wallet_link_required"
+    store.enqueue.assert_not_called()
+
+
+def test_keyed_call_is_subject_to_the_daily_generation_quota(monkeypatch, token):
+    """N2 — the quota runs for a keyed caller, keyed on ITS account id.
+
+    ``TESTING`` is unset so the quota branch actually executes (the same trick
+    ``test_generate_payment_gate.py::test_quota_runs_before_the_paywall`` uses),
+    and the quota is stubbed to refuse. A key that skipped the quota would come
+    back 202.
+    """
+    monkeypatch.delenv("TESTING", raising=False)
+    seen: list[str] = []
+
+    async def _blocked(request, user_id):  # signature must match the real enforce_generation_quota
+        seen.append(user_id)
+        raise HTTPException(status_code=429, detail="daily cap reached")
+
+    store = _mock_store()
+    p1, p2, p3 = _harness(store)
+    with p1, p2, p3, patch("archimedes.api.generate_routes.enforce_generation_quota", _blocked):
+        response = _client().post("/api/generate/start", json=_BODY, headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 429
+    assert seen == ["user-parity"], "the quota was not keyed on the key's own account"
+    store.enqueue.assert_not_called()
+
+
+def test_a_bad_key_never_reaches_the_gates_at_all(monkeypatch):
+    """A7 on the live app — an unauthenticated caller is 401 at the router-level
+    ``require_current_user``, before any quota, paywall or queue admission."""
+    monkeypatch.setenv("GENERATION_PAYMENT_REQUIRED", "true")
+    store = _mock_store()
+    p1, p2, p3 = _harness(store)
+    with p1, p2, p3:
+        response = _client().post(
+            "/api/generate/start",
+            json=_BODY,
+            headers={"Authorization": "Bearer archim_0000000000000000_never-minted"},
+        )
+    assert response.status_code == 401
+    store.enqueue.assert_not_called()
+
+
+# ── N1: no gate learned the word "key" ────────────────────────────────
+
+
+def test_no_gate_module_knows_that_api_keys_exist():
+    """N1/N2, structurally — the property that keeps A10 true next quarter.
+
+    A10 proves today's behaviour; this proves there is *no place to put* a bypass
+    without it being obvious. If a future change makes a gate branch on the
+    credential, this fails and the reviewer is forced to justify it in the diff
+    rather than in a comment nobody reads.
+
+    Deliberately narrow: it checks the four modules that actually gate access, not
+    the whole tree, and it looks for the credential vocabulary, not the word
+    "key" (which legitimately appears as ``Idempotency-Key``, dict keys, and
+    ``INTERNAL_AGENT_API_KEY``).
+    """
+    from archimedes.api import generate_routes
+    from archimedes.services import generation_payment, generation_quota
+
+    forbidden = ("api_key_auth", "auth_credential", "CREDENTIAL_API_KEY", "archim_")
+    for module in (generate_routes, generation_payment, generation_quota):
+        source = py_inspect.getsource(module)
+        for needle in forbidden:
+            assert needle not in source, (
+                f"{module.__name__} references {needle!r} — a gate that can tell credentials "
+                "apart is a gate that can be made to skip one of them"
+            )

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -14,10 +14,19 @@ Two reasons this matters:
 2. **The agent-user segment** — an agent that sends a non-browser `User-Agent` is
    classified as an external agent by the telemetry middleware and its
    `generation_started` is attributed in the conversion funnel ([#787](https://github.com/a-apin/archimedes/issues/787)).
+   An agent holding an **API key** does better: it is classified `keyed` from the
+   credential itself rather than from a header it chose.
 
-**READ** needs no authentication. **GENERATE requires Better Auth session**:
+**READ** needs no authentication. **GENERATE requires an account credential**:
 anonymous `POST /api/generate/start` returns 401, and per-job stream/status/jobs/candidates
 reads are scoped by canonical user ID. Wallet connection alone never authenticates.
+
+Two credentials establish that account identity, and **they are interchangeable
+everywhere except key management**: the Better Auth **session cookie**, and an
+`Authorization: Bearer archim_…` **API key** (see [API keys](#api-keys-bearer)). Both
+resolve to the same canonical user ID at the same chokepoint
+(`api/account_auth.py`), so no route, quota, rate limit, or paywall can tell them
+apart — a key is a credential, never a bypass.
 
 ## Quick start
 
@@ -256,6 +265,58 @@ Use `ARCHIMEDES_EMAIL` and `ARCHIMEDES_PASSWORD` for reference client. Never pas
 credentials as command-line arguments or commit them. `--ephemeral` creates disposable
 account for smoke testing.
 
+### API keys (Bearer)
+
+A cookie expires in seven days and can only be refreshed by re-sending the account
+password. For anything unattended, mint a key once instead.
+
+```bash
+# mint (session cookie required — see below)
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/account/keys \
+  -H 'Content-Type: application/json' -d '{"name":"ci-nightly"}'
+```
+
+```json
+{ "id": "9f3c1a77b204de51", "name": "ci-nightly", "prefix": "archim_9f3c1a77b204de51",
+  "created_at": "…", "last_used_at": null, "revoked_at": null,
+  "key": "archim_9f3c1a77b204de51_KtQ8yv…" }
+```
+
+Then every account-gated call in this document is one header:
+
+```bash
+curl -sS -H "Authorization: Bearer $ARCHIMEDES_KEY" $BASE/api/account/usage
+```
+
+| Endpoint | Method | Credential | Notes |
+| --- | --- | --- | --- |
+| `/api/account/keys` | `POST` | **cookie only** | Body `{"name": "…"}` (1–64 chars). `201`. Returns `key` **once**. `409 api_key_limit_reached` past 25 live keys. |
+| `/api/account/keys` | `GET` | **cookie only** | `id`, `name`, `prefix`, `created_at`, `last_used_at`, `revoked_at`. Never the key. |
+| `/api/account/keys/{id}` | `DELETE` | **cookie only** | `204`, idempotent. Another account's id → `404`. |
+| everything else account-gated | — | cookie **or** key | Identical behaviour either way. |
+
+The contract, precisely:
+
+- **Format** `archim_<key_id>_<secret>`. `secret` is 32 random bytes from `secrets`;
+  `archim_<key_id>` is the non-secret `prefix` the list returns.
+- **Shown once.** The server stores a per-key salted SHA-256 of the secret and nothing
+  else, so the token cannot be read back by anyone, including operators. Lost key →
+  revoke and mint another.
+- **Verification is constant-time** (`hmac.compare_digest`) on the hit path *and* the
+  miss path, so response timing does not tell an attacker whether a key id exists.
+- **Revocation is immediate** — read from the row on every request, no cache, no TTL.
+  The next call with a revoked key is `401`.
+- **Scoped to one account.** A key resolves to its own account and no other; another
+  account's key id is `404`, not `403`, so the surface is not an enumeration oracle.
+- **Never a bypass.** Same daily caps, same per-route rate limits, same x402 paywall,
+  same wallet precondition. A keyed `POST /api/generate/start` returns the same `402`,
+  with the same quote, that a cookie call returns.
+- **A key cannot manage keys.** The three endpoints above answer `403` to a bearer key.
+  Containment: a leaked key must not be able to mint successors that outlive your
+  revoking the one you know about.
+- **Telemetry.** A keyed caller classifies as `agent_type: "keyed"` — an identity, unlike
+  `external`, which is a User-Agent guess about an unauthenticated client.
+
 ### Optional EIP-4361 wallet link
 
 Wallet is needed only for wallet/on-chain operations. Account session must exist first.
@@ -420,13 +481,19 @@ python scripts/agent_journey.py --no-auth --read-only --monitor-address 0x<vault
 
 ### What's NOT covered here
 
-Tracked in [#788](https://github.com/a-apin/archimedes/issues/788), but out of
-scope for this document / the harness: the issue's funnel/telemetry
-acceptance line ("the agent path is reflected in the funnel/telemetry as
-`agent_type`") is only partly built. `/api/metrics` already classifies
-traffic as human/internal-agent/external-agent
-(`telemetry_middleware.py`), but the conversion funnel itself (`FunnelStore`,
-[#787](https://github.com/a-apin/archimedes/issues/787)) records
-distinct-visitor counts per stage only — `landed`, `wallet_connected`,
-`generation_started`, `vault_deployed` are not currently segmented by
-`agent_type`. Segmenting the funnel by `agent_type` remains open work.
+The reference harness (`scripts/agent_journey.py`) does **not** use API keys — it
+still drives the cookie recipe above. Teaching it the key lane is follow-up work,
+not part of the key lane itself.
+
+**Correction (2026-08-31).** An earlier version of this section said funnel
+segmentation by `agent_type` "remains open work". That was true when it was
+written and is not true now: [#788](https://github.com/a-apin/archimedes/issues/788)
+shipped, and `GET /api/metrics/funnel` returns a per-stage `by_agent_type`
+breakdown over `internal` / `keyed` / `external` / `human`. What is still open is
+**interpretation**: before the API-key lane, an authenticated agent was
+indistinguishable from a human (`classify_request` resolved a session to `human`
+before any agent heuristic ran), so historical `external: 0` at
+`generation_started` measures the absence of the question, not the absence of
+agents. `keyed` is the first `agent_type` on that endpoint that reflects a
+credential rather than a guess; readings taken before it existed cannot be
+compared with readings taken after.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -2,7 +2,7 @@
 
 > **status:** current
 > **owner:** Dan Browne
-> **updated:** 2026-08-30
+> **updated:** 2026-08-31
 
 You are an autonomous agent that has never seen this API. This page is the shortest
 deterministic path from "no account" to "a strategy running in a paper-trading ledger you
@@ -28,14 +28,20 @@ human.
 Conventions used below:
 
 - `$BASE` is `https://archimedes-arc.com` in production, `http://localhost:8080` locally.
-- `-c/-b /tmp/agora.jar` is the session cookie jar. One jar for the whole run; it is the
-  only auth mechanism (there is no bearer token for this API).
+- `-c/-b /tmp/agora.jar` is the session cookie jar. One jar for the whole run.
+- **Or skip the jar entirely.** Every step below marked `cookie` also accepts
+  `-H "Authorization: Bearer $ARCHIMEDES_KEY"` — a long-lived API key you mint once at
+  step 4b. Same account, same limits, same paywall; no jar, and no re-sending your
+  password when the 7-day cookie expires. If you are writing CI, do step 4b and use the
+  header everywhere.
 - Response bodies are shown **shape-first**: field names and types are exact, values are
   illustrative. `…` means "more fields of the same kind that this page does not depend on."
   **The one exception is step 1** — its values are the live production ones, because there
   the value *is* the decision.
 - A non-browser `User-Agent` classifies you as an external agent in the telemetry
-  middleware. Send one; it costs nothing and makes your traffic legible.
+  middleware. Send one; it costs nothing and makes your traffic legible. **A key does
+  better:** a keyed call classifies as `agent_type: "keyed"` from the credential itself,
+  which is an identity rather than a guess about a header you chose.
 
 ---
 
@@ -48,7 +54,8 @@ Conventions used below:
 | 2 | Create an account | `POST /api/auth/sign-up/email` | none |
 | 3 | Sign in (get the cookie) | `POST /api/auth/sign-in/email` | none |
 | 4 | Confirm the session | `GET /api/auth/get-session` | cookie |
-| 5 | Check your quota | `GET /api/account/usage` | cookie |
+| 4b | Mint an API key — once, if you are automating | `POST /api/account/keys` | cookie **only** |
+| 5 | Check your quota | `GET /api/account/usage` | cookie **or key** |
 | 6 | Submit the brief | `POST /api/generate/start` | cookie |
 | 6a | Link a wallet — once, if step 1 said `true` | `POST /api/wallets/challenge` then `POST /api/wallets/verify` | cookie |
 | 6b | Pay the $2 and retry | `POST /api/generate/start` + `Payment-Signature` | cookie + wallet |
@@ -61,6 +68,9 @@ Conventions used below:
 
 Step 9 is not optional. Step 8's verdict is the *generation-time* one; step 9 is the live
 gate the server enforces. They can disagree, and step 9 wins.
+
+Every row that says `cookie` accepts a key instead, **except step 4b itself** — see there
+for why.
 
 ---
 
@@ -170,10 +180,78 @@ curl -sS -b /tmp/agora.jar $BASE/api/auth/get-session
 A bare `null` (still HTTP 200) means not authenticated — that is the signal, not an error.
 If you see `null` here, every cookie-gated step below will 401; fix it now.
 
+### 4b. Mint an API key — do this once, then stop carrying a jar
+
+Optional for a one-shot run; **do it if anything about your caller is unattended.** The
+cookie from step 3 expires in seven days, and the only way to refresh it is to re-send your
+account password. A key does not expire, is revocable on its own, and turns every
+remaining step into one header.
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/account/keys \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"ci-nightly"}'
+```
+
+```json
+{
+  "id": "9f3c1a77b204de51",
+  "name": "ci-nightly",
+  "prefix": "archim_9f3c1a77b204de51",
+  "created_at": "2026-08-31T20:14:03.118Z",
+  "last_used_at": null,
+  "revoked_at": null,
+  "key": "archim_9f3c1a77b204de51_KtQ8yv…"
+}
+```
+
+**`key` is shown exactly once and is never recoverable.** The server keeps only a salted
+hash of it, so nobody — including us — can read it back to you. Store it now; if you lose
+it, revoke it and mint another.
+
+```bash
+export ARCHIMEDES_KEY='archim_9f3c1a77b204de51_KtQ8yv…'
+```
+
+From here on, **every step below that shows `-b /tmp/agora.jar` works with one header
+instead.** Step 6 is the one you will actually run in CI:
+
+```bash
+# with the jar (steps 3 + 4 first, and again every 7 days):
+curl -sS -b /tmp/agora.jar -X POST $BASE/api/generate/start -H 'Content-Type: application/json' -d "$BRIEF"
+
+# with a key (step 4b once, ever):
+curl -sS -H "Authorization: Bearer $ARCHIMEDES_KEY" -X POST $BASE/api/generate/start -H 'Content-Type: application/json' -d "$BRIEF"
+```
+
+What a key is **not**: it is not a way around anything. It resolves to the same account
+the cookie resolves to, so the daily caps, the rate limits, the paywall and the wallet
+precondition all apply identically — a keyed `POST /api/generate/start` returns the same
+`402` with the same quote a cookie call returns. It is a different *credential*, not a
+different *tier*.
+
+The one thing a key cannot do is manage keys. `POST`/`GET`/`DELETE` on
+`/api/account/keys` require a session cookie and answer `403` to a key, so a leaked key
+cannot mint itself successors that survive your revoking the one you know about.
+
+List and revoke (session cookie, as above):
+
+```bash
+curl -sS -b /tmp/agora.jar $BASE/api/account/keys
+curl -sS -b /tmp/agora.jar -X DELETE $BASE/api/account/keys/9f3c1a77b204de51   # 204
+```
+
+The list never contains a key — only `prefix` (`archim_<id>`, which identifies a key and
+cannot be used as one), `created_at`, `last_used_at` (minute resolution) and `revoked_at`.
+Revocation takes effect on the **next** request that presents the key; there is no cache
+and no grace period. Up to 25 live keys per account.
+
 ### 5. Check your quota before spending a generation
 
 ```bash
 curl -sS -b /tmp/agora.jar $BASE/api/account/usage
+# …or, with a key:
+curl -sS -H "Authorization: Bearer $ARCHIMEDES_KEY" $BASE/api/account/usage
 ```
 
 ```json
@@ -464,7 +542,9 @@ you will only see after step 3 succeeds. Fix the session first, then re-read the
 
 | Status | Body | What happened | Fix |
 |---|---|---|---|
-| **401** | `{"detail": "Authentication required"}` + `WWW-Authenticate: Session` | No valid session cookie on a cookie-gated route | Redo steps 3–4. Signing up (step 2) does **not** sign you in; only step 3 sets the cookie. Check the jar is passed with `-b`. |
+| **401** | `{"detail": "Authentication required"}` + `WWW-Authenticate: Session` | No valid credential on a gated route — no session cookie, **or** an API key that is unknown, malformed, or revoked | Redo steps 3–4. Signing up (step 2) does **not** sign you in; only step 3 sets the cookie. Check the jar is passed with `-b`. If you are using a key: the header must be exactly `Authorization: Bearer archim_…`, and a revoked key 401s from the next call onward — mint a new one at step 4b. A wrong key and an unknown key are the same answer on purpose. |
+| **403** | `{"detail": "API keys cannot manage API keys. …"}` | You called `/api/account/keys` with `Authorization: Bearer archim_…` | Use the session cookie for key management. This is containment, not a bug: a leaked key must not be able to issue successors. |
+| **409** | `{"detail": {"reason": "api_key_limit_reached", "message": "…"}}` | 25 live keys already | Revoke one (`DELETE /api/account/keys/{id}`) before minting another. |
 | **402** | `{"detail": {"reason": "payment_required", "message": "…", "quote": {…}}}` + `PAYMENT-REQUIRED` header | The generation paywall is on and no `Payment-Signature` was presented | **Expected on production** — step 6b, not a bug. Sign the x402 requirements in the header with your **linked** wallet and retry with `Payment-Signature` (plus an `Idempotency-Key`). `GET /api/generate/quote` → `payment_required` tells you which host you are on; only when it is `false` can this not happen. |
 | **409** | `{"detail": {"reason": "idempotency_key_already_used", "message": "…"}}` | The `Idempotency-Key` you replayed already paid for a generation that started | Do not re-sign. That run exists — find it via `GET /api/generate/jobs/{job_id}`; use a fresh key for a genuinely new run. |
 | **402** | `{"detail": "Model '…' is a premium (Anthropic) model and requires an entitlement. …"}` | You named a premium `model` without entitlement | Omit `model` (the free default is used) or name an allowlisted free model. The request is **not** silently downgraded. |
@@ -487,6 +567,13 @@ you will only see after step 3 succeeds. Fix the session first, then re-read the
   host. `GET /api/generate/quote` is the only authority, it is public, and it costs you
   nothing to ask — the source defaults disagree with production on purpose, so reading the
   code instead of the endpoint gets you the wrong answer.
+- **Do not treat an API key as a lighter-weight credential.** It is the full account. Put
+  it in an environment variable or a secret store, never in a URL, a query string, a
+  committed file, or a log line — the server never logs it and neither should you. If it
+  leaks, `DELETE /api/account/keys/{id}` ends it on the next request.
+- **Do not expect a key to get you past anything.** Same caps, same rate limits, same
+  paywall, same wallet precondition. If you are looking for a way around the 402, the key
+  is not it.
 - **Do not re-sign an x402 payment to retry.** A fresh signature is a fresh real charge.
   Carry an `Idempotency-Key`, and let an undelivered run's credit pay for the next attempt.
 - **Do not treat a `pending` or `fail` rigor gate as a pass.** A gate that never says no is

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -234,11 +234,17 @@ The one thing a key cannot do is manage keys. `POST`/`GET`/`DELETE` on
 `/api/account/keys` require a session cookie and answer `403` to a key, so a leaked key
 cannot mint itself successors that survive your revoking the one you know about.
 
-List and revoke (session cookie, as above):
+List with `GET /api/account/keys` (session cookie, as above):
 
 ```bash
 curl -sS -b /tmp/agora.jar $BASE/api/account/keys
-curl -sS -b /tmp/agora.jar -X DELETE $BASE/api/account/keys/9f3c1a77b204de51   # 204
+```
+
+Revoke with `DELETE /api/account/keys/{key_id}` — `204`, and idempotent:
+
+```bash
+export KEY_ID=9f3c1a77b204de51
+curl -sS -b /tmp/agora.jar -X DELETE $BASE/api/account/keys/$KEY_ID
 ```
 
 The list never contains a key — only `prefix` (`archim_<id>`, which identifies a key and
@@ -544,7 +550,7 @@ you will only see after step 3 succeeds. Fix the session first, then re-read the
 |---|---|---|---|
 | **401** | `{"detail": "Authentication required"}` + `WWW-Authenticate: Session` | No valid credential on a gated route — no session cookie, **or** an API key that is unknown, malformed, or revoked | Redo steps 3–4. Signing up (step 2) does **not** sign you in; only step 3 sets the cookie. Check the jar is passed with `-b`. If you are using a key: the header must be exactly `Authorization: Bearer archim_…`, and a revoked key 401s from the next call onward — mint a new one at step 4b. A wrong key and an unknown key are the same answer on purpose. |
 | **403** | `{"detail": "API keys cannot manage API keys. …"}` | You called `/api/account/keys` with `Authorization: Bearer archim_…` | Use the session cookie for key management. This is containment, not a bug: a leaked key must not be able to issue successors. |
-| **409** | `{"detail": {"reason": "api_key_limit_reached", "message": "…"}}` | 25 live keys already | Revoke one (`DELETE /api/account/keys/{id}`) before minting another. |
+| **409** | `{"detail": {"reason": "api_key_limit_reached", "message": "…"}}` | 25 live keys already | Revoke one (`DELETE /api/account/keys/{key_id}`) before minting another. |
 | **402** | `{"detail": {"reason": "payment_required", "message": "…", "quote": {…}}}` + `PAYMENT-REQUIRED` header | The generation paywall is on and no `Payment-Signature` was presented | **Expected on production** — step 6b, not a bug. Sign the x402 requirements in the header with your **linked** wallet and retry with `Payment-Signature` (plus an `Idempotency-Key`). `GET /api/generate/quote` → `payment_required` tells you which host you are on; only when it is `false` can this not happen. |
 | **409** | `{"detail": {"reason": "idempotency_key_already_used", "message": "…"}}` | The `Idempotency-Key` you replayed already paid for a generation that started | Do not re-sign. That run exists — find it via `GET /api/generate/jobs/{job_id}`; use a fresh key for a genuinely new run. |
 | **402** | `{"detail": "Model '…' is a premium (Anthropic) model and requires an entitlement. …"}` | You named a premium `model` without entitlement | Omit `model` (the free default is used) or name an allowlisted free model. The request is **not** silently downgraded. |
@@ -570,7 +576,7 @@ you will only see after step 3 succeeds. Fix the session first, then re-read the
 - **Do not treat an API key as a lighter-weight credential.** It is the full account. Put
   it in an environment variable or a secret store, never in a URL, a query string, a
   committed file, or a log line — the server never logs it and neither should you. If it
-  leaks, `DELETE /api/account/keys/{id}` ends it on the next request.
+  leaks, `DELETE /api/account/keys/{key_id}` ends it on the next request.
 - **Do not expect a key to get you past anything.** Same caps, same rate limits, same
   paywall, same wallet precondition. If you are looking for a way around the 402, the key
   is not it.

--- a/docs/api-surface-status.md
+++ b/docs/api-surface-status.md
@@ -67,6 +67,7 @@ per-surface reference doc yet (a real gap, not an oversight to paper over).
 | `/api/selection-bias` | `archimedes.api.selection_bias_routes.selection_bias_router` | public | live | [`api/strategies-and-rigor.md`](api/strategies-and-rigor.md) |
 | `/api/rigor` | `archimedes.api.rigor_verify_routes.rigor_verify_router` | session | live | — |
 | `/api/account` | `archimedes.api.account_usage_routes.account_usage_router` | session | live | — |
+| `/api/account/keys` | `archimedes.api.api_key_routes.api_key_router` | session | live | [`api/api-keys.md`](api/api-keys.md) |
 | `/api/payments` | `archimedes.api.payment_routes.payment_router` | session | live | [`api/generation.md`](api/generation.md) |
 | `/api/papers` | `archimedes.api.papers_routes.papers_router` | public | live | — |
 | `/api/user` | `archimedes.api.user_routes.user_router` | session | live | — |
@@ -78,9 +79,9 @@ per-surface reference doc yet (a real gap, not an oversight to paper over).
 | `/api/metrics/private` | `archimedes.api.metrics_private_routes.metrics_private_router` | private-admin | degraded-capable | [`api/admin-private.md`](api/admin-private.md) |
 | `/api/leaderboard` | `archimedes.api.leaderboard_routes.leaderboard_router` | public | degraded-capable | [`api/leaderboard-and-metrics.md`](api/leaderboard-and-metrics.md) |
 
-30 rows, one per `include_router` call in `main.py` (two calls each mount
+31 rows, one per `include_router` call in `main.py` (two calls each mount
 `generate_routes.py`'s pair of routers and `auth_siwe.py`'s legacy router
-under a shared prefix with a sibling — see notes). 14/30 have a detailed doc
+under a shared prefix with a sibling — see notes). 15/31 have a detailed doc
 in `docs/api/`; the other 16 are real documentation debt, not an oversight —
 tracked here rather than silently absent.
 
@@ -101,6 +102,14 @@ tracked here rather than silently absent.
   by `backend/tests/test_sole_generation_route_guard.py`. Historic context: it
   never had a UI consumer, and cluster-4 chose to route it through the
   generation quota meter rather than delete it; deletion is the resolution.
+- **`api_key_router`** — `session`, and **stricter than every other `session`
+  row here.** Since #1653 D3 an `Authorization: Bearer archim_…` API key
+  satisfies `require_current_user` everywhere else in this table; these three
+  routes require the Better Auth *cookie* specifically
+  (`require_session_credential`) and answer `403` to a key. A key that could
+  mint keys would issue itself successors, and revoking the token an operator
+  knows about would not end the compromise. Shares the `/api/account` prefix
+  with `account_usage_router`; the two never collide (`/usage` vs `/keys`).
 - **`traces_router`** — reads are public. `POST /publish` requires
   `X-Internal-Agent-Key` (`require_internal_agent_key`) — the agent runner
   only, never the browser.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -30,7 +30,7 @@ these five levels:
 | Level | Requirement | Failure mode |
 |---|---|---|
 | `anonymous` | Nothing. No cookie, no header. | N/A — never 401s on auth grounds. |
-| `account-session` | A live Better Auth session — the `better-auth.session_token` cookie, verified by FastAPI against the colocated Better Auth sidecar's `GET /api/auth/get-session` on every request. | `401` with no/expired session. |
+| `account-session` | An authenticated account, established by **either** credential: the `better-auth.session_token` cookie (verified by FastAPI against the colocated Better Auth sidecar's `GET /api/auth/get-session` on every request), **or** an `Authorization: Bearer archim_…` API key (see [`api-keys.md`](api-keys.md)). Both resolve to the same canonical user at the same chokepoint, so no route distinguishes them — a key is a credential, never a bypass. The three key-management routes are the sole exception and require the cookie specifically. | `401` with no/expired session and no valid key. |
 | `linked-wallet` | An `account-session`, **plus** a wallet verified-linked to that account (`require_linked_wallet`). | `401` with no session; `403` with a session but no linked wallet. |
 | `platform-admin` | A `linked-wallet`, **plus** that wallet listed in the `PLATFORM_ADMIN_WALLETS` env allowlist. Grants **no fund/custody/treasury authority** — it is a read gate on the internal cost/ops dashboard, nothing more. | `401` no session; `403` linked-but-non-admin wallet. |
 | `internal-key` | A matching `X-Internal-Agent-Key` header, compared with `hmac.compare_digest` against `INTERNAL_AGENT_API_KEY`. Fails closed (rejects everyone) if that env var is unset. Used only by internal services (the agent runner) — never reachable from the browser UI. | `403` on any missing/wrong key. |
@@ -46,6 +46,7 @@ Each level nests into the one above it (`linked-wallet` implies
 | Doc | Covers |
 |---|---|
 | [`auth-and-accounts.md`](auth-and-accounts.md) | The Better Auth sidecar (`/api/auth/*`): email/password + OAuth sign-up/sign-in, session lookup, email verification. |
+| [`api-keys.md`](api-keys.md) | `/api/account/keys/*` — mint, list, and revoke the bearer API keys that let a machine caller authenticate as an account without a cookie jar. |
 | [`wallets.md`](wallets.md) | `/api/wallets/*` — EIP-4361 wallet-link challenge/verify, linking a wallet to an already-signed-in account. |
 
 ### Generation & rigor

--- a/docs/api/api-keys.md
+++ b/docs/api/api-keys.md
@@ -1,0 +1,110 @@
+# API Keys
+
+> **status:** current
+> **owner:** Dan Browne
+> **updated:** 2026-08-31
+
+`/api/account/keys/*` — a long-lived bearer credential for machine callers, and the
+second way (beside the Better Auth session cookie) to authenticate as an account.
+
+**Why this exists.** Before it, the only credential a CI job or agent runner could hold
+was the `better-auth.session_token` cookie, and the only way to obtain or refresh one was
+`POST /api/auth/sign-in/email` **with the account password in the body**, every seven days
+when the cookie expires. That makes the machine credential *the human's password*: it
+cannot be scoped, it cannot be revoked without locking the human out, and it goes over the
+wire on a weekly cycle. Owner decision **D3** on
+[#1653](https://github.com/a-apin/archimedes/pull/1653) closed that gap.
+
+## The credential
+
+```
+archim_9f3c1a77b204de51_KtQ8yv…
+^^^^^^ ^^^^^^^^^^^^^^^^ ^^^^^^^
+|      |                32 random bytes from `secrets`, urlsafe-base64
+|      the PUBLIC key id — the database lookup handle. Not a secret.
+fixed prefix, so a leaked token is greppable by shape
+```
+
+Present it as `Authorization: Bearer archim_…`. `archim_<key_id>` alone is the `prefix`
+the list endpoint returns: it identifies a key and cannot be used as one.
+
+## Properties, and where each is enforced
+
+| Property | How |
+|---|---|
+| **Shown once.** The full token appears only in the `POST` response body. | The server stores a per-key salted SHA-256 of the secret and nothing else, so no one — including operators — can read the token back. Lose it → revoke and mint another. |
+| **Constant-time verification**, on the hit path *and* the miss path. | `hmac.compare_digest`, the same primitive the `internal-key` guard uses. An unknown key id still performs a full comparison against a dummy digest, so response timing cannot be used to enumerate key ids. |
+| **Immediate revocation.** | `revoked_at` is read from the row on every request. No cache, no TTL, no grace period — the next call with a revoked key is `401`. |
+| **Scoped to one account.** | Every query is filtered by `user_id`. Another account's key id answers `404`, never `403`: a `403` would confirm the id exists. |
+| **Never a bypass.** | The key is resolved into the same `CurrentUser` a cookie resolves to, at the same chokepoint (`api/account_auth.py`), so daily quotas, per-route rate limits, the x402 paywall and the wallet precondition all apply identically. A keyed `POST /api/generate/start` returns the same `402`, with the same quote, that a cookie call returns. No route knows keys exist. |
+| **A key cannot manage keys.** | All three routes below require `account-session` **specifically** and answer `403` to a bearer key. Containment: a leaked key must not be able to mint successors that outlive revoking the one you know about. The cost is real — a fully unattended agent cannot rotate its own key. |
+| **Never logged.** | No log line in `api/api_key_auth.py`, `api/api_key_routes.py`, or `models/api_key.py` takes a token, a secret, or a digest. The public key id *is* logged, deliberately: that is how an operator ties an audit line to a row without the line being a credential. |
+
+Auth levels used below are defined in [`README.md`](README.md#auth-model). Note that
+`account-session` there now means "a live Better Auth session **or** a valid API key" for
+every other route in this directory — these three are the sole exception.
+
+---
+
+### POST /api/account/keys
+Mint a key for the calling account. | **Auth**: `account-session` — **cookie only**, an
+API key gets `403` | **Flags**: rate-limited 10/hour; max 25 live keys per account
+
+Request: JSON body `{name: str}` (1–64 characters, non-blank after trimming).
+Response `201`: `{id, name, prefix, created_at, last_used_at, revoked_at, key}` — `key` is
+the full token and **this is the only response in the system that contains one**.
+Errors: `401` no credential · `403` presented an API key rather than a session ·
+`409 api_key_limit_reached` already holding 25 live keys · `422` blank or over-length name.
+
+```bash
+curl -sS -b /tmp/agora.jar -X POST http://localhost:8080/api/account/keys \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"ci-nightly"}'
+```
+
+### GET /api/account/keys
+List the calling account's keys, newest first. | **Auth**: `account-session` — **cookie
+only**, an API key gets `403` | **Flags**: none
+
+Request: no parameters.
+Response `200`: a list of `{id, name, prefix, created_at, last_used_at, revoked_at}`.
+**Never contains a token** — the response model has no field for one and the record it is
+built from holds no token. `last_used_at` is coarsened to the minute (a write per request
+would put a database `UPDATE` on the hot path of every authenticated agent call).
+Revoked keys are retained and returned with a `revoked_at`, as an audit trail.
+Errors: `401` no credential · `403` presented an API key rather than a session.
+
+```bash
+curl -sS -b /tmp/agora.jar http://localhost:8080/api/account/keys
+```
+
+### DELETE /api/account/keys/{key_id}
+Revoke a key. | **Auth**: `account-session` — **cookie only**, an API key gets `403` |
+**Flags**: none
+
+Request: path `key_id` — the `id` from the create or list response.
+Response `204`: no body. Idempotent — revoking an already-revoked key is also `204`, so a
+retried automation is not punished for it. Effective on the **next** request that presents
+the key.
+Errors: `401` no credential · `403` presented an API key rather than a session · `404` no
+such key **or** it belongs to another account (the two are deliberately the same answer).
+
+```bash
+curl -sS -b /tmp/agora.jar -X DELETE http://localhost:8080/api/account/keys/$KEY_ID
+```
+
+---
+
+## Telemetry
+
+A keyed caller classifies as `agent_type: "keyed"` in
+[`leaderboard-and-metrics.md`](leaderboard-and-metrics.md)'s funnel breakdown — an
+*identity*, unlike `external`, which is a User-Agent guess about an unauthenticated
+client. This matters for reading the numbers: before this credential existed, the
+classifier resolved any account session to `human` before any agent heuristic ran, so an
+authenticated agent was indistinguishable from a person. Funnel readings taken before the
+key lane cannot be compared with readings taken after it.
+
+See also: [`../agent-quickstart.md`](../agent-quickstart.md) step 4b (the walkthrough),
+[`../agent-api.md`](../agent-api.md#api-keys-bearer) (the agent-facing summary), and
+[`auth-and-accounts.md`](auth-and-accounts.md) (the cookie credential these sit beside).

--- a/docs/api/leaderboard-and-metrics.md
+++ b/docs/api/leaderboard-and-metrics.md
@@ -175,7 +175,12 @@ Two sources, not two views of the same data:
 - **`source=visitor`** (default) — the pre-#1028 anonymous browser-id funnel
   (`landed → wallet_connected → generation_started → vault_deployed`),
   backed by Redis HyperLogLog. Every stage also carries `by_agent_type`
-  (`internal`/`external`/`human` breakdown), additive to `distinct_visitors`.
+  (`internal`/`keyed`/`external`/`human` breakdown), additive to `distinct_visitors`.
+  `keyed` is a caller authenticated by a scoped API key (`Authorization: Bearer
+  archim_…`) — an identity, unlike `external`, which is a User-Agent guess about
+  an unauthenticated client. Readings that predate the key lane cannot be
+  compared with later ones: before it, an authenticated agent classified as
+  `human`.
 - **`source=identity`** — `wallet_connected → generation_started →
   vault_deployed`, each a live `COUNT(DISTINCT wallet)` over the durable
   `identity_events` ledger, no Redis/HLL involved. `human_only=true`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
   - API Reference:
       - api/README.md
       - api/auth-and-accounts.md
+      - api/api-keys.md
       - api/generation.md
       - api/strategies-and-rigor.md
       - api/vaults-and-chain.md

--- a/ui/src/account-deletion.js
+++ b/ui/src/account-deletion.js
@@ -27,6 +27,7 @@
 // privacy: it is where the Fernet-encrypted contact email lives.
 export const DELETION_ERASED = [
   { table: 'auth_sessions', label: 'every signed-in session, on every device' },
+  { table: 'api_keys', label: 'every API key minted for this account — revoked and erased; any script still holding one gets 401 on its next call' },
   { table: 'auth_accounts', label: 'your sign-in methods — the password itself, and any linked Google or GitHub' },
   { table: 'linked_wallets', label: 'your wallet links (the account↔wallet binding here, never anything on-chain)' },
   { table: 'wallet_link_challenges', label: 'any wallet-link challenge still outstanding' },


### PR DESCRIPTION
Closes #1680
Part of #1653

Owner decision **D3**: build the scoped API-key lane. Requirements as given — *strict, sane, secure, safe; auditable by anyone reading the code; exposing no sensitive information.*

---

## The problem, quoted from where it lives

`docs/agent-quickstart.md` before this PR:

```
$ grep -c 'agora.jar' docs/agent-quickstart.md
17
```

Seventeen of the quickstart's curls carry `-b /tmp/agora.jar`, and step 3 says in as many words:

> Sets `better-auth.session_token` (HttpOnly, `SameSite=Lax`, **7-day expiry**). **Keep the jar…**

The only way to refresh that cookie is `POST /api/auth/sign-in/email` **with the account password in the body**. So the credential a machine holds today *is the human's password*. It cannot be scoped, it cannot be revoked without locking the human out, and it goes over the wire on a weekly cycle. D3 reads as an ergonomics complaint; underneath it is a credential-hygiene defect.

## What this is

`archim_<key_id>_<secret>` — 32 random bytes from `secrets`, shown **once**, stored **only** as a per-key salted SHA-256, compared with `hmac.compare_digest`.

The load-bearing decision is one sentence: **`Authorization: Bearer archim_…` is resolved at the same chokepoint the cookie is, into the same `CurrentUser`, built from the same `auth_users` row.** After `api/account_auth.py` returns there is nothing left to tell the two credentials apart — so "same quotas, same rate limits, same paywall" is not a promise routes keep, it is a property they *cannot break*, because no route knows keys exist.

```
                       ┌────────────────────────────────────────────────┐
  Cookie ─────────────►│ account_auth.better_auth_session_middleware     │
  Bearer archim_… ────►│   cookie first → else key                      │
                       │   request.state.current_user  ← ONE object     │
                       └───────────────────┬────────────────────────────┘
                                           │
        require_current_user ──────────────┴──── quota · rate limit · paywall · ownership
                (unchanged)                                (all unchanged)
```

The difference survives in exactly one place, `request.state.auth_credential`, read by exactly two things, neither of which grants account access:

1. `require_session_credential` — key management needs a session (A16, below);
2. the telemetry classifier — a keyed caller is an **agent**, not a mislabelled human.

## Why `keyed` had to join the `agent_type` vocabulary

#1653's finding 1, restated: `classify_request` resolved "session ⇒ `human`" **before** any agent heuristic, and every funnel stage past `landed` sits behind `require_current_user`. So no authenticated agent could ever be *counted* as one, and the live `external: 0` at `generation_started` measured the absence of the question rather than the absence of agents.

A key is the first credential that says what the caller **is**, instead of guessing from a header the caller chose. So it classifies ahead of the session rule and gets its own type. Folding it into `external` would put the only high-confidence agent signal we have back into a bucket of User-Agent heuristics.

An unrecognised `agent_type` **silently no-ops** on write in `FunnelStore.record`, so forgetting to extend the vocabulary would have made keyed traffic vanish rather than fail loudly. All four sites move in this diff — `telemetry_middleware.classify_request`, `funnel_store.AGENT_TYPES`, `models/telemetry.py`'s field description, and the docs — and the classifier module now names the other three so the next person has a list.

---

## Adversarial demonstrations — every guard shown rejecting

CLAUDE.md § *"A guard must be shown to reject something"*. Ten mutations, each applied to the tree, run, confirmed failing, reverted. Tree verified clean after every one (`git status --porcelain` → empty).

| # | Mutation | Guard | Result |
|---|---|---|---|
| M1 | `verify()`'s miss path returns early instead of running the dummy comparison | `test_unknown_key_id_still_performs_a_comparison` | **FAILED** — `the unknown-key-id path skipped the constant-time comparison` |
| M2 | `_digest()` returns the secret (plaintext storage) | `test_token_never_appears_in_any_column_or_in_the_database_file` | **FAILED** — `the secret half is stored in api_keys.secret_hash` |
| M3 | `verify()` stops reading `revoked_at` | `test_revoked_key_is_401_on_the_next_call` | **FAILED** — `assert 200 == 401` |
| M4 | `get_owned_key` drops the `user_id` filter | `test_key_a_cannot_read_or_revoke_account_b` | **FAILED** — `assert 204 == 404` |
| M5 | `to_payload` surfaces the stored column + `_digest` returns the secret | `test_create_returns_the_secret_once_and_list_never_does` | **FAILED** — `the list endpoint returned the secret` |
| M6 | `require_session_credential` stops checking the credential | `test_api_key_cannot_manage_api_keys` | **FAILED** — `assert 201 == 403` |
| M7 | keyed rule removed → keyed caller falls through to `human` | `test_keyed_caller_classifies_as_agent_with_its_own_type` + the end-to-end one | **FAILED** — `assert (False, 'human') == (True, 'keyed')` and `assert 'false' == 'true'` |
| M8 | `AGENT_TYPES` left un-extended | `test_keyed_caller_classifies_as_agent_with_its_own_type` | **FAILED** — `funnel_store would silently drop keyed traffic from the breakdown` |
| M9 | paywall skipped for keyed callers | `test_keyed_call_hits_the_same_paywall_…` + `test_no_gate_module_knows_that_api_keys_exist` | **FAILED** — `a key walked past the paywall a session is stopped by` and `generate_routes references 'auth_credential'` |
| M10 | the create route logs the token | `test_no_key_material_reaches_the_logs` | **FAILED** — `a log record contains the full token` |

<details><summary>Transcripts (M1–M5)</summary>

```
─────────────────────────────────────────────────────────────
MUTATION: M1 miss path returns early instead of doing the constant-time compare
FAILED backend/tests/test_api_key_auth.py::test_unknown_key_id_still_performs_a_comparison
  - AssertionError: the unknown-key-id path skipped the constant-time comparison
1 failed, 1 warning in 2.60s

─────────────────────────────────────────────────────────────
MUTATION: M2 secret stored in plaintext instead of a salted hash
FAILED backend/tests/test_api_key_auth.py::test_token_never_appears_in_any_column_or_in_the_database_file
  - AssertionError: the secret half is stored in api_keys.secret_hash
1 failed, 1 warning in 2.26s

─────────────────────────────────────────────────────────────
MUTATION: M3 verify stops reading revoked_at (revocation becomes cosmetic)
FAILED backend/tests/test_api_key_auth.py::test_revoked_key_is_401_on_the_next_call - assert 200 == 401
1 failed, 1 warning in 2.78s

─────────────────────────────────────────────────────────────
MUTATION: M4 revoke lookup no longer scoped by account (cross-account revoke)
FAILED backend/tests/test_api_key_auth.py::test_key_a_cannot_read_or_revoke_account_b - assert 204 == 404
1 failed, 1 warning in 2.53s

─────────────────────────────────────────────────────────────
MUTATION: M5 the list endpoint surfaces the stored column
    assert secret not in body, "the list endpoint returned the secret"
E   assert 'F2KPz2XiD7T...WEe47DHk5F4w' not in '[{"id": "11..._at": null}]'
FAILED backend/tests/test_api_key_auth.py::test_create_returns_the_secret_once_and_list_never_does
  - AssertionError: the list endpoint returned the secret
1 failed, 1 warning in 2.24s
```
</details>

<details><summary>Transcripts (M6–M10)</summary>

```
─────────────────────────────────────────────────────────────
MUTATION: M6 key-management no longer requires a session credential
FAILED backend/tests/test_api_key_auth.py::test_api_key_cannot_manage_api_keys - assert 201 == 403
1 failed, 1 warning in 2.93s

─────────────────────────────────────────────────────────────
MUTATION: M7 keyed caller falls through to 'human' (the finding this lane fixes)
FAILED …::test_keyed_caller_classifies_as_agent_with_its_own_type - AssertionError: assert (False, 'human') == (True, 'keyed')
FAILED …::test_keyed_request_is_tagged_as_an_agent_end_to_end   - AssertionError: assert 'false' == 'true'
2 failed, 1 warning in 1.57s

─────────────────────────────────────────────────────────────
MUTATION: M8 funnel vocabulary not extended — keyed traffic silently dropped
FAILED …::test_keyed_caller_classifies_as_agent_with_its_own_type
  - AssertionError: funnel_store would silently drop keyed traffic from the breakdown
1 failed, 1 warning in 2.76s

─────────────────────────────────────────────────────────────
MUTATION: M9 paywall skipped for keyed callers
FAILED …::test_keyed_call_hits_the_same_paywall_a_session_call_hits
  - AssertionError: a key walked past the paywall a session is stopped by
FAILED …::test_no_gate_module_knows_that_api_keys_exist
  - AssertionError: archimedes.api.generate_routes references 'auth_credential'…
2 failed, 3 warnings in 5.10s

─────────────────────────────────────────────────────────────
MUTATION: M10 the create route logs the token
FAILED …::test_no_key_material_reaches_the_logs - AssertionError: a log record contains the full token
1 failed, 1 warning in 3.00s

─────────────────────────────────────────────────────────────
TREE AFTER ALL MUTATIONS (must be empty):
$ git status --porcelain
$
```
</details>

### The four demos the task named, individually

**1. Wrong key → 401.** `test_wrong_key_is_401`, parametrised over five shapes — a well-formed-but-never-minted token, an empty secret, the bare prefix, no separator, and junk — plus `test_right_key_id_wrong_secret_is_401` (knowing the public id buys nothing) and `test_non_conforming_authorization_headers_are_ignored` (no scheme / `Basic` / lowercase `bearer` / a JWT). Every one `401 {"detail": "Authentication required"}`.

**2. Revoked key → 401 on the next call.** `test_revoked_key_is_401_on_the_next_call` drives `200` → `DELETE` (`204`) → `401`, then re-`DELETE`s to prove idempotence, then reads the list to prove the row **survives** as an audit record with a `revoked_at`. M3 above shows the guard rejecting a build where `verify` stops reading the column.

**3. Cross-account → 404.** `test_key_a_cannot_read_or_revoke_account_b`, four steps: A's key resolves to A and not B; B's key id is absent from A's list; A's `DELETE` of B's key id is **404** with `{"detail": "API key not found"}`; and B's key still works afterwards. 404 rather than 403 is deliberate — a 403 confirms the id exists in *someone's* account, which is an enumeration oracle. It is enforced at the query, not after it: `get_owned_key` filters on `user_id` **and** `id`, so "not yours" and "does not exist" are literally the same answer and no caller can forget the check. M4 shows the guard rejecting the unscoped version.

**4. The list never leaks the secret.** `test_create_returns_the_secret_once_and_list_never_does` serialises the list response with `json.dumps` and greps the whole string for both the token and its secret half, then asserts the field set is exactly `{id, name, prefix, created_at, last_used_at, revoked_at}`, then presents the `prefix` as a credential and confirms it 401s. Two independent reasons it cannot leak: the response model has no field for a token, and `ApiKeyRecord.to_payload` builds from an object that holds none.

**5. Timing — the constant-time mechanism, named.** `hmac.compare_digest`, the same primitive `auth_guard.require_internal_agent_key` already uses for the internal key. The part worth auditing is the **miss** path: an unknown key id would otherwise return before any comparison, making "no such key" measurably faster than "wrong secret" and letting an attacker enumerate valid key ids by timing alone. So `verify()` compares against a fixed dummy salt/digest generated once at import and throws the result away:

```python
if record is None:
    # Deliberate: burn the same work an existing key would, so timing does
    # not answer "is this a real key id?". Do NOT replace with `return None`.
    hmac.compare_digest(_digest(_DUMMY_SALT, secret), _DUMMY_DIGEST)
    return None
```

`test_unknown_key_id_still_performs_a_comparison` spies on `compare_digest` and asserts `call_count == 1` on the miss; its sibling asserts the same on the hit. M1 is that guard rejecting the "optimised" version. **Honest scope:** this equalises the *comparison*, not the whole request — a hit still does an `AuthUser` lookup and (at most once a minute) an `UPDATE`. What it removes is the cheap, reliable oracle; it is not a claim of end-to-end timing indistinguishability, and I am not making that claim.

**6. Grep-proof: no key material in logs.** Every logger call in all three new modules, in full:

```
$ grep -n "logger\." backend/archimedes/api/api_key_auth.py \
                     backend/archimedes/api/api_key_routes.py \
                     backend/archimedes/models/api_key.py
api_key_auth.py:239:   logger.warning("api key resolution failed: %s", type(exc).__name__)
api_key_routes.py:117: logger.info("api key created: id=%s user=%s", payload_out["id"], user.id)
api_key_routes.py:125: logger.error("api key creation failed: %s", type(exc).__name__)
api_key_routes.py:163: logger.info("api key revoked: id=%s user=%s", key_id, user.id)
api_key_routes.py:170: logger.error("api key revocation failed: %s", type(exc).__name__)
```

Five calls. Two carry the **public** key id, deliberately — that is how an operator ties an audit line to a row without the line being a credential. Three carry an exception **type name** only, the same discipline `better_auth_session_middleware` already follows. And because a grep only covers what I thought to grep for, `test_no_key_material_reaches_the_logs` attaches a `caplog` handler at **DEBUG** across mint → verify → a failed verify → list → revoke and asserts the secret appears in no emitted record (while asserting the public id does). M10 is that guard rejecting a build where the token is logged.

One line changed during self-review for a reason worth naming: the revoke log used to interpolate the **path parameter**. It could only ever be a 16-hex-char id (the log runs after `get_owned_key` matched a row on it), so no injection was actually reachable — but a reader has to prove that to themselves before they can move on. It now logs `record.id`, the value that came out of the database rather than the one that came off the wire, so no caller-controlled string reaches a log line and log forging stops being a question at all.

---

## Acceptance criteria — every one, run

| # | Criterion | Result |
|---|---|---|
| A1 | `archim_` + ≥32-byte secret from `secrets`; mints unique | ✅ `test_minted_token_shape_and_entropy` — 100 mints, 100 distinct, prefix + id length + decoded-entropy floor asserted against the `SECRET_BYTES` constant (not a literal, so lowering it breaks the test) |
| A2 | Plaintext never persisted | ✅ `test_token_never_appears_in_any_column_or_in_the_database_file` — every column of every row **and** the raw bytes of the SQLite file |
| A3 | Constant-time on hit **and** miss | ✅ two tests + M1; mechanism named above |
| A4 | Key and cookie resolve to the same `CurrentUser` | ✅ `test_key_and_cookie_resolve_the_same_account_identity` — same `user_id`, same `email`; only `credential` differs. Plus `test_when_both_credentials_are_present_the_cookie_wins_deterministically`: a request carrying *both* resolves to one identity, always the same one |
| A5 | Secret returned exactly once | ✅ create body has `key`; list body does not |
| A6 | List exposes prefix + created + last_used, nothing secret | ✅ exact field set asserted; JSON grepped; `prefix` presented as a credential → 401 |
| A7 | Wrong key → 401 | ✅ 7 cases |
| A8 | Revoked key → 401 next call | ✅ + idempotent re-revoke + audit row survives |
| A9 | Key A cannot read or revoke account B | ✅ 4-step test, 404 not 403 |
| A10 | Keyed call hits the same paywall | ✅ `test_keyed_call_hits_the_same_paywall_a_session_call_hits` — both `402`, both carry `PAYMENT-REQUIRED`, **identical `quote` and `accepts`**; plus the 409 wallet precondition applies equally |
| A11 | Distinct `agent_type`, vocabulary extended not broken | ✅ pure-function test + end-to-end (`X-Telemetry-Agent: true`, `increment_agent` awaited, `increment_human` not); existing funnel/metrics tests unmodified and green |
| A12 | No key material loggable | ✅ grep above + DEBUG `caplog` test |
| A13 | Docs: cookie jar → one `-H` | ✅ below |
| A14 | Real Alembic revision, serial chain | ✅ below |
| A15 | Suite green, ruff clean | ✅ below |
| **A16** | **An API key cannot manage API keys** (added to the issue during the build, [comment](https://github.com/a-apin/archimedes/issues/1680#issuecomment-5486004151)) | ✅ `test_api_key_cannot_manage_api_keys` — all three verbs 403, database asserts nothing was minted |

### A13 — the curl that needed a cookie jar

```bash
# before: steps 3 + 4 first, and again every 7 days, password in the body
curl -sS -b /tmp/agora.jar -X POST $BASE/api/generate/start -H 'Content-Type: application/json' -d "$BRIEF"

# after: step 4b once, ever
curl -sS -H "Authorization: Bearer $ARCHIMEDES_KEY" -X POST $BASE/api/generate/start -H 'Content-Type: application/json' -d "$BRIEF"
```

`docs/agent-quickstart.md` gains step **4b** (mint, store, use, list, revoke — with the "shown once" warning stated where it bites), a path-table row, three error-table rows (401 extended for key failures, 403 for the containment rule, 409 for the ceiling), and two anti-goals. `docs/agent-api.md` gains an **API keys (Bearer)** section with the full contract. `docs/api/api-keys.md` is the new per-route reference.

Two corrections to existing docs, both forced by this change rather than opportunistic:

- **`docs/api/README.md`'s auth-model table.** `account-session` said "a live Better Auth session — the cookie". That is now incomplete for every route in the directory, so the row says both credentials and names the three-route exception.
- **`docs/agent-api.md` § What's NOT covered here** said funnel segmentation by `agent_type` "remains open work". #788 shipped; it is live, and this PR adds a value to it. Leaving that paragraph beside my new claim would mislead, so it is corrected in place, dated, and it now says what *is* still open: interpretation, because readings from before the key lane cannot be compared with readings after it. (This is follow-up #2 from #1653's "Not done" list; folding it in was the smaller lie.)

`make docs-check`:

```
links: scanned 1531 in 169 markdown files; broken 0 (0.0%)
index: 164 docs under docs/; 164 indexed, 0 orphaned.
staleness: 0 of 69 `current` docs older than 60 days; 2 missing an `updated` date.
```

(The two undated docs — `agent-api.md`, `asset-universe.md` — predate this branch. I did not add the front matter to `agent-api.md`: it is a separate change and #1653 already tracks it.)

### A14 — the migration

`c1d8e6f30a72_add_api_keys.py`, chained onto `a7f2c93b1d64` (the head at authoring time). Replayed from zero:

```
$ DATABASE_URL="sqlite:///…" alembic upgrade head
…
INFO  [alembic.runtime.migration] Running upgrade a7f2c93b1d64 -> c1d8e6f30a72, add api_keys …

CREATE TABLE api_keys (
	id VARCHAR(32) NOT NULL,
	user_id VARCHAR(64) NOT NULL,
	name VARCHAR(64) NOT NULL,
	salt VARCHAR(64) NOT NULL,
	secret_hash VARCHAR(64) NOT NULL,
	created_at DATETIME NOT NULL,
	last_used_at DATETIME,
	revoked_at DATETIME,
	PRIMARY KEY (id),
	FOREIGN KEY(user_id) REFERENCES auth_users (id) ON DELETE CASCADE
)
ix_api_keys_user_revoked | CREATE INDEX … ON api_keys (user_id, revoked_at)
ix_api_keys_user_id      | CREATE INDEX … ON api_keys (user_id)
```

`test_alembic_migrations.py` (which asserts exactly one head) is green. **Backfill: none, and none is possible** — no API key has ever existed. The cookie lane is untouched; this is a second credential beside it, not a replacement.

---

## Anti-goals — each checked by command

| # | Anti-goal | Check | Result |
|---|---|---|---|
| N1 | No route learns the word "key" | `git diff --name-only` over `api/*routes.py` | Two files: `api_key_routes.py` (new, and it *is* the key surface) and `metrics_routes.py` — whose diff is **one docstring line** listing the `agent_type` values. No existing route gained an auth branch. |
| N2 | No gate can tell credentials apart | `test_no_gate_module_knows_that_api_keys_exist` — asserts `generate_routes`, `generation_payment`, `generation_quota` contain none of `api_key_auth` / `auth_credential` / `CREDENTIAL_API_KEY` / `archim_` | ✅, and M9 shows it rejecting a real bypass |
| N3 | No scopes/permissions model this repo cannot enforce | no permission enum in the diff | ✅ — "scoped" means **scoped to one account**, which A9 proves. A `scope` column nothing enforces would be a claim the code does not keep |
| N4 | Token never stored, logged, or returned after creation | A2, A5, A6, A12 | ✅ |
| N5 | Existing `agent_type` vocabulary not broken | existing funnel/metrics tests unmodified, green | ✅ — the type is **added**; the model description and both docs move in the same commit |
| N6 | No UI, no CLI, no MCP server | `git diff --name-only \| grep -E '^(ui\|cli)/'` | empty |
| N7 | No prod, no flag flips, no seeded key | `git diff --name-only \| grep '^infra/'` | empty |
| N8 | No unenforced security claim in prose | every claim above carries a transcript | ✅ — and where a claim has limits (the timing one) the limits are stated |

---

## Suite + lint

```
$ /opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest -m "not integration" -q
5071 passed, 3 skipped, 2 deselected, 299 warnings in 444.53s (0:07:24)

$ ruff check <every file this PR touches>
All checks passed!
$ ruff format --check backend/
568 files already formatted
```

Two pre-existing findings I did **not** fold in: `db.py`'s `__all__` is not sorted (RUF022) — confirmed pre-existing by stashing this branch and re-running ruff on `origin/main`'s file — and the repo-wide informational `ruff check .` has unrelated findings in files this PR does not touch.

---

## Judgement calls, stated rather than buried

1. **`require_session_credential` is stricter than the issue asked for**, and it has a real cost: a fully unattended agent **cannot rotate its own key**. I chose containment anyway — a key that can mint keys makes revoking the token you know about useless — and filed the reasoning as A16 on the issue *before* meeting it rather than shipping it quietly. If it blocks a real CI workflow, the answer is a separate narrow rotation grant, not widening this.
2. **sha256, not bcrypt/argon2.** A slow KDF exists to defeat enumeration of a ~30-bit human password. This secret carries 256 bits; there is no dictionary and no feasible enumeration, so a KDF buys latency on every request and nothing else. The salt stays per-key. The reasoning is written into `models/api_key.py` because "why isn't this bcrypt" is the first question an auditor asks and the answer belongs in the file.
3. **The key id is public and travels in the token.** The alternative — scan every row and compare each digest — is O(keys) per request *and* leaks timing that grows with table size. An opaque, indexed lookup handle is strictly better on both counts, and `archim_<id>` doubles as the list's `prefix`.
4. **`last_used_at` is coarsened to one write per minute.** Full resolution would put a database `UPDATE` on the hot path of every authenticated agent request. Minute resolution answers both questions the column exists for ("is this key still in use", "when did the leak start"). Pinned by `test_last_used_is_recorded_and_coarsened`.
5. **`get_owned_key` returns `None` for both "not yours" and "not found"** so the 404 cannot drift into a 403 through a later refactor. The check is in the query, not after it.
6. **The token is split with `partition("_")`, not `split("_")`.** `secrets.token_urlsafe` emits `A–Za–z0–9-_`, so roughly half of all secrets contain an underscore — measured, because "roughly half" is the kind of thing that should not be a guess:

   ```
   secrets containing an underscore, out of 20000: 9669
   parse of an underscore-heavy secret: ('01c592199cf41fac', '_', 'ab_cd-ef_gh')
   ```

   The key id is hex, so the **first** underscore is always the separator and `partition` hands back the rest of the secret untouched. A `split("_")` (or a `split("_", 2)` read the wrong way) would have truncated about half of all keys — a bug that would look like intermittent, unreproducible 401s.
7. **Cookie beats key when a request carries both.** Not a security boundary — holding another account's cookie is already full compromise of that account — but leaving it unpinned means the order is whatever a future refactor happens to run first, and a caller cannot predict which account it is acting as. Pinned by a test, with the reasoning in it.
8. **The reference harness (`scripts/agent_journey.py`) still uses cookies.** Teaching it the key lane is a separate change; `docs/agent-api.md` says so rather than implying otherwise.
9. **No UI.** Keys are mintable only by curl today. D2 (MCP) and D6 (CLI) are still open on #1653 and this PR does not pre-empt either.

## Not done — honest list

- **No key rotation endpoint.** Revoke-and-mint is the whole story. A `POST /{key_id}/rotate` that returns a new token and revokes the old one atomically would be nicer for CI; it is not here, and #1680 did not ask for it.
- **No expiry.** A key lives until revoked. An optional `expires_at` is the obvious next hardening step and would have widened this PR past one logical change.
- **No per-key scoping *within* an account** (read-only keys, generation-only keys). Deliberate — see N3. The repo has no permission model to scope against, and inventing one to populate a column nothing checks is the failure mode this codebase's first rule forbids.
- **The identity read is synchronous inside async middleware.** One indexed primary-key lookup, only on requests that carry a parseable `archim_` bearer header — every other request short-circuits at the header parse before touching the database. Consistent with how every route in this repo already calls `get_session()`, but it is a blocking call on the event loop and worth knowing.
- **`last_used_at` is minute-resolution**, so it cannot support fine-grained "which of my two keys served this request" forensics. The public key id in the log line can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7
