### PR TITLE
[docs] local-vs-prod: leak 3 is closed — say so

### DIFF
--- a/docs/local-vs-prod.md
+++ b/docs/local-vs-prod.md
@@ -214,7 +214,7 @@ can both hold it.
 |---|---|
 | `profiles` | `COMPOSE_PROFILES` selects `localdb` and does **not** select `runners`. |
 | `runners-off` | No funds-adjacent runner would start. Fails both if a runner loses its `profiles: ["runners"]` gate and if the active profile set would start one anyway. |
-| `no-ecr-pull` | No service carrying `build:` resolves to a remote registry with `ECR_REGISTRY` / `IMAGE_TAG` unset — the fresh-clone case. **Currently failing; that is leak 3.** |
+| `no-ecr-pull` | No service carrying `build:` resolves to a remote registry with `ECR_REGISTRY` / `IMAGE_TAG` unset — the fresh-clone case. Closed by #1683: local images resolve to project-scoped `:local` tags; the ECR pull path is the explicit opt-in overlay `docker-compose.ecr.yml`. |
 | `no-prod-secrets` | `PUBLIC_DOMAIN` blank (so `main.py`'s SSM gate never fires) and `AWS_SSM_PATH_PREFIX` blank. |
 | `local-datastores` | With `localdb` active, `DATABASE_URL` / `REDIS_URL` address the in-stack containers, not Aurora / ElastiCache. |
 


### PR DESCRIPTION
One-row fix-forward: the #1671↔#1683 bidirectional sync guard (`test_the_open_ecr_leak_is_documented_while_it_is_open`) went red on merged main when both landed in TRAIN-SEC — the compose leak closed and the doc still said open. The row now records the #1683 closure and the `docker-compose.ecr.yml` opt-in. `pytest backend/tests/test_local_mode_contract.py -q` → **32 passed**.

Part of #1044.