### PR TITLE
Fix API-key mint 500: declare the response param slowapi injects into

### DIFF
--- a/backend/archimedes/api/api_key_routes.py
+++ b/backend/archimedes/api/api_key_routes.py
@@ -12,6 +12,13 @@ What each one exposes, precisely
            remedy is to revoke it and mint another — which is the correct behaviour
            for a credential we cannot read back either.
 
+           **Transactional in effect**, and that is a safety property rather than a
+           tidiness one: because the token is unrecoverable, a row that is committed
+           but not returned is a permanently consumed slot out of
+           ``MAX_KEYS_PER_ACCOUNT``, findable only by listing and revoking it. So the
+           response body is built *before* the commit and every side effect runs
+           *after* it, individually suppressed. See :func:`create_api_key`.
+
 ``GET``    returns ``id``, ``name``, ``prefix`` (``archim_<id>`` — the non-secret
            half), ``created_at``, ``last_used_at``, ``revoked_at``. There is no
            code path that can add the token: the serialiser is
@@ -27,6 +34,7 @@ What each one exposes, precisely
 
 from __future__ import annotations
 
+import contextlib
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -86,14 +94,60 @@ class ApiKeyCreateResponse(ApiKeySummary):
     )
 
 
+def _after_mint(response: Response, key_id: str, user_id: str) -> None:
+    """Side effects that run *after* the key is durable. **Nothing here may raise.**
+
+    Past this point the row is committed and the caller is owed the one and only
+    copy of its token. An exception escaping here does not undo the key — it
+    replaces the response that carries the token with a 500, which strands a
+    slot the account can never use and can only find by listing and revoking it.
+    So every side effect is suppressed individually: one failing must not skip
+    the next, and none of them may reach the client.
+
+    Add future side effects (telemetry, funnel, a webhook) *inside this function*,
+    each in its own ``suppress`` — never between the commit and the return.
+    """
+    with contextlib.suppress(Exception):
+        # The id is safe to log (it is the public half and appears in the token
+        # prefix); the token is not, and is not passed to any logger anywhere.
+        logger.info("api key created: id=%s user=%s", key_id, user_id)
+
+    with contextlib.suppress(Exception):
+        # This is the only response in the system that carries a token, so it
+        # must not sit in a proxy, a browser cache, or a `curl -O` on disk.
+        # It also gives `response` a second, visible job — the parameter is
+        # load-bearing for slowapi (see the signature) and a reader who deletes
+        # it as unused reintroduces the 500 this function documents.
+        response.headers["Cache-Control"] = "no-store"
+
+
 @api_key_router.post("", response_model=ApiKeyCreateResponse, status_code=201)
 @limiter.limit("10/hour")
 async def create_api_key(
     payload: ApiKeyCreateRequest,
     request: Request,  # noqa: ARG001 — slowapi's decorator requires it by name; also read by require_session_credential
+    response: Response,
     user: CurrentUser = Depends(require_session_credential),
 ) -> ApiKeyCreateResponse:
-    """Mint a key for the calling account. The token is in the response, once."""
+    """Mint a key for the calling account. The token is in the response, once.
+
+    Transactional in effect: the response body is built **before** the commit, so
+    anything that can fail while turning the row into a body fails while the
+    transaction is still open and the ``except`` below rolls the row back. A
+    caller who gets a 500 from this endpoint has not burned one of their
+    ``MAX_KEYS_PER_ACCOUNT`` slots on a key whose token nobody will ever hold.
+
+    ``response`` is **not** optional decoration. ``@limiter.limit`` wraps this
+    coroutine, and slowapi injects its ``X-RateLimit-*`` headers into whatever the
+    handler returned — but a handler returning a pydantic model instead of a
+    ``Response`` sends it to ``kwargs["response"]`` instead, and
+    ``Limiter._inject_headers`` *raises* when that is ``None``. That raise happens
+    in slowapi's wrapper, outside this function's ``try``, after the commit: a
+    plain-text 500 with the key already persisted. It is invisible to the unit
+    suite because ``limiter.enabled`` is ``False`` under ``TESTING``, which is why
+    this endpoint 500'd on every production mint while CI stayed green.
+    ``test_api_key_mint.py`` pins both halves.
+    """
     session = get_session()
     try:
         if live_key_count(session, user.id) >= MAX_KEYS_PER_ACCOUNT:
