### PR TITLE
Fix prod cookie-name P0: accept __Secure- and bare session cookie names

### DIFF
--- a/cli/src/archimedes_cli/cli.py
+++ b/cli/src/archimedes_cli/cli.py
@@ -33,7 +33,7 @@ import click
 import httpx
 
 from . import __version__, exits
-from .session import SESSION_COOKIE_NAME, load_session, save_session
+from .session import load_session, pick_session_cookie, save_session
 
 DEFAULT_API_URL = "https://archimedes-arc.com"
 
@@ -278,8 +278,8 @@ def login(api_url: str, as_json: bool) -> None:
             message=f"sign-in failed: HTTP {response.status_code}: {_response_detail(response)}",
         )
 
-    token = response.cookies.get(SESSION_COOKIE_NAME)
-    if not token:
+    picked = pick_session_cookie(response.cookies)
+    if picked is None:
         _fail(
             "login",
             as_json=as_json,
@@ -287,11 +287,14 @@ def login(api_url: str, as_json: bool) -> None:
             error="no_session_cookie",
             message="sign-in succeeded but the server did not return a session cookie",
         )
+    cookie_name, token = picked
 
     # Confirm the cookie actually round-trips, and read back the canonical account email,
-    # before trusting it — mirrors scripts/agent_journey.py's step_auth.
+    # before trusting it — mirrors scripts/agent_journey.py's step_auth. Sent back under
+    # the SAME name it arrived as: a prod cookie is `__Secure-`-prefixed and a local one
+    # is bare, and only the name it was actually issued under will round-trip.
     try:
-        with _http_client(api_url, cookies={SESSION_COOKIE_NAME: token}) as client:
+        with _http_client(api_url, cookies={cookie_name: token}) as client:
             session_response = client.get("/api/auth/get-session")
         session_payload = session_response.json() if session_response.is_success else None
     except (httpx.HTTPError, ValueError):
@@ -311,7 +314,7 @@ def login(api_url: str, as_json: bool) -> None:
             message="signed in, but the session cookie did not round-trip on GET /api/auth/get-session",
         )
 
-    path = save_session(api_url=api_url, cookies={SESSION_COOKIE_NAME: token}, email=confirmed_email)
+    path = save_session(api_url=api_url, cookies={cookie_name: token}, email=confirmed_email)
 
     if as_json:
         click.echo(json.dumps({"ok": True, "email": confirmed_email}))

--- a/cli/src/archimedes_cli/session.py
+++ b/cli/src/archimedes_cli/session.py
@@ -8,6 +8,15 @@ sets, forwarded verbatim on later requests. The CLI never parses or validates th
 itself — same division of responsibility as the server side, which also never parses it and
 just forwards it to Better Auth's ``/api/auth/get-session``
 (``backend/archimedes/api/account_auth.py``, ``_fetch_session``).
