### PR TITLE
[infra] Budget ladder: one SNS subscriber per rung (AWS API constraint)

### DIFF
--- a/backend/tests/test_cost_kill_switch_guards.py
+++ b/backend/tests/test_cost_kill_switch_guards.py
@@ -358,14 +358,17 @@ def _budget_notifications(tf_path: Path = COST_TF) -> list[dict[str, str]]:
 def test_budget_has_exactly_the_three_documented_thresholds():
     notifications = _budget_notifications()
     thresholds = sorted(int(n["threshold"]) for n in notifications)
-    assert thresholds == [50, 80, 120], (
-        "The ladder is 50% notify / 80% notify / 120% KILL. Found "
+    assert thresholds == [50, 80, 100, 120], (
+        "The ladder is 50/80/100% notify / 120% KILL. Found "
         f"{thresholds}. Dropping a rung removes a warning the owner is "
-        "supposed to get before anything shuts itself off."
+        "supposed to get before anything shuts itself off. (100 exists because "
+        "the Budgets API allows ONE SNS subscriber per notification — "
+        "CreationLimitExceededException, 2026-09-01 — so the kill rung cannot "
+        "also carry the human topic; the human hears at 100 instead.)"
     )
 
 
-@pytest.mark.parametrize("threshold", [50, 80, 120])
+@pytest.mark.parametrize("threshold", [50, 80, 100, 120])
 def test_every_threshold_is_actual_not_forecast(threshold):
     notification = next(n for n in _budget_notifications() if int(n["threshold"]) == threshold)
     assert notification["notification_type"] == '"ACTUAL"', (
@@ -389,12 +392,24 @@ def test_notify_rungs_go_to_the_existing_alerts_topic_and_not_the_kill_topic(thr
 
 
 def test_kill_rung_reaches_the_kill_topic_and_still_tells_a_human():
-    notification = next(n for n in _budget_notifications() if int(n["threshold"]) == 120)
-    subscribers = notification["subscriber_sns_topic_arns"]
-    assert "aws_sns_topic.cost_kill_switch.arn" in subscribers, "120% must invoke the Lambda"
-    assert "aws_sns_topic.alerts.arn" in subscribers, (
-        "120% must ALSO publish to the human alerts topic, so a broken Lambda "
-        "cannot turn a shutdown-worthy bill into silence."
+    """The redundancy moved: Budgets allows ONE SNS subscriber per notification
+    (CreationLimitExceededException on the 2026-09-01 apply), so 120% carries
+    the Lambda topic ALONE, and "a broken Lambda cannot mean silence" is held
+    by two other wires this test pins: the 100% rung mails the human first,
+    and the EstimatedCharges tripwire fires BOTH topics at the same boundary.
+    """
+    kill = next(n for n in _budget_notifications() if int(n["threshold"]) == 120)
+    assert kill["subscriber_sns_topic_arns"] == "[aws_sns_topic.cost_kill_switch.arn]", (
+        "120% must invoke the Lambda, and ONLY the Lambda — a second subscriber "
+        "is rejected by the Budgets API and would fail the apply."
+    )
+    human = next(n for n in _budget_notifications() if int(n["threshold"]) == 100)
+    assert human["subscriber_sns_topic_arns"] == "[aws_sns_topic.alerts.arn]", (
+        "100% is where the human hears the budget is blown before the kill fires."
+    )
+    tripwire = _read(COST_TF)
+    assert "aws_sns_topic.alerts.arn" in tripwire and "aws_sns_topic.cost_kill_switch.arn" in tripwire, (
+        "the tripwire must still reach both topics — that is the broken-Lambda redundancy now"
     )
 
 

--- a/infra/cost_kill_switch.tf
+++ b/infra/cost_kill_switch.tf
@@ -285,15 +285,32 @@ resource "aws_budgets_budget" "cost_kill_switch" {
     subscriber_sns_topic_arns = [aws_sns_topic.alerts.arn]
   }
 
-  # Rung 3 — KILL. Publishes to BOTH topics: the kill topic invokes the Lambda,
-  # the alerts topic makes sure a human hears the same thing through the same
-  # channel as rungs 1 and 2 even if the Lambda itself is broken.
+  # Rung 3 — the human "budget exceeded" signal, one step before the kill.
+  # Exists because the API constraint below forces the kill rung to carry the
+  # Lambda topic alone, so this is where a person hears it through the same
+  # channel as rungs 1 and 2.
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.alerts.arn]
+  }
+
+  # Rung 4 — KILL. ONE subscriber, and that is an AWS API constraint, not a
+  # choice: CreateNotification rejects a second SNS subscriber per notification
+  # (CreationLimitExceededException, learned on the 2026-09-01 first apply).
+  # The "a broken Lambda cannot mean silence" property this rung used to carry
+  # via a second topic lives elsewhere now, twice over: the 100% rung above
+  # mails a human before this fires, and the EstimatedCharges tripwire
+  # (billing_estimated_charges_high) fires BOTH topics at the same dollar
+  # boundary — CloudWatch alarms, unlike Budgets notifications, allow it.
   notification {
     comparison_operator       = "GREATER_THAN"
     threshold                 = 120
     threshold_type            = "PERCENTAGE"
     notification_type         = "ACTUAL"
-    subscriber_sns_topic_arns = [aws_sns_topic.cost_kill_switch.arn, aws_sns_topic.alerts.arn]
+    subscriber_sns_topic_arns = [aws_sns_topic.cost_kill_switch.arn]
   }
 }
 


### PR DESCRIPTION
Fix-forward for the 2026-09-01 apply error (`CreationLimitExceededException: one notification can only have 1 subscribers with type of SNS`). Ladder becomes 50/80/**100** → alerts, **120 → kill topic only**; the broken-Lambda-cannot-mean-silence property now lives in the 100% human rung + the EstimatedCharges tripwire's dual action (verified live: the tripwire alarm already carries both topics). Guards updated to pin the corrected design with the API constraint named. `test_cost_kill_switch_*` → **43 passed**.

Operator step after merge (the half-created budget must go before re-apply):
```
aws budgets delete-budget --account-id 037613907429 --budget-name archimedes-cost-kill-switch-monthly
cd infra && terraform apply
```
Interim safety: the kill path is already armed via the tripwire (both topics confirmed live).