@@ -109,14 +163,11 @@ async def create_api_key(
             )
 
         record, token = mint(session, user_id=user.id, name=payload.name)
-        payload_out = record.to_payload()
+        # Build the body BEFORE the commit — see the docstring. Serialisation,
+        # a null timestamp, a model-validation error: all of them land in the
+        # ``except`` below while the row is still rollback-able.
+        body = ApiKeyCreateResponse(**record.to_payload(), key=token)
         session.commit()
-
-        # The id is safe to log (it is the public half and appears in the token
-        # prefix); the token is not, and is not passed to any logger anywhere.
-        logger.info("api key created: id=%s user=%s", payload_out["id"], user.id)
-
-        return ApiKeyCreateResponse(**payload_out, key=token)
     except HTTPException:
         session.rollback()
         raise
@@ -126,6 +177,10 @@ async def create_api_key(
         raise HTTPException(status_code=500, detail="Could not create API key") from exc
     finally:
         session.close()
+
+    # ── The key is durable and the caller is owed its token. Nothing below raises. ──
+    _after_mint(response, body.id, user.id)
+    return body
 
 
 @api_key_router.get("", response_model=list[ApiKeySummary])

--- a/backend/tests/test_api_key_mint.py
+++ b/backend/tests/test_api_key_mint.py
@@ -1,0 +1,268 @@
+"""``POST /api/account/keys`` — the two properties the production 500 broke.
+
+The incident: every mint on production returned a plain-text ``500 Internal
+Server Error`` while persisting the key row, so each attempt consumed one of the
+account's 25 slots and returned no token — a slot that can only be recovered by
+listing and revoking it. The unit suite was green throughout.
+
+**Why green meant nothing.** ``api/limiter.py`` builds the shared ``Limiter``
+with ``enabled=not os.getenv("TESTING")`` and ``headers_enabled=True``.
+``conftest.py`` sets ``TESTING=1`` before any archimedes import, so under pytest
+``limiter.enabled`` is ``False`` and slowapi's wrapper — including the
+header-injection branch that raised — is skipped in its entirety. The suite was
+not testing a passing version of the endpoint; it was testing a version of the
+stack where the failing code does not run. That is the shape of defect
+``CLAUDE.md`` § "the green check may not mean what you think" is about, so the
+first test here turns the limiter back **on** and exercises the real wrapper.
+
+Hermetic: no Redis. The limiter's storage is swapped for a fresh in-memory one
+so re-enabling it cannot reach a developer's local Redis, and the database is a
+per-test tmp-file SQLite via ``tests/db_isolation.py``.
+
+Three guards, in widening scope:
+
+1. the endpoint answers 201 with the token **with the rate limiter enabled** —
+   the production configuration, not the test one;
+2. a mint whose response body cannot be built leaves **no row behind** — the
+   burned-slot safeguard, which is what makes a future 500 recoverable rather
+   than a permanently consumed slot;
+3. **no** ``@limiter.limit``-decorated handler anywhere in ``archimedes/api``
+   can hit the same slowapi raise — the class of bug, not this instance of it.
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+from archimedes.api import account_auth, api_key_routes
+from archimedes.api.limiter import limiter
+from archimedes.db import get_session
+from archimedes.models.account import AuthUser
+from archimedes.models.api_key import ApiKeyRecord
+from fastapi import FastAPI
+from limits.storage import MemoryStorage
+from slowapi.errors import RateLimitExceeded
+
+from tests.db_isolation import redirect_to_tmp_sqlite
+
+USER_ID = "mint-user"
+
+#: Every FastAPI route module. The scan below reads all of them.
+_API_DIR = Path(__file__).resolve().parents[1] / "archimedes" / "api"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _tmp_db(tmp_path):
+    yield from redirect_to_tmp_sqlite(tmp_path)
+
+
+@pytest.fixture()
+def account() -> str:
+    session = get_session()
+    try:
+        now = datetime.now(UTC)
+        session.add(
+            AuthUser(
+                id=USER_ID,
+                name=USER_ID,
+                email=f"{USER_ID}@example.test",
+                email_verified=True,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+    return USER_ID
+
+
+@pytest.fixture()
+def live_limiter(monkeypatch):
+    """Run the limiter the way production does: enabled, headers on, in memory.
+
+    ``enabled=True`` is the whole point — it restores slowapi's wrapper around
+    the endpoint, which is where the production exception was raised and which
+    the rest of the suite never executes. The storage swap keeps that hermetic:
+    the module-level limiter picked its backend at import from ``REDIS_URL``, and
+    a developer with Redis on the default port would otherwise have this test
+    write to it.
+    """
+    storage = MemoryStorage()
+    monkeypatch.setattr(limiter, "_limiter", type(limiter.limiter)(storage))
+    monkeypatch.setattr(limiter, "_storage", storage)
+    monkeypatch.setattr(limiter, "enabled", True)
+    return limiter
+
+
+@pytest.fixture()
+def app(live_limiter) -> FastAPI:
+    application = FastAPI()
+    application.state.limiter = live_limiter
+    application.add_exception_handler(RateLimitExceeded, lambda _request, _exc: None)
+    application.middleware("http")(account_auth.better_auth_session_middleware)
+    application.include_router(api_key_routes.api_key_router)
+    return application
+
+
+@pytest.fixture()
+def client(app, monkeypatch) -> httpx.AsyncClient:
+    """A signed-in browser session — the only credential this surface accepts."""
+
+    async def _fetch(_request):
+        return {
+            "user": {
+                "id": USER_ID,
+                "email": f"{USER_ID}@example.test",
+                "name": USER_ID,
+                "emailVerified": True,
+            },
+            "session": {"expiresAt": "2099-01-01T00:00:00Z"},
+        }
+
+    monkeypatch.setattr(account_auth, "_fetch_session", _fetch)
+    # raise_app_exceptions=False so an escaping exception becomes the plain-text
+    # 500 a real client sees, instead of surfacing as a test error.
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        headers={"host": "archimedes-arc.com", "cookie": "better-auth.session_token=opaque"},
+    )
+
+
+def _rows() -> list[ApiKeyRecord]:
+    session = get_session()
+    try:
+        return session.query(ApiKeyRecord).all()
+    finally:
+        session.close()
+
+
+# ── 1. The production path ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mint_returns_the_token_with_the_rate_limiter_enabled(account, client):
+    """The endpoint must work in the configuration production actually runs.
+
+    Before the fix this was a plain-text 500: ``@limiter.limit`` sends the
+    header injection to ``kwargs["response"]`` whenever the handler returns
+    something that is not a ``Response``, and ``Limiter._inject_headers`` raises
+    ``Exception("parameter `response` must be an instance of
+    starlette.responses.Response")`` when that key is absent. The raise lands in
+    slowapi's wrapper, outside the endpoint's own ``try``, after the commit.
+    """
+    async with client as http:
+        resp = await http.post("/api/account/keys", json={"name": "ci-nightly"})
+
+    assert resp.status_code == 201, f"{resp.status_code}: {resp.text[:200]}"
+    body = resp.json()
+    assert body["key"].startswith(f"archim_{body['id']}_")
+    assert body["prefix"] == f"archim_{body['id']}"
+
+    # The headers the injection was trying to add. Their presence is what proves
+    # the wrapper ran to completion rather than being skipped.
+    assert resp.headers["x-ratelimit-limit"] == "10"
+    assert "x-ratelimit-remaining" in resp.headers
+    # The one response in the system that carries a token must not be cached.
+    assert resp.headers["cache-control"] == "no-store"
+
+    assert len(_rows()) == 1
+
+
+# ── 2. The burned-slot safeguard ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_failed_response_build_leaves_no_row_behind(account, client, monkeypatch):
+    """A 500 must not consume one of the account's 25 slots.
+
+    The row is only durable once the body it will be returned in already exists,
+    so any failure between minting and answering rolls the mint back. Without
+    that ordering the caller is left holding a key id they cannot see and a
+    secret nobody has — recoverable only by listing and revoking it.
+    """
+
+    def _explode(**_kwargs):
+        raise TypeError("simulated response-construction failure")
+
+    monkeypatch.setattr(api_key_routes, "ApiKeyCreateResponse", _explode)
+
+    async with client as http:
+        resp = await http.post("/api/account/keys", json={"name": "doomed"})
+
+    assert resp.status_code == 500
+    # Handled, not escaped: a JSON detail rather than plain-text "Internal Server Error".
+    assert resp.json()["detail"] == "Could not create API key"
+    assert _rows() == [], "a failed mint stranded a key slot"
+
+
+# ── 3. The class of bug ───────────────────────────────────────────────
+
+
+def rate_limited_handlers_missing_response(paths: list[Path]) -> list[str]:
+    """Names of ``@limiter.limit`` handlers in *paths* that omit ``response``.
+
+    slowapi injects its ``X-RateLimit-*`` headers into the handler's return value
+    when that value is a ``Response``, and into ``kwargs["response"]`` otherwise
+    — raising if the parameter is not declared. A FastAPI handler returning a
+    pydantic model, a dict, or a list therefore **must** declare ``response:
+    Response``; every other rate-limited route in this repo already does.
+    """
+    offenders: list[str] = []
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+                continue
+            decorated = any(
+                isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute) and dec.func.attr == "limit"
+                for dec in node.decorator_list
+            )
+            if not decorated:
+                continue
+            names = {arg.arg for arg in node.args.args} | {arg.arg for arg in node.args.kwonlyargs}
+            if "response" not in names:
+                offenders.append(f"{path.name}:{node.lineno} {node.name}")
+    return offenders
+
+
+def test_no_rate_limited_handler_omits_the_response_parameter():
+    """The whole API surface, not just the endpoint that broke."""
+    modules = sorted(_API_DIR.glob("*.py"))
+    assert modules, f"no route modules found under {_API_DIR}"
+    assert rate_limited_handlers_missing_response(modules) == []
+
+
+def test_the_guard_rejects_a_handler_that_omits_response(tmp_path):
+    """The guard above must fail something — this is the input it has to reject.
+
+    ``bad.py`` is the exact pre-fix signature of ``create_api_key``; ``good.py``
+    is the fixed one. A guard that passed both would enforce nothing.
+    """
+    bad = tmp_path / "bad.py"
+    bad.write_text(
+        "@api_key_router.post('')\n"
+        "@limiter.limit('10/hour')\n"
+        "async def create_api_key(payload, request, user=Depends(require_session_credential)):\n"
+        "    ...\n",
+        encoding="utf-8",
+    )
+    good = tmp_path / "good.py"
+    good.write_text(
+        "@api_key_router.post('')\n"
+        "@limiter.limit('10/hour')\n"
+        "async def create_api_key(payload, request, response, user=Depends(require_session_credential)):\n"
+        "    ...\n",
+        encoding="utf-8",
+    )
+
+    assert rate_limited_handlers_missing_response([bad]) == ["bad.py:3 create_api_key"]
+    assert rate_limited_handlers_missing_response([good]) == []


### PR DESCRIPTION
## What broke

`POST /api/account/keys` answered a plain-text `500 Internal Server Error` on **every** production call while persisting the key row — so each attempt burned one of the account's `MAX_KEYS_PER_ACCOUNT = 25` slots on a key whose token nobody will ever hold. The dogfood P0: no agent runner or CI job could obtain the machine credential #1653 D3 exists to provide.

`create_api_key` is decorated `@limiter.limit("10/hour")` and returns a **pydantic model**, not a `starlette.responses.Response`. slowapi handles that case by injecting its `X-RateLimit-*` headers into the handler's `response` *parameter* instead:

```python
# slowapi/extension.py:738-747  (0.1.10)
response = await func(*args, **kwargs)
if self.enabled:
    if not isinstance(response, Response):
        self._inject_headers(kwargs.get("response"), request.state.view_rate_limit)   # <- None
```
```python
# slowapi/extension.py:378-385
if not isinstance(response, Response):
    raise Exception("parameter `response` must be an instance of starlette.responses.Response")
```

The endpoint declared no `response` parameter. `api/limiter.py` sets `headers_enabled=True`, so the branch was always live in production. Three things follow, in the order they bite:

1. **The raise is outside the handler's `try`** — so the endpoint's own `except Exception → HTTPException(500, "Could not create API key")` never saw it and Starlette's `ServerErrorMiddleware` answered instead. The plain-text body was the tell that the exception escaped the route entirely.
2. **It fires after `session.commit()`** — the row was durable before the response existed. Hence "persisted but not retrievable".
3. **The rate-limit token is consumed too** — `_check_request_limit` runs before the handler, so ten failed attempts burned ten slots *and* locked the endpoint out for an hour.

## Why the suite was green

`conftest.py:14` sets `TESTING=1` before any archimedes import; `api/limiter.py:80` reads it as `enabled=not os.getenv("TESTING")`. With `limiter.enabled == False`, slowapi's wrapper is skipped **entirely** — both the limit check and the injection that raises. The suite was not testing a working endpoint; it was testing a configuration in which the failing code does not run. `CLAUDE.md` § "the green check may not mean what you think", rule 3.

## The fix

- **`response: Response` on the signature.** The root cause. It is used, not vestigial — `_after_mint` writes `Cache-Control: no-store` through it, so a reader who deletes it as unused breaks a visible assertion rather than silently reintroducing the 500.
- **Transactional in effect.** The body is built *before* the commit, so serialisation, a null timestamp, a model-validation error all land in the `except` while the row is still rollback-able. A 500 from this endpoint can no longer strand a slot.
- **Side effects after the commit, individually suppressed** (`_after_mint`). Past the commit the caller is owed the one and only copy of the token, so nothing there may raise; each effect is wrapped separately so one failing cannot skip the next. Future telemetry/funnel emits go inside that function, never between the commit and the return.
- `Cache-Control: no-store` — this is the only response in the system that carries a token, and it should not sit in a proxy or a browser cache.

I checked the two other suspects and neither was implicated: there is no post-commit telemetry or funnel emit on this route (and `telemetry_middleware` / `funnel_middleware` already swallow everything), and `request.state.auth_credential` is read only by `require_session_credential`, before the handler body.

## Scope: one route, and now enforced

AST scan of all 21 `@limiter.limit` handlers under `backend/archimedes/api/`:

```
MISSING `response` param (slowapi header-injection will raise):
   api_key_routes.py:91 create_api_key  params=['payload', 'request', 'user']

HAS `response` param: 20 routes
```

Every other rate-limited route already carries it, most with `# noqa: ARG001 — slowapi @limiter.limit inspects param name`. `create_api_key` was the single omission. Nothing enforced the convention, so `test_no_rate_limited_handler_omits_the_response_parameter` now does.

## Repro — before / after

Against docker compose `postgres:18-alpine` + `redis:7-alpine`, real ASGI stack (`telemetry` → `visitor-id` → `better_auth_session` → router), valid cookie session, with the single environment difference that separates prod from CI: **`TESTING` unset**.

**Before:**
```
limiter.enabled       = True
limiter storage       = redis://127.0.0.1:56379/1

POST /api/account/keys -> 500
content-type: text/plain; charset=utf-8
body: Internal Server Error

api_keys rows persisted: 1
  id=d3e83dfda2b17b9a name=dogfood-ci revoked_at=None

VERDICT: status=500 token_returned=False rows=1
```

with `raise_app_exceptions=True`:
```
  File ".../fastapi/routing.py", line 352, in run_endpoint_function
    return await dependant.call(**values)
  File ".../slowapi/extension.py", line 741, in async_wrapper
    self._inject_headers(
  File ".../slowapi/extension.py", line 383, in _inject_headers
    raise Exception(
Exception: parameter `response` must be an instance of starlette.responses.Response
```

**After:**
```
limiter.enabled       = True
limiter storage       = redis://127.0.0.1:56379/1

POST /api/account/keys -> 201
content-type: application/json
body: {"id":"c27ce283…","name":"dogfood-ci","prefix":"archim_c27ce283…","created_at":"2026-09-01T13:10:27.135506+00:00","last_used_at":null,"revoked_at":null,"key":"archim_c27ce283…<redacted>"}

api_keys rows persisted: 1
VERDICT: status=201 token_returned=True rows=1
```

and the headers that had never once shipped on this endpoint, because the call that adds them was the call that raised:
```
headers: {'cache-control': 'no-store', 'x-ratelimit-limit': '10',
          'x-ratelimit-remaining': '6', 'x-ratelimit-reset': '1788271728.699718'}
```

## Adversarial demonstration

Per `CLAUDE.md` rules 3 and 4 — a test that passes against the unfixed code proves nothing, and a guard must be shown to reject something. I stashed the source fix and re-ran the new file against the **unfixed** route:

```
backend/tests/test_api_key_mint.py FFF.

FAILED test_mint_returns_the_token_with_the_rate_limiter_enabled
  AssertionError: 500: Internal Server Error
  assert 500 == 201

FAILED test_a_failed_response_build_leaves_no_row_behind
  AssertionError: a failed mint stranded a key slot
  assert [<archimedes....ApiKeyRecord>] == []

FAILED test_no_rate_limited_handler_omits_the_response_parameter
  AssertionError: assert ['api_key_rou...eate_api_key'] == []

3 failed, 1 passed
```

All three guards reject the pre-fix state, each for its own reason. The fourth is the guard's own adversarial case — it feeds `rate_limited_handlers_missing_response` the exact pre-fix signature and asserts it is flagged, then the fixed signature and asserts it is not, so the scan cannot degrade into a function that returns `[]` unconditionally. It passes both ways by design, because it tests the guard rather than the route.

Restored, all four pass.

## Validation

```
$ pytest -m "not integration" -q
5561 passed, 3 skipped, 2 deselected, 327 warnings in 575.34s
```

```
$ ruff format --check <changed files>   # 2 files already formatted
$ ruff check <changed files>            # All checks passed!
```

Hermeticity: `test_api_key_mint.py` swaps the shared limiter's storage for a fresh `MemoryStorage` before enabling it, so re-enabling the limiter cannot reach a developer's local Redis; the database is a per-test tmp SQLite via `tests/db_isolation.py`.

## Operational follow-up (not in this PR)

Rows already stranded on production are recoverable, but only by hand: `GET /api/account/keys` lists them (`revoked_at: null`, no token), `DELETE /api/account/keys/{id}` frees the slot. Worth draining before the next mint, since the ceiling is shared with real keys. Deliberately not automated here — `models/api_key.revoke_key` keeps revoked rows on purpose, and a heuristic that deletes "probably orphaned" credential rows is not something I'd ship without Dan's call.

Closes #1723
