### PR TITLE
[chain] Route the oracle runner's crypto pricing through the market-data seam; name every excluded push symbol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -425,6 +425,29 @@ TIINGO_API_TOKEN=
 # existing staleness/deviation push-gates stay meaningful (stale equity feeds
 # off-hours are correctly rejected → fall back).
 PRICE_SOURCE=yfinance
+
+# ── Oracle crypto source order (#1710) ────────────────────────────────────
+# Which source prices the push set's CRYPTO synths, and in what order. Before
+# #1710 this leg was hardcoded to CoinGecko with NO fallback and no connection
+# to the MARKET_DATA_PROVIDER seam, so a CoinGecko miss dropped the symbol from
+# the push cycle silently and its on-chain oracle aged into staleness.
+#   coingecko      — CoinGecko first, MARKET_DATA_PROVIDER seam as fallback.
+#                    DEFAULT. The happy path is byte-for-byte the old behavior
+#                    (source="coingecko"); only a MISS behaves differently.
+#   coingecko_only — literal pre-#1710 behavior: CoinGecko, no fallback.
+#   provider       — seam first, CoinGecko as fallback. Flip to this once the
+#                    active provider can serve intraday crypto quotes.
+#   provider_only  — seam only, NO CoinGecko fallback. Licensing-strict: a miss
+#                    stays a miss rather than being filled from a free API.
+# NOTE: MARKET_DATA_PROVIDER=tiingo cannot serve this leg today —
+# TiingoProvider.get_intraday_quotes_batch raises NotImplementedError (daily
+# bars only; docs/adr/market-data-sourcing.md states the same). Under
+# 'provider' that refusal is logged by name and CoinGecko serves; under
+# 'provider_only' nothing is priced and the symbol is logged as excluded.
+# Whatever the outcome, a symbol no source could price is NEVER given a
+# fabricated price — it is excluded from the push with a named log line.
+# ORACLE_CRYPTO_SOURCE=coingecko
+
 # Pyth Hermes base URL (public endpoint by default; override for self-hosted).
 PYTH_HERMES_URL=https://hermes.pyth.network
 # Optional manual price overrides (inline JSON or a file path), applied on top of

