### PR TITLE
[auth][security] Give the rate limiter a client IP it can trust — nginx sets X-Client-IP, Better Auth keys on it

### DIFF
--- a/auth/auth.js
+++ b/auth/auth.js
@@ -660,28 +660,67 @@ export function createAuth({ database, env = process.env, mailer = createMailer(
         // rules stay as defense-in-depth regardless: this rule (3 signups /
         // 10 min per Better Auth's rate key), nginx's /api/auth/ limit_req
         // zone, and — decisively — the per-IP DAILY generation cap
-        //
-        // CAVEAT (#1691, found by the 2026-08-31 pre-flip audit): "per Better
-        // Auth's rate key" is not per-caller in production today. The key is
-        // `${ip}|${path}` (@better-auth/core/dist/utils/ip.mjs:225), and
-        // getIp trusts a forwarded header only when it carries exactly ONE
-        // value (:189 `if (forwardedIps.length !== 1) return null`) unless
-        // advanced.ipAddress.trustedProxies is configured — which nothing
-        // below does. Behind CloudFront -> ALB -> nginx every hop appends
-        // (nginx/nginx.conf:179), so no IP resolves and the limiter falls
-        // back to one shared `no-trusted-ip|<path>` bucket, logging a
-        // warning that says so. These rules therefore bound TOTAL rate, not
-        // per-abuser rate. Layers 2 and 3 above are unaffected. Pinned in
-        // both directions by auth/test/email-flows.test.js; do not "fix" it
-        // by trusting the leftmost XFF token, which is client-controlled and
-        // strictly worse than a shared bucket.
         // (services/generation_quota.py): a fresh account does not raise its
         // address's generation allowance, so disposable accounts gain
         // nothing at the endpoint that actually spends money.
+        //
+        // WHAT "Better Auth's rate key" RESOLVES TO (#1691, fixed here). The
+        // key is `${ip}|${path}` (@better-auth/core/dist/utils/ip.mjs:225).
+        // Until #1691 no ip resolved in production: getIp trusts a forwarded
+        // header only when it carries exactly ONE value (ip.mjs:189 `if
+        // (forwardedIps.length !== 1) return null`), and behind
+        // CloudFront -> ALB -> nginx every hop appends to X-Forwarded-For, so
+        // the limiter fell back to a single shared `no-trusted-ip|<path>`
+        // bucket for the entire internet. advanced.ipAddress.ipAddressHeaders
+        // below now points the resolver at the single-valued, nginx-SET
+        // X-Client-IP header instead — the same trusted value layers 2 and 3
+        // key on. These rules are per-rate-key, and the rate key is now that
+        // header; see the ipAddress block for exactly whose address it is.
+        // Pinned in both directions by auth/test/email-flows.test.js; do not
+        // "fix" it further by trusting the leftmost XFF token, which is
+        // client-controlled and strictly worse than a shared bucket.
         '/sign-up/email': { window: 600, max: 3 },
+        // Pinned, not inherited — the same argument session.freshAge rests on.
+        // These two are the mail-sending endpoints, so they are the pair the
+        // EMAIL_VERIFICATION_ENFORCED flip puts under load and the pair SES
+        // production access is judged on. The values match the library's own
+        // default for this path set (better-auth/dist/api/rate-limiter/
+        // index.mjs:378-382, window 60 / max 3), so this changes no behaviour;
+        // it makes the bound readable here and stops a library upgrade from
+        // moving a security-relevant number silently.
+        '/request-password-reset': { window: 60, max: 3 },
+        '/send-verification-email': { window: 60, max: 3 },
       },
     },
     advanced: {
+      // Where the rate limiter gets its client IP (#1691). Better Auth's getIp
+      // walks these header names in order (@better-auth/core/dist/utils/ip.mjs
+      // :203) and trusts a value only if it is single-valued; the DEFAULT list
+      // is ['x-forwarded-for'], which is multi-hop behind CloudFront -> ALB ->
+      // nginx and so resolved to null on every production request, collapsing
+      // every rate-limit bucket into one global `no-trusted-ip|<path>`.
+      //
+      // x-client-ip is set — not appended — by nginx from its realip-resolved
+      // $remote_addr (nginx/nginx.conf, the server-level proxy header block),
+      // so a caller cannot supply it: whatever the client sends under that name
+      // is overwritten before the request reaches this process. It is the same
+      // value the FastAPI limiter and the daily generation cap already key on
+      // via X-Real-IP. Behind CloudFront it identifies the CloudFront EDGE, not
+      // the viewer (nginx trusts only the ALB CIDR) — so buckets are per-edge:
+      // unspoofable, no longer global, coarser than one caller. Say that, don't
+      // round it up to "per user".
+      //
+      // Deliberately NOT trustedProxies: that would re-admit X-Forwarded-For
+      // and require carrying CloudFront's published edge ranges in this file,
+      // where a stale list degrades silently back to the shared bucket. And
+      // deliberately not a fallback to 'x-forwarded-for' after this one — a
+      // single-valued XFF reaching this process is exactly the shape a
+      // direct-to-container caller can forge. No header, no key: the limiter
+      // falls back to its shared bucket, which fails safe (over-limiting), not
+      // open.
+      ipAddress: {
+        ipAddressHeaders: ['x-client-ip'],
+      },
       useSecureCookies: production,
       defaultCookieAttributes: {
         httpOnly: true,

--- a/auth/test/email-flows.test.js
+++ b/auth/test/email-flows.test.js
@@ -351,26 +351,37 @@ test('a refused sign-in does not silently re-send verification mail — the user
   assert.equal(mailer.sent.length, afterSignup, 'a refused sign-in re-sent verification mail on its own')
 })
 
-// ── FINDING EV-1: the production rate limiter has no client IP to key on ───
+// ── EV-1 (#1691): the production rate limiter's client-IP resolution ───────
 //
-// Better Auth's limiter keys every bucket on `${ip}|${path}`
-// (@better-auth/core/dist/utils/ip.mjs:225 createRateLimitKey). It resolves
-// that IP from X-Forwarded-For, and — with no `advanced.ipAddress.trustedProxies`
-// configured, which auth.js does not set — it trusts the header ONLY when it
-// carries exactly one value (ip.mjs:189 `if (forwardedIps.length !== 1) return
-// null`), because every other token in a chain is spoofable. In production the
-// request reaches the auth container through CloudFront -> ALB -> nginx, and
-// each hop appends: CloudFront sets the client, the ALB appends the edge it
-// saw, and nginx appends `$proxy_add_x_forwarded_for` (nginx/nginx.conf:179).
-// So the header is never single-valued, no IP resolves, and every caller in
-// the world shares one bucket per path — the library even says so in a startup
-// warning ("Rate limiting could not determine a client IP and is falling back
-// to a single shared per-path bucket").
+// Better Auth keys every rate-limit bucket on `${ip}|${path}`
+// (@better-auth/core/dist/utils/ip.mjs:225 createRateLimitKey) and resolves
+// that ip from the headers named in `advanced.ipAddress.ipAddressHeaders`,
+// trusting a value only when it is SINGLE-valued (ip.mjs:189 `if
+// (forwardedIps.length !== 1) return null`) — every other token in a forwarded
+// chain is client-supplied and therefore spoofable, so refusing is correct.
 //
-// The two tests below are a matched pair on purpose: the first shows the
-// limiter working per-client when an IP DOES resolve, so the second cannot be
-// read as "the limiter is broken" or "the test is wrong". The only difference
-// between them is the number of hops in the header.
+// The finding: the default header list is ['x-forwarded-for'], and in
+// production that header is never single-valued — CloudFront sets the viewer,
+// the ALB appends the edge it saw, nginx appends `$proxy_add_x_forwarded_for`.
+// No ip resolved, so `no-trusted-ip` was substituted and the entire internet
+// shared one bucket per path: three password-reset requests from anywhere
+// exhausted /request-password-reset for everybody.
+//
+// The fix (option A in #1691): nginx SETS `X-Client-IP: $remote_addr` — its
+// realip-resolved address, bound to the trusted ALB CIDR — and auth.js points
+// ipAddressHeaders at that one header. The tests below are a matched set:
+//   1. control      — buckets separate per client when X-Client-IP resolves,
+//                     WITH the multi-hop X-Forwarded-For production sends.
+//   2. adversarial  — a caller rotating X-Forwarded-For, and forging its own
+//                     X-Client-IP as an XFF token, buys no extra bucket.
+//   3. adversarial  — nginx OVERWRITES a client-supplied X-Client-IP, so a
+//                     spoof from a non-edge source never reaches this process
+//                     (source-pinned against nginx/nginx.conf).
+//   4. fail-safe    — no X-Client-IP at all (a request that skipped nginx)
+//                     falls back to the shared bucket, i.e. over-limits rather
+//                     than handing the caller a key it controls.
+//   5. mechanism    — the library-level reads the four above rest on.
+// Test 1 is the mutation guard: revert either half of the fix and it fails.
 //
 // NOTE ON FIDELITY: these run with the process's own NODE_ENV unset, so
 // @better-auth/core's isTest()/isDevelopment() are both false
@@ -379,63 +390,134 @@ test('a refused sign-in does not silently re-send verification mail — the user
 // createAuth (`rateLimit.enabled = production` in auth.js), which is why these
 // pass NODE_ENV: 'production' in the env object.
 
-async function signUpOverHttp(auth, email, forwardedFor) {
+// The header shape nginx produces behind CloudFront + ALB: viewer, CloudFront
+// edge, nginx's own peer. Never single-valued, which is the whole finding.
+const MULTI_HOP_XFF = clientToken => `${clientToken}, 70.132.1.2, 10.0.3.4`
+
+async function signUpOverHttp(auth, email, headers) {
   const response = await auth.handler(new Request('http://localhost:3000/api/auth/sign-up/email', {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
       origin: 'http://localhost:3000',
-      'x-forwarded-for': forwardedFor,
+      ...headers,
     },
     body: JSON.stringify({ email, password: PASSWORD, name: 'U' }),
   }))
   return response.status
 }
 
-test('rate-limit buckets separate per client when the forwarded header carries exactly one hop', async () => {
+test('rate-limit buckets separate per client behind the multi-hop header production sends', async () => {
   const { auth } = await harness({ NODE_ENV: 'production' })
+  // Both clients carry the three-hop X-Forwarded-For the live chain produces —
+  // the header that used to defeat resolution entirely. What separates them is
+  // the single-valued X-Client-IP nginx sets from $remote_addr.
+  //
+  // MUTATION GUARD (#1691, CLAUDE.md "a guard must be shown to reject
+  // something"): drop `ipAddress.ipAddressHeaders` from auth.js's advanced
+  // block — or point it back at 'x-forwarded-for' — and client B's FIRST
+  // request 429s on client A's spending, failing this test on the assertion
+  // below. Removing nginx's `proxy_set_header X-Client-IP` has the same effect
+  // in production and is pinned separately by the nginx test further down.
+  const a = { 'x-client-ip': '203.0.113.7', 'x-forwarded-for': MULTI_HOP_XFF('203.0.113.7') }
+  const b = { 'x-client-ip': '198.51.100.9', 'x-forwarded-for': MULTI_HOP_XFF('198.51.100.9') }
+
   // '/sign-up/email' is 3 per 600s in auth.js's customRules.
   for (let i = 1; i <= 3; i += 1) {
-    assert.equal(await signUpOverHttp(auth, `single-a${i}@example.com`, '203.0.113.7'), 200)
+    assert.equal(await signUpOverHttp(auth, `edge-a${i}@example.com`, a), 200)
   }
-  assert.equal(await signUpOverHttp(auth, 'single-a4@example.com', '203.0.113.7'), 429, 'client A was not limited')
+  assert.equal(await signUpOverHttp(auth, 'edge-a4@example.com', a), 429, 'client A was not limited')
 
-  // A different client is untouched by A's spending — this is what the
-  // per-IP claim in auth.js's rateLimit comment and docs/account-authentication.md
-  // describes, and it holds exactly when the client IP resolves.
-  assert.equal(await signUpOverHttp(auth, 'single-b1@example.com', '198.51.100.9'), 200, 'client B was limited by A')
-})
-
-test('FINDING: with the multi-hop header production actually sends, every client shares ONE bucket', async () => {
-  const { auth } = await harness({ NODE_ENV: 'production' })
-  // client, CloudFront edge, nginx's own view — the shape nginx.conf:179
-  // produces behind CloudFront + ALB.
-  const clientA = '203.0.113.7, 70.132.1.2, 10.0.3.4'
-  const clientB = '198.51.100.9, 70.132.9.9, 10.0.3.4'
-
-  for (let i = 1; i <= 3; i += 1) {
-    assert.equal(await signUpOverHttp(auth, `multi-a${i}@example.com`, clientA), 200)
-  }
-  // An entirely unrelated client, first request of its life.
+  // An entirely unrelated client, first request of its life. Under the finding
+  // this was a 429; it is what the per-rate-key claim in auth.js's rateLimit
+  // comment and docs/account-authentication.md actually asserts.
   assert.equal(
-    await signUpOverHttp(auth, 'multi-b1@example.com', clientB),
-    429,
-    'client B was NOT limited by client A — the IP now resolves and finding EV-1 is fixed; update this test',
+    await signUpOverHttp(auth, 'edge-b1@example.com', b),
+    200,
+    'client B was rate-limited by client A — the client IP is not resolving; EV-1 has regressed',
   )
 })
 
-test('FINDING EV-1, mechanism: a multi-hop forwarded header resolves to no client IP without trustedProxies', async () => {
-  const { getIp } = await import('@better-auth/core/utils/ip')
-  const request = xff => new Request('https://archimedes-arc.com/api/auth/sign-in/email', {
-    headers: { 'x-forwarded-for': xff },
+test('SECURITY: forging X-Forwarded-For buys no extra bucket — the key follows the nginx-set header', async () => {
+  const { auth } = await harness({ NODE_ENV: 'production' })
+  // One abuser at one address, rotating every token it controls: a fresh
+  // leftmost XFF hop per request, and — belt and braces — its own X-Client-IP
+  // planted in the chain, which is precisely the value an attacker would forge
+  // if the leftmost token were trusted. nginx's X-Client-IP is the only thing
+  // read, and it does not move.
+  const spoof = i => ({
+    'x-client-ip': '203.0.113.7',
+    'x-forwarded-for': `10.0.0.${i}, 198.51.100.${i}, 70.132.1.2, 10.0.3.4`,
   })
 
-  assert.equal(getIp(request('203.0.113.7'), {}), '203.0.113.7')
-  assert.equal(getIp(request('203.0.113.7, 70.132.1.2'), {}), null)
-  assert.equal(getIp(request('203.0.113.7, 70.132.1.2, 10.0.3.4'), {}), null)
+  for (let i = 1; i <= 3; i += 1) {
+    assert.equal(await signUpOverHttp(auth, `spoof-a${i}@example.com`, spoof(i)), 200)
+  }
+  assert.equal(
+    await signUpOverHttp(auth, 'spoof-a4@example.com', spoof(4)),
+    429,
+    'rotating X-Forwarded-For minted a fresh bucket — a spoofable token is being trusted (#1691 anti-goal)',
+  )
+})
 
-  // auth.js sets no advanced.ipAddress config at all — this is the absence
-  // the two tests above are a consequence of.
+test('SECURITY: nginx SETS X-Client-IP, so a spoof from a non-edge source never reaches this process', async () => {
+  // The auth container trusts x-client-ip because nothing outside the edge can
+  // write it. That property lives in nginx.conf, so it is pinned there —
+  // source-pinned the same way the better-auth reads above are, and the same
+  // way auth.test.js pins ../../.env.example.
+  const conf = readFileSync(new URL('../../nginx/nginx.conf', import.meta.url), 'utf8')
+
+  // `proxy_set_header` REPLACES the header; `$proxy_add_x_forwarded_for`
+  // (used one line below for X-Forwarded-For) is what APPENDS a client value.
+  // X-Client-IP must never be built that way.
+  assert.match(conf, /^\s*proxy_set_header X-Client-IP \$remote_addr;$/m)
+  assert.equal(/X-Client-IP\s+\$proxy_add_x_forwarded_for/.test(conf), false)
+  assert.equal((conf.match(/proxy_set_header X-Client-IP/g) ?? []).length, 1)
+
+  // $remote_addr is only ever influenced by X-Forwarded-For when the socket
+  // peer is inside the ALB CIDR: `real_ip_header` is bound by set_real_ip_from,
+  // and that CIDR is the narrowed one from AUDIT I7 (not the RFC1918 ranges,
+  // which would have let the box itself spoof). A request from any other
+  // source contributes nothing to the value it is keyed on.
+  assert.match(conf, /^\s*set_real_ip_from 10\.0\.0\.0\/16;$/m)
+  assert.match(conf, /^\s*real_ip_header X-Forwarded-For;$/m)
+  assert.equal(/set_real_ip_from (?!10\.0\.0\.0\/16)/.test(conf), false)
+})
+
+test('fail-safe: a request that never passed through nginx gets the shared bucket, not a key it controls', async () => {
+  const { getIp } = await import('@better-auth/core/utils/ip')
+  const options = { advanced: { ipAddress: { ipAddressHeaders: ['x-client-ip'] } } }
+  const request = headers => new Request('https://archimedes-arc.com/api/auth/request-password-reset', { headers })
+
+  // No x-client-ip (only the spoofable chain): null, which the limiter turns
+  // into the shared `no-trusted-ip|<path>` bucket. Over-limiting, never open.
+  assert.equal(getIp(request({ 'x-forwarded-for': '203.0.113.7' }), options), null)
+  assert.equal(getIp(request({}), options), null)
+  // And x-forwarded-for is not consulted as a fallback: a single-valued XFF is
+  // exactly what a direct-to-container caller would forge.
+  assert.equal(getIp(request({ 'x-forwarded-for': '203.0.113.7', 'x-client-ip': '198.51.100.9' }), options), '198.51.100.9')
+})
+
+test('EV-1 mechanism: ipAddressHeaders is what makes the key resolve, and it is pinned in auth.js', async () => {
+  const { getIp } = await import('@better-auth/core/utils/ip')
+  const request = headers => new Request('https://archimedes-arc.com/api/auth/sign-in/email', { headers })
+
+  // The finding, unchanged and still true of the DEFAULT header list: a
+  // multi-hop forwarded header resolves to no client IP.
+  assert.equal(getIp(request({ 'x-forwarded-for': '203.0.113.7' }), {}), '203.0.113.7')
+  assert.equal(getIp(request({ 'x-forwarded-for': '203.0.113.7, 70.132.1.2' }), {}), null)
+  assert.equal(getIp(request({ 'x-forwarded-for': MULTI_HOP_XFF('203.0.113.7') }), {}), null)
+
+  // The fix: a single-valued header nginx controls, named explicitly.
   const { auth } = await harness({ NODE_ENV: 'production' })
-  assert.equal(auth.options.advanced.ipAddress, undefined)
+  assert.deepEqual(auth.options.advanced.ipAddress.ipAddressHeaders, ['x-client-ip'])
+  assert.equal(auth.options.advanced.ipAddress.disableIpTracking, undefined)
+  assert.equal(auth.options.advanced.ipAddress.trustedProxies, undefined)
+  assert.equal(getIp(request({ 'x-client-ip': '203.0.113.7', 'x-forwarded-for': MULTI_HOP_XFF('203.0.113.7') }), auth.options), '203.0.113.7')
+
+  // The mail endpoints the EMAIL_VERIFICATION_ENFORCED flip puts under load
+  // are pinned explicitly rather than inherited (#1691 scope item 5); the
+  // values match better-auth/dist/api/rate-limiter/index.mjs:378-382.
+  assert.deepEqual(auth.options.rateLimit.customRules['/request-password-reset'], { window: 60, max: 3 })
+  assert.deepEqual(auth.options.rateLimit.customRules['/send-verification-email'], { window: 60, max: 3 })
 })

--- a/docs/account-authentication.md
+++ b/docs/account-authentication.md
@@ -101,14 +101,23 @@ should expect:
 
 Independently of enforcement, disposable accounts are bounded by three layers:
 
-1. Better Auth's production rate limiter: `/sign-up/email` at 3 per 10
-   minutes (`auth/auth.js` `rateLimit.customRules`). **Caveat — this layer does not
-   currently work as described in production** ([#1691](https://github.com/a-apin/archimedes/issues/1691)):
-   the limiter keys every bucket on the client IP, and behind CloudFront → ALB → nginx no
-   client IP resolves (Better Auth trusts a forwarded header only when it carries exactly
-   one value, and each hop appends one), so the bucket is shared by every caller rather
-   than held per address. It bounds total rate, not per-abuser rate. Layers 2 and 3 are
-   unaffected and do key per address.
+1. Better Auth's production rate limiter: `/sign-up/email` at 3 per 10 minutes, and
+   `/request-password-reset` + `/send-verification-email` at 3 per minute — all three
+   pinned in `auth/auth.js` `rateLimit.customRules`. **What the bucket is keyed on**
+   ([#1691](https://github.com/a-apin/archimedes/issues/1691), fixed): every bucket key is
+   `${ip}|${path}`, and Better Auth trusts a forwarded header only when it carries exactly
+   one value. Behind CloudFront → ALB → nginx each hop appends one, so until #1691 *no*
+   client IP resolved and the entire internet shared one bucket per path — three password
+   resets from anywhere exhausted the endpoint for everybody. nginx now **sets**
+   `X-Client-IP` from its realip-resolved `$remote_addr` and `advanced.ipAddress.
+   ipAddressHeaders` points the resolver at that one header, which is the same trusted
+   value layers 2 and 3 key on. Because `proxy_set_header` overwrites, a client-supplied
+   `X-Client-IP` cannot reach the auth service. **Stated exactly: nginx trusts only the ALB
+   CIDR, so behind CloudFront this address is the CloudFront *edge* that relayed the
+   request, not the viewer** — buckets are per-edge (unspoofable, no longer global, coarser
+   than one caller). Sharpening that further means trusting CloudFront's published edge
+   ranges, which is deliberately not done: that list changes and a stale one degrades
+   silently.
 2. nginx's `/api/auth/` `limit_req` zone.
 3. Decisively: the **per-IP daily generation cap**
    (`backend/archimedes/services/generation_quota.py`). Generation is the

--- a/docs/runbooks/email-verification-validation.md
+++ b/docs/runbooks/email-verification-validation.md
@@ -93,8 +93,10 @@ aws logs filter-log-events --region us-east-1 --log-group-name /archimedes/app \
   --start-time $(( ($(date +%s) - 86400) * 1000 )) \
   --filter-pattern '"email send failed"' --query 'events[].message'
 
-# Findings check (see § 7, EV-1). If this line is present, the Better Auth rate limiter
-# has no client IP to key on and every caller in the world is sharing one bucket per path.
+# Findings check (see § 7, EV-1). EV-1 is FIXED (#1691) — nginx sets X-Client-IP and
+# auth.js resolves the rate key from it. This line must therefore return NOTHING dated
+# after that deploy; if it reappears, the header stopped arriving and every caller in the
+# world is back to sharing one bucket per path.
 aws logs filter-log-events --region us-east-1 --log-group-name /archimedes/app \
   --start-time $(( ($(date +%s) - 604800) * 1000 )) \
   --filter-pattern '"Rate limiting could not determine a client IP"' --query 'events[].message'
@@ -270,7 +272,7 @@ From the 2026-08-31 code-truth audit. The first two are the ones to close before
 
 | ID | Finding | Where | Status |
 |---|---|---|---|
-| **EV-1** | Behind CloudFront → ALB → nginx the `X-Forwarded-For` header is multi-hop, and Better Auth trusts a forwarded header only when it carries exactly one value. No client IP resolves, so **every rate-limit bucket is global per-path**, not per-IP: three signups from anywhere exhaust `/sign-up/email` for the whole internet for ten minutes, and `/request-password-reset` + `/send-verification-email` are 3-per-minute *globally*. That last pair is exactly the traffic this flip creates. The claim "3 signups / 10 min per rate key" in `auth/auth.js` and `account-authentication.md` does not hold in production. | `auth/auth.js` sets no `advanced.ipAddress`; `nginx/nginx.conf:179` | **open — [#1691](https://github.com/a-apin/archimedes/issues/1691).** Pinned by two matched tests in `auth/test/email-flows.test.js`; the library logs a warning naming this exact condition (grep in § 2) |
+| **EV-1** | Behind CloudFront → ALB → nginx the `X-Forwarded-For` header is multi-hop, and Better Auth trusts a forwarded header only when it carries exactly one value. No client IP resolved, so **every rate-limit bucket was global per-path**, not per-IP: three signups from anywhere exhausted `/sign-up/email` for the whole internet for ten minutes, and `/request-password-reset` + `/send-verification-email` were 3-per-minute *globally* — exactly the traffic this flip creates. | `auth/auth.js` set no `advanced.ipAddress`; `nginx/nginx.conf` appends `$proxy_add_x_forwarded_for` | **fixed — [#1691](https://github.com/a-apin/archimedes/issues/1691).** nginx now SETS `X-Client-IP` from its realip-resolved `$remote_addr` and `auth.js` sets `advanced.ipAddress.ipAddressHeaders: ['x-client-ip']`; the mail endpoints are pinned at 3/60s explicitly. Buckets are per-CloudFront-edge, not per-viewer (nginx trusts only the ALB CIDR) — coarser than one caller, but unspoofable and no longer global. Pinned by five tests in `auth/test/email-flows.test.js`, two of them adversarial. Post-deploy check: the § 2 warning grep must return nothing new |
 | **EV-2** | Verification and reset token lifetimes were inherited library defaults, invisible to a reader of `auth/auth.js` and free to move on a version bump. | `auth/auth.js` | **fixed** — both pinned at 3600s, behaviour unchanged, with tests asserting both the literal and what reaches the wire |
 | **EV-3** | `POST /api/auth/send-verification-email` is reachable with no session and was an account-existence oracle: Better Auth's 500 ms constant-time floor was defeated because the mail callback awaited the SES round trip (measured: unknown 504 ms, known-and-unverified 922 ms against a 900 ms mailer). The endpoint only becomes user-facing at this flip. | `auth/auth.js` `sendVerificationEmail` | **fixed** — fire-and-forget, mirroring `sendResetPassword`; regression-guarded by a timing test |
 | **EV-4** | Completing a password reset proves mailbox control but does not set `emailVerified`, so under enforcement a successful reset still ends in a 403. | `auth/auth.js` — no `onPasswordReset` hook configured | **open, owner decision.** Closing it is a few lines; it is a security-semantics call, not a bug fix |

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -176,6 +176,37 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
+    # X-Client-IP carries the SAME realip-resolved $remote_addr as X-Real-IP
+    # above, under a name the auth service owns (#1691). Better Auth keys every
+    # rate-limit bucket on `${ip}|${path}` and resolves that ip from the headers
+    # named in `advanced.ipAddress.ipAddressHeaders` — auth/auth.js sets exactly
+    # ['x-client-ip'], so this line is the whole supply. Reading X-Forwarded-For
+    # instead cannot work: the header is multi-valued here (CloudFront sets the
+    # viewer, the ALB appends the edge it saw, `$proxy_add_x_forwarded_for`
+    # below appends nginx's own peer), and Better Auth refuses a multi-hop
+    # header outright rather than trust a spoofable token
+    # (@better-auth/core/dist/utils/ip.mjs:189) — which collapsed every caller
+    # in the world into one shared bucket per path.
+    #
+    # WHY THIS IS NOT SPOOFABLE: `proxy_set_header` SETS, it does not append, so
+    # a client-supplied `X-Client-IP: 1.2.3.4` is overwritten before the request
+    # leaves nginx. $remote_addr itself is either the socket peer or — only when
+    # that peer is inside the `set_real_ip_from 10.0.0.0/16` ALB CIDR above — the
+    # realip module's resolution of X-Forwarded-For. A request from anywhere
+    # outside that CIDR therefore contributes nothing to the value it is keyed
+    # on. Identical reasoning, and the identical value, to the two limiters that
+    # already depend on X-Real-IP: backend/archimedes/api/limiter.py and
+    # services/generation_quota.py ("never trust X-Forwarded-For").
+    #
+    # SCOPE, stated exactly: with only the ALB CIDR trusted and
+    # `real_ip_recursive on`, this resolves to the RIGHTMOST forwarded address
+    # outside 10.0.0.0/16 — behind CloudFront that is the CloudFront edge that
+    # relayed the request, not the viewer. Buckets are therefore per-edge, not
+    # per-viewer: unspoofable and no longer global, but coarser than one caller.
+    # Sharpening it further means trusting CloudFront's published edge ranges
+    # here, which is deliberately NOT done — that list changes, and a stale one
+    # degrades silently. Layers 2 and 3 have always keyed on this same value.
+    proxy_set_header X-Client-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header Connection "";


### PR DESCRIPTION
## What this changes

Better Auth's production rate limiter had **no client IP to key on**. Every bucket key is
`${ip}|${path}` (`@better-auth/core/dist/utils/ip.mjs:225`), and `getIp` trusts a forwarded
header only when it carries exactly one value (`:189 if (forwardedIps.length !== 1) return
null`). Behind CloudFront → ALB → nginx every hop appends, so no IP ever resolved, the
library substituted the literal `no-trusted-ip`, and **the entire internet shared one bucket
per path** — three `/request-password-reset` calls from anywhere exhausted the endpoint for
everybody. That is precisely the traffic the `EMAIL_VERIFICATION_ENFORCED` flip creates.

**Option A from the issue**, both halves:

- `nginx/nginx.conf` — `proxy_set_header X-Client-IP $remote_addr;` in the server-level
  proxy header block. `proxy_set_header` **sets**, it does not append, so a client-supplied
  `X-Client-IP` is overwritten before the request leaves nginx. `$remote_addr` is the
  realip-resolved value, and `real_ip_header` is bound to `set_real_ip_from 10.0.0.0/16` —
  the narrowed AUDIT I7 CIDR.
- `auth/auth.js` — `advanced.ipAddress: { ipAddressHeaders: ['x-client-ip'] }`. No
  `trustedProxies` (that re-admits `X-Forwarded-For` and would require carrying CloudFront's
  edge ranges in this file, where a stale list degrades silently). No fallback to
  `x-forwarded-for` either — a single-valued XFF is exactly the shape a direct-to-container
  caller forges.

This is the same trusted value `backend/archimedes/api/limiter.py` and
`services/generation_quota.py` already key on via `X-Real-IP` ("never trust
X-Forwarded-For"); layer 1 now matches layers 2 and 3 instead of contradicting them.

Also pins `/request-password-reset` and `/send-verification-email` at 3/60s explicitly
(scope item 5) — the values match the library's own default for that path set
(`better-auth/dist/api/rate-limiter/index.mjs:378-382`), so no behaviour changes; a bump can
no longer move a security-relevant number silently.

### Said plainly, because the issue is about untrue claims

nginx trusts only the ALB CIDR, so with `real_ip_recursive on` the resolved address is the
rightmost forwarded token outside `10.0.0.0/16` — **behind CloudFront that is the CloudFront
edge that relayed the request, not the viewer.** Buckets are therefore **per-edge**:
unspoofable and no longer global, but coarser than one caller. That is stated in
`nginx.conf`, in `auth.js`, in `docs/account-authentication.md`, and in the runbook's EV-1
row — not rounded up to "per user". Measured, not assumed; see case 2 below.

## Adversarial guard demo

### 1. A spoofed header from a non-edge source is not trusted — real nginx, this exact config

The unmodified `nginx/nginx.conf` running in `nginxinc/nginx-unprivileged:1.31.2-alpine`
(the pinned image), on a docker network at `10.0.0.0/16` to stand in for the ALB, plus a
second network at `172.28.0.0/16` for a caller outside the trusted CIDR. The origin echoes
the headers it received.

```
=== CASE 1: spoofer on evilnet (172.28.0.0/16 — NOT the trusted ALB CIDR) ===
  sent: X-Client-IP: 1.2.3.4   X-Forwarded-For: 9.9.9.9, 8.8.8.8
  auth service received:
X-Client-IP=172.28.0.3 | X-Real-IP=172.28.0.3 | X-Forwarded-For=9.9.9.9, 8.8.8.8, 172.28.0.3

=== CASE 2: ALB-shaped source on edgenet (10.0.0.0/16 — trusted), prod XFF chain ===
  sent: X-Client-IP: 1.2.3.4   X-Forwarded-For: 203.0.113.7, 70.132.1.2
  auth service received:
X-Client-IP=70.132.1.2 | X-Real-IP=70.132.1.2 | X-Forwarded-For=203.0.113.7, 70.132.1.2, 70.132.1.2
```

Case 1: the forged `X-Client-IP: 1.2.3.4` is **gone** — overwritten with the caller's actual
peer address `172.28.0.3`. The forged `X-Forwarded-For` is passed along but is not what the
key is read from. A caller outside the ALB CIDR contributes nothing to the value it is
keyed on.

Case 2 is the honesty check on the paragraph above: from inside the trusted CIDR with the
production chain, the resolved value is `70.132.1.2` — the **edge**, not the viewer
`203.0.113.7`. Per-edge, exactly as documented. Not claimed to be per-viewer.

### 2. Forging X-Forwarded-For buys no extra bucket — against the real `auth.handler`

`SECURITY: forging X-Forwarded-For buys no extra bucket`: one abuser at one address rotates
a fresh leftmost XFF hop on every request *and* plants its own `X-Client-IP` value inside
the chain — the value an attacker would forge if the leftmost token were trusted. It still
429s on request 4.

### 3. Mutation transcript — both halves reverted, one at a time

**Mutation A — drop `ipAddress.ipAddressHeaders` from `auth/auth.js` (revert to the library
default `['x-forwarded-for']`):**

```
ℹ tests 75   ℹ pass 73   ℹ fail 2

✖ rate-limit buckets separate per client behind the multi-hop header production sends
  AssertionError [ERR_ASSERTION]: client B was rate-limited by client A — the client IP is
  not resolving; EV-1 has regressed
  429 !== 200
    at .../auth/test/email-flows.test.js:434:10
    actual: 429, expected: 200, operator: 'strictEqual'

✖ EV-1 mechanism: ipAddressHeaders is what makes the key resolve, and it is pinned in auth.js
  TypeError: Cannot read properties of undefined (reading 'ipAddressHeaders')
    at .../auth/test/email-flows.test.js:513:52
```

**Mutation B — delete `proxy_set_header X-Client-IP $remote_addr;` from `nginx/nginx.conf`:**

```
ℹ tests 75   ℹ pass 74   ℹ fail 1

✖ SECURITY: nginx SETS X-Client-IP, so a spoof from a non-edge source never reaches this process
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression
  /^\s*proxy_set_header X-Client-IP \$remote_addr;$/m
```

Each half of the fix is guarded, and neither guard passes without it. Both mutations
reverted; the tree here is the fixed state.

## Tests

The two `FINDING` tests are rewritten to assert the fixed behaviour, and the matched
control/finding pairing is kept — the control test now carries the **multi-hop**
`X-Forwarded-For` production actually sends, so it cannot be read as "the test dodged the
hard case". Five tests, two of them adversarial:

1. control — buckets separate per client with the multi-hop XFF present (the mutation guard)
2. adversarial — rotating XFF mints no new bucket
3. adversarial — `nginx.conf` is source-pinned: `proxy_set_header`, never
   `$proxy_add_x_forwarded_for`, exactly once, with the AUDIT I7 CIDR intact
4. fail-safe — no `X-Client-IP` (a request that skipped nginx) → `null` → the shared bucket:
   over-limits, never opens
5. mechanism — the library-level reads the four above rest on

The `no-trusted-ip` warning the library logged during the suite is gone from the run output.

## Acceptance criteria

- [x] `cd auth && npm ci && npm test` → `pass 75`, `fail 0` (was 73)
- [x] The rewritten multi-hop test fails when the fix is reverted — transcript above
- [x] `grep -n "per Better Auth's rate key" auth/auth.js` → one match, now followed by a
      `WHAT "Better Auth's rate key" RESOLVES TO` paragraph naming the header, the file that
      sets it, and the per-edge scope
- [x] `grep -n "X-Client-IP" nginx/nginx.conf` → present; `grep -n "ipAddressHeaders"
      auth/auth.js` → present
- [x] `python3 .github/scripts/docs_links.py` → `scanned 1633 in 175 markdown files;
      broken 0`
- [x] `"$ENV_BIN/pytest" -m "not integration" -q` → `5502 passed, 3 skipped, 0 failed`
      (re-run after rebasing onto current `main`)

Also: the config in this PR loads clean in the pinned nginx image (the demo above is the
`nginx -t` equivalent — workers started against this exact file).

## Anti-goals honoured

Leftmost XFF token never trusted; rate limiting not disabled and no window widened;
`disableIpTracking` not set (asserted in test 5); no `infra/ecs.tf` flag touched — the only
infra-adjacent file changed is `nginx/nginx.conf`, one added `proxy_set_header`; the
single-hop control is not removed, it is strengthened into the multi-hop case.

## After deploy

The issue's own verify step: `docs/runbooks/email-verification-validation.md` § 2's
CloudWatch filter for `"Rate limiting could not determine a client IP"` must return nothing
dated after this deploy. The runbook comment now says exactly that, and the EV-1 row in § 7
is marked fixed with the per-edge scope written down.

Closes #1691