+
+**Two names, one cookie.** Better Auth issues :data:`SECURE_SESSION_COOKIE_NAME`
+(``__Secure-better-auth.session_token``) on any deploy with ``useSecureCookies: true``
+(``auth/auth.js`` sets that from ``production`` — so every HTTPS deploy, including
+``archimedes-arc.com``) and the bare :data:`SESSION_COOKIE_NAME` everywhere else, because
+the ``__Secure-`` prefix cannot legally be set without TLS. This module and
+``archimedes_mcp.credentials`` both go through :func:`pick_session_cookie` rather than a
+single hardcoded name, so they work against local HTTP and production alike, and store
+back exactly the name+value pair that was actually issued.
 """
 
 from __future__ import annotations
@@ -17,9 +26,44 @@ import os
 from pathlib import Path
 
 SESSION_COOKIE_NAME = "better-auth.session_token"
-"""The cookie Better Auth issues on sign-in, matching the fragment
-``backend/archimedes/api/account_auth.py``'s ``_SESSION_COOKIE_FRAGMENT`` looks for
-(``"better-auth.session_token="``)."""
+"""The bare cookie name Better Auth issues on sign-in over plain HTTP — matching the
+fragment ``backend/archimedes/api/account_auth.py``'s ``_SESSION_COOKIE_FRAGMENT`` looks
+for (``"better-auth.session_token="``, which matches this name as a substring of either
+form below). This is the ONLY name a local ``docker compose`` stack can ever set: the
+``__Secure-`` prefix is a browser/client-enforced rule (RFC 6265bis) forbidding it without
+TLS, so local HTTP keeps using this bare name."""
+
+SECURE_SESSION_COOKIE_NAME = f"__Secure-{SESSION_COOKIE_NAME}"
+"""The name Better Auth issues instead, in production. ``auth/auth.js`` sets
+``useSecureCookies: production``, which prefixes every auth cookie with ``__Secure-``
+when the deploy is production — so ``archimedes-arc.com`` never sets the bare name above,
+it sets this one. A client that only recognized :data:`SESSION_COOKIE_NAME` could sign in
+against prod (``POST /api/auth/sign-in/email`` 200s) and then find no session cookie in
+the response at all — the #1653-adjacent P0 this module fixes."""
+
+SESSION_COOKIE_NAMES = (SECURE_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME)
+"""Both cookie names this CLI (and anything built on :func:`load_session`) accepts, in
+preference order. Secure-prefixed first because that is the one a real deployment
+actually sets; the bare name second so local HTTP keeps working. Never both at once in
+practice — a given host's Better Auth config sets exactly one — but checking in this
+order means whichever one shows up is picked without the caller having to know which
+environment it is talking to."""
+
+
+def pick_session_cookie(cookies) -> tuple[str, str] | None:
+    """The session cookie in ``cookies``, as ``(name, value)`` — or ``None`` if neither
+    name in :data:`SESSION_COOKIE_NAMES` is present with a non-empty string value.
+
+    ``cookies`` is anything with a ``.get(name)`` — an ``httpx.Cookies`` (reading a
+    sign-in response) or a plain ``dict`` (reading the cached session file) both work.
+    Checked in :data:`SESSION_COOKIE_NAMES` order, so the ``__Secure-`` prefixed name
+    wins when both are somehow present; returns the first match, never a merge of both.
+    """
+    for name in SESSION_COOKIE_NAMES:
+        value = cookies.get(name)
+        if isinstance(value, str) and value:
+            return name, value
+    return None
 
 
 def session_path() -> Path:
@@ -76,4 +120,12 @@ def save_session(*, api_url: str, cookies: dict[str, str], email: str) -> Path:
     return path
 
 
-__all__ = ["SESSION_COOKIE_NAME", "load_session", "save_session", "session_path"]
+__all__ = [
+    "SECURE_SESSION_COOKIE_NAME",
+    "SESSION_COOKIE_NAME",
+    "SESSION_COOKIE_NAMES",
+    "load_session",
+    "pick_session_cookie",
+    "save_session",
+    "session_path",
+]

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -24,7 +24,7 @@ import pytest
 from archimedes_cli import __version__
 from archimedes_cli.cli import main
 from archimedes_cli.exits import AUTH, GATE_FAILED, INCOMPLETE, NOT_IMPLEMENTED, OK, USAGE
-from archimedes_cli.session import SESSION_COOKIE_NAME, save_session, session_path
+from archimedes_cli.session import SECURE_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, save_session, session_path
 from click.testing import CliRunner
 
 # ── Fixtures & test-only helpers ────────────────────────────────────────
@@ -196,12 +196,12 @@ _VERIFY_NOT_EVALUABLE_BODY = {
 }
 
 