--- a/backend/archimedes/chain/oracle_updater.py
+++ b/backend/archimedes/chain/oracle_updater.py
@@ -4,10 +4,16 @@ Implements IOracleUpdater from archimedes/interfaces/chain.py.
 Equity/ETF prices (and the #775 cross-check's secondary reading) come from
 the market-data provider seam (``archimedes.services.market_data_provider``,
 #1218) — default provider yfinance, unchanged behavior; vendor-swappable via
-``MARKET_DATA_PROVIDER``. Crypto still comes straight from CoinGecko
-(unaffected by that seam). Pushes prices via Circle Developer Controlled
-Wallets API (the oracle owner wallet is a Circle-managed wallet — no raw
-private key available).
+``MARKET_DATA_PROVIDER``. Crypto reaches that same seam as of #1710, through
+an ordered ``ORACLE_CRYPTO_SOURCE`` cascade whose default keeps CoinGecko as
+the primary and adds the provider seam as the documented fallback. Pushes
+prices via Circle Developer Controlled Wallets API (the oracle owner wallet is
+a Circle-managed wallet — no raw private key available).
+
+Every symbol in the push set that ends a cycle with NO price from ANY
+configured source is logged by name with its reason
+(``_log_push_exclusions``) and left unpushed. No price is ever fabricated,
+defaulted or carried forward to fill a source gap.
 """
 
 from __future__ import annotations
@@ -49,6 +55,88 @@ YFINANCE_MAP = {
 CRYPTO_MAP = {
     "sBTC": "bitcoin",
 }
+
+# Symbol → market-data-provider vendor ticker for the SAME crypto synths (#1710).
+#
+# CRYPTO_MAP above stays the push-set SSOT (``oracle_health._push_set_symbols``
+# reads it) and keeps holding CoinGecko ids; this map is the second coordinate
+# the same symbols need to be askable through the ``MARKET_DATA_PROVIDER`` seam
+# (``services.market_data_provider``). Ticker shape is the yfinance/SSOT
+# convention ("<BASE>-USD", matching ``synthetic_universe.json``'s
+# ``yfinance_ticker`` for every crypto entry) because that is what the seam's
+# adapters take: ``YFinanceProvider`` passes it straight through and
+# ``TiingoProvider._classify_tiingo_ticker`` routes it to the crypto endpoint
+# family by that exact shape.
+#
+# A symbol present in CRYPTO_MAP but absent here is not a silent gap: the
+# provider leg records "no vendor ticker mapped" as its named exclusion reason.
+CRYPTO_VENDOR_TICKERS = {
+    "sBTC": "BTC-USD",
+}
+
+# ─── Crypto source order (#1710) ───
+# Before this, the crypto leg was hardcoded to CoinGecko with NO fallback and
+# NO seam involvement, so a CoinGecko miss (429/timeout/shape change) silently
+# dropped the symbol from the push cycle — the on-chain oracle then aged out
+# and `/health`'s `oracle_fresh` flipped false with nothing in the log naming
+# the symbol as excluded. Both halves of that are fixed here: crypto is now
+# askable through the ``MARKET_DATA_PROVIDER`` seam like every other price
+# (docs/adr/market-data-sourcing.md's "reversible by build" claim was not true
+# of this leg), and a symbol no configured source could price is excluded from
+# the push attempt with a NAMED reason (never a fabricated or substituted
+# price).
+#
+# Modes map to an ordered (primary, …fallback) source list:
+#   • ``coingecko``      (DEFAULT) — CoinGecko first, provider seam as the
+#                        documented fallback. Deploying this change is a
+#                        no-op on the happy path: the price still comes from
+#                        CoinGecko with ``source="coingecko"``, byte-for-byte
+#                        as before. Only a CoinGecko MISS behaves differently
+#                        (it now has somewhere to go instead of vanishing).
+#   • ``coingecko_only`` — literal pre-#1710 behavior: CoinGecko, no fallback.
+#   • ``provider``       — seam first, CoinGecko as the documented fallback.
+#                        This is the flip to make once the active provider can
+#                        actually serve intraday crypto quotes.
+#   • ``provider_only``  — seam only, NO CoinGecko fallback. The licensing-
+#                        strict mode: the ADR's "never mix vendors" rule means
+#                        an operator who flipped to a licensed vendor may want
+#                        a miss to stay a miss rather than be quietly filled
+#                        from an unlicensed free API.
+#
+# NOTE (verified against the adapter, not assumed): ``TiingoProvider`` raises
+# ``NotImplementedError`` from ``get_intraday_quotes_batch`` — the ADR's
+# "the live oracle push … is not cutover-ready" consequence. So with
+# ``MARKET_DATA_PROVIDER=tiingo``, ``provider`` mode logs that refusal by name
+# and falls back to CoinGecko, and ``provider_only`` prices nothing. Tiingo
+# serves crypto DAILY bars only today.
+DEFAULT_CRYPTO_SOURCE = "coingecko"
+_CRYPTO_SOURCE_ORDER: dict[str, tuple[str, ...]] = {
+    "coingecko": ("coingecko", "provider"),
+    "coingecko_only": ("coingecko",),
+    "provider": ("provider", "coingecko"),
+    "provider_only": ("provider",),
+}
+
+
+def _crypto_source_order() -> tuple[str, ...]:
+    """Ordered crypto source legs from ``ORACLE_CRYPTO_SOURCE``.
+
+    Fails SAFE to the default on an unrecognized value (logged), matching
+    ``_int_env`` and ``price_source.price_source_mode`` — a config typo must
+    not crash a funds-adjacent singleton runner.
+    """
+    raw = os.getenv("ORACLE_CRYPTO_SOURCE", DEFAULT_CRYPTO_SOURCE).strip().lower()
+    order = _CRYPTO_SOURCE_ORDER.get(raw)
+    if order is None:
+        logger.warning(
+            "unknown ORACLE_CRYPTO_SOURCE=%r (expected one of %s) — falling back to %r",
+            raw,
+            ", ".join(sorted(_CRYPTO_SOURCE_ORDER)),
+            DEFAULT_CRYPTO_SOURCE,
+        )
+        return _CRYPTO_SOURCE_ORDER[DEFAULT_CRYPTO_SOURCE]
+    return order
+
 
 CIRCLE_API_BASE = "https://api.circle.com/v1/w3s"
 CIRCLE_BLOCKCHAIN = "ARC-TESTNET"
@@ -196,6 +284,10 @@ class OracleUpdater:
 
     def __init__(self) -> None:
         self._price_cache: dict[str, AssetPrice] = {}
+        # symbol → why no source produced an observation THIS cycle (#1710).
+        # Cleared at the top of every fetch_prices(); read by
+        # _log_push_exclusions to name each excluded symbol in the runner log.
+        self._source_miss_reasons: dict[str, str] = {}
         self._circle_public_key: str | None = None  # cached per instance lifetime
 
         # Circle credentials from env
@@ -267,6 +359,10 @@ class OracleUpdater:
         # runner imports cleanly.
         from archimedes.services.price_source import load_admin_prices, price_source_mode
 
+        # Named-exclusion bookkeeping is per-cycle (#1710): last cycle's reasons
+        # must never be reported against this cycle's misses.
+        self._source_miss_reasons = {}
+
         now = datetime.now(UTC)
         mode = price_source_mode()
         equity_symbols = {k: v for k, v in YFINANCE_MAP.items() if k.startswith("s")}
@@ -288,7 +384,42 @@ class OracleUpdater:
             self._price_cache[p.symbol] = p
 
         logger.info("Fetched %d prices (source=%s)", len(prices), mode)
+        self._log_push_exclusions(prices)
         return prices
+
+    def _log_push_exclusions(self, prices: list[AssetPrice]) -> None:
+        """Name every push-set symbol this cycle produced no price for (#1710).
+
+        The push set is derived the SAME way ``oracle_health._push_set_symbols``
+        derives the probed set — ``YFINANCE_MAP``'s leading-``"s"`` synth keys
+        plus ``CRYPTO_MAP`` — so the set that gets a "why it is missing" line
+        here is exactly the set ``/health``'s ``oracle_fresh`` keys on. Without
+        this, a symbol whose upstream returned nothing simply never appeared in
+        ``push_prices_on_chain``'s loop: no rejection line (that only fires for
+        a price that EXISTS and fails a gate), no exclusion line, nothing —
+        while its on-chain oracle quietly aged past ``MAX_STALENESS`` and held
+        ``archimedes-oracle-stale`` in ALARM. That is the "starved symbol"
+        failure mode #1710 reports, and it was invisible to a runner-log grep.
+
+        WARNING level on purpose: this is not a routine event, and the issue's
+        acceptance criterion ("no push-universe symbol whose source errored in
+        the prior 24h") is a grep over exactly these lines.
+
+        No price is ever synthesized to fill the gap — the anti-goal is
+        explicit in the issue and restated in the log text so a reader of the
+        line cannot mistake exclusion for substitution.
+        """
+        expected = {s for s in YFINANCE_MAP if s.startswith("s")} | set(CRYPTO_MAP)
+        have = {p.symbol for p in prices}
+        for symbol in sorted(expected - have):
+            reason = self._source_miss_reasons.get(symbol) or "no observation returned by any configured source"
+            logger.warning(
+                "oracle push exclusion: %s EXCLUDED from this push cycle — %s. "
+                "No price fabricated or substituted; the on-chain oracle keeps its previous "
+                "value and will read stale until a source returns data for this symbol.",
+                symbol,
+                reason,
+            )
 
     async def _fetch_cascade(
         self, equity_symbols: dict[str, str], now: datetime, *, strict_pyth: bool
@@ -672,8 +803,12 @@ class OracleUpdater:
            backend-only widening would revert on-chain and burn a tx).
 
         Single-source design (deferred multi-source to v2 per issue #508):
-        Each symbol currently has exactly one upstream source (yfinance for
-        equities/futures, CoinGecko for sBTC). Multi-source corroboration
+        Each symbol still resolves to exactly ONE upstream observation per
+        cycle. #1710 gave the crypto leg an ordered FALLBACK chain
+        (``ORACLE_CRYPTO_SOURCE``) — a second source is consulted only when the
+        first produced nothing, and the winner's true vendor is stamped on
+        ``AssetPrice.source``. That is failover, not corroboration; no two
+        sources are ever compared here. Multi-source corroboration
         would require N independent feeds; that is a v2 enhancement documented
         in docs/design.md § Price Oracle. Today, we validate upstream
         freshness and deviation bounds against the last known good on-chain
@@ -1029,17 +1164,81 @@ class OracleUpdater:
 
         quotes = get_provider().get_intraday_quotes_batch(symbols)
         source = provider_name()
+        # Named-exclusion bookkeeping (#1710): a ticker the provider had no data
+        # for is absent from `quotes` per the seam's per-item-skip contract. Record
+        # WHY here so _log_push_exclusions can name it instead of the push cycle
+        # dropping the symbol with nothing in the log tying it to a source gap.
+        for synth_symbol, ticker in symbols.items():
+            if synth_symbol not in quotes:
+                self._source_miss_reasons[synth_symbol] = (
+                    f"provider {source!r} returned no intraday observation for {ticker}"
+                )
         return [
             AssetPrice(symbol=synth_symbol, price_usd=price, timestamp=timestamp, source=source)
             for synth_symbol, (price, _bar_ts) in quotes.items()
         ]
 
     async def _fetch_crypto(self, timestamp: datetime) -> list[AssetPrice]:
-        """Fetch crypto prices from CoinGecko API."""
+        """Fetch crypto prices through an ordered, NAMED source cascade (#1710).
+
+        Order comes from ``ORACLE_CRYPTO_SOURCE`` (see ``_crypto_source_order``
+        and the constant block's mode table). Default ``coingecko`` keeps
+        CoinGecko as the primary — an unchanged happy path — and adds the
+        ``MARKET_DATA_PROVIDER`` seam as the documented fallback, which is what
+        puts this leg behind the vendor abstraction the market-data ADR claims
+        the whole codebase already sits behind.
+
+        Every returned price carries its TRUE ``source`` (``"coingecko"`` or the
+        active provider name), so a downstream consumer — including the #775
+        cross-check, which treats "same source" as "skip" — can still tell the
+        vendors apart. Nothing is filled in from a stale cache and no default
+        is invented: a symbol no leg could price is left OUT of the result with
+        its reason recorded in ``_source_miss_reasons`` for
+        ``_log_push_exclusions`` to name.
+        """
+        order = _crypto_source_order()
         results: list[AssetPrice] = []
+        served: set[str] = set()
+        reasons: dict[str, list[str]] = {}
+
+        for leg in order:
+            remaining = {s: cg_id for s, cg_id in CRYPTO_MAP.items() if s not in served}
+            if not remaining:
+                break
+            if leg == "coingecko":
+                got, why = await self._fetch_crypto_coingecko(remaining, timestamp)
+            else:
+                got, why = await self._fetch_crypto_provider(sorted(remaining), timestamp)
+            results.extend(got)
+            served.update(p.symbol for p in got)
+            for symbol, msg in why.items():
+                reasons.setdefault(symbol, []).append(msg)
+
+        for symbol in CRYPTO_MAP:
+            if symbol in served:
+                continue
+            self._source_miss_reasons[symbol] = (
+                f"crypto sources exhausted (ORACLE_CRYPTO_SOURCE order: {'→'.join(order)}): "
+                + " | ".join(reasons.get(symbol, ["no source attempted"]))
+            )
+        return results
+
+    async def _fetch_crypto_coingecko(
+        self, wanted: dict[str, str], timestamp: datetime
+    ) -> tuple[list[AssetPrice], dict[str, str]]:
+        """CoinGecko leg. Returns ``(prices, {symbol: named failure reason})``.
+
+        Behavior for a symbol CoinGecko DOES serve is unchanged from the
+        pre-#1710 implementation, down to the URL and the ``source`` string.
+        What changed is that a failure now produces a reason string the caller
+        can attribute to the symbol, instead of only a log line that the push
+        loop never sees.
+        """
+        results: list[AssetPrice] = []
+        reasons: dict[str, str] = {}
         try:
             async with aiohttp.ClientSession() as session:
-                for symbol, cg_id in CRYPTO_MAP.items():
+                for symbol, cg_id in wanted.items():
                     try:
                         url = f"https://api.coingecko.com/api/v3/simple/price?ids={cg_id}&vs_currencies=usd"
                         async with session.get(url) as resp:
@@ -1054,11 +1253,78 @@ class OracleUpdater:
                                         source="coingecko",
                                     )
                                 )
+                            else:
+                                reasons[symbol] = f"coingecko HTTP {resp.status} for id {cg_id!r}"
                     except Exception as e:
                         logger.warning(f"Failed to fetch {symbol} from CoinGecko: {e}")
+                        reasons[symbol] = f"coingecko fetch failed for id {cg_id!r}: {e}"
         except Exception as e:
             logger.warning(f"Crypto fetch error: {e}")
-        return results
+            for symbol, cg_id in wanted.items():
+                reasons.setdefault(symbol, f"coingecko session error (id {cg_id!r}): {e}")
+        return results, reasons
+
+    async def _fetch_crypto_provider(
+        self, wanted: list[str], timestamp: datetime
+    ) -> tuple[list[AssetPrice], dict[str, str]]:
+        """Market-data-provider leg (#1218 seam) for crypto. Returns
+        ``(prices, {symbol: named failure reason})``.
+
+        Uses the same batched intraday call the equity leg uses
+        (``get_intraday_quotes_batch``) so the two legs share one vendor
+        abstraction rather than two. Like ``_fetch_yfinance``, this stamps the
+        POLL time rather than the vendor's bar time — the known, tracked
+        honesty gap documented on that method (a bar-time change is split out
+        to its own review because it would stop every off-hours push), and
+        keeping the two legs identical here means this change cannot quietly
+        alter what ``_validate_for_push``'s staleness gate compares.
+
+        A provider that cannot serve intraday at all (``TiingoProvider`` raises
+        ``NotImplementedError`` — the ADR's stated "live oracle push is not
+        cutover-ready" consequence) is reported by name for every requested
+        symbol rather than swallowed.
+        """
+        from archimedes.services.market_data_provider import get_provider, provider_name
+
+        results: list[AssetPrice] = []
+        reasons: dict[str, str] = {}
+
+        tickers = {s: CRYPTO_VENDOR_TICKERS[s] for s in wanted if s in CRYPTO_VENDOR_TICKERS}
+        for symbol in wanted:
+            if symbol not in CRYPTO_VENDOR_TICKERS:
+                reasons[symbol] = "no vendor ticker mapped in CRYPTO_VENDOR_TICKERS — provider leg cannot ask for it"
+        if not tickers:
+            return results, reasons
+
+        name = provider_name()
+        try:
+            quotes = await asyncio.to_thread(get_provider().get_intraday_quotes_batch, tickers)
+        except NotImplementedError as e:
+            for symbol, ticker in tickers.items():
+                reasons[symbol] = (
+                    f"provider {name!r} does not implement intraday quotes for {ticker} "
+                    f"(daily bars only — see docs/adr/market-data-sourcing.md): {e}"
+                )
+            logger.warning(
+                "crypto provider leg unavailable: MARKET_DATA_PROVIDER=%s cannot serve intraday quotes (%s)",
+                name,
+                e,
+            )
+            return results, reasons
+        except Exception as e:
+            for symbol, ticker in tickers.items():
+                reasons[symbol] = f"provider {name!r} fetch failed for {ticker}: {e}"
+            logger.warning("crypto provider leg failed (provider=%s): %s", name, e)
+            return results, reasons
+
+        for symbol, ticker in tickers.items():
+            quote = quotes.get(symbol)
+            if quote is None:
+                reasons[symbol] = f"provider {name!r} returned no observation for {ticker}"
+                continue
+            price = quote[0] if isinstance(quote, tuple) else quote
+            results.append(AssetPrice(symbol=symbol, price_usd=price, timestamp=timestamp, source=name))
+        return results, reasons
 
     async def _fetch_yfinance_single(self, symbol: str) -> tuple[float, datetime] | None:
         """Fetch a single provider price + its bar timestamp (e.g. VIX, or the

--- a/backend/archimedes/services/strategy_signal_evaluator.py
+++ b/backend/archimedes/services/strategy_signal_evaluator.py
@@ -610,11 +610,20 @@ def _fetch_price_history(symbol: str, period: str = "2y") -> pd.Series:
     yf_ticker = entry[0]
 
     try:
-        from archimedes.services.market_data_provider import get_provider
+        from archimedes.services.market_data_provider import get_provider, provider_name
 
         fetched = get_provider().get_daily_close_batch({symbol: yf_ticker}, period=period)
         close = fetched.get(symbol)
         if close is None or close.empty:
+            # Named, never silent (#1710) — same reason as the batch path below.
+            logger.warning(
+                "market-data gap: no price history for %s (%s) from provider %r (period=%s) — "
+                "EXCLUDED, no series synthesized.",
+                symbol,
+                yf_ticker,
+                provider_name(),
+                period,
+            )
             return pd.Series(dtype=float)
         close = close.copy()
         close.name = symbol
@@ -680,6 +689,30 @@ def _fetch_price_histories(
         series.name = synth
         _cache_put(synth, series)
         result[synth] = series
+
+    # Name the symbols the vendor had NO data for (#1710). The seam's
+    # documented per-item-skip contract leaves an unfetchable ticker simply
+    # ABSENT from `fetched`, so before this the only trace was whatever the
+    # vendor library itself chose to print — for yfinance, a bare
+    # "possibly delisted; no price data found" ERROR carrying vendor tickers
+    # and no synth symbols, no provider name and no indication that the
+    # evaluator then ran a strategy over a universe missing those names. This
+    # line is the operator-legible half: which synths, which vendor tickers,
+    # which provider. Excluded, never padded or forward-filled.
+    missing = sorted(set(ticker_for_synth) - set(result))
+    if missing:
+        from archimedes.services.market_data_provider import provider_name
+
+        logger.warning(
+            "market-data gap: no price history for %d/%d requested symbols from provider %r "
+            "(period=%s) — %s. These symbols are EXCLUDED from signal evaluation this run; "
+            "no series is synthesized to replace them.",
+            len(missing),
+            len(ticker_for_synth),
+            provider_name(),
+            period,
+            ", ".join(f"{s}({ticker_for_synth[s]})" for s in missing),
+        )
 
     return result
 

--- a/backend/tests/chain/test_oracle_crypto_source.py
+++ b/backend/tests/chain/test_oracle_crypto_source.py
@@ -1,0 +1,334 @@
+"""Oracle crypto source cascade + named push exclusions (#1710).
+
+Target: backend/archimedes/chain/oracle_updater.py
+
+Two defects this pins, both reported by #1710's runner log:
+
+1. **The crypto leg was off the vendor seam entirely.** It called CoinGecko
+   directly with no fallback, so `docs/adr/market-data-sourcing.md`'s
+   "reversible by build — one env var selects the vendor" property did not
+   hold for the prices this runner actually pushes on-chain.
+2. **A starved symbol vanished silently.** A symbol no source could price was
+   simply absent from `fetch_prices()`'s result. `push_prices_on_chain` never
+   saw it, so it logged no rejection (that path only fires for a price that
+   EXISTS and fails a gate) and nothing else logged an exclusion either — the
+   on-chain oracle aged past MAX_STALENESS with no log line naming the symbol,
+   which is precisely why the ALARM had no grep-able cause.
+
+Hermetic: the aiohttp CoinGecko boundary and the market-data provider seam are
+both mocked. No network.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from archimedes.chain.oracle_updater import (
+    CRYPTO_MAP,
+    CRYPTO_VENDOR_TICKERS,
+    OracleUpdater,
+    _crypto_source_order,
+)
+
+
+@pytest.fixture
+def updater() -> OracleUpdater:
+    return OracleUpdater()
+
+
+def _coingecko_session(*, status: int = 200, payload: dict | None = None, raises: Exception | None = None):
+    """A mocked `aiohttp.ClientSession` context manager for the CoinGecko leg."""
+    if raises is not None:
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(side_effect=raises)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+        return session_cm
+
+    resp = MagicMock(status=status)
+    resp.json = AsyncMock(return_value=payload or {})
+    get_cm = MagicMock()
+    get_cm.__aenter__ = AsyncMock(return_value=resp)
+    get_cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=get_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return session_cm
+
+
+def _provider(quotes: dict[str, tuple[float, datetime]] | None = None, raises: Exception | None = None):
+    """A fake MarketDataProvider for the seam leg."""
+    fake = MagicMock()
+    if raises is not None:
+        fake.get_intraday_quotes_batch = MagicMock(side_effect=raises)
+    else:
+        fake.get_intraday_quotes_batch = MagicMock(return_value=quotes or {})
+    return fake
+
+
+class TestCryptoSourceOrder:
+    def test_default_is_coingecko_primary_with_provider_fallback(self, monkeypatch):
+        monkeypatch.delenv("ORACLE_CRYPTO_SOURCE", raising=False)
+        assert _crypto_source_order() == ("coingecko", "provider")
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("coingecko_only", ("coingecko",)),
+            ("provider", ("provider", "coingecko")),
+            ("provider_only", ("provider",)),
+            ("  PROVIDER  ", ("provider", "coingecko")),  # case/space tolerant
+        ],
+    )
+    def test_modes_parse(self, monkeypatch, value, expected):
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", value)
+        assert _crypto_source_order() == expected
+
+    def test_unknown_value_fails_safe_to_default(self, monkeypatch, caplog):
+        """A config typo must not crash a funds-adjacent singleton runner."""
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "tiingo-ish")
+        with caplog.at_level("WARNING"):
+            assert _crypto_source_order() == ("coingecko", "provider")
+        assert "unknown ORACLE_CRYPTO_SOURCE" in caplog.text
+
+
+class TestCryptoCascade:
+    async def test_default_mode_happy_path_is_unchanged_coingecko(self, updater, monkeypatch):
+        """Deploying #1710 is a no-op when CoinGecko answers: same price, same
+        `source`, and the provider seam is never consulted."""
+        monkeypatch.delenv("ORACLE_CRYPTO_SOURCE", raising=False)
+        fake_provider = _provider({"sBTC": (99999.0, datetime.now(UTC))})
+        with (
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(payload={"bitcoin": {"usd": 64000.0}}),
+            ),
+            patch("archimedes.services.market_data_provider.get_provider", return_value=fake_provider),
+        ):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+
+        assert {r.symbol: (r.price_usd, r.source) for r in results} == {"sBTC": (64000.0, "coingecko")}
+        fake_provider.get_intraday_quotes_batch.assert_not_called()
+        assert updater._source_miss_reasons == {}
+
+    async def test_coingecko_miss_falls_through_to_the_provider_seam(self, updater, monkeypatch):
+        """THE FIX. Old behavior: a CoinGecko failure returned [] and the symbol
+        was dropped from the push cycle. New: the seam serves it, stamped with
+        the TRUE vendor name (never "coingecko")."""
+        monkeypatch.delenv("ORACLE_CRYPTO_SOURCE", raising=False)
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "yfinance")
+        fake_provider = _provider({"sBTC": (63500.25, datetime.now(UTC))})
+        with (
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(raises=RuntimeError("coingecko 429")),
+            ),
+            patch("archimedes.services.market_data_provider.get_provider", return_value=fake_provider),
+        ):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+
+        assert [(r.symbol, r.price_usd, r.source) for r in results] == [("sBTC", 63500.25, "yfinance")]
+        fake_provider.get_intraday_quotes_batch.assert_called_once_with(CRYPTO_VENDOR_TICKERS)
+        assert updater._source_miss_reasons == {}
+
+    async def test_coingecko_only_never_touches_the_seam(self, updater, monkeypatch):
+        """The escape hatch back to literal pre-#1710 behavior."""
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "coingecko_only")
+        fake_provider = _provider({"sBTC": (1.0, datetime.now(UTC))})
+        with (
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(raises=RuntimeError("coingecko down")),
+            ),
+            patch("archimedes.services.market_data_provider.get_provider", return_value=fake_provider),
+        ):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+
+        assert results == []
+        fake_provider.get_intraday_quotes_batch.assert_not_called()
+        assert "sBTC" in updater._source_miss_reasons
+
+    async def test_provider_mode_asks_the_seam_first(self, updater, monkeypatch):
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "provider")
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "yfinance")
+        fake_provider = _provider({"sBTC": (64100.0, datetime.now(UTC))})
+        session = _coingecko_session(payload={"bitcoin": {"usd": 1.0}})
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session),
+            patch("archimedes.services.market_data_provider.get_provider", return_value=fake_provider),
+        ):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+
+        assert [(r.symbol, r.price_usd, r.source) for r in results] == [("sBTC", 64100.0, "yfinance")]
+
+    async def test_provider_that_cannot_serve_intraday_is_named_then_falls_back(self, updater, monkeypatch, caplog):
+        """`TiingoProvider.get_intraday_quotes_batch` raises NotImplementedError
+        (daily bars only — the ADR's "live oracle push is not cutover-ready").
+        That refusal must be reported BY NAME, not swallowed, and must not
+        prevent CoinGecko from serving."""
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "provider")
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "tiingo")
+        fake_provider = _provider(
+            raises=NotImplementedError("TiingoProvider.get_intraday_quotes_batch is out of scope")
+        )
+        with (
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(payload={"bitcoin": {"usd": 64000.0}}),
+            ),
+            patch("archimedes.services.market_data_provider.get_provider", return_value=fake_provider),
+            caplog.at_level("WARNING"),
+        ):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+
+        assert [(r.symbol, r.source) for r in results] == [("sBTC", "coingecko")]
+        assert "tiingo" in caplog.text
+        assert "cannot serve intraday quotes" in caplog.text
+
+    async def test_provider_only_with_tiingo_prices_nothing_and_never_fabricates(self, updater, monkeypatch):
+        """Licensing-strict mode: a miss stays a miss. No CoinGecko fill-in, no
+        invented price — the symbol is simply absent, with a named reason."""
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "provider_only")
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "tiingo")
+        fake_provider = _provider(raises=NotImplementedError("daily bars only"))
+        session = _coingecko_session(payload={"bitcoin": {"usd": 64000.0}})
+        with (
+            patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session),
+            patch("archimedes.services.market_data_provider.get_provider", return_value=fake_provider),
+        ):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+
+        assert results == []
+        session.__aenter__.assert_not_awaited()
+        reason = updater._source_miss_reasons["sBTC"]
+        assert "tiingo" in reason
+        assert "does not implement intraday quotes" in reason
+
+    async def test_every_source_exhausted_records_a_named_reason(self, updater, monkeypatch):
+        monkeypatch.delenv("ORACLE_CRYPTO_SOURCE", raising=False)
+        monkeypatch.setenv("MARKET_DATA_PROVIDER", "yfinance")
+        with (
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(status=503),
+            ),
+            patch("archimedes.services.market_data_provider.get_provider", return_value=_provider({})),
+        ):
+            results = await updater._fetch_crypto(datetime.now(UTC))
+
+        assert results == []
+        reason = updater._source_miss_reasons["sBTC"]
+        assert "coingecko HTTP 503" in reason
+        assert "returned no observation for BTC-USD" in reason
+        assert "coingecko→provider" in reason
+
+
+class TestNamedPushExclusions:
+    """`fetch_prices` must name every push-set symbol it produced no price for.
+
+    This is the grep the issue's acceptance criterion depends on ("no
+    push-universe symbol whose source errored in the prior 24h").
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_admin_pins(self, monkeypatch):
+        """Admin price overrides are applied on top of every mode and would
+        otherwise supply a symbol this test expects to be starved."""
+        monkeypatch.delenv("ADMIN_PRICES_JSON", raising=False)
+
+    async def test_starved_symbol_is_named_and_not_fabricated(self, updater, monkeypatch, caplog):
+        monkeypatch.setenv("PRICE_SOURCE", "yfinance")
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "coingecko_only")
+        with (
+            patch.object(updater, "_fetch_yfinance", return_value=[]),
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(raises=RuntimeError("coingecko down")),
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            prices = await updater.fetch_prices()
+
+        # Nothing invented to fill the gap.
+        assert prices == []
+        # Every push-set symbol is named as EXCLUDED, with a reason.
+        for symbol in {"sSPY"} | set(CRYPTO_MAP):
+            assert f"oracle push exclusion: {symbol} EXCLUDED" in caplog.text
+        assert "No price fabricated or substituted" in caplog.text
+        assert "coingecko down" in caplog.text
+
+    async def test_no_exclusion_line_when_every_symbol_priced(self, updater, monkeypatch, caplog):
+        monkeypatch.setenv("PRICE_SOURCE", "yfinance")
+        monkeypatch.delenv("ORACLE_CRYPTO_SOURCE", raising=False)
+        now = datetime.now(UTC)
+        from archimedes.models.asset import AssetPrice
+
+        with (
+            patch.object(
+                updater,
+                "_fetch_yfinance",
+                return_value=[AssetPrice(symbol="sSPY", price_usd=500.0, timestamp=now, source="yfinance")],
+            ),
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(payload={"bitcoin": {"usd": 64000.0}}),
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            prices = await updater.fetch_prices()
+
+        assert {p.symbol for p in prices} == {"sSPY", "sBTC"}
+        assert "oracle push exclusion" not in caplog.text
+
+    async def test_reasons_do_not_leak_across_cycles(self, updater, monkeypatch, caplog):
+        """A symbol that failed LAST cycle and succeeds this one must not carry
+        a stale reason — the bookkeeping is per-cycle."""
+        monkeypatch.setenv("PRICE_SOURCE", "yfinance")
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "coingecko_only")
+        with (
+            patch.object(updater, "_fetch_yfinance", return_value=[]),
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(raises=RuntimeError("transient")),
+            ),
+        ):
+            await updater.fetch_prices()
+        assert "sBTC" in updater._source_miss_reasons
+
+        now = datetime.now(UTC)
+        from archimedes.models.asset import AssetPrice
+
+        with (
+            patch.object(
+                updater,
+                "_fetch_yfinance",
+                return_value=[AssetPrice(symbol="sSPY", price_usd=500.0, timestamp=now, source="yfinance")],
+            ),
+            patch(
+                "archimedes.chain.oracle_updater.aiohttp.ClientSession",
+                return_value=_coingecko_session(payload={"bitcoin": {"usd": 64000.0}}),
+            ),
+        ):
+            await updater.fetch_prices()
+        assert updater._source_miss_reasons == {}
+
+
+class TestVendorTickerMapParity:
+    def test_every_crypto_push_symbol_has_a_vendor_ticker(self):
+        """A CRYPTO_MAP entry with no CRYPTO_VENDOR_TICKERS row can never reach
+        the seam — the provider leg would report "no vendor ticker mapped" for
+        it forever. Adding a crypto synth to the push set must add both."""
+        assert set(CRYPTO_MAP) <= set(CRYPTO_VENDOR_TICKERS)
+
+    def test_vendor_tickers_use_the_ssot_crypto_shape(self):
+        """`TiingoProvider._classify_tiingo_ticker` routes to the crypto
+        endpoint family by the `<BASE>-USD` shape, and that is also the shape
+        `synthetic_universe.json` stores. A ticker in any other shape would be
+        silently classified as an EQUITY and fetched from the wrong endpoint."""
+        from archimedes.services.market_data_provider import _classify_tiingo_ticker
+
+        for symbol, ticker in CRYPTO_VENDOR_TICKERS.items():
+            assert _classify_tiingo_ticker(ticker) == "crypto", f"{symbol} → {ticker}"

--- a/backend/tests/chain/test_oracle_updater_fetch.py
+++ b/backend/tests/chain/test_oracle_updater_fetch.py
@@ -150,14 +150,27 @@ class TestFetchCrypto:
         by_symbol = {r.symbol: r.price_usd for r in results}
         assert by_symbol["sBTC"] == 64000.0
 
-    async def test_coingecko_error_is_swallowed(self, updater):
-        # A non-200 / raising session must not crash — returns [] for that symbol.
+    async def test_coingecko_error_is_swallowed(self, updater, monkeypatch):
+        """A raising session must not crash the cycle.
+
+        Pinned to ``ORACLE_CRYPTO_SOURCE=coingecko_only`` (#1710) so this keeps
+        asserting exactly what it always asserted — the CoinGecko leg alone,
+        returning [] on failure. The DEFAULT mode now consults the provider
+        seam after a CoinGecko miss, which is a different contract and is
+        covered by ``test_oracle_crypto_source.py``; leaving this test on the
+        default would silently turn it into a LIVE yfinance fetch (it has no
+        provider double), which is both non-hermetic and no longer a test of
+        this leg.
+        """
+        monkeypatch.setenv("ORACLE_CRYPTO_SOURCE", "coingecko_only")
         session_cm = MagicMock()
         session_cm.__aenter__ = AsyncMock(side_effect=RuntimeError("network down"))
         session_cm.__aexit__ = AsyncMock(return_value=False)
         with patch("archimedes.chain.oracle_updater.aiohttp.ClientSession", return_value=session_cm):
             results = await updater._fetch_crypto(datetime.now(UTC))
         assert results == []
+        # Not silent: the symbol carries a named reason for _log_push_exclusions.
+        assert "network down" in updater._source_miss_reasons["sBTC"]
 
 
 class TestFetchMarketSnapshot:

--- a/docs/operations/feature-flag-fliplist.md
+++ b/docs/operations/feature-flag-fliplist.md
@@ -123,6 +123,7 @@ require them.
 | `PRICE_SOURCE` | mode selector | `"cascade"` in `infra/ecs.tf` (flipped 2026-07-04, Pyth live). Code default stays `"yfinance"` for local/CI safety. Reader: [`services/price_source.py:62`](../../backend/archimedes/services/price_source.py). |
 | `PRICE_CROSSCHECK_BAND_BPS` / `PRICE_CROSSCHECK_MAX_STALENESS_SECONDS` | tunable | 5000 bps (50%) / 345600 s (4 d). Only bite while `PRICE_SOURCE=cascade`. Band tuning owned by Önder. |
 | `MARKET_DATA_PROVIDER` | mode selector | Default `"yfinance"`. |
+| `ORACLE_CRYPTO_SOURCE` | mode selector | Default `"coingecko"` (CoinGecko primary, `MARKET_DATA_PROVIDER` seam as fallback). Also `coingecko_only` / `provider` / `provider_only`. Unset in `infra/*` — the default IS the pre-#1710 happy path. Reader: [`chain/oracle_updater.py`](../../backend/archimedes/chain/oracle_updater.py) (`_crypto_source_order`). **Gotcha:** `provider`/`provider_only` with `MARKET_DATA_PROVIDER=tiingo` cannot price this leg — Tiingo serves daily bars only and raises `NotImplementedError` for intraday. |
 | `GENERATION_PRICE_USD` | tunable | `"2.00"` in `infra/ecs.tf`. Flat `flat_v1` pricing until #1217's measured budget replaces it behind the same `quote()` seam. |
 | `GENERATION_PAYMENT_RECIPIENT` | required config | Terraform variable (#1414). Flag-on with no recipient is a deliberate 503, never a free pass. |
 | `GENERATION_DAILY_CAP_PER_USER` / `_PER_IP` | tunable | `100` / `200` in `infra/ecs.tf`. Both layers must pass; `<= 0` disables a layer. |


### PR DESCRIPTION
Closes #1710
Part of #1594

## What this fixes

Two defects in the runner's price-sourcing path, both of which the issue's log
line is a symptom of:

1. **The oracle push's crypto leg was outside the `MARKET_DATA_PROVIDER` seam
   entirely** — a hardcoded CoinGecko call with no fallback. The market-data
   ADR's "reversible by build: a new vendor is one class plus one env var" is
   simply not true of this leg today; the ADR names `chain.oracle_updater` as a
   seam call site, and the crypto half never was one.
2. **A push-set symbol no source could price vanished silently.** It never
   entered `push_prices_on_chain`'s loop, so no rejection line fired (that path
   only runs for a price that *exists* and fails a gate), and nothing else
   logged an exclusion — while its on-chain oracle aged past `MAX_STALENESS`
   and held `archimedes-oracle-stale` in ALARM with **no grep-able cause**.
   The issue's acceptance criterion ("no push-universe symbol whose source
   errored in the prior 24h — runner-log grep") was not checkable, because
   there was nothing to grep for.

## First: a correction to the issue's diagnosis, with the evidence

**The five named tickers are not in the oracle push set, and cannot be what
holds `oracle_fresh` false.** Verified on `main`:

- `oracle_updater.YFINANCE_MAP` synth keys = `{sSPY}`; `CRYPTO_MAP` = `{sBTC}`.
- `oracle_health._push_set_symbols()` derives the probed set from exactly those
  two maps — `["sBTC", "sSPY"]`, pinned by
  `backend/tests/test_oracle_health_telemetry.py:92`.
- `sPOL`/`sIMX`/`sGRT`/`sSUI`/`sGMX` are 5 of the ~279 deployed-but-never-pushed
  oracles. `/health`'s `oracle_fresh` never reads them.

**Where the log line actually comes from:** `period=2y` is the tell. That is
`strategy_signal_evaluator._fetch_price_histories(..., period="2y")` — the
**agent** runner's signal evaluation over `GLOBAL_ASSETS`, not the oracle push.
`infra/runner-user-data.sh` ships both runners' stdout to the same
`/archimedes/runners` CloudWatch log group (streams `oracle` and `agent`), which
is how the two got read as one.

**But the failure class the issue reports is real in the push path**, on `sBTC`:
one hardcoded vendor, no fallback, and a miss that disappears without naming the
symbol. That is what this PR fixes, and it is why the fix is worth landing even
though the diagnosis needed correcting.

## Does Tiingo cover those five tickers? Yes — verified live, not assumed

Probed `https://api.tiingo.com/tiingo/crypto/prices` with the prod SSM token
(`/archimedes/prod/TIINGO_API_TOKEN`), `startDate=2026-08-25`,
`resampleFreq=1day`, read-only:

| ticker | Tiingo symbol | HTTP | daily bars returned |
|---|---|---|---|
| `POL-USD` | `polusd` | 200 | 8 (last close `0.09302` @ 2026-09-01) |
| `IMX-USD` | `imxusd` | 200 | 8 |
| `GRT-USD` | `grtusd` | 200 | 8 |
| `SUI-USD` | `suiusd` | 200 | 8 |
| `GMX-USD` | `gmxusd` | 200 | 8 |
| `BTC-USD` (control) | `btcusd` | 200 | 8 |

`TiingoProvider._classify_tiingo_ticker` already routes `<BASE>-USD` to the
crypto family and `_fetch_crypto_rows` already lower-cases and strips the dash,
so **no adapter change is needed for these five on the daily-bar surface.**

**Therefore: no universe change is proposed here, and none is needed.** The
issue offered "drop dead symbols from the push universe with documented reason"
as an option; the data says those symbols are not dead, yfinance just cannot see
them. Dropping them would remove real instruments to work around one vendor's
gap. **The owner decision this leaves open is the provider flip, not a universe
edit** — see "What is still owner's call" below.

## What changed

### 1. Crypto pricing joins the provider seam (`chain/oracle_updater.py`)

New `CRYPTO_VENDOR_TICKERS` (`sBTC → BTC-USD`) gives the crypto push symbols the
second coordinate they need to be askable through `MARKET_DATA_PROVIDER`.
`CRYPTO_MAP` is untouched and stays the push-set SSOT that `oracle_health` reads.

`_fetch_crypto` is now an ordered, named cascade selected by
`ORACLE_CRYPTO_SOURCE`:

| mode | order | note |
|---|---|---|
| `coingecko` | CoinGecko → provider seam | **default.** Happy path byte-for-byte unchanged (`source="coingecko"`, same URL). Only a *miss* behaves differently. |
| `coingecko_only` | CoinGecko | literal pre-PR behavior, escape hatch |
| `provider` | provider seam → CoinGecko | the flip to make once the provider serves intraday crypto |
| `provider_only` | provider seam | licensing-strict: the ADR's "never mix vendors" rule means a miss should be allowed to stay a miss rather than be filled from a free API |

Every price keeps its **true** `source` (`"coingecko"` or `provider_name()`), so
the #775 cross-check's "same source → skip" logic still works. Unknown env value
fails safe to the default with a warning — a config typo must not crash a
funds-adjacent singleton.

**Honest limit, stated because it is load-bearing:** with
`MARKET_DATA_PROVIDER=tiingo`, `TiingoProvider.get_intraday_quotes_batch` raises
`NotImplementedError` (daily bars only — exactly the ADR's "the live oracle push
… is not cutover-ready" consequence). So `provider` mode with Tiingo logs that
refusal *by name* and CoinGecko serves; `provider_only` prices nothing and logs
the symbol as excluded. **Tiingo does not price the oracle push today**, and this
PR does not claim otherwise.

### 2. Named push exclusions (`_log_push_exclusions`)

`fetch_prices` now ends by naming every push-set symbol it produced no price
for, at WARNING, with the recorded reason and an explicit statement that nothing
was fabricated. The push set is derived the *same* way `oracle_health` derives
the probed set, so the symbols that get a "why" line are exactly the symbols
`oracle_fresh` keys on. Reasons are per-cycle (cleared at the top of
`fetch_prices`) so last cycle's failure is never reported against this one.

### 3. The daily-bar path stops dropping symbols silently
(`services/strategy_signal_evaluator.py`)

`_fetch_price_histories` / `_fetch_price_history` now name the symbols the vendor
had no data for — synth symbol, vendor ticker, provider name, period — instead of
leaving only yfinance's own `possibly delisted; no price data found` ERROR, which
carries vendor tickers, no synth symbols, no provider, and no indication that a
strategy then ran over a universe missing those names. This is the line that would
have made #1710 self-diagnosing.

## Adversarial demo

Repro feeds the captured scenario — every push-set symbol's source returns no
data (CoinGecko unreachable for `sBTC`, provider returns `{}` for `sSPY`) — and
prints the runner log.

**BEFORE (`origin/main`, source file stashed):**

```
WARNING archimedes.chain.oracle_updater Crypto fetch error: coingecko unreachable (captured scenario)
INFO    archimedes.chain.oracle_updater Fetched 0 prices (source=yfinance)

>>> RESULT: 0 prices -> []
>>> A price was FABRICATED for a starved symbol: False
```

`sSPY` gets **no line at all**. `sBTC` gets a generic vendor warning that names
no symbol as excluded from the push. Nothing to grep; nothing tying either
symbol to the stale oracle.

**AFTER (this branch, same script, same mocks):**

```
WARNING ... Crypto fetch error: coingecko unreachable (captured scenario)
INFO    ... Fetched 0 prices (source=yfinance)
WARNING ... oracle push exclusion: sBTC EXCLUDED from this push cycle — crypto sources exhausted
          (ORACLE_CRYPTO_SOURCE order: coingecko→provider): coingecko session error (id 'bitcoin'):
          coingecko unreachable (captured scenario) | provider 'yfinance' returned no observation for
          BTC-USD. No price fabricated or substituted; the on-chain oracle keeps its previous value
          and will read stale until a source returns data for this symbol.
WARNING ... oracle push exclusion: sSPY EXCLUDED from this push cycle — provider 'yfinance' returned
          no intraday observation for SPY. No price fabricated or substituted; ...

>>> RESULT: 0 prices -> []
>>> A price was FABRICATED for a starved symbol: False
```

Both symbols named, both reasons named, both sources named, and the
no-fabrication property holds in both trees (it was never the defect — the
silence was).

### The guards were shown to reject

Per CLAUDE.md rule 4, each new guard was neutered and confirmed to fail:

1. **Remove the exclusion report** (`self._log_push_exclusions(prices)` → comment):
   `1 failed, 17 passed` —
   `TestNamedPushExclusions::test_starved_symbol_is_named_and_not_fabricated`
   `AssertionError: assert 'oracle push exclusion: sBTC EXCLUDED' in '...'`
2. **Remove the seam fallback** (`"coingecko": ("coingecko", "provider")` →
   `("coingecko",)`): `4 failed, 14 passed` — including
   `test_coingecko_miss_falls_through_to_the_provider_seam`
   `AssertionError: assert [] == [('sBTC', 635..., 'yfinance')]`.
3. New tests against the unfixed source file collect-error (the symbols do not
   exist on `main`), which is why demos 1 and 2 are surgical rather than a full
   revert.

### One pre-existing test had to change, and the reason matters

`test_oracle_updater_fetch.py::TestFetchCrypto::test_coingecko_error_is_swallowed`
failed on the first full-suite run with `assert [AssetPrice(...source='yfinance')] == []`.
It has no provider double, so under the new default mode it made a **live network
call to Yahoo**. Pinned to `ORACLE_CRYPTO_SOURCE=coingecko_only` so it keeps
testing exactly the leg it was written for and stays hermetic; the default-mode
contract is covered by the new file.

## Validation

```
/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest -m "not integration" -q
5546 passed, 3 skipped, 2 deselected in 511.26s
```
Rebased onto current `main` (`0569a8c4`) and re-run after the rebase — the 12
commits `main` gained mid-work touch only frontend/infra, no file in this diff.
`ruff format --check` and `ruff check` clean on every changed file.

## Deploy behavior

**A deploy of this is a no-op on the happy path.** `ORACLE_CRYPTO_SOURCE` is
unset everywhere in `infra/`, the default is `coingecko`, and a successful
CoinGecko fetch produces the identical `AssetPrice` it did before. What changes
is what happens on a *miss*: a fallback is attempted, and the symbol is named if
nothing works.

## What is still owner's call (deliberately not decided here)

1. **`MARKET_DATA_PROVIDER=tiingo` for the daily-bar surface.** This is what
   would actually fix the five starved crypto tickers in the agent runner's
   signal evaluation — Tiingo has their data (verified above), yfinance does
   not. It is a global flip on a seam the ADR says is not cutover-ready for
   *other* surfaces (oracle push intraday, VIX/S&P regime reads, Explore's
   history modal all raise `NotImplementedError` under Tiingo), so it is not a
   flip to make inside this PR. Per-surface provider selection, or implementing
   the three declined methods, is the prerequisite — worth its own issue.
2. **Closing the intraday gap.** `GET /tiingo/crypto/top` returns real-time
   top-of-book with a `lastSaleTimestamp` (probed: HTTP 200 for
   `btcusd,polusd`) — the exact shape `get_intraday_quotes_batch` needs. That
   would make `ORACLE_CRYPTO_SOURCE=provider` a real option rather than a
   documented refusal. Separate PR: it changes the Tiingo adapter's declared
   surface and touches the licensing posture the ADR gates.
3. **The alarm's scope.** Nothing here mutes anything. `oracle_fresh` still keys
   on the oldest of `{sBTC, sSPY}` and #1594's probe-timeout latency remains the
   other live contributor to `archimedes-oracle-stale`.

## Anti-goals honored

- No alarm muting, no threshold widening, no change to `_push_set_symbols`.
- No fabricated, defaulted or carried-forward price — asserted in the demo and
  in `test_provider_only_with_tiingo_prices_nothing_and_never_fabricates`.
- No universe change (and the data says none is warranted).
- No ADR relitigated: the "not cutover-ready" and "never mix vendors"
  consequences are honored, not worked around.
