### PR TITLE
[chain] oracle_updater: skip confirmation re-poll on submit-time COMPLETE (#1711)

### DIFF
--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -362,9 +362,11 @@ class OracleUpdater:
         from archimedes.chain.client import chain_client
 
         oracle_addresses = chain_client.settings.oracle_addresses
-        # (symbol, human price, 6-dec int, Circle tx id) per accepted submission,
-        # pending on-chain confirmation.
-        submitted: list[tuple[str, float, int, str]] = []
+        # (symbol, human price, 6-dec int, Circle tx id, state already reported
+        # by the create-transaction call itself — None when the submission was
+        # still in flight) per accepted submission, pending on-chain
+        # confirmation.
+        submitted: list[tuple[str, float, int, str, str | None]] = []
         confirmed_tx_ids: list[str] = []
 
         async with aiohttp.ClientSession() as session:
@@ -488,7 +490,7 @@ class OracleUpdater:
                         tx_id = data.get("id") if isinstance(data, dict) else None
                         state = data.get("state") if isinstance(data, dict) else None
                         if tx_id and state not in _TX_FAILURE_STATES:
-                            submitted.append((price.symbol, price.price_usd, price_int, tx_id))
+                            submitted.append((price.symbol, price.price_usd, price_int, tx_id, state))
                             logger.info(
                                 f"Submitted {price.symbol} price {price.price_usd:.2f} → Circle tx {tx_id}"
                                 + (f" ({state})" if state else "")
@@ -508,8 +510,29 @@ class OracleUpdater:
             # counts as pushed; anything else leaves the cached deviation
             # reference untouched and is logged loudly so a stuck oracle is
             # visible to operators, never masked.
-            for symbol, price_usd, price_int, tx_id in submitted:
-                state = await self._poll_circle_tx(session, tx_id)
+            for symbol, price_usd, price_int, tx_id, submit_state in submitted:
+                # The create-transaction call itself can already report a
+                # terminal-success state (#1711: an idempotency-key dedup hit
+                # on a tx that completed several cycles ago — unchanged price,
+                # e.g. an equity synth over a weekend, keeps producing the
+                # same idempotency key). Re-polling that tx via
+                # `_poll_circle_tx` (`/transactions?pageSize=50`) is not just
+                # wasteful, it is WRONG: that endpoint only returns the most
+                # recent 50 transactions account-wide, so an already-resolved
+                # tx from a prior cycle can have scrolled off the window by
+                # the time this poll runs. `_poll_circle_tx` would then report
+                # "TIMEOUT" for a push that had already succeeded — logging a
+                # false error AND feeding the wedge tracker below, which after
+                # `_tx_max_repolls` consecutive false hits abandons a
+                # perfectly good tx and submits a genuinely NEW on-chain
+                # transaction for a price already pushed, burning gas for
+                # nothing. A submit-time terminal-success state is already
+                # authoritative — narrow the parse to trust it instead of
+                # re-deriving the same fact from a narrower, staler view.
+                if submit_state in _TX_SUCCESS_STATES:
+                    state = submit_state
+                else:
+                    state = await self._poll_circle_tx(session, tx_id)
                 was_reseed = symbol in self._pending_reseed
                 if state in _TX_SUCCESS_STATES:
                     self._last_pushed_price_int[symbol] = price_int

--- a/backend/tests/chain/test_oracle_updater.py
+++ b/backend/tests/chain/test_oracle_updater.py
@@ -473,6 +473,106 @@ class TestSubmissionResponseParsing:
         assert any("Circle API error" in m for m in error_messages), error_messages
 
 
+# ── Dedup-hit COMPLETE must skip the re-poll entirely (#1711) ──────────────
+
+
+@pytest.mark.usefixtures("circle_creds")
+class TestDedupHitCompleteSkipsRepoll:
+    """#1525 fixed the create-transaction response's OWN grading (200/COMPLETE
+    is a success, not an error). But the confirmation phase then unconditionally
+    re-polled every submission via `_poll_circle_tx`, which only inspects the
+    most recent 50 transactions account-wide — so a dedup-hit tx that actually
+    completed several cycles ago (unchanged price, e.g. an equity synth over a
+    weekend keeps reproducing the same idempotency key) can have scrolled off
+    that window by the time the poll runs. The captured production symptom
+    (issue #1711): `Circle API error for sSPY (200): {'data': {'id':
+    'c94fa26b-...', 'state': 'COMPLETE'}}` re-logged every cycle for a push
+    that had already succeeded — and, left unbounded, the false TIMEOUT this
+    produced would feed the wedge tracker into abandoning a perfectly good tx
+    and submitting a genuinely NEW on-chain transaction, burning gas for a
+    price already pushed. The fix: a submit-time terminal-success state is
+    already authoritative, so it must never be re-derived from that narrower,
+    staler view."""
+
+    def _updater_with_dedup_hit(self, tx_id: str, state: str = "COMPLETE"):
+        updater = OracleUpdater()
+        updater._circle_public_key = "cached-pem"
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"data": {"id": tx_id, "state": state}})
+        return updater, _mock_aiohttp_session(post_response=resp)
+
+    async def test_exact_captured_payload_skips_repoll_and_logs_info(self, caplog):
+        # The exact shape from the issue's live log line: HTTP 200, a
+        # dedup-hit tx id, state already COMPLETE.
+        tx_id = "c94fa26b-1234-5678-9abc-def012345678"
+        updater, (session_cm, _session) = self._updater_with_dedup_hit(tx_id)
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            # If the fix regresses and this gets called, make the regression
+            # loud: TIMEOUT is exactly what a scrolled-off-the-window poll
+            # would return for an already-complete tx in production.
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="TIMEOUT")) as poll,
+            caplog.at_level(logging.INFO, logger="archimedes.chain.oracle_updater"),
+        ):
+            result = await updater.push_prices_on_chain([good])
+
+        assert result == tx_id
+        assert updater._last_pushed_price_int["sSPY"] == _int6(110.0)
+        poll.assert_not_called()  # submit-time COMPLETE is authoritative — no re-poll
+        assert "sSPY" not in updater._wedge_tracking
+        error_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not error_messages, error_messages
+        info_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+        assert any(tx_id in m and "COMPLETE" in m for m in info_messages), info_messages
+
+    async def test_repeated_dedup_hits_never_trigger_wedge_retry(self):
+        # Gas-waste guard: an unchanged weekend price reproduces the identical
+        # idempotency key every cycle, so Circle keeps returning the SAME
+        # dedup-hit 200/COMPLETE for MANY consecutive cycles — well past
+        # ORACLE_TX_MAX_REPOLLS. None of that may ever be misread as a wedge:
+        # a real retry here is a real on-chain forceless setPrice tx, i.e. real
+        # gas spent on a price that was already pushed.
+        tx_id = "c94fa26b-1234-5678-9abc-def012345678"
+        updater, (session_cm, _session) = self._updater_with_dedup_hit(tx_id)
+        updater._tx_max_repolls = 10
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="TIMEOUT")) as poll,
+        ):
+            for _ in range(25):  # well past the 10-cycle abandonment threshold
+                result = await updater.push_prices_on_chain([good])
+                assert result == tx_id
+
+        poll.assert_not_called()
+        assert updater._wedge_tracking == {}
+        assert updater._tx_retry_salt.get("sSPY", 0) == 0  # no retry ever fired
+
+    async def test_non_terminal_submission_still_polls_normally(self, caplog):
+        # Regression guard: this fix must not swallow the normal path — a
+        # submission that is genuinely still in flight (no terminal state yet)
+        # must still go through the real confirmation poll.
+        tx_id = "tx-in-flight"
+        updater, (session_cm, _session) = self._updater_with_dedup_hit(tx_id, state="PENDING")
+        good = _price(symbol="sSPY", usd=110.0)
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm),
+            patch("archimedes.chain.oracle_updater._encrypt_entity_secret", return_value="ciphertext"),
+            patch.object(updater, "_get_reference_price_int", AsyncMock(return_value=(_int6(100.0), True))),
+            patch.object(updater, "_poll_circle_tx", AsyncMock(return_value="COMPLETE")) as poll,
+        ):
+            result = await updater.push_prices_on_chain([good])
+
+        assert result == tx_id
+        poll.assert_called_once()
+        assert updater._last_pushed_price_int["sSPY"] == _int6(110.0)
+
+
 # ── Wedged-tx abandonment (#1525) ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`oracle_updater.push_prices_on_chain`'s confirmation phase unconditionally