-def _login_ok_route(*, cookie: str = "tok123", email: str = "dan@example.com"):
+def _login_ok_route(*, cookie: str = "tok123", email: str = "dan@example.com", cookie_name: str = SESSION_COOKIE_NAME):
     return {
         ("POST", "/api/auth/sign-in/email"): httpx.Response(
             200,
             json={"redirect": False},
-            headers=[("set-cookie", f"{SESSION_COOKIE_NAME}={cookie}; Path=/; HttpOnly")],
+            headers=[("set-cookie", f"{cookie_name}={cookie}; Path=/; HttpOnly")],
         ),
         ("GET", "/api/auth/get-session"): httpx.Response(
             200,
@@ -310,6 +310,88 @@ class TestLogin:
         cached = json.loads(session_path().read_text())
         assert cached["email"] == "dan@example.com"
         assert cached["cookies"][SESSION_COOKIE_NAME] == "tok123"
+
+    def test_login_accepts_the_secure_prefixed_cookie_production_actually_sets(self, runner, monkeypatch):
+        """The P0 this fix closes: production sets `__Secure-better-auth.session_token`
+        (Better Auth's `useSecureCookies: production`, `auth/auth.js`), never the bare
+        name. A client that only recognized the bare name would report
+        `no_session_cookie` on every real login against archimedes-arc.com."""
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "correct horse battery staple")
+        _install_transport(
+            monkeypatch,
+            _route(_login_ok_route(cookie="tok-secure", cookie_name=SECURE_SESSION_COOKIE_NAME)),
+        )
+
+        result = runner.invoke(main, ["login", "--json"])
+
+        assert result.exit_code == OK
+        assert json.loads(result.stdout) == {"ok": True, "email": "dan@example.com"}
+
+        cached = json.loads(session_path().read_text())
+        assert cached["cookies"] == {SECURE_SESSION_COOKIE_NAME: "tok-secure"}
+        assert SESSION_COOKIE_NAME not in cached["cookies"]
+
+    def test_login_round_trips_the_secure_cookie_under_its_own_name_not_the_bare_one(self, runner, monkeypatch):
+        """Adversarial: proves the round-trip GET /api/auth/get-session is sent the cookie
+        under the NAME IT WAS ISSUED AS, not a hardcoded bare name. A build that hardcoded
+        `SESSION_COOKIE_NAME` for the round trip would send no recognizable cookie here,
+        get-session would report nobody signed in, and login would wrongly fail
+        `session_not_confirmed` even though sign-in issued a good `__Secure-` cookie."""
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "whatever")
+
+        def get_session(request: httpx.Request) -> httpx.Response:
+            jar = dict(
+                pair.strip().split("=", 1) for pair in request.headers.get("cookie", "").split(";") if "=" in pair
+            )
+            if jar.get(SECURE_SESSION_COOKIE_NAME) != "tok-secure":
+                return httpx.Response(200, json={"user": None, "session": None})
+            return httpx.Response(
+                200, json={"user": {"id": "u1", "email": "dan@example.com", "name": "Dan"}, "session": {"id": "s1"}}
+            )
+
+        _install_transport(
+            monkeypatch,
+            _route(
+                {
+                    ("POST", "/api/auth/sign-in/email"): httpx.Response(
+                        200,
+                        json={"redirect": False},
+                        headers=[("set-cookie", f"{SECURE_SESSION_COOKIE_NAME}=tok-secure; Path=/; Secure; HttpOnly")],
+                    ),
+                    ("GET", "/api/auth/get-session"): get_session,
+                }
+            ),
+        )
+
+        result = runner.invoke(main, ["login", "--json"])
+        assert result.exit_code == OK
+        assert json.loads(result.stdout) == {"ok": True, "email": "dan@example.com"}
+        assert json.loads(session_path().read_text())["cookies"] == {SECURE_SESSION_COOKIE_NAME: "tok-secure"}
+
+    def test_adversarial_an_unrelated_cookie_is_not_mistaken_for_the_session(self, runner, monkeypatch):
+        """A Set-Cookie for something that is neither recognized name (a CSRF token, a
+        load-balancer affinity cookie) must not be picked up as the session — this is
+        the input that should fail `pick_session_cookie` and it must fail closed."""
+        monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
+        monkeypatch.setenv("ARCHIMEDES_PASSWORD", "whatever")
+        _install_transport(
+            monkeypatch,
+            _route(
+                {
+                    ("POST", "/api/auth/sign-in/email"): httpx.Response(
+                        200,
+                        json={"redirect": False},
+                        headers=[("set-cookie", "csrf_token=irrelevant; Path=/")],
+                    ),
+                }
+            ),
+        )
+        result = runner.invoke(main, ["login", "--json"])
+        assert result.exit_code == AUTH
+        assert json.loads(result.stdout)["error"] == "no_session_cookie"
+        assert not session_path().exists()
 
     def test_session_file_is_written_mode_600(self, runner, monkeypatch):
         monkeypatch.setenv("ARCHIMEDES_EMAIL", "dan@example.com")
@@ -452,6 +534,27 @@ class TestMeter:
         result = runner.invoke(main, ["meter", "--json"])
         assert result.exit_code == OK
         assert f"{SESSION_COOKIE_NAME}=tok-xyz" in seen["cookie"]
