### PR TITLE
[migrations] Re-point the trigram migration onto the free-generations head

### DIFF
--- a/backend/migrations/versions/c1d7f4a9b3e2_papers_trigram_search_indexes.py
+++ b/backend/migrations/versions/c1d7f4a9b3e2_papers_trigram_search_indexes.py
@@ -62,7 +62,7 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "c1d7f4a9b3e2"
-down_revision: str | Sequence[str] | None = "a7f2c93b1d64"
+down_revision: str | Sequence[str] | None = "c4e17b93a2d8"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
Fix-forward for red main: #1685's migration merged with its build-time `down_revision` (a7f2c93b1d64) after #1698 and #1658 moved the head — two heads, 22 alembic failures in the union suite. One-line re-point restores the serial chain. `pytest backend/tests/test_alembic_migrations.py -q` → **27 passed**.

Part of #1665.