re-polled *every* accepted submission via `_poll_circle_tx`
(`GET /transactions?pageSize=50`) — even when the create-transaction call
itself already reported a terminal-success state (`COMPLETE`/`CONFIRMED`).
That poll endpoint only returns the most recent 50 transactions
account-wide, so a **dedup-hit** submission — an unchanged price (e.g. an
equity synth over a weekend) reproduces the same deterministic idempotency
key every cycle, and Circle just hands back the *already-resolved* tx id —
can have scrolled off that window by the time the re-poll runs. The re-poll
then reports `TIMEOUT` for a push that had already succeeded, which:

1. logs a **false ERROR** ("`Oracle push for … ended TIMEOUT — on-chain
   price NOT updated`") for a transaction that was, in fact, COMPLETE, and
2. feeds the wedge tracker — after `ORACLE_TX_MAX_REPOLLS` (default 10)
   consecutive false TIMEOUTs, the runner **abandons a perfectly good tx and
   submits a genuinely new on-chain transaction for a price that was already
   pushed**, burning gas for nothing.

This is the mechanism behind #1711's captured runner log: `Circle API error
for sSPY (200): {'data': {'id': 'c94fa26b-…', 'state': 'COMPLETE'}}`. #1525
already fixed the create-response's *own* grading (a 200 with a terminal
success state is no longer graded as an error at submit time) — but the
confirmation phase threw that information away and re-derived the same fact
from a narrower, staler view, reopening the same failure mode one step
later.

## Fix

Narrow, no `except` broadened: the submission tuple now carries the state
the create-transaction call already reported. The confirmation loop trusts
a submit-time terminal-success state directly and **skips the re-poll**
entirely for it; a submission that is genuinely still in flight (no
terminal state yet) is unaffected and still goes through the real
`_poll_circle_tx` confirmation, unchanged.

`backend/archimedes/chain/oracle_updater.py`:
- `submitted` tuples now carry the submit-time `state` alongside
  `(symbol, price_usd, price_int, tx_id)`.
- The confirmation loop: `if submit_state in _TX_SUCCESS_STATES: state =
  submit_state else: state = await self._poll_circle_tx(...)`.

## Adversarial demo

New test class `TestDedupHitCompleteSkipsRepoll`
(`backend/tests/chain/test_oracle_updater.py`):

- `test_exact_captured_payload_skips_repoll_and_logs_info` — feeds the
  **exact captured payload shape** from the issue (`HTTP 200`,
  `{"data": {"id": "c94fa26b-…", "state": "COMPLETE"}}`) through
  `push_prices_on_chain`, with `_poll_circle_tx` mocked to return
  `"TIMEOUT"` (exactly what a scrolled-off-the-window poll would do in
  production). Asserts: the push succeeds (`result == tx_id`), the
  deviation-guard reference is updated, **no ERROR is logged**,
  `_poll_circle_tx` is **never called**, and no wedge-tracking entry is
  created.
- `test_repeated_dedup_hits_never_trigger_wedge_retry` — runs 25 consecutive
  cycles of the identical dedup-hit COMPLETE response (simulating an
  unchanged weekend price) and asserts `_tx_retry_salt` for the symbol
  **never increments** — i.e. no gas-wasting retry ever fires, well past the
  10-cycle abandonment threshold.
- `test_non_terminal_submission_still_polls_normally` — regression control:
  a genuinely in-flight submission (`state: "PENDING"`) still goes through
  the real poll.

**Verified against the pre-fix code** (`git stash` the source change,
tests unchanged): both new tests fail —
`AssertionError: assert None == 'c94fa26b-…'`, with the log showing
`ERROR … Oracle push for sSPY … ended TIMEOUT — on-chain price NOT
updated`. Re-applying the fix (`git stash pop`) makes both pass. This is
direct, reproduced evidence of the real mechanism: a completed transaction
silently downgraded to a false failure by the blind re-poll.

The existing `TestSubmissionResponseParsing` class (from #1525) already
covers "a real failure payload still errors" — unchanged and still green.

## Validation

```
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest -m "not integration" -q
```

Full non-integration suite: all green (see CI). Targeted:
`pytest backend/tests/chain/test_oracle_updater.py` — 51 passed (48
pre-existing + 3 new).

`ruff format --check` clean on both touched files. `ruff check` on the test
file surfaces only 4 pre-existing `RUF059` (unused-unpack) findings in
unrelated `TestSubmissionResponseParsing` tests predating this change
(confirmed present on `origin/main` before this branch, 70 total in the
file) — informational-only per `quality-gate.yml`, not introduced here.

Closes #1711