+
+    def test_sends_a_secure_prefixed_cached_cookie_under_its_own_name(self, runner, monkeypatch):
+        """A session cached from a production login (`__Secure-`-prefixed) must reach the
+        wire under that same name — nothing downstream of `load_session` may special-case
+        or rewrite the bare name, because rewriting it is exactly what would make prod
+        reject the request."""
+        save_session(
+            api_url="https://archimedes-arc.com",
+            cookies={SECURE_SESSION_COOKIE_NAME: "tok-secure-xyz"},
+            email="dan@example.com",
+        )
+        seen = {}
+
+        def handler(request):
+            seen["cookie"] = request.headers.get("cookie", "")
+            return httpx.Response(200, json=_USAGE_BODY)
+
+        _install_transport(monkeypatch, handler)
+        result = runner.invoke(main, ["meter", "--json"])
+        assert result.exit_code == OK
+        assert f"{SECURE_SESSION_COOKIE_NAME}=tok-secure-xyz" in seen["cookie"]
 
     def test_human_table_renders_caps_and_price(self, runner, monkeypatch):
         _seed_session()

--- a/cli/tests/test_session_cookie_names.py
+++ b/cli/tests/test_session_cookie_names.py
@@ -1,0 +1,63 @@
+"""Unit coverage for ``archimedes_cli.session.pick_session_cookie`` and the two cookie
+name constants it picks between.
+
+Production sets the ``__Secure-``-prefixed cookie (Better Auth's ``useSecureCookies:
+production`` in ``auth/auth.js``); local HTTP can only ever set the bare name. Everything
+downstream of :func:`load_session` — this CLI's own commands and the MCP server's
+credential resolver — goes through :func:`pick_session_cookie` rather than a single
+hardcoded name, so this file is the one place that logic is pinned directly, independent
+of the HTTP-level login/meter tests in ``test_cli.py``.
+"""
+
+from __future__ import annotations
+
+from archimedes_cli.session import (
+    SECURE_SESSION_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
+    SESSION_COOKIE_NAMES,
+    pick_session_cookie,
+)
+
+
+def test_the_secure_name_is_the_bare_name_with_the_prefix():
+    assert f"__Secure-{SESSION_COOKIE_NAME}" == SECURE_SESSION_COOKIE_NAME
+
+
+def test_names_are_distinct_and_secure_is_preferred():
+    assert SESSION_COOKIE_NAME != SECURE_SESSION_COOKIE_NAME
+    assert SESSION_COOKIE_NAMES == (SECURE_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME)
+
+
+def test_picks_the_bare_cookie_local_http_sets():
+    assert pick_session_cookie({SESSION_COOKIE_NAME: "tok"}) == (SESSION_COOKIE_NAME, "tok")
+
+
+def test_picks_the_secure_prefixed_cookie_production_sets():
+    """This is the exact shape production returns and the bare-name-only reader missed —
+    the P0 this module fixes."""
+    assert pick_session_cookie({SECURE_SESSION_COOKIE_NAME: "tok"}) == (SECURE_SESSION_COOKIE_NAME, "tok")
+
+
+def test_prefers_the_secure_name_when_both_are_somehow_present():
+    cookies = {SESSION_COOKIE_NAME: "bare-value", SECURE_SESSION_COOKIE_NAME: "secure-value"}
+    assert pick_session_cookie(cookies) == (SECURE_SESSION_COOKIE_NAME, "secure-value")
+
+
+def test_adversarial_an_unrelated_cookie_name_is_not_picked_up():
+    """The input that should fail: a cookie jar holding something else entirely (a CSRF
+    token, a load-balancer affinity cookie) must not be mistaken for a session."""
+    assert pick_session_cookie({"csrf_token": "irrelevant", "other": "x"}) is None
+
+
+def test_adversarial_an_empty_value_is_not_a_session():
+    """A key present with an empty string is not a usable credential — same as absent."""
+    assert pick_session_cookie({SECURE_SESSION_COOKIE_NAME: ""}) is None
+
+
+def test_adversarial_a_non_string_value_is_not_a_session():
+    """Defensive against a malformed/corrupted cache (e.g. a stray int from bad JSON)."""
+    assert pick_session_cookie({SECURE_SESSION_COOKIE_NAME: 12345}) is None
+
+
+def test_empty_cookies_yield_nothing():
+    assert pick_session_cookie({}) is None

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -2,7 +2,7 @@
 
 > **status:** current
 > **owner:** Dan Browne
-> **updated:** 2026-08-31
+> **updated:** 2026-09-01
 
 You are an autonomous agent that has never seen this API. This page is the shortest
 deterministic path from "no account" to "a strategy running in a paper-trading ledger you
