### PR TITLE
[frontend] Insights: stop the NotFound flash without assuming admin (#1648 residual)

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,8 +1,19 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 
 import { fetchAdminProbe } from "./adminProbe.js";
-import { isInsightsPageBlocked, resolveInsightsAdminState } from "./insightsGate.js";
+import {
+	isInsightsPageBlocked,
+	resolveInsightsAdminState,
+	resolveInsightsView,
+} from "./insightsGate.js";
+import {
+	adminIdentityKey,
+	normalizeWalletAddress,
+	readInsightsAdmin,
+	rememberInsightsAdmin,
+} from "./insightsAdminMemo.js";
 import { useAuth } from "./AuthContext";
+import { getAddress } from "./config";
 import { defaultFeatures, fetchFeatures } from "./features";
 import { pageToPath, resolveRoute } from "./routes";
 import { canStore } from "./storage-consent.js";
@@ -38,23 +49,38 @@ export default function App() {
 	// has answered. Server truth only — never derived from `user`/wallet
 	// local state, which cannot know PLATFORM_ADMIN_WALLETS membership.
 	const [insightsAdmin, setInsightsAdmin] = useState(null);
-	// Bumped on every 'wallet-changed' event (config.js — fired on a raw
-	// account swap in the injected/EIP-6963 wallet, independent of sign-in
-	// state) so the insights-admin-probe effect below re-runs even while
-	// already sitting on /app/insights. A [route.page]-only dependency left
-	// a stale `insightsAdmin === true` (and the live dashboard it gates)
-	// rendering after switching from an admin-linked wallet to a
+	// The connected wallet ADDRESS (config.js's 'wallet-changed' event — fired
+	// on a raw account swap in the injected/EIP-6963 wallet, independent of
+	// sign-in state), tracked so the insights-admin-probe effect below re-runs
+	// even while already sitting on /app/insights. A [route.page]-only
+	// dependency left a stale `insightsAdmin === true` (and the live dashboard
+	// it gates) rendering after switching from an admin-linked wallet to a
 	// non-admin one on the same account, because route.page never changes on
 	// an in-place wallet swap (round-2 finding: the cache-reset in
 	// AuthenticatedApp's wallet-changed handler only helps a FUTURE probe
 	// caller — this effect is the one that has to actually become that
-	// caller). App.jsx has no other reason to track the connected wallet
-	// (that's AuthenticatedApp's walletAddr, the LINKED-and-verified
-	// subset), so a plain counter is used rather than duplicating that state.
-	const [walletChangeSeq, setWalletChangeSeq] = useState(0);
+	// caller).
+	//
+	// #1648 / I-8 B2: this used to be a plain counter bumped on EVERY
+	// wallet-changed event. That made the re-probe fire on events that carry
+	// no change at all — an injected provider re-announces `accountsChanged`
+	// with the SAME account on tab focus — and each fire blanked the page an
+	// admin was already using. Holding the address VALUE instead means React
+	// bails out of the state update when the announced account is unchanged,
+	// so a no-op announcement no longer re-runs the effect at all. Seeded from
+	// getAddress() so a wallet connected before this component mounted is part
+	// of the identity the first probe is recorded under, not a null that a
+	// later announcement would look like a swap away from. Normalized on both
+	// paths so a checksummed re-announcement of the same account is the same
+	// VALUE, and React's bail-out actually fires. (config.js is already in
+	// this chunk — api.js imports it — so this adds no bundle weight.)
+	const [walletAddr, setWalletAddr] = useState(() =>
+		normalizeWalletAddress(getAddress()),
+	);
 
 	useEffect(() => {
-		const onWalletChanged = () => setWalletChangeSeq((n) => n + 1);
+		const onWalletChanged = (event) =>
+			setWalletAddr(normalizeWalletAddress(event?.detail?.address));
 		window.addEventListener("wallet-changed", onWalletChanged);
 		return () => window.removeEventListener("wallet-changed", onWalletChanged);
 	}, []);
@@ -122,26 +148,41 @@ export default function App() {
 		window.location.replace(`/sign-in?next=${encodeURIComponent(next)}`);
 	}, [route.kind, route.anonymousOk, route.page, authLoading, user]);
 
+	const userId = user?.id ?? null;
 	useEffect(() => {
 		// Re-probe every time navigation LANDS on insights (not on every
-		// render while already there) — reset to "checking" first so a stale
-		// true/false from a previous visit this session can't flash before the
-		// fresh answer arrives. Also re-probes on a wallet swap that happens
-		// WHILE already sitting on insights (walletChangeSeq dep, see above) —
-		// route.page alone would miss that transition entirely.
+		// render while already there), and on a wallet swap that happens WHILE
+		// already sitting on insights (walletAddr dep, see above) — route.page
+		// alone would miss that transition entirely.
+		//
+		// #1648 / I-8 B2: this used to hard-reset to `null` on entry, and
+		// `null` renders the not-found treatment — so an admin saw a visible
+		// NotFound → dashboard flip on every single entry, and again on every
+		// tab-focus `accountsChanged`. The fix is NOT to assume admin while
+		// waiting (that would render the gated dashboard to whoever asks); it
+		// is to seed from the last answer THIS SERVER actually gave for THIS
+		// exact identity (account + connected wallet — see
+		// insightsAdminMemo.js for why the key has to include the wallet), and
+		// to render a quiet holding state rather than a decision when there is
+		// no such answer. A key miss still yields `null`, so a swap to an
+		// unseen wallet resolves from the server exactly as before.
 		if (route.page !== "insights") {
 			setInsightsAdmin(null);
 			return;
 		}
+		const identity = adminIdentityKey(userId, walletAddr);
 		let cancelled = false;
-		setInsightsAdmin(null);
+		setInsightsAdmin(readInsightsAdmin(identity));
 		fetchAdminProbe().then((result) => {
-			if (!cancelled) setInsightsAdmin(resolveInsightsAdminState(result));
+			if (cancelled) return;
+			const admin = resolveInsightsAdminState(result);
+			rememberInsightsAdmin(identity, admin);
+			setInsightsAdmin(admin);
 		});
 		return () => {
 			cancelled = true;
 		};
-	}, [route.page, walletChangeSeq]);
+	}, [route.page, walletAddr, userId]);
 
 	useEffect(() => {
 		const titles = {
@@ -250,17 +291,43 @@ export default function App() {
 
 	if (route.kind === "app" && route.page === "insights") {
 		// Server-truth admin gate (owner directive 2026-08-20, supersedes
-		// #1028 D8): a denied OR still-resolving probe renders EXACTLY the
-		// not-found page — same component the true 404 above uses — never a
-		// "you need admin access" message (would itself confirm the page
-		// exists) and never an intermediate "Loading…" screen either (round 3
-		// fix: a genuinely unknown route never shows a loading state on first
-		// paint, so a chrome-free loader while the probe resolves was itself a
-		// vector for telling "gated route" apart from "unknown route" — the
-		// exact thing this gate exists to prevent). isInsightsPageBlocked
-		// treats `null` (unresolved) the same as `false` (denied): both render
-		// NotFound immediately.
-		if (isInsightsPageBlocked(route.page, insightsAdmin)) return <NotFound user={user} />;
+		// #1028 D8): a DENIED probe renders EXACTLY the not-found page — the
+		// same component the true 404 above uses — never a "you need admin
+		// access" message, which would itself confirm the page exists.
+		//
+		// #1648 / I-8 B2 changes only the UNRESOLVED (`null`) branch, and only
+		// inside a session. Round 3 had collapsed unresolved into denied so
+		// that a chrome-free loader could not be used to tell "gated route"
+		// from "unknown route"; that reasoning holds for an anonymous caller
+		// and resolveInsightsView keeps it exactly (`hasSession === false` →
+		// not-found, first paint identical to an unknown route, matching what
+		// nginx's pre-auth gate already returns for both). What it cost was
+		// paid entirely by the admin: `null` on every entry meant a visible
+		// NotFound → dashboard flip on a page they are allowed to use. Inside
+		// a session, unresolved now renders a quiet neutral holding state that
+		// asserts nothing — not the dashboard (which would leak the page to
+		// whoever waited), not a denial (which is a claim the server has not
+		// made yet). See resolveInsightsView for the residual this leaves.
+		const view = resolveInsightsView(
+			route.page,
+			insightsAdmin,
+			authLoading || Boolean(user),
+		);
+		if (view === "not-found") return <NotFound user={user} />;
+		if (view === "resolving") {
+			return (
+				<main
+					className="min-h-screen grid place-items-center"
+					aria-busy="true"
+				>
+					{/* Deliberately the same neutral wording the auth-resolution
+					    loader below uses, and deliberately NOT "Loading
+					    Insights…" — the holding state must not name a page the
+					    server has not yet said this visitor may see. */}
+					Loading…
+				</main>
+			);
+		}
 		// admin === true falls through to the normal authenticated render below.
 	}
 

--- a/ui/src/AuthContext.jsx
+++ b/ui/src/AuthContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
 import { _resetAdminProbeCache } from './adminProbe.js'
+import { _resetInsightsAdminMemo } from './insightsAdminMemo.js'
 import { getSession, signOut as endSession } from './auth-client'
 
 const AuthContext = createContext(null)
@@ -30,6 +31,13 @@ export function AuthProvider({ children }) {
     // so it has to be cleared explicitly here rather than expiring on its
     // own short TTL.
     _resetAdminProbeCache()
+    // Same reason, for the per-session memo of the last answer (#1648): it is
+    // keyed on the account id, so it CANNOT be read by a different account
+    // signing in next — but an admin signing out and back in should still get
+    // a fresh determination rather than seeing the previous session's grant
+    // painted before the server has re-confirmed it. Defence in depth, not the
+    // load-bearing isolation (that is the key — insightsAdminMemo.js).
+    _resetInsightsAdminMemo()
   }, [])
 
   const value = useMemo(() => ({

--- a/ui/src/insightsAdminMemo.js
+++ b/ui/src/insightsAdminMemo.js
@@ -1,0 +1,97 @@
+// Per-session memo of the LAST SERVER ANSWER the admin gate received, keyed
+// on the identity that answer was given for (#1648 / I-8 B2).
+//
+// Why this exists, and why it is not the same thing as adminProbeCache.js:
+// that module caches an in-flight/just-resolved probe PROMISE for 30 s so two
+// mount points share one request. It says nothing about what to RENDER while a
+// fresh probe is in flight after that window closes — and App.jsx's gate reset
+// `insightsAdmin` to `null` on every entry to /app/insights and on every
+// `wallet-changed` event, so an admin re-entering the page (or simply
+// refocusing the tab, which makes an injected provider re-announce the SAME
+// account) watched the page flip to the not-found treatment and back. This
+// memo is what lets the second and later visits render the answer the server
+// already gave, instead of re-deciding from scratch.
+//
+// The honesty constraint (owner directive, #1648): this is a memo of a real
+// server answer, NEVER an optimistic assumption. Two properties enforce that:
+//
+//   1. It is keyed on the identity the answer was resolved under — account id
+//      AND connected wallet address. `require_platform_admin` can give a
+//      genuinely different answer per wallet on the same account, so a memo
+//      recorded under wallet A must not be readable after a swap to wallet B.
+//      A key miss returns `null` ("unknown"), never a stale `true`.
+//   2. Anonymous callers get a `null` key (see adminIdentityKey) and are
+//      therefore never memoized and never able to read a memo — a signed-out
+//      browser cannot inherit the previous session's determination.
+//
+// Both `true` and `false` are memoized. Remembering the denial matters as much
+// as remembering the grant: it is what lets a non-admin's second visit render
+// the not-found treatment instantly, exactly like a genuinely unknown route,
+// with no resolving state in between.
+//
+// Deliberately zero imports, matching adminProbeCache.js / insightsGate.js's
+// "stays unit-testable under a bare `node --test`" discipline.
+
+let memoKey = null;
+let memoAdmin = null;
+
+/**
+ * Canonical form of a connected-wallet address for identity purposes: lowercase
+ * or `null`. Exported (rather than inlined at the two App.jsx call sites) so
+ * the property that actually stops the tab-focus re-probe is testable: an
+ * injected provider re-announcing the SAME account — possibly checksummed on
+ * one announcement and lowercase on another — must map to the SAME value, so
+ * React's setState bail-out fires and the probe effect does not re-run.
+ * @param {string|null|undefined} address
+ * @returns {string|null}
+ */
+export function normalizeWalletAddress(address) {
+	return typeof address === "string" && address ? address.toLowerCase() : null;
+}
+
+/**
+ * Builds the identity key an admin answer is recorded under. Returns `null`
+ * for an anonymous caller — a null key is never written and never matches on
+ * read, so signed-out browsers are excluded from the memo by construction
+ * rather than by a cleanup call somebody has to remember to make.
+ * @param {string|null|undefined} userId — the authenticated account id.
+ * @param {string|null|undefined} walletAddress — the currently connected
+ *   wallet, lowercased here so a checksummed/lowercase announcement of the
+ *   same account is the same key (an `accountsChanged` re-announcement on tab
+ *   focus must not read as a different identity).
+ * @returns {string|null}
+ */
+export function adminIdentityKey(userId, walletAddress) {
+	if (!userId) return null;
+	return `${userId}|${(walletAddress ?? "").toLowerCase()}`;
+}
+
+/**
+ * Records a server answer against the identity it was given for. A `null`
+ * identity (anonymous) is dropped.
+ * @param {string|null} identity
+ * @param {boolean} admin
+ */
+export function rememberInsightsAdmin(identity, admin) {
+	if (!identity) return;
+	memoKey = identity;
+	memoAdmin = admin === true;
+}
+
+/**
+ * Reads back the memoized answer for `identity`, or `null` ("no answer for
+ * this identity — the gate must resolve it from the server") when the key
+ * does not match what was last recorded, or the caller is anonymous.
+ * @param {string|null} identity
+ * @returns {boolean|null}
+ */
+export function readInsightsAdmin(identity) {
+	if (!identity || identity !== memoKey) return null;
+	return memoAdmin;
+}
+
+/** Test/sign-out hook: forgets the memoized answer entirely. */
+export function _resetInsightsAdminMemo() {
+	memoKey = null;
+	memoAdmin = null;
+}

--- a/ui/src/insightsGate.js
+++ b/ui/src/insightsGate.js
@@ -57,6 +57,56 @@ export function isInsightsPageBlocked(routePage, insightsAdmin) {
 }
 
 /**
+ * Which of the three treatments /app/insights should render right now
+ * (#1648 / I-8 B2). Splits the single boolean `isInsightsPageBlocked`
+ * collapses into the two cases that genuinely differ:
+ *
+ *   `"allow"`      — the server answered `admin === true`; render the page.
+ *   `"resolving"`  — no answer yet (`null`) AND there is a session in play;
+ *                    render a quiet neutral holding state, never a decision.
+ *   `"not-found"`  — an authoritative denial (`false`), or no answer yet with
+ *                    no session in play; render the not-found treatment.
+ *
+ * Why the `hasSession` input, rather than simply rendering the holding state
+ * for every `null`: the round-3 note on `isInsightsPageBlocked` is about a
+ * real vector — a genuinely unknown route never shows a loading state, so a
+ * loader on this path is a signal that the path is special. That signal only
+ * matters where the observer is *outside* the session boundary. Anonymous
+ * callers therefore keep the round-3 behaviour exactly (`null` → not-found,
+ * indistinguishable from an unknown route on first paint), which is also the
+ * only case nginx's pre-auth gate can be probed alongside.
+ *
+ * Inside an authenticated session the trade goes the other way, on the owner's
+ * call (#1648, I-8 B2): rendering "this page does not exist" to an admin on
+ * every entry, for as long as a round trip takes, is a visible NotFound →
+ * dashboard flip on a page they are allowed to use. The residual, stated
+ * honestly rather than papered over: a signed-in NON-admin's FIRST visit of a
+ * session sees a brief neutral holding state where an unknown route would show
+ * not-found immediately. That window closes after one answer —
+ * insightsAdminMemo.js remembers the denial too, so every later visit in that
+ * session renders not-found with no holding state at all — and the tab title
+ * still reads "Page not found" throughout (App.jsx keeps titling off
+ * isInsightsPageBlocked, whose `null` branch is unchanged).
+ *
+ * `hasSession` is deliberately "a session may exist" (auth still loading OR a
+ * user is present), not "a user is present": on a hard load of /app/insights
+ * the auth check has not resolved yet, and treating that instant as anonymous
+ * would reintroduce the exact flash this function exists to remove for the one
+ * case — a full page load — where it is most visible.
+ *
+ * @param {string|null} routePage
+ * @param {boolean|null} insightsAdmin
+ * @param {boolean} hasSession
+ * @returns {"allow"|"resolving"|"not-found"}
+ */
+export function resolveInsightsView(routePage, insightsAdmin, hasSession) {
+	if (routePage !== "insights") return "allow";
+	if (insightsAdmin === true) return "allow";
+	if (insightsAdmin === null && hasSession === true) return "resolving";
+	return "not-found";
+}
+
+/**
  * Filters the Ops nav group's items down to the ones a visitor with the
  * given admin-gate state should see — i.e. drops the `insights` item unless
  * the probe has affirmatively resolved `true`. Every other item passes

--- a/ui/test/admin-probe.test.js
+++ b/ui/test/admin-probe.test.js
@@ -11,7 +11,15 @@ import {
 	filterInsightsNavItem,
 	isInsightsPageBlocked,
 	resolveInsightsAdminState,
+	resolveInsightsView,
 } from "../src/insightsGate.js";
+import {
+	_resetInsightsAdminMemo,
+	adminIdentityKey,
+	normalizeWalletAddress,
+	readInsightsAdmin,
+	rememberInsightsAdmin,
+} from "../src/insightsAdminMemo.js";
 import { NAV } from "../src/navConfig.js";
 
 // ── getCachedAdminProbe: shared TTL cache backing fetchAdminProbe()
@@ -227,7 +235,8 @@ test("App.jsx: the insights page gate calls the shared fetchAdminProbe(), routin
 	assert.match(app, /from ["']\.\/insightsGate\.js["']/);
 	assert.match(
 		app,
-		/fetchAdminProbe\(\)\.then\(\(result\) => \{\n\s+if \(!cancelled\) setInsightsAdmin\(resolveInsightsAdminState\(result\)\)/,
+		/fetchAdminProbe\(\)\.then\(\(result\) => \{\n\s+if \(cancelled\) return;\n\s+const admin = resolveInsightsAdminState\(result\);\n\s+rememberInsightsAdmin\(identity, admin\);\n\s+setInsightsAdmin\(admin\);/,
+		"the probe result must still be routed through resolveInsightsAdminState() — and the value written to the #1648 memo must be that SAME resolved boolean, not the raw probe body",
 	);
 	assert.doesNotMatch(
 		app,
@@ -289,8 +298,23 @@ test("App.jsx: the insights admin probe re-runs on a wallet swap, not just on na
 	);
 	assert.match(
 		app,
-		/\}, \[route\.page, walletChangeSeq\]\)/,
+		/\}, \[route\.page, walletAddr, userId\]\)/,
 		"the insights-probe effect must depend on the wallet-change signal, not just route.page",
+	);
+	// #1648 / I-8 B2: the signal must be the address VALUE, not a counter.
+	// A counter changes on EVERY wallet-changed event — including the
+	// `accountsChanged` an injected provider re-fires with the same account on
+	// tab focus — which is what made the page blank under an admin who was
+	// already using it. A value lets React bail out on a no-op announcement.
+	assert.doesNotMatch(
+		app,
+		/walletChangeSeq/,
+		"the probe must not re-run on a monotonic counter bumped by every wallet-changed event (#1648)",
+	);
+	assert.match(
+		app,
+		/setWalletAddr\(normalizeWalletAddress\(event\?\.detail\?\.address\)\)/,
+		"the wallet-changed handler must store the normalized address value",
 	);
 });
 
@@ -336,4 +360,205 @@ test("Insights.jsx does not label the token tile as an all-time/total figure, an
 	assert.doesNotMatch(insights, /Total LLM tokens/);
 	assert.match(insights, /LLM tokens \(measured jobs\)/);
 	assert.match(insights, /engagement\.generation_costs\?\.note/);
+});
+
+// ── #1648 / I-8 B2: the NotFound flash ──────────────────────────────────────
+//
+// The gate's security posture was right and its rendering was wrong. App.jsx
+// reset `insightsAdmin` to `null` unconditionally on every entry to
+// /app/insights and on every `wallet-changed` event, and `null` rendered the
+// not-found treatment — so an admin watched the page they are allowed to use
+// flip NotFound → dashboard on every navigation, and blank again whenever an
+// injected provider re-announced the same account on tab focus.
+//
+// The fix must not become an optimistic admin assumption. What follows pins
+// both halves: an unknown state renders a holding state rather than a
+// decision, and the only thing that can render the dashboard early is an
+// answer the server actually gave, for this exact identity, this session.
+
+test("resolveInsightsView: an UNRESOLVED probe inside a session renders the holding state — never the not-found treatment (#1648)", () => {
+	assert.equal(resolveInsightsView("insights", null, true), "resolving");
+	// Adversarial companion — revert resolveInsightsView to the old
+	// `insightsAdmin !== true` collapse and this pair is what fails: the
+	// unresolved case would return "not-found" here, which is the flash.
+	assert.notEqual(resolveInsightsView("insights", null, true), "not-found");
+});
+
+test("resolveInsightsView: an AUTHORITATIVE denial still renders not-found, holding state or not (#1648 must not open the page)", () => {
+	assert.equal(resolveInsightsView("insights", false, true), "not-found");
+	assert.equal(resolveInsightsView("insights", false, false), "not-found");
+	// The only input that renders the page is a literal true.
+	assert.equal(resolveInsightsView("insights", true, true), "allow");
+	for (const bogus of [undefined, 0, 1, "true", "admin", {}, []]) {
+		assert.equal(
+			resolveInsightsView("insights", bogus, true),
+			"not-found",
+			`a non-boolean gate state (${JSON.stringify(bogus)}) must never render the page`,
+		);
+	}
+});
+
+test("resolveInsightsView: an ANONYMOUS caller keeps the round-3 behaviour exactly — unresolved is indistinguishable from unknown-route (#1648 anti-goal)", () => {
+	// The disclosure argument round 3 made is about someone OUTSIDE the
+	// session boundary: a genuinely unknown route never shows a loading state,
+	// so a loader here would mark the path as special. With no session in
+	// play, unresolved must still render not-found on first paint.
+	assert.equal(resolveInsightsView("insights", null, false), "not-found");
+	assert.equal(resolveInsightsView("insights", null, undefined), "not-found");
+});
+
+test("resolveInsightsView: never blocks or stalls a route other than insights", () => {
+	for (const state of [null, true, false]) {
+		assert.equal(resolveInsightsView("library", state, true), "allow");
+		assert.equal(resolveInsightsView(null, state, false), "allow");
+	}
+});
+
+test("App.jsx: the insights branch dispatches on resolveInsightsView, and its holding arm renders neither NotFound nor the dashboard", () => {
+	assert.match(app, /from ["']\.\/insightsAdminMemo\.js["']/);
+	assert.match(
+		app,
+		/const view = resolveInsightsView\(\s*\n?\s*route\.page,\s*\n?\s*insightsAdmin,\s*\n?\s*authLoading \|\| Boolean\(user\),?\s*\n?\s*\);/,
+		"the session input must be 'auth is still loading OR a user is present' — treating the pre-resolution instant as anonymous reintroduces the flash on a hard load",
+	);
+	assert.match(app, /if \(view === "not-found"\) return <NotFound user=\{user\} \/>;/);
+	assert.match(app, /if \(view === "resolving"\) \{/);
+	// The holding arm must not name the page it is holding for.
+	assert.doesNotMatch(app, /Loading Insights/i);
+	// Still exactly two NotFound call sites: the true 404 and the denial.
+	// A third would mean the denial treatment had been forked again.
+	const notFoundCalls = app.match(/return <NotFound user=\{user\} \/>/g) || [];
+	assert.equal(notFoundCalls.length, 2);
+});
+
+test("App.jsx: the tab title still treats an unresolved probe as not-found (only the RENDER branch changed)", () => {
+	// I-8 anti-goal: isInsightsPageBlocked's contract is unchanged, and the
+	// title effect still uses it — so even during the holding state the tab
+	// never reads "Insights · Archimedes" to a visitor the server has not
+	// cleared.
+	assert.match(app, /isInsightsPageBlocked\(route\.page, insightsAdmin\)/);
+	assert.equal(isInsightsPageBlocked("insights", null), true);
+	assert.equal(isInsightsPageBlocked("insights", false), true);
+	assert.equal(isInsightsPageBlocked("insights", true), false);
+});
+
+// ── insightsAdminMemo: the last SERVER ANSWER, keyed on the identity it was
+// given for. This is what makes the second and later visits flash-free, and
+// what keeps that from being a guess. ───────────────────────────────────────
+
+test("insightsAdminMemo: a remembered grant is readable only under the identity it was recorded for", () => {
+	_resetInsightsAdminMemo();
+	const walletA = adminIdentityKey("user-1", "0xAAA");
+	rememberInsightsAdmin(walletA, true);
+	assert.equal(readInsightsAdmin(walletA), true);
+	// Same account, DIFFERENT wallet — require_platform_admin can answer
+	// differently per wallet, so this must be a miss, not a stale true.
+	assert.equal(readInsightsAdmin(adminIdentityKey("user-1", "0xBBB")), null);
+	// Different account entirely — a miss.
+	assert.equal(readInsightsAdmin(adminIdentityKey("user-2", "0xAAA")), null);
+	// Anonymous — a miss, and cannot inherit the signed-in determination.
+	assert.equal(readInsightsAdmin(adminIdentityKey(null, "0xAAA")), null);
+});
+
+test("insightsAdminMemo: an anonymous answer is never recorded — and cannot evict a signed-in one", () => {
+	_resetInsightsAdminMemo();
+	rememberInsightsAdmin(adminIdentityKey(null, "0xAAA"), true);
+	assert.equal(readInsightsAdmin(adminIdentityKey(null, "0xAAA")), null);
+	assert.equal(readInsightsAdmin(adminIdentityKey("user-1", "0xAAA")), null);
+	// Dropping the anonymous write is what keeps it from CLOBBERING a real
+	// one: without the guard, `memoKey` would be overwritten with null and the
+	// grant below would be evicted — which is how a "flash-free" page starts
+	// flashing again the moment a probe runs before auth resolves.
+	const signedIn = adminIdentityKey("user-1", "0xAAA");
+	rememberInsightsAdmin(signedIn, true);
+	rememberInsightsAdmin(adminIdentityKey(null, "0xAAA"), false);
+	assert.equal(readInsightsAdmin(signedIn), true);
+});
+
+test("insightsAdminMemo: only a literal true is remembered as a grant — a truthy non-boolean is recorded as a denial", () => {
+	_resetInsightsAdminMemo();
+	const id = adminIdentityKey("user-1", "0xAAA");
+	rememberInsightsAdmin(id, "yes");
+	assert.equal(readInsightsAdmin(id), false);
+});
+
+test("insightsAdminMemo: a DENIAL is memoized too — a non-admin's later visits render not-found with no holding state at all", () => {
+	_resetInsightsAdminMemo();
+	const id = adminIdentityKey("user-9", "0xNOTADMIN");
+	rememberInsightsAdmin(id, false);
+	assert.equal(readInsightsAdmin(id), false);
+	assert.equal(
+		resolveInsightsView("insights", readInsightsAdmin(id), true),
+		"not-found",
+		"a remembered denial must render the not-found treatment immediately, exactly like an unknown route",
+	);
+});
+
+test("insightsAdminMemo: _resetInsightsAdminMemo forgets the grant (sign-out path)", () => {
+	_resetInsightsAdminMemo();
+	const id = adminIdentityKey("user-1", "0xAAA");
+	rememberInsightsAdmin(id, true);
+	_resetInsightsAdminMemo();
+	assert.equal(readInsightsAdmin(id), null);
+});
+
+test("AuthContext clears the insights-admin memo on sign-out, alongside the probe cache", () => {
+	const authContext = readFileSync(
+		new URL("../src/AuthContext.jsx", import.meta.url),
+		"utf8",
+	);
+	assert.match(authContext, /_resetInsightsAdminMemo\(\)/);
+});
+
+// ── The tab-focus case, end to end over the real modules ────────────────────
+
+test("normalizeWalletAddress: a checksummed and a lowercase announcement of the SAME account are the same value (so React bails out and the probe does not re-run)", () => {
+	const checksummed = "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01";
+	assert.equal(
+		normalizeWalletAddress(checksummed),
+		normalizeWalletAddress(checksummed.toLowerCase()),
+	);
+	assert.equal(normalizeWalletAddress(null), null);
+	assert.equal(normalizeWalletAddress(undefined), null);
+	assert.equal(normalizeWalletAddress(""), null);
+	// A genuinely different account is a genuinely different value — the
+	// bail-out must not swallow a real swap.
+	assert.notEqual(
+		normalizeWalletAddress(checksummed),
+		normalizeWalletAddress("0x1111111111111111111111111111111111111111"),
+	);
+});
+
+test("#1648 end to end: a tab-focus accountsChanged carrying the same account cannot blank a page the admin is already on", () => {
+	_resetInsightsAdminMemo();
+	const userId = "user-admin";
+	const announced = "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01";
+
+	// First visit: the server answers admin.
+	const firstIdentity = adminIdentityKey(
+		userId,
+		normalizeWalletAddress(announced),
+	);
+	rememberInsightsAdmin(firstIdentity, resolveInsightsAdminState({ admin: true }));
+	assert.equal(resolveInsightsView("insights", true, true), "allow");
+
+	// Tab focus: the injected provider re-announces the SAME account, this
+	// time lowercased. Even if the effect were to re-run, the seed is the
+	// memoized answer — not null — so the page never renders NotFound.
+	const refocusIdentity = adminIdentityKey(
+		userId,
+		normalizeWalletAddress(announced.toLowerCase()),
+	);
+	assert.equal(refocusIdentity, firstIdentity);
+	const seed = readInsightsAdmin(refocusIdentity);
+	assert.equal(seed, true);
+	assert.equal(resolveInsightsView("insights", seed, true), "allow");
+
+	// A REAL swap to an unseen wallet is a memo miss — it must resolve from
+	// the server (holding state), never carry the previous wallet's grant.
+	const swapped = adminIdentityKey(userId, normalizeWalletAddress("0xBEEF"));
+	const swappedSeed = readInsightsAdmin(swapped);
+	assert.equal(swappedSeed, null);
+	assert.equal(resolveInsightsView("insights", swappedSeed, true), "resolving");
+	assert.notEqual(resolveInsightsView("insights", swappedSeed, true), "allow");
 });


### PR DESCRIPTION
## What

The **frontend residual** of #1648. The backend account-gate half landed as #1675; this is the Insights **NotFound flash** described in the I-8 comment's item **B2**.

`ui/src/App.jsx` set `insightsAdmin = null` unconditionally on every entry to `/app/insights` and on every `wallet-changed` event, and `insightsGate.js` correctly treats `null` as denied — so the *correct* security posture rendered a visible **NotFound → dashboard flip on every navigation**, and blanked the page again whenever an injected provider re-announced `accountsChanged` on tab focus, under an admin who was already using it.

Fixed without any optimistic admin assumption. Three pieces:

| | |
| --- | --- |
| `ui/src/insightsGate.js` | New `resolveInsightsView(routePage, insightsAdmin, hasSession)` → `"allow"` / `"resolving"` / `"not-found"`. An unresolved probe **inside a session** renders a quiet holding state — a state, not a decision. |
| `ui/src/insightsAdminMemo.js` (new) | Per-session memo of the last **server answer**, keyed on the identity it was given for (`auth_users.id` + connected wallet, lowercased). A key miss returns `null`, never a stale `true`. |
| `ui/src/App.jsx` | Tracks the wallet **address value** instead of a monotonic counter, so a no-op `accountsChanged` on tab focus no longer re-runs the probe at all. |

### What is deliberately *not* changed

- **`isInsightsPageBlocked`'s contract is untouched** (I-8 anti-goal). It still returns `true` for `null`, and it still drives the tab-title effect — so even during the holding state the tab reads `Page not found · Archimedes`, never `Insights · Archimedes`.
- **Anonymous callers keep round 3's behaviour exactly.** `hasSession === false` → `not-found` on first paint, indistinguishable from an unknown route, matching what nginx's pre-auth gate already returns for both. Round 3's disclosure argument is about an observer *outside* the session boundary, and that observer sees nothing new here.
- **`git diff backend/` is empty.** No backend files in this PR.
- Only the **`null`** branch's rendering changed. `false` still renders the identical `<NotFound user={user} />` the true 404 uses — still exactly 2 call sites, asserted.

### The residual, stated rather than papered over

A signed-in **non-admin's first visit of a session** sees a brief neutral holding state where an unknown route shows not-found immediately. That is the owner's call in I-8 ("a skeleton behind an already-authenticated session leaks nothing new"), and it is narrowed further here: the memo remembers **denials** too, so every later visit in that session renders not-found with no holding state at all. It is documented in `resolveInsightsView`'s docstring, not left implicit.

## Adversarial guard demo

Per CLAUDE.md — every new guard was shown to reject the thing it claims to reject, by mutating the source and confirming the failure. Seven mutations, all rejected; tree restored and re-verified green after each (`diff` against pre-mutation copies → clean).

```
===== MUTATION 1: revert resolveInsightsView to the old null-collapses-to-denied behaviour =====
  return routePage === "insights" && insightsAdmin !== true ? "not-found" : "allow";
✖ resolveInsightsView: an UNRESOLVED probe inside a session renders the holding state — never the not-found treatment (#1648)
✖ #1648 end to end: a tab-focus accountsChanged carrying the same account cannot blank a page the admin is already on
ℹ pass 861   ℹ fail 2

===== MUTATION 2: open the holding state to ANONYMOUS callers too (drops the round-3 property) =====
  if (insightsAdmin === null) return "resolving";
✖ resolveInsightsView: an ANONYMOUS caller keeps the round-3 behaviour exactly — unresolved is indistinguishable from unknown-route (#1648 anti-goal)
ℹ pass 862   ℹ fail 1

===== MUTATION 3: optimistic admin — the holding state renders the dashboard instead =====
  if (insightsAdmin === null && hasSession === true) return "allow";
✖ resolveInsightsView: an UNRESOLVED probe inside a session renders the holding state — never the not-found treatment (#1648)
✖ #1648 end to end: a tab-focus accountsChanged carrying the same account cannot blank a page the admin is already on
ℹ pass 861   ℹ fail 2

===== MUTATION 4: drop the wallet from the memo key (a grant under wallet A survives a swap to B) =====
  return `${userId}`;
✖ insightsAdminMemo: a remembered grant is readable only under the identity it was recorded for
✖ #1648 end to end: a tab-focus accountsChanged carrying the same account cannot blank a page the admin is already on
ℹ pass 861   ℹ fail 2

===== MUTATION 5: memo ignores the identity on read (any caller inherits the last answer) =====
  return memoAdmin;   // inserted before the key check
✖ insightsAdminMemo: a remembered grant is readable only under the identity it was recorded for
✖ #1648 end to end: a tab-focus accountsChanged carrying the same account cannot blank a page the admin is already on
ℹ pass 861   ℹ fail 2

===== MUTATION 6: revert App.jsx to the every-event counter (tab-focus accountsChanged re-probes) =====
  }, [route.page, walletChangeSeq]);  +  setWalletChangeSeq((n) => n + 1)
✖ App.jsx: the insights admin probe re-runs on a wallet swap, not just on navigation (round 2)
ℹ pass 862   ℹ fail 1

===== MUTATION 7: drop the anonymous-write guard (an anonymous probe evicts the admin's grant) =====
  (guard removed)
✖ insightsAdminMemo: an anonymous answer is never recorded — and cannot evict a signed-in one
ℹ pass 862   ℹ fail 1

===== RESTORED =====
ℹ tests 863   ℹ pass 863   ℹ fail 0
```

Mutations 3, 4 and 5 are the ones that matter most: each is a *plausible* way to kill the flash that would have opened the page (3) or carried a stale grant across a wallet swap (4, 5) — i.e. traded the flash for the hole #1675 just closed. All three are now rejected by a behavioral test, not a source regex.

Note on test shape: `ui/` has no jsdom/vitest (CLAUDE.md convention), so the *decisions* are tested by executing the real modules with real inputs — `resolveInsightsView`, `adminIdentityKey`, `readInsightsAdmin`, `rememberInsightsAdmin`, `normalizeWalletAddress` — and only the wiring (which module App.jsx routes through, the effect's dependency array) is asserted on source text. `normalizeWalletAddress` is exported rather than inlined specifically so the tab-focus property is executable: two announcements of the same account, one checksummed and one lowercase, must produce the same value for React's bail-out to fire.

## Verification

```
cd ui && npm test        → ℹ tests 863  ℹ pass 863  ℹ fail 0
cd ui && npm run lint    → 0 problems
cd ui && npm run build   → ✓ built in 2.06s
$ENV_BIN/pytest -m "not integration" -q
                         → 5460 passed, 3 skipped, 2 deselected, 0 failed (515s)
```

`grep -n "isInsightsPageBlocked" ui/src/` — still used by the title effect in `App.jsx`; its `false`-branch behaviour is unchanged and the unit tests pinning `("insights", false) === true` / `("insights", true) === false` / `("insights", null) === true` all still pass.

## Not in this PR

I-8's **B3** (`engagement_metrics.py`: seven separate sessions, two swallowed exceptions logged at DEBUG) is backend, out of this residual's scope, and untouched — `git diff backend/` is empty. It needs its own issue.

Closes #1648