@@ -129,6 +129,7 @@ curl -sS $BASE/api/generate/quote
   "chain": "arcTestnet",
   "recipient": "0xffa7abba5f17cb8471ebf150bf808bd6fb8856c1",
   "dry_run": false,
+  "halted": false,
   "how": "POST /api/generate/start without a Payment-Signature header returns 402 with these requirements in the PAYMENT-REQUIRED header; sign them (x402 / Circle Gateway) and retry with Payment-Signature."
 }
 ```
@@ -136,7 +137,10 @@ curl -sS $BASE/api/generate/quote
 Public on purpose: price the run before you hold a session. **This is the one response on
 this page whose values are not illustrative** — the block above is what
 `https://archimedes-arc.com` actually returned on 2026-08-30, and those values decide
-whether the rest of the journey costs money.
+whether the rest of the journey costs money. `halted` is the operator kill switch
+(`services/generation_payment.py`'s `_payments_halted`) — `true` means an operator has
+frozen payments and `POST /api/generate/start` will 503 rather than take money it cannot
+honestly settle; it is orthogonal to `dry_run` and to `payment_required`.
 
 `payment_required` and `dry_run` are the runtime truth, and they are the truth *of the
 host you asked*:
@@ -208,9 +212,13 @@ curl -sS -c /tmp/agora.jar -X POST $BASE/api/auth/sign-in/email \
 { "redirect": false, "token": "…", "url": null, "user": { "id": "…", "email": "…", "…": "…" } }
 ```
 
-Sets `better-auth.session_token` (HttpOnly, `SameSite=Lax`, 7-day expiry). **Keep the jar
-for every remaining step.** The `token` in the body is not a bearer credential for this
-API — the cookie is what `require_current_user` reads.
+Sets a session cookie (HttpOnly, `SameSite=Lax`, 7-day expiry) — `__Secure-better-auth.session_token`
+on `https://archimedes-arc.com`, or bare `better-auth.session_token` on a local `http://`
+checkout, because production's HTTPS lets Better Auth apply the `__Secure-` cookie prefix
+(a browser-enforced rule that can't be satisfied without TLS) and local HTTP cannot. **Keep
+the jar for every remaining step** — `-c/-b` carries whichever name the server actually
+sent, so nothing below needs to know which one that was. The `token` in the body is not a
+bearer credential for this API — the cookie is what `require_current_user` reads.
 
 ### 4. Confirm the session
 

--- a/mcp-server/src/archimedes_mcp/contract.py
+++ b/mcp-server/src/archimedes_mcp/contract.py
@@ -64,7 +64,9 @@ AUTH_CREDENTIAL = "credential"
 
 CREDENTIAL_SOURCES = (
     "ARCHIMEDES_API_KEY  ->  Authorization: Bearer <key>",
-    "~/.config/archimedes/session.json  ->  the better-auth.session_token cookie `archimedes login` cached (mode 600)",
+    "~/.config/archimedes/session.json  ->  the session cookie `archimedes login` cached "
+    "(mode 600) -- __Secure-better-auth.session_token in production, "
+    "better-auth.session_token on local HTTP",
 )
 
 TOOLS: tuple[dict, ...] = (

--- a/mcp-server/src/archimedes_mcp/credentials.py
+++ b/mcp-server/src/archimedes_mcp/credentials.py
@@ -16,7 +16,11 @@ Two ways to authenticate as an account, in this order:
    ``archimedes_cli.session.load_session``: imported, not reimplemented. Copying that
    loader would mean two definitions of "is there a usable session", and the copy would be
    the one that drifts — the exact second-surface failure mode this whole server was
-   scoped to avoid.
+   scoped to avoid. That cookie is one of *two* names depending on which host issued it —
+   ``__Secure-better-auth.session_token`` in production, the bare
+   ``better-auth.session_token`` on local HTTP (``archimedes_cli.session`` picks between
+   them; see :func:`~archimedes_cli.session.pick_session_cookie`) — and this module sends
+   back exactly the name it was captured under, never a hardcoded one.
 
 **One credential goes on the wire, never two.** If both are present the API key wins here,
 and no ``Cookie`` header is sent at all. The server side pins the opposite precedence
@@ -34,7 +38,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 
-from archimedes_cli.session import SESSION_COOKIE_NAME, load_session, session_path
+from archimedes_cli.session import SESSION_COOKIE_NAME, load_session, pick_session_cookie, session_path
 
 API_KEY_ENV = "ARCHIMEDES_API_KEY"
 API_URL_ENV = "ARCHIMEDES_API_URL"
@@ -57,6 +61,12 @@ class Credential:
     kind: str
     source: str
     _secret: str = field(repr=False)
+    cookie_name: str = SESSION_COOKIE_NAME
+    """Which of ``SESSION_COOKIE_NAMES`` this secret was actually captured under —
+    ``__Secure-better-auth.session_token`` for a session cached against production,
+    the bare name for one cached against local HTTP. Meaningless (and ignored) for an
+    API-key credential; defaults to the bare name only because a dataclass field needs
+    *some* default, never read in that branch."""
 
     def auth_headers(self) -> dict[str, str]:
         """Headers that carry this credential. Empty for a cookie credential."""
@@ -65,9 +75,10 @@ class Credential:
         return {}
 
     def auth_cookies(self) -> dict[str, str]:
-        """Cookies that carry this credential. Empty for an API-key credential."""
+        """Cookies that carry this credential, under the name it was captured as.
+        Empty for an API-key credential."""
         if self.kind == KIND_SESSION_COOKIE:
-            return {SESSION_COOKIE_NAME: self._secret}
+            return {self.cookie_name: self._secret}
         return {}
 
     def __repr__(self) -> str:  # pragma: no cover - exercised via str()/f-string in tests
@@ -93,12 +104,15 @@ def resolve_credential() -> Credential | None:
     session = load_session()
     if session is None:
         return None
-    token = session["cookies"].get(SESSION_COOKIE_NAME)
-    if not isinstance(token, str) or not token:
+    picked = pick_session_cookie(session["cookies"])
+    if picked is None:
         # A cache holding some other cookie is not a session this API can use. Same
-        # fail-quiet posture as `load_session` itself.
+        # fail-quiet posture as `load_session` itself. Checks BOTH the `__Secure-`
+        # prefixed name (a session cached against production) and the bare one (local
+        # HTTP) — see `archimedes_cli.session.pick_session_cookie`.
         return None
-    return Credential(kind=KIND_SESSION_COOKIE, source=str(session_path()), _secret=token)
+    cookie_name, token = picked
+    return Credential(kind=KIND_SESSION_COOKIE, source=str(session_path()), _secret=token, cookie_name=cookie_name)
 
 
 def resolve_api_url(credential_session: dict | None = None) -> str:

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -36,11 +36,27 @@ def _isolated_env(tmp_path, monkeypatch):
 
 @pytest.fixture
 def cached_session(tmp_path):
-    """Write a session cache exactly as ``archimedes login`` would, and hand back the token."""
+    """Write a session cache exactly as ``archimedes login`` would against LOCAL HTTP
+    (the bare cookie name), and hand back the token."""
     from archimedes_cli.session import SESSION_COOKIE_NAME, save_session
 
     token = "SESSION-TOKEN-b8b1f0c2e5a94d17"
     save_session(api_url=TEST_API_URL, cookies={SESSION_COOKIE_NAME: token}, email="agent@example.test")
+    assert (Path(tmp_path) / ".config" / "archimedes" / "session.json").exists()
+    return token
+
+
+@pytest.fixture
+def cached_secure_session(tmp_path):
+    """The same, but as ``archimedes login`` would cache it against PRODUCTION — the
+    ``__Secure-``-prefixed cookie name Better Auth actually issues over HTTPS
+    (``useSecureCookies: production`` in ``auth/auth.js``). A separate fixture, not a
+    parametrization of ``cached_session`` above, so a test can assert on the exact name
+    it expects without threading a parameter through every caller."""
+    from archimedes_cli.session import SECURE_SESSION_COOKIE_NAME, save_session
+
+    token = "SESSION-TOKEN-secure-3a9c7e1f0b6d"
+    save_session(api_url=TEST_API_URL, cookies={SECURE_SESSION_COOKIE_NAME: token}, email="agent@example.test")
     assert (Path(tmp_path) / ".config" / "archimedes" / "session.json").exists()
     return token
 

--- a/mcp-server/tests/test_credentials.py
+++ b/mcp-server/tests/test_credentials.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from archimedes_cli.session import SESSION_COOKIE_NAME
+from archimedes_cli.session import SECURE_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME
 from archimedes_mcp import client
 from archimedes_mcp.credentials import (
     KIND_API_KEY,
@@ -38,6 +38,19 @@ def test_session_cache_is_the_fallback(cached_session):
     assert credential is not None
     assert credential.kind == KIND_SESSION_COOKIE
     assert credential.auth_cookies() == {SESSION_COOKIE_NAME: cached_session}
+    assert credential.auth_headers() == {}
+
+
+def test_a_session_cached_against_production_uses_the_secure_prefixed_cookie(cached_secure_session):
+    """The P0 this fix closes, at the credential-resolution layer: a session cached from
+    a login against production (``__Secure-better-auth.session_token``) must resolve to a
+    usable credential, and the cookie it sends must be the SAME name it was cached
+    under — never silently rewritten to the bare name, which prod would not recognize."""
+    credential = resolve_credential()
+    assert credential is not None
+    assert credential.kind == KIND_SESSION_COOKIE
+    assert credential.auth_cookies() == {SECURE_SESSION_COOKIE_NAME: cached_secure_session}
+    assert SESSION_COOKIE_NAME not in credential.auth_cookies()
     assert credential.auth_headers() == {}
 
 
@@ -101,6 +114,15 @@ def test_api_key_call_sends_a_bearer_header_and_no_cookie(mock_api, api_key, cac
 def test_session_call_sends_a_cookie_and_no_authorization_header(mock_api, cached_session):
     request = _capture(mock_api, resolve_credential())
     assert SESSION_COOKIE_NAME in request.headers["Cookie"]
+    assert "authorization" not in {k.lower() for k in request.headers}
+
+
+def test_session_call_against_a_production_style_cache_sends_the_secure_cookie(mock_api, cached_secure_session):
+    """Wire-level version of the credential-resolution test above: a call made with a
+    production-cached credential must put ``__Secure-better-auth.session_token`` on the
+    request, not the bare name — this is what actually reaches ``archimedes-arc.com``."""
+    request = _capture(mock_api, resolve_credential())
+    assert f"{SECURE_SESSION_COOKIE_NAME}=" in request.headers["Cookie"]
     assert "authorization" not in {k.lower() for k in request.headers}
 
 

--- a/mcp-server/tests/test_no_credential_leak.py
+++ b/mcp-server/tests/test_no_credential_leak.py
@@ -83,6 +83,15 @@ def test_session_token_never_appears_in_anything_the_caller_sees(name, status, m
 
 
 @pytest.mark.parametrize("name", contract.TOOL_NAMES)
+def test_a_secure_prefixed_session_token_never_appears_either(name, mock_api, caplog, cached_secure_session):
+    """Same guarantee, for a session cached against production (the ``__Secure-``-prefixed
+    cookie). Not the full status matrix above — that redaction is already proven
+    status-independent; this pins that it is also cookie-name-independent, on the one
+    status (200) most likely to echo request state back into a result."""
+    assert cached_secure_session not in _drive(name, RESPONSES["200"], mock_api, caplog)
+
+
+@pytest.mark.parametrize("name", contract.TOOL_NAMES)
 def test_no_credential_leaks_through_a_transport_error(name, mock_api, caplog, api_key):
     assert api_key not in _drive(name, _transport_error, mock_api, caplog)
 


### PR DESCRIPTION
## What

Production sets the session cookie as `__Secure-better-auth.session_token` (Better Auth's
`useSecureCookies: production` in `auth/auth.js`), but `cli/src/archimedes_cli/session.py`,
the MCP server's credential resolver, and `docs/agent-quickstart.md` all only knew the bare
`better-auth.session_token` name — so no external agent could authenticate via the CLI or
the MCP server against prod at all. This fixes all three surfaces to accept and forward
*either* name, preferring the `__Secure-` prefixed one when present. Also adds the
undocumented `halted` field to the quickstart's step-1 quote example (second dogfood drift
found alongside the cookie one).

## Why

`archimedes login` (`POST /api/auth/sign-in/email`) captured the session token with
`response.cookies.get("better-auth.session_token")`. Against `archimedes-arc.com` the
server never sets that name — it sets `__Secure-better-auth.session_token`, because Better
Auth prefixes every auth cookie with `__Secure-` whenever the deploy serves over HTTPS (the
`__Secure-` prefix is a browser/client-enforced RFC 6265bis rule that cannot be satisfied
without TLS, so local HTTP keeps the bare name). The lookup silently returned `None`, login
failed with `no_session_cookie`, and every downstream command (`meter`, `verify`,
`generate`) and the MCP server built on the same session cache inherited the same blind
spot. This is P0 for the agent-onboarding story: it means no agent following
`docs/agent-quickstart.md` or using the MCP server could ever get past step 3 against the
one host that matters.

Fixed at the root: `archimedes_cli.session` now exports `SECURE_SESSION_COOKIE_NAME`,
`SESSION_COOKIE_NAMES` (secure-prefixed preferred), and `pick_session_cookie(cookies)`,
which both `cli.py`'s `login()` and `archimedes_mcp.credentials.resolve_credential()` use
instead of a single hardcoded name. The captured cookie is cached and re-sent under
*whichever name it actually arrived as* — never rewritten — so a session cached from a
prod login stays a `__Secure-`-prefixed cookie all the way through `meter`/`verify`/
`generate` and every MCP tool call.

## Issues

Part of #1653

## Verification

```
# cli + mcp-server suites (run with PYTHONPATH pointed at this worktree's src/, since the
# env's editable install currently points at a different worktree):
cd cli && PYTHONPATH=$PWD/src:$PWD/../mcp-server/src pytest -q
# 102 passed

cd mcp-server && PYTHONPATH=$PWD/../cli/src:$PWD/src pytest -q
# 213 passed

# repo-root unit gate (the exact CI command):
pytest -m "not integration" -q
# 0 failed (ran clean; see note below on wall-clock)

# the drift guards this PR's doc edit must keep green:
pytest -q backend/tests/test_agent_quickstart_drift.py backend/tests/test_mcp_contract_drift.py backend/tests/test_agent_discovery.py
# 43 passed
```

**Adversarial revert, per CLAUDE.md's guard rule** — reverted `SESSION_COOKIE_NAMES` to
bare-name-only (`(SESSION_COOKIE_NAME,)`, i.e. the old behavior) and re-ran the new tests:

```
FAILED tests/test_cli.py::TestLogin::test_login_accepts_the_secure_prefixed_cookie_production_actually_sets
FAILED tests/test_cli.py::TestLogin::test_login_round_trips_the_secure_cookie_under_its_own_name_not_the_bare_one
FAILED tests/test_session_cookie_names.py::test_names_are_distinct_and_secure_is_preferred
FAILED tests/test_session_cookie_names.py::test_picks_the_secure_prefixed_cookie_production_sets
FAILED tests/test_session_cookie_names.py::test_prefers_the_secure_name_when_both_are_somehow_present
5 failed, 2 passed

# mcp-server side:
FAILED tests/test_credentials.py::test_a_session_cached_against_production_uses_the_secure_prefixed_cookie
FAILED tests/test_credentials.py::test_session_call_against_a_production_style_cache_sends_the_secure_cookie
2 failed, 9 passed
```

Restored the fix; both suites back to green (102 / 213 passed). This proves the new tests
actually pin the P0 — they fail against the pre-fix behavior and pass against the fix.

Also added `test_adversarial_an_unrelated_cookie_is_not_mistaken_for_the_session` (cli) and
`test_adversarial_an_unrelated_cookie_name_is_not_picked_up` /
`test_adversarial_an_empty_value_is_not_a_session` /
`test_adversarial_a_non_string_value_is_not_a_session` (unit) — the guard must be shown to
*reject* something too: a Set-Cookie for an unrelated name (CSRF token, LB affinity cookie)
must not be mistaken for a session, and it doesn't.

## What a reviewer should push back on

- `docs/api/auth-and-accounts.md` (lines ~23, ~76) also names the bare
  `better-auth.session_token` cookie without the `__Secure-` prod variant. Left untouched —
  out of the three surfaces this issue named — but it is the same drift and probably wants
  its own follow-up.
- `mcp-server/src/archimedes_mcp/contract.py`'s `CREDENTIAL_SOURCES` string was reworded to
  name both cookies; nothing asserts its exact text (checked
  `backend/tests/test_mcp_contract_drift.py`'s `test_the_contract_names_both_credential_lanes`,
  which only substring-checks for `ARCHIMEDES_API_KEY` / `Authorization: Bearer` /
  `session.json`), so this is a prose-only change with no test coverage of the new wording
  itself — flagging in case a reviewer wants a pinned assertion there too.
- The full repo-root `pytest -m "not integration"` gate shares this machine with two other
  concurrent full-suite runs from sibling worktree sessions, so wall-clock was slow; the
  scoped runs above (cli, mcp-server, the three drift-guard files) are the fast confirmation
  and were run in isolation.
