### PR TITLE
Reproduction harness + A/B rig for the #1632 psycopg2 abort

### DIFF
--- a/docs/operations/feature-flag-fliplist.md
+++ b/docs/operations/feature-flag-fliplist.md
@@ -191,6 +191,7 @@ require them.
 | `TESTING` | test harness | Forces hermetic paths (fixture pipeline, `refresh_enabled()` off). Never set in a deployed environment. |
 | `PAPER_TRACE_BACKFILL_MAX` | tunable | Default 500. |
 | `REVENUE_SWEEP_INTERVAL_S` / `REVENUE_SWEEP_MIN_USDC` | tunable | Only consulted once `REVENUE_SWEEP_ENABLED=true`. |
+| `REPRO_DISABLE_MITIGATION` | diagnostic harness | Read **only** by [`scripts/repro/issue-1632/repro_1632.py`](../../scripts/repro/issue-1632/repro_1632.py), the #1632 reproduction rig, and injected only by its own `docker-compose.repro.yml`. Default `1` monkeypatches the #1725/#1728 OHLCV write chunking + lock off inside the harness process so it drives the pre-mitigation crash shape; `0` leaves them on. No deployed service reads it, and nothing in `infra/` sets it — flipping it in production would do nothing. Delete this row with the harness once #1632 has a proven cause. |
 
 ---
 

--- a/scripts/repro/issue-1632/.gitignore
+++ b/scripts/repro/issue-1632/.gitignore
@@ -1,0 +1,2 @@
+.certs/
+.logs/

--- a/scripts/repro/issue-1632/Dockerfile.psycopg2-source
+++ b/scripts/repro/issue-1632/Dockerfile.psycopg2-source
@@ -1,0 +1,43 @@
+# The B half of the #1632 A/B: the SAME prod image, with psycopg2 rebuilt from
+# source against the system libpq/libssl instead of the `psycopg2-binary` wheel
+# that bundles its own OpenSSL.
+#
+# Derived from the already-built image rather than re-running the full
+# `pip install -r requirements.txt`, so the ONLY difference between the two
+# variants is the psycopg2 flavour — torch, web3, aiohttp and the rest are the
+# byte-identical layers of the A half. That is what makes the comparison mean
+# something.
+ARG BASE_IMAGE=archimedes-repro1632:binary
+FROM ${BASE_IMAGE}
+
+# Must match the psycopg2-binary version in the base image (run.sh reads it off
+# the A image and passes it in) so the A/B differs in flavour, not in version.
+ARG PSYCOPG2_VERSION=2.9.12
+
+USER root
+
+# libpq-dev pulls libpq5, which the compiled extension needs at RUNTIME too —
+# so this image keeps the toolchain installed. It is a diagnostic image, never
+# a deploy artifact; the production Dockerfile already has gcc + libpq-dev in
+# its builder stage, so the real fix costs no runtime bloat there.
+# NOTE FOR THE FIX PR: `gcc libpq-dev` alone is NOT enough — python:3.12-slim
+# ships gcc without the libc headers, so compiling psycopg2 dies on
+# `Python.h:23: fatal error: stdlib.h: No such file or directory`. libc6-dev is
+# required. backend/Dockerfile's builder stage currently installs only
+# `gcc libpq-dev` and gets away with it because psycopg2-BINARY is a prebuilt
+# wheel that never compiles; switching that requirement to source-built
+# psycopg2 without adding libc6-dev will break the image build.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libc6-dev libpq-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /deps/psycopg2 /deps/psycopg2_binary.libs /deps/psycopg2_binary-*.dist-info \
+    && pip install --no-cache-dir --no-binary psycopg2 --target=/deps "psycopg2==${PSYCOPG2_VERSION}"
+
+# Fail the build rather than silently ship a still-bundled variant: if
+# psycopg2_binary.libs survived, the A/B would be comparing an image with
+# itself.
+RUN test ! -d /deps/psycopg2_binary.libs \
+    && ldd /deps/psycopg2/_psycopg*.so | grep -q '/lib/.*libpq.so.5' \
+    && echo "verified: psycopg2 links the system libpq"
+
+USER nonroot

--- a/scripts/repro/issue-1632/README.md
+++ b/scripts/repro/issue-1632/README.md
@@ -1,0 +1,222 @@
+# Repro rig — issue #1632 (backend SIGABRTs in `psycopg2` `do_executemany`)
+
+A local, prod-shaped harness for the crash where the production backend dies
+with a bare `Fatal Python error: Aborted` — no glibc message, no C++
+`terminate`, no OpenSSL error string — inside `psycopg2`'s `do_executemany`
+during the OHLCV cache-write commit on the paper-replay tick.
+
+The flag added in #1725 is the tourniquet. This directory is the diagnosis: it
+drives the exact crash path in a loop and A/Bs the leading mechanism.
+
+## The hypothesis under test
+
+The shipped image installs `psycopg2-binary` (`backend/requirements-base.txt`),
+the wheel flavour that bundles its own OpenSSL — the one
+[psycopg2's own documentation warns against for production][psycopg2-docs] for
+precisely this reason. The result is **three different OpenSSL builds in one
+address space**:
+
+Measured by `openssl_inventory.py` against the image built from
+`backend/Dockerfile` (2026-09-01, `linux/arm64`) — **5 mappings, 2 distinct
+OpenSSL builds**:
+
+| library | build | who uses it |
+| --- | --- | --- |
+| `/usr/lib/*/libssl.so.3` + `libcrypto.so.3` | OpenSSL 3.5.6 | the interpreter's `_ssl` → aiohttp, web3, httpx, boto3 |
+| `psycopg2_binary.libs/libssl-ad00b19a.so.3` + `libcrypto-a90fc9c6.so.3` | OpenSSL 3.5.6 — *a separate build with separate global state* | the wheel's bundled `libpq` → the TLS session to Aurora |
+| `psycopg2_binary.libs/libcrypto-6aa7cfbd.so.1.1.1k` | **OpenSSL 1.1.1k FIPS (2021)** | the wheel's bundled krb5 / ldap stack |
+
+The same tool against the source-built variant reports **2 mappings, 1 build** —
+the exposure is gone, which is what makes it a usable A/B control.
+
+Prod's `DATABASE_URL` (`infra/outputs.tf`) carries no `sslmode`, so libpq
+defaults to `prefer` and *does* negotiate TLS against Aurora — the bundled
+OpenSSL is live, not merely resident.
+
+That is a hypothesis to confirm or kill, not a conclusion. Run the A/B.
+
+[psycopg2-docs]: https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
+
+## What the harness drives
+
+The narrowest slice that still contains the whole prod failure path:
+
+```
+paper_advance_loop            asyncio.to_thread → DEFAULT executor thread
+  └─ replay → fetch_real_panel → _fetch_one
+       └─ CachingMarketDataProvider.get_daily_ohlcv       ← real, shipped code
+            └─ read miss → inner fetch → _write_cached_ohlcv
+                 └─ session.commit()  →  psycopg2 do_executemany  →  ABORT
+```
+
+The **only** substitution is the vendor: `_ReplayFrameProvider` returns a
+recorded 2 600-bar OHLCV frame instead of calling yfinance, so the loop is
+deterministic, offline, and spends its time on the cache write rather than on
+HTTP. `CachingMarketDataProvider`, `_read_cached_ohlcv`, `_write_cached_ohlcv`,
+`archimedes.db`'s engine, and the `AssetDailyBar` mapping are all the shipped
+implementations.
+
+### The write that actually reaches `do_executemany` is the UPDATE
+
+Measured, not assumed — the harness counts `do_executemany` and `do_execute`
+separately and prints the statements it saw:
+
+| `_write_cached_ohlcv` branch | what SQLAlchemy 2.0 emits | psycopg2 entry point |
+| --- | --- | --- |
+| new rows (`session.add`) | one `INSERT … VALUES (…),(…) RETURNING id` via *insertmanyvalues* | `do_execute` |
+| existing rows (attribute set) | `UPDATE asset_daily_bars SET … WHERE id = %(id)s` batched by PK | **`do_executemany`** |
+
+So an insert-only loop scores thousands of cache writes and **zero** calls to
+the frame prod aborted in. Measured on a 40 s run: `REPRO_TICKER_MODE=rotate`
+(all-INSERT) → `do_executemany: 0`; the default `mixed` → 41 calls, 106 600
+param rows, every one of them `UPDATE asset_daily_bars`.
+
+That narrows the prod crash: it happens re-writing a **warm** cache entry, not
+priming a cold one. The harness refuses to report "no crash" from a run whose
+`do_executemany` counter is zero — it exits 3 and calls the run a NON-RESULT.
+
+Three further things are deliberately faithful to prod, because the mechanism
+may depend on all of them:
+
+1. **The process image.** The harness runs inside the image built from
+   `backend/Dockerfile` — never bare-metal. The bundled libssl only exists
+   inside the pip wheel, and `import archimedes.main` loads the same ~286 C
+   extensions (ckzg, greenlet, uvloop, torch, …) prod loads.
+2. **TLS on the DB connection.** The repo's `docker-compose.yml` `localdb`
+   postgres runs `ssl=off`, which would leave the bundled libssl untouched. The
+   compose file here is otherwise the same service (`postgres:18-alpine`,
+   matching prod Aurora 18.3) with TLS switched on, and the harness prints
+   `pg_stat_ssl` at startup so a silent plaintext regression is visible.
+3. **Concurrent interpreter-side TLS.** aiohttp clients hammer a loopback TLS
+   server (new `SSLContext` + new session every round) on the event loop while
+   the writer threads commit — the co-activity that would make two OpenSSL
+   copies collide. `uvloop` is installed, as `uvicorn[standard]` does in prod.
+
+## Running it
+
+```bash
+scripts/repro/issue-1632/run.sh              # full A/B, 30 min per variant
+scripts/repro/issue-1632/run.sh binary       # prod flavour only
+scripts/repro/issue-1632/run.sh source       # psycopg2-from-source only
+REPRO_DURATION_S=120 scripts/repro/issue-1632/run.sh   # smoke test
+```
+
+Requires Docker. First run builds the ~2.7 GB backend image (cached after).
+Logs and per-variant verdicts land in `.logs/` (gitignored); the self-signed
+postgres cert lands in `.certs/` (gitignored).
+
+Standalone evidence, no database needed:
+
+```bash
+docker run --rm -v "$PWD/scripts/repro/issue-1632:/repro:ro" \
+  archimedes-repro1632:binary python /repro/openssl_inventory.py
+```
+
+### The A/B
+
+`Dockerfile.psycopg2-source` derives from the *already-built* prod image and
+swaps only the psycopg2 flavour — rebuilding it from source against the system
+`libpq`/`libssl`. torch, web3, aiohttp and every other layer stay byte-identical
+between the two halves, so a difference in outcome is attributable to psycopg2
+and nothing else. Each variant gets a virgin postgres data directory
+(`down -v` between runs), so the halves cannot contaminate each other.
+
+**Note for the fix PR:** compiling psycopg2 in `python:3.12-slim` needs
+`libc6-dev` on top of `gcc libpq-dev`. `backend/Dockerfile`'s builder stage
+installs only `gcc libpq-dev` today and gets away with it because
+`psycopg2-binary` is a prebuilt wheel that never compiles. Switching the
+requirement without adding `libc6-dev` fails the image build with
+`Python.h:23: fatal error: stdlib.h: No such file or directory`.
+
+## Knobs
+
+| env | default | meaning |
+| --- | --- | --- |
+| `REPRO_DURATION_S` | `1800` | wall-clock budget per variant |
+| `REPRO_WRITERS` | `2` | concurrent commit threads on the default executor |
+| `REPRO_BARS` | `2600` | rows per cache write (the `executemany` batch size) |
+| `REPRO_TLS_CLIENTS` | `8` | concurrent aiohttp TLS clients |
+| `REPRO_TICKER_MODE` | `mixed` | `rotate` = all-INSERT batches, `fixed` = all-UPDATE, `mixed` = both |
+| `REPRO_RECYCLE_EVERY` | `25` | `engine.dispose()` every N writes (forces fresh libpq TLS handshakes); `0` disables |
+| `REPRO_TLS_URLS` | *(local server)* | comma-separated HTTPS URLs to hammer instead of the loopback server |
+| `REPRO_DISABLE_MITIGATION` | `1` | `1` drives the pre-#1725 crash shape; `0` leaves the tourniquet on |
+
+Every knob must also appear in `docker-compose.repro.yml`'s `environment:`
+block — one set on the host but missing there silently never reaches the
+container, and the run reports the default while looking like it honoured you.
+
+### The #1725 tourniquet, and why it is off by default
+
+The mitigation (#1725/#1728) landed *inside* the function this harness drives:
+`_write_cached_ohlcv` now flushes every `_OHLCV_WRITE_CHUNK_ROWS` (500) rows,
+and `get_daily_ohlcv` wraps the write+commit in a process-wide
+`_OHLCV_CACHE_WRITE_LOCK`. Both target exactly the batch size and the
+concurrency the harness exists to stress, so running against them measures the
+tourniquet rather than the wound. `configure_mitigation()` therefore neuters
+both by default and says so in the log.
+
+Verified in both directions on a 40 s run — mean `executemany` batch size is
+the observable:
+
+| | log line | mean rows / `do_executemany` |
+| --- | --- | --- |
+| `REPRO_DISABLE_MITIGATION=1` (default) | `mitigation: DISABLED … pre-#1725 crash shape` | **2600** (= `REPRO_BARS`, one batch per frame) |
+| `REPRO_DISABLE_MITIGATION=0` | `mitigation: LEFT ON — flush every 500 rows` | **433** (under the 500 cap) |
+
+Both lookups are `hasattr`-guarded, so this file keeps working once the
+mitigation is deleted — which is the point of finding the real cause.
+
+`MARKET_DATA_CACHE_TTL_HOURS=0` is set in the compose file so every read is a
+freshness miss and every iteration therefore reaches the commit.
+
+## Reading the result
+
+`run.sh` prints a per-variant verdict: exit code (134 = SIGABRT, 139 = SIGSEGV,
+3 = non-result), elapsed vs budget, cache-write count, **`do_executemany` call
+count**, libssl copies loaded, and the `Fatal Python error` block if one
+appeared. Check the `do_executemany` line first: if it is 0, nothing else in
+the verdict means anything.
+
+### First run — 2026-09-01, `linux/arm64`
+
+Run at base `e43abe9f`, i.e. **before** the #1725/#1728 mitigation landed on
+`main`. On this branch the default `REPRO_DISABLE_MITIGATION=1` reproduces that
+same shape — confirmed by the mean batch size below matching `REPRO_BARS`
+exactly (2600 rows per `do_executemany`, one batch per frame).
+
+| | A: `psycopg2-binary` (prod) | B: psycopg2 from source |
+| --- | --- | --- |
+| wall clock | 1823 s of 1800 s | 1815 s of 1800 s |
+| cache writes | 3 664 | 4 794 |
+| `do_executemany` | **1 685** (4 381 000 param rows) | **2 206** (5 735 600 param rows) |
+| statement | `UPDATE asset_daily_bars` ×1685 | `UPDATE asset_daily_bars` ×2206 |
+| `do_execute` | 13 415 | 17 546 |
+| aiohttp TLS requests | 290 051 | 311 955 |
+| libpq connection | `ssl=True`, TLSv1.3, `TLS_AES_256_GCM_SHA384` | same |
+| libssl/libcrypto mappings | **5** (2 distinct OpenSSL builds) | **2** (1 build) |
+| C extensions | 287 | 287 |
+| errors | 0 | 0 |
+| **aborted?** | **no** | **no** |
+
+**Neither variant reproduced the crash.** The dual-OpenSSL condition is
+confirmed *present* in the prod image, but this harness did not show it to be
+*sufficient*: 1 685 calls through the exact `do_executemany` frame, on a TLS
+libpq connection, concurrent with 290 k interpreter-side TLS requests, did not
+abort. The hypothesis is neither confirmed nor killed — what is killed is the
+idea that the co-activity alone is enough on arm64 against a local postgres.
+See the fidelity gaps below for what to vary next.
+
+**A non-repro is a result.** If neither variant aborts inside its budget, report
+that plainly along with what was varied — do not tune the harness until
+something breaks. Known fidelity gaps to state alongside any non-repro:
+
+- **Architecture.** This runs `linux/arm64` (Apple silicon); prod Fargate is
+  `linux/amd64`. The wheel bundles OpenSSL on both, but the binaries differ.
+- **Server.** Local `postgres:18-alpine` vs Aurora 18.3 behind a VPC network —
+  different TLS peer, different latency, different idle-timeout behaviour.
+- **Load shape.** No FastAPI request traffic, no LLM calls, no on-chain RPC.
+- **The B image is not a pure one-variable swap.** Its `apt-get update &&
+  install` layer also moves the system OpenSSL 3.5.6 → 3.5.7 and libpq
+  170009 → 170011. Both are patch-level bumps and neither is the psycopg2
+  flavour, but a difference in outcome between the halves would need this ruled
+  out before being attributed to the flavour alone.

--- a/scripts/repro/issue-1632/docker-compose.repro.yml
+++ b/scripts/repro/issue-1632/docker-compose.repro.yml
@@ -1,0 +1,64 @@
+# Repro rig for issue #1632 — see README.md. Driven by run.sh, not by hand.
+#
+# Deliberately NOT the repo's docker-compose.yml `localdb` profile: that
+# postgres runs with ssl=off, and prod's DATABASE_URL (no `sslmode`) means
+# libpq's default `prefer` negotiates TLS against Aurora. A plaintext local DB
+# would never exercise psycopg2-binary's bundled libssl, which is the thing
+# under test. Everything else — image tag, major version, credentials shape —
+# mirrors that service.
+services:
+  postgres:
+    image: postgres:18-alpine # same image/major as docker-compose.yml (prod Aurora 18.3)
+    environment:
+      POSTGRES_USER: archimedes
+      POSTGRES_PASSWORD: repro1632
+      POSTGRES_DB: archimedes
+    # NB: ssl is switched on by initdb-ssl.sh writing postgresql.conf, NOT here
+    # — options passed on the command line also reach the entrypoint's
+    # bootstrap server, which runs before the cert exists and would refuse to
+    # start. See the comment in initdb-ssl.sh.
+    command: ["postgres", "-c", "max_connections=200"]
+    volumes:
+      - ./initdb-ssl.sh:/docker-entrypoint-initdb.d/00-ssl.sh:ro
+      - ./.certs:/repro-ssl:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U archimedes"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    # No named volume on purpose: every `down -v` gives the next variant a
+    # virgin data dir, so the A/B halves cannot contaminate each other.
+
+  harness:
+    # run.sh sets REPRO_IMAGE to archimedes-repro1632:binary or :source.
+    image: ${REPRO_IMAGE:-archimedes-repro1632:binary}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      # No `sslmode` — byte-for-byte the shape of prod's SSM DATABASE_URL, so
+      # libpq picks `prefer` here exactly as it does against Aurora.
+      DATABASE_URL: postgresql://archimedes:repro1632@postgres:5432/archimedes
+      PYTHONFAULTHANDLER: "1"
+      PYTHONUNBUFFERED: "1"
+      MARKET_DATA_PROVIDER: yfinance
+      # TTL 0 => every read is a freshness miss => EVERY iteration reaches
+      # _write_cached_ohlcv + commit. Without this, the fixed-ticker half of
+      # REPRO_TICKER_MODE=mixed warms the cache and stops writing after its
+      # first pass, halving the executemany volume under test.
+      MARKET_DATA_CACHE_TTL_HOURS: "0"
+      REPRO_DURATION_S: ${REPRO_DURATION_S:-1800}
+      REPRO_WRITERS: ${REPRO_WRITERS:-2}
+      REPRO_BARS: ${REPRO_BARS:-2600}
+      REPRO_TLS_CLIENTS: ${REPRO_TLS_CLIENTS:-8}
+      REPRO_TICKER_MODE: ${REPRO_TICKER_MODE:-mixed}
+      REPRO_RECYCLE_EVERY: ${REPRO_RECYCLE_EVERY:-25}
+      # Every knob the driver reads MUST be listed here — a variable set on the
+      # host but absent from this block silently never reaches the container,
+      # and the run reports the default while looking like it honoured you.
+      REPRO_DISABLE_MITIGATION: ${REPRO_DISABLE_MITIGATION:-1}
+      REPRO_TLS_URLS: ${REPRO_TLS_URLS:-}
+    volumes:
+      # Mounted, not baked: iterating on the driver must not mean a 2.7 GB rebuild.
+      - ./repro_1632.py:/repro/repro_1632.py:ro
+    command: ["python", "/repro/repro_1632.py"]

--- a/scripts/repro/issue-1632/initdb-ssl.sh
+++ b/scripts/repro/issue-1632/initdb-ssl.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Runs once, as the `postgres` user, inside the postgres:18-alpine entrypoint
+# (docker-entrypoint-initdb.d) before the server accepts connections.
+#
+# Why not generate the pair here: postgres:18-alpine ships no `openssl` CLI, so
+# run.sh generates it on the host and mounts it read-only at /repro-ssl. The
+# copy is what matters — postgres refuses a key file that is group/world
+# readable or not owned by the server user, and a bind-mounted file is neither
+# chmod-able nor postgres-owned.
+set -eu
+
+cp /repro-ssl/server.crt "$PGDATA/server.crt"
+cp /repro-ssl/server.key "$PGDATA/server.key"
+chmod 600 "$PGDATA/server.key"
+chmod 644 "$PGDATA/server.crt"
+
+# `ssl = on` is enabled HERE rather than via the compose `command:` because the
+# entrypoint applies command-line options to the *bootstrap* server it runs
+# before this script — and at that point the cert does not exist yet, so the
+# bootstrap server dies with "could not load server certificate file". Writing
+# postgresql.conf instead defers ssl to the final `exec postgres`, which starts
+# after every initdb.d script has run.
+cat >> "$PGDATA/postgresql.conf" <<'CONF'
+
+# repro-1632: TLS, so libpq (sslmode=prefer, as in prod) negotiates a real
+# session on psycopg2-binary's bundled OpenSSL.
+ssl = on
+ssl_cert_file = 'server.crt'
+ssl_key_file = 'server.key'
+CONF
+
+echo "repro-1632: TLS key/cert installed in $PGDATA and ssl=on written to postgresql.conf"

--- a/scripts/repro/issue-1632/openssl_inventory.py
+++ b/scripts/repro/issue-1632/openssl_inventory.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Evidence tool for #1632: what OpenSSL builds does the prod process image
+actually load, and which one does each consumer use?
+
+Run it inside a candidate image — it needs no database, no network, no compose:
+
+    docker run --rm archimedes-repro1632:binary python /repro/openssl_inventory.py
+
+(``run.sh`` mounts this directory at /repro; standalone, mount it yourself:
+``docker run --rm -v "$PWD:/repro:ro" IMAGE python /repro/openssl_inventory.py``)
+
+It imports the prod graph, then reports every distinct libssl/libcrypto mapped
+into the address space and asks each one, via ``OpenSSL_version()``/
+``SSLeay_version()``, what build it is. Three different OpenSSL builds in one
+process — which is what ``psycopg2-binary`` produces here — is the condition
+psycopg2's own docs warn about for production use.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ssl
+import sys
+
+
+def mapped_crypto_libs() -> list[str]:
+    seen: dict[str, None] = {}
+    with open("/proc/self/maps", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            path = line.rsplit(" ", 1)[-1].strip()
+            if path.rsplit("/", 1)[-1].startswith(("libssl", "libcrypto")):
+                seen[path] = None
+    return sorted(seen)
+
+
+def version_of(path: str) -> str:
+    """Ask a specific libcrypto/libssl which OpenSSL build it is."""
+    try:
+        lib = ctypes.CDLL(path, mode=ctypes.RTLD_LOCAL)
+    except OSError as exc:
+        return f"<dlopen failed: {exc}>"
+    for sym in ("OpenSSL_version", "SSLeay_version"):  # 3.x name, then 1.1.x name
+        try:
+            fn = getattr(lib, sym)
+        except AttributeError:
+            continue
+        fn.restype = ctypes.c_char_p
+        fn.argtypes = [ctypes.c_int]
+        try:
+            return fn(0).decode()  # 0 == OPENSSL_VERSION
+        except Exception as exc:  # pragma: no cover - diagnostic only
+            return f"<{sym} raised {exc!r}>"
+    return "<no version symbol>"
+
+
+def main() -> int:
+    print(f"python              : {sys.version.split()[0]}")
+    print(f"interpreter _ssl uses: {ssl.OPENSSL_VERSION}")
+
+    print("\nimporting the prod graph (archimedes.main + aiohttp + web3)…")
+    for mod in ("archimedes.main", "aiohttp", "web3"):
+        try:
+            __import__(mod)
+        except Exception as exc:
+            print(f"  WARNING: import {mod} failed: {exc!r}")
+
+    try:
+        import psycopg2
+
+        print(f"\npsycopg2            : {psycopg2.__version__}")
+        print(f"psycopg2 libpq      : {psycopg2.__libpq_version__}")
+    except Exception as exc:
+        print(f"\npsycopg2            : IMPORT FAILED {exc!r}")
+
+    libs = mapped_crypto_libs()
+    print(f"\n{len(libs)} distinct libssl/libcrypto mapping(s) in this process:")
+    builds: set[str] = set()
+    for path in libs:
+        ver = version_of(path)
+        builds.add(ver)
+        origin = "psycopg2-binary wheel" if "psycopg2_binary.libs" in path else "system / interpreter"
+        print(f"  {path}")
+        print(f"      build : {ver}")
+        print(f"      origin: {origin}")
+
+    print(f"\ndistinct OpenSSL builds co-resident: {len(builds)}")
+    for b in sorted(builds):
+        print(f"  - {b}")
+    if len(builds) > 1:
+        print(
+            "\nVERDICT: multiple OpenSSL builds share this address space. This is the\n"
+            "         configuration psycopg2 documents as unsupported in production."
+        )
+    else:
+        print("\nVERDICT: single OpenSSL build — no dual-OpenSSL exposure in this image.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/issue-1632/repro_1632.py
+++ b/scripts/repro/issue-1632/repro_1632.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+"""Reproduction harness for issue #1632 — prod backend SIGABRTs inside
+``psycopg2`` ``do_executemany`` on the paper-replay tick.
+
+WHAT IT DRIVES
+--------------
+The exact prod crash path, narrowed to its smallest faithful slice:
+
+    paper_advance_loop  (asyncio.to_thread → DEFAULT executor thread)
+      └─ replay → fusion_market_data.fetch_real_panel → _fetch_one
+           └─ market_data_provider.CachingMarketDataProvider.get_daily_ohlcv
+                └─ read miss → inner fetch → _write_cached_ohlcv(session, …)
+                     └─ session.commit()   ←  psycopg2 do_executemany  ←  ABORT
+
+The vendor call is the only thing replaced: ``_ReplayFrameProvider`` returns a
+*recorded* OHLCV frame (deterministic, offline) so the loop hammers the cache
+write instead of yfinance. Everything below the provider — the real
+``CachingMarketDataProvider``, the real ``_read_cached_ohlcv`` /
+``_write_cached_ohlcv``, the real ``archimedes.db`` engine and its psycopg2
+driver, the real ``AssetDailyBar`` ORM mapping — is the shipped code.
+
+WHY THE CO-ACTIVITY MATTERS (the hypothesis under test)
+-------------------------------------------------------
+The prod image loads *three* OpenSSL crypto builds into one address space:
+
+  * ``/lib/*/libcrypto.so.3`` + ``libssl.so.3``   — the interpreter's, used by
+    ``_ssl`` and therefore by aiohttp / web3 / httpx / boto3.
+  * ``psycopg2_binary.libs/libcrypto-*.so.3`` + ``libssl-*.so.3`` — bundled in
+    the ``psycopg2-binary`` wheel, used by its bundled ``libpq`` for the TLS
+    session to Aurora (prod ``DATABASE_URL`` carries no ``sslmode``, so libpq
+    defaults to ``prefer`` and *does* negotiate TLS).
+  * ``psycopg2_binary.libs/libcrypto-*.so.1.1.1k`` — OpenSSL 1.1.1, dragged in
+    by the wheel's bundled krb5/ldap stack.
+
+``psycopg2``'s own documentation warns against the binary wheel in production
+for exactly this reason. So the harness deliberately runs interpreter-side TLS
+churn (aiohttp client + a local TLS server, both on the interpreter's OpenSSL)
+*concurrently* with the psycopg2 commit loop, on the same default executor
+layout prod uses. If the abort is a dual-OpenSSL symbol clash, the co-activity
+is load-bearing and this is where it shows up.
+
+A NON-REPRO IS A RESULT. If neither variant aborts, say so — do not tune the
+harness until something breaks.
+
+USAGE
+-----
+    scripts/repro/issue-1632/run.sh              # full A/B, 30 min per variant
+    REPRO_DURATION_S=120 scripts/repro/issue-1632/run.sh   # smoke
+
+Knobs (all env, all optional):
+    REPRO_DURATION_S      wall-clock budget per variant           (1800)
+    REPRO_WRITERS         concurrent commit threads               (2)
+    REPRO_BARS            rows per cache write (executemany size) (2600)
+    REPRO_TLS_CLIENTS     concurrent aiohttp TLS clients          (8)
+    REPRO_TICKER_MODE     rotate | fixed | mixed                  (mixed)
+    REPRO_RECYCLE_EVERY   engine.dispose() every N writes, 0=off  (25)
+    REPRO_TLS_URLS        comma-separated https URLs to hammer
+                          instead of the built-in local TLS server
+    REPRO_DISABLE_MITIGATION  1 = drive the pre-#1725 crash shape (default),
+                          0 = leave the #1725/#1728 tourniquet on
+
+Every knob must ALSO be listed in docker-compose.repro.yml's `environment:`
+block, or it silently never reaches the container.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import faulthandler
+import os
+import random
+import ssl
+import sys
+import threading
+import time
+import traceback
+from datetime import UTC, date, datetime, timedelta
+
+# Fatal-signal tracebacks (this is what produced prod's "Fatal Python error:
+# Aborted" frame pointing at do_executemany). Must be enabled before anything
+# else can abort.
+faulthandler.enable()
+
+STARTED = time.monotonic()
+_STOP = threading.Event()
+_COUNTS: dict[str, int] = {
+    "writes": 0,
+    "rows": 0,
+    "tls": 0,
+    "errors": 0,
+    # do_executemany is the frame prod aborted in. Counted separately from
+    # do_execute because they are DIFFERENT psycopg2 entry points and only one
+    # of them is the crash site — see instrument_dbapi().
+    "executemany": 0,
+    "executemany_rows": 0,
+    "execute": 0,
+}
+_EXECUTEMANY_STATEMENTS: dict[str, int] = {}
+_COUNTS_LOCK = threading.Lock()
+
+
+def log(msg: str) -> None:
+    print(f"[{time.monotonic() - STARTED:8.1f}s] {msg}", flush=True)
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+DURATION_S = float(_int_env("REPRO_DURATION_S", 1800))
+WRITERS = _int_env("REPRO_WRITERS", 2)
+BARS = _int_env("REPRO_BARS", 2600)
+TLS_CLIENTS = _int_env("REPRO_TLS_CLIENTS", 8)
+TICKER_MODE = os.environ.get("REPRO_TICKER_MODE", "mixed")
+RECYCLE_EVERY = _int_env("REPRO_RECYCLE_EVERY", 25)
+
+
+# --------------------------------------------------------------------------
+# 0. Environment fingerprint — the "how many libssl copies" evidence.
+# --------------------------------------------------------------------------
+
+
+def _loaded_crypto_libs() -> list[str]:
+    """Distinct libssl/libcrypto mappings in this process, from /proc/self/maps."""
+    found: dict[str, None] = {}
+    try:
+        with open("/proc/self/maps", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                parts = line.rsplit(" ", 1)
+                path = parts[-1].strip()
+                base = path.rsplit("/", 1)[-1]
+                if base.startswith(("libssl", "libcrypto")):
+                    found[path] = None
+    except OSError:
+        pass
+    return sorted(found)
+
+
+def _count_c_extensions() -> int:
+    return sum(1 for m in list(sys.modules.values()) if getattr(m, "__file__", "") and str(m.__file__).endswith(".so"))
+
+
+def fingerprint(tag: str) -> None:
+    log(f"===== OpenSSL fingerprint ({tag}) =====")
+    log(f"python            : {sys.version.split()[0]}  ({os.uname().machine})")
+    log(f"ssl.OPENSSL_VERSION: {ssl.OPENSSL_VERSION}")
+    try:
+        import psycopg2
+
+        log(f"psycopg2          : {psycopg2.__version__}")
+        log(f"psycopg2 libpq    : {psycopg2.__libpq_version__}")
+        log(f"psycopg2 module   : {psycopg2.__file__}")
+        import psycopg2._psycopg as _pg
+
+        log(f"psycopg2 _psycopg : {_pg.__file__}")
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        log(f"psycopg2          : IMPORT FAILED {exc!r}")
+    libs = _loaded_crypto_libs()
+    log(f"libssl/libcrypto mappings loaded: {len(libs)}")
+    for path in libs:
+        log(f"    {path}")
+    log(f"C extensions loaded: {_count_c_extensions()}")
+    log("=" * 46)
+
+
+# --------------------------------------------------------------------------
+# 1. Load the prod process image (all ~230 C extensions), like uvicorn does.
+# --------------------------------------------------------------------------
+
+
+def load_app_modules() -> None:
+    """Import what the prod backend imports, so the address space matches.
+
+    Deliberately imports ``archimedes.main`` — the FastAPI app module whose
+    transitive imports pull in web3/ckzg/greenlet/uvloop/torch/… That import
+    graph is half the hypothesis: it is what puts the interpreter's OpenSSL in
+    the same process as psycopg2's bundled one.
+    """
+    log("importing archimedes.main (prod import graph)…")
+    t0 = time.monotonic()
+    try:
+        import archimedes.main  # noqa: F401
+    except Exception as exc:
+        log(f"WARNING: archimedes.main import failed ({exc!r}); continuing with a narrower graph")
+        traceback.print_exc()
+    # Belt and braces: the TLS-side consumers, imported explicitly so a
+    # main.py refactor can never silently drop them out of the repro.
+    for mod in ("aiohttp", "web3", "ssl", "sqlalchemy", "psycopg2"):
+        try:
+            __import__(mod)
+        except Exception as exc:
+            log(f"WARNING: import {mod} failed: {exc!r}")
+    log(f"import graph loaded in {time.monotonic() - t0:.1f}s")
+
+
+# --------------------------------------------------------------------------
+# 2. The recorded OHLCV frame + a provider that serves it (no vendor calls).
+# --------------------------------------------------------------------------
+
+
+def recorded_frame(n_bars: int, seed: int = 1632):
+    """A deterministic, realistic daily OHLCV frame — the shape
+    ``fetch_ohlcv`` returns (DatetimeIndex; Open/High/Low/Close/Volume)."""
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(seed)
+    idx = pd.bdate_range(end=pd.Timestamp(date.today()) - pd.Timedelta(days=1), periods=n_bars)
+    steps = rng.normal(0.0004, 0.011, size=n_bars)
+    close = 100.0 * np.exp(np.cumsum(steps))
+    spread = np.abs(rng.normal(0.004, 0.002, size=n_bars)) * close
+    open_ = close - rng.normal(0, 0.5, size=n_bars) * spread
+    return pd.DataFrame(
+        {
+            "Open": open_,
+            "High": np.maximum(open_, close) + spread,
+            "Low": np.minimum(open_, close) - spread,
+            "Close": close,
+            "Volume": rng.integers(1_000_000, 90_000_000, size=n_bars).astype(float),
+        },
+        index=idx,
+    )
+
+
+class _ReplayFrameProvider:
+    """Stands in for the yfinance/tiingo vendor: the ONLY substitution in the
+    harness. Returns the recorded frame so every cache miss becomes a full
+    ``_write_cached_ohlcv`` + ``commit`` — i.e. a ``do_executemany``."""
+
+    def __init__(self, frame) -> None:
+        self._frame = frame
+
+    # The signatures keep the real MarketDataProvider parameter names (the
+    # arguments are deliberately ignored — that IS the stand-in), hence the
+    # ARG002 suppressions.
+    def get_daily_ohlcv(self, ticker: str, start: str, end: str):  # noqa: ARG002
+        return self._frame
+
+    # Never reached by this harness (it drives get_daily_ohlcv only); present
+    # so the object is a complete stand-in if the driver is extended.
+    def get_daily_close_batch(self, tickers, period):  # noqa: ARG002
+        return dict.fromkeys(tickers, self._frame["Close"])
+
+    def get_intraday_quote(self, ticker):  # noqa: ARG002
+        return None
+
+    def get_intraday_quotes_batch(self, tickers):  # noqa: ARG002
+        return {}
+
+    def get_series(self, ticker, period, interval):  # noqa: ARG002
+        return self._frame["Close"]
+
+
+# --------------------------------------------------------------------------
+# 3. The commit loop — runs on the DEFAULT executor, as paper_advance_loop does.
+# --------------------------------------------------------------------------
+
+
+def instrument_dbapi() -> None:
+    """Count ``do_executemany`` vs ``do_execute`` calls.
+
+    THE GUARD ON THIS WHOLE HARNESS. Prod aborted inside psycopg2's
+    ``do_executemany``; a run that only ever reaches ``do_execute`` is not
+    exercising the crash frame, however busy it looks. SQLAlchemy 2.0 routes
+    ORM INSERTs that need the generated PK back through *insertmanyvalues* —
+    one rendered ``INSERT … VALUES (…), (…) RETURNING id`` via ``do_execute``,
+    NOT ``executemany`` — so an insert-only loop can score thousands of
+    "writes" and zero calls to the frame under test. Bulk UPDATE-by-PK is what
+    still goes through ``do_executemany``, which is why REPRO_TICKER_MODE
+    defaults to `mixed` (it produces both).
+
+    If the executemany counter stays at zero, the run is a non-result, and the
+    harness says so loudly rather than reporting a reassuring "no crash".
+    """
+    # Patch the CONCRETE dialect class, not DefaultDialect: PGDialect_psycopg2
+    # overrides do_executemany (that is where its execute_values /
+    # execute_batch modes live), so a DefaultDialect patch never fires and the
+    # counter reads a permanent, silent zero.
+    from archimedes.db import engine
+
+    dialect_cls = type(engine.dialect)
+    log(f"instrumenting dialect class {dialect_cls.__module__}.{dialect_cls.__name__}")
+
+    orig_many = dialect_cls.do_executemany
+    orig_one = dialect_cls.do_execute
+
+    def counting_executemany(self, cursor, statement, parameters, context=None):
+        with _COUNTS_LOCK:
+            _COUNTS["executemany"] += 1
+            with contextlib.suppress(TypeError):  # parameters is not always sized
+                _COUNTS["executemany_rows"] += len(parameters)
+            key = " ".join(str(statement).split()[:4])
+            _EXECUTEMANY_STATEMENTS[key] = _EXECUTEMANY_STATEMENTS.get(key, 0) + 1
+        return orig_many(self, cursor, statement, parameters, context)
+
+    def counting_execute(self, cursor, statement, parameters, context=None):
+        with _COUNTS_LOCK:
+            _COUNTS["execute"] += 1
+        return orig_one(self, cursor, statement, parameters, context)
+
+    dialect_cls.do_executemany = counting_executemany  # type: ignore[method-assign]
+    dialect_cls.do_execute = counting_execute  # type: ignore[method-assign]
+    log("instrumented do_executemany / do_execute")
+
+
+def configure_mitigation() -> None:
+    """Turn the #1725/#1728 tourniquet off (default) or leave it on.
+
+    That mitigation landed INSIDE the function this harness drives: it flushes
+    ``_write_cached_ohlcv`` every ``_OHLCV_WRITE_CHUNK_ROWS`` (500) rows and
+    wraps the write+commit in the process-wide ``_OHLCV_CACHE_WRITE_LOCK``.
+    Both are deliberately aimed at the batch size and the concurrency this
+    harness exists to stress, so running against them measures the tourniquet,
+    not the wound.
+
+    Default is therefore OFF — the harness reproduces the shape the fleet was
+    actually crashing in. ``REPRO_DISABLE_MITIGATION=0`` leaves it on, which is
+    how you check whether the tourniquet holds.
+
+    Both attributes are looked up defensively: this file must keep working
+    after the mitigation is deleted, which is the whole point of finding the
+    real cause.
+    """
+    from archimedes.services import market_data_provider as mdp
+
+    raw = os.environ.get("REPRO_DISABLE_MITIGATION", "1").strip().lower()
+    disable = raw not in ("0", "false", "no")
+
+    has_chunk = hasattr(mdp, "_OHLCV_WRITE_CHUNK_ROWS")
+    has_lock = hasattr(mdp, "_OHLCV_CACHE_WRITE_LOCK")
+    if not (has_chunk or has_lock):
+        log("mitigation: absent from this checkout (pre-#1725, or already reverted) — nothing to configure")
+        return
+    if not disable:
+        log(f"mitigation: LEFT ON — flush every {getattr(mdp, '_OHLCV_WRITE_CHUNK_ROWS', '?')} rows, write lock held")
+        return
+
+    if has_chunk:
+        # Larger than any frame, so `pending >= chunk` never trips and the whole
+        # frame goes to the server as ONE executemany, as it did pre-#1725.
+        mdp._OHLCV_WRITE_CHUNK_ROWS = 10**9  # noqa: SLF001 — reaching into the mitigation is the point
+    if has_lock:
+        # nullcontext is reentrant and thread-safe, so one instance serves every
+        # writer thread.
+        mdp._OHLCV_CACHE_WRITE_LOCK = contextlib.nullcontext()  # noqa: SLF001 — same
+    log(
+        f"mitigation: DISABLED for this run (chunking={'off' if has_chunk else 'n/a'}, "
+        f"write lock={'off' if has_lock else 'n/a'}) — driving the pre-#1725 crash shape"
+    )
+
+
+def ensure_schema() -> None:
+    from archimedes.db import engine
+    from archimedes.models.asset_daily_bars import AssetDailyBar
+
+    AssetDailyBar.__table__.create(bind=engine, checkfirst=True)
+    log(f"schema ready on {engine.url.render_as_string(hide_password=True)}")
+
+    # PROOF that psycopg2's bundled OpenSSL is actually doing TLS on this
+    # connection — the whole hypothesis rests on it. Prod's DATABASE_URL
+    # carries no sslmode either, so libpq's default `prefer` is what decides;
+    # if this prints ssl=False the harness is NOT reproducing prod's setup.
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        try:
+            row = conn.execute(
+                text("SELECT ssl, version, cipher FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+            ).first()
+            log(f"libpq connection TLS: ssl={row[0]} version={row[1]} cipher={row[2]}")
+            if not row[0]:
+                log(
+                    "WARNING: connection is PLAINTEXT — the bundled libssl is not exercised; fidelity to prod is broken"
+                )
+        except Exception as exc:
+            log(f"WARNING: could not read pg_stat_ssl ({exc!r})")
+
+
+def prune(keep_symbol_prefix: str) -> None:
+    """Keep the table bounded so the repro is memory/disk stable over 30 min."""
+    from archimedes.db import get_session
+    from archimedes.models.asset_daily_bars import AssetDailyBar
+    from sqlalchemy import delete
+
+    session = get_session()
+    try:
+        session.execute(delete(AssetDailyBar).where(AssetDailyBar.symbol.like(f"{keep_symbol_prefix}%")))
+        session.commit()
+    except Exception:
+        session.rollback()
+    finally:
+        session.close()
+
+
+def writer_thread(worker: int, frame) -> None:
+    """One paper-replay-tick equivalent, on repeat."""
+    from archimedes.db import engine
+    from archimedes.services.market_data_provider import CachingMarketDataProvider
+
+    provider = CachingMarketDataProvider(_ReplayFrameProvider(frame), source_name="yfinance")
+    start = (date.today() - timedelta(days=int(BARS * 1.5))).isoformat()
+    end = date.today().isoformat()
+    prefix = f"RPRO{worker}_"
+    i = 0
+    while not _STOP.is_set():
+        i += 1
+        if TICKER_MODE == "fixed":
+            ticker = f"{prefix}FIX"
+        elif TICKER_MODE == "rotate":
+            ticker = f"{prefix}{i}"
+        else:  # mixed: alternate fresh-insert executemany and update executemany
+            ticker = f"{prefix}FIX" if i % 2 else f"{prefix}{i}"
+
+        try:
+            # THE CRASH PATH. read miss → provider fetch → _write_cached_ohlcv
+            # → session.commit() → psycopg2 do_executemany.
+            out = provider.get_daily_ohlcv(ticker, start, end)
+            with _COUNTS_LOCK:
+                _COUNTS["writes"] += 1
+                _COUNTS["rows"] += 0 if out is None else len(out)
+        except Exception as exc:
+            with _COUNTS_LOCK:
+                _COUNTS["errors"] += 1
+            log(f"writer{worker}: iteration {i} raised {type(exc).__name__}: {exc}")
+
+        if RECYCLE_EVERY and i % RECYCLE_EVERY == 0:
+            # Force fresh libpq TLS handshakes (prod gets these from pool
+            # recycle / Aurora idle timeouts). Handshakes are where the
+            # bundled OpenSSL does its heaviest work.
+            engine.dispose()
+            prune(prefix)
+            log(f"writer{worker}: {i} iterations, engine recycled")
+
+
+# --------------------------------------------------------------------------
+# 4. Interpreter-side TLS churn, concurrent with the commits.
+# --------------------------------------------------------------------------
+
+
+def start_local_tls_server() -> str:
+    """A loopback HTTPS server on the interpreter's OpenSSL.
+
+    Used instead of the public internet so the harness is deterministic and
+    works offline; ``REPRO_TLS_URLS`` overrides it when hammering real hosts
+    is wanted.
+    """
+    import http.server
+    import tempfile
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.now(UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=2))
+        .sign(key, hashes.SHA256())
+    )
+    tmp = tempfile.mkdtemp(prefix="repro1632-")
+    pem = os.path.join(tmp, "server.pem")
+    with open(pem, "wb") as fh:
+        fh.write(
+            key.private_bytes(
+                serialization.Encoding.PEM, serialization.PrivateFormat.TraditionalOpenSSL, serialization.NoEncryption()
+            )
+        )
+        fh.write(cert.public_bytes(serialization.Encoding.PEM))
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:
+            body = b'{"ok":true}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args) -> None:
+            pass
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    # PROTOCOL_TLS_SERVER alone still permits TLS 1.0/1.1 (CodeQL
+    # py/insecure-protocol). Pinning the floor is also the more faithful
+    # setting: the libpq side of this harness negotiates TLS 1.3 against
+    # postgres, so a 1.0-capable loopback server would be exercising OpenSSL
+    # paths prod never touches.
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.load_cert_chain(pem)
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    srv.socket = ctx.wrap_socket(srv.socket, server_side=True)
+    threading.Thread(target=srv.serve_forever, daemon=True, name="repro-tls-server").start()
+    url = f"https://127.0.0.1:{srv.server_address[1]}/ping"
+    log(f"local TLS server up at {url}")
+    return url
+
+
+async def tls_client(url: str, n: int) -> None:
+    """Hammer TLS on the interpreter's OpenSSL: new SSLContext + new session
+    every round, so context creation/teardown (not just record I/O) churns."""
+    import aiohttp
+
+    while not _STOP.is_set():
+        ctx = ssl.create_default_context()
+        # Verification off ONLY because the peer is this process's own
+        # throwaway self-signed loopback server (start_local_tls_server), which
+        # exists so the harness needs no network. The handshake, the cipher
+        # negotiation and the OpenSSL state churn under test are unaffected by
+        # skipping chain validation. Point REPRO_TLS_URLS at a real host and
+        # this becomes a genuine trust bypass — do not copy this pattern into
+        # anything that talks to a peer it did not create.
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        try:
+            connector = aiohttp.TCPConnector(ssl=ctx, limit=4, force_close=True)
+            async with aiohttp.ClientSession(connector=connector) as sess:
+                for _ in range(20):
+                    if _STOP.is_set():
+                        break
+                    async with sess.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                        await resp.read()
+                    with _COUNTS_LOCK:
+                        _COUNTS["tls"] += 1
+        except Exception as exc:
+            with _COUNTS_LOCK:
+                _COUNTS["errors"] += 1
+            if n == 0:
+                log(f"tls client: {type(exc).__name__}: {exc}")
+            await asyncio.sleep(0.5)
+        await asyncio.sleep(0)
+
+
+async def heartbeat() -> None:
+    last = 0.0
+    while not _STOP.is_set():
+        await asyncio.sleep(15)
+        with _COUNTS_LOCK:
+            snap = dict(_COUNTS)
+        log(
+            f"alive: writes={snap['writes']} rows={snap['rows']} "
+            f"executemany={snap['executemany']} (rows={snap['executemany_rows']}) "
+            f"execute={snap['execute']} tls={snap['tls']} errors={snap['errors']} "
+            f"(+{snap['writes'] - last:.0f} writes since last)"
+        )
+        if snap["writes"] >= 4 and snap["executemany"] == 0:
+            log(
+                "!!! do_executemany has NOT been called — this run is NOT exercising the "
+                "#1632 crash frame. Treat any 'no crash' as a non-result."
+            )
+        last = snap["writes"]
+
+
+async def main_async() -> int:
+    url = os.environ.get("REPRO_TLS_URLS")
+    urls = [u.strip() for u in url.split(",") if u.strip()] if url else [start_local_tls_server()]
+
+    frame = recorded_frame(BARS)
+    log(f"recorded frame: {len(frame)} bars {frame.index[0].date()} → {frame.index[-1].date()}")
+    configure_mitigation()
+    instrument_dbapi()
+    ensure_schema()
+
+    loop = asyncio.get_running_loop()
+    # asyncio.to_thread → the DEFAULT executor. This is precisely how
+    # paper_advance_loop runs advance_all(), and it is the layout under test:
+    # psycopg2 committing on a worker thread while the event loop does TLS.
+    writers = [loop.run_in_executor(None, writer_thread, w, frame) for w in range(WRITERS)]
+    clients = [asyncio.create_task(tls_client(urls[i % len(urls)], i)) for i in range(TLS_CLIENTS)]
+    beat = asyncio.create_task(heartbeat())
+
+    log(f"running for {DURATION_S:.0f}s: {WRITERS} writer thread(s), {TLS_CLIENTS} TLS client(s), {BARS} bars/write")
+    try:
+        await asyncio.sleep(DURATION_S)
+    finally:
+        _STOP.set()
+        beat.cancel()
+        for c in clients:
+            c.cancel()
+        await asyncio.gather(*clients, beat, return_exceptions=True)
+        await asyncio.gather(*writers, return_exceptions=True)
+
+    fingerprint("end of run")
+    with _COUNTS_LOCK:
+        snap = dict(_COUNTS)
+        stmts = dict(_EXECUTEMANY_STATEMENTS)
+    log(
+        f"SURVIVED {DURATION_S:.0f}s — writes={snap['writes']} rows={snap['rows']} "
+        f"tls={snap['tls']} errors={snap['errors']}"
+    )
+    # Mean batch size is the observable that PROVES which shape ran: the
+    # #1725 mitigation caps a flush at 500 rows, the pre-#1725 path sends the
+    # whole frame (REPRO_BARS) in one go. If this prints ~500 when the log
+    # claims the mitigation is disabled, the knob did not take.
+    mean_rows = (snap["executemany_rows"] / snap["executemany"]) if snap["executemany"] else 0
+    log(
+        f"do_executemany calls: {snap['executemany']} (param rows: {snap['executemany_rows']}, "
+        f"mean {mean_rows:.0f} rows/call)"
+    )
+    for stmt, n in sorted(stmts.items(), key=lambda kv: -kv[1]):
+        log(f"    {n:>7} x  {stmt}")
+    log(f"do_execute calls    : {snap['execute']}")
+    if snap["executemany"] == 0:
+        log("VERDICT: NON-RESULT — do_executemany was never reached; the #1632 frame was not exercised")
+        return 3
+    log("VERDICT: no abort in this variant/run")
+    return 0
+
+
+def main() -> int:
+    random.seed(1632)
+    fingerprint("before app import")
+    load_app_modules()
+    fingerprint("after app import")
+    try:
+        import uvloop  # prod runs uvicorn[standard] → uvloop
+
+        uvloop.install()
+        log("event loop: uvloop (matches prod uvicorn[standard])")
+    except Exception:
+        log("event loop: asyncio default (uvloop unavailable)")
+    return asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/issue-1632/run.sh
+++ b/scripts/repro/issue-1632/run.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# A/B runner for issue #1632 — see README.md.
+#
+#   ./run.sh                 both variants, REPRO_DURATION_S each (default 1800)
+#   ./run.sh binary          just the psycopg2-binary (prod) variant
+#   ./run.sh source          just the psycopg2-from-source variant
+#
+# Exit status is 0 whether or not a crash happened: a crash IS the result, and
+# a non-repro is a result too. Read the verdict block it prints at the end.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../../.." && pwd)"
+LOGDIR="${REPRO_LOGDIR:-${HERE}/.logs}"
+CERTDIR="${HERE}/.certs"
+DURATION_S="${REPRO_DURATION_S:-1800}"
+PROJECT="repro1632"
+
+mkdir -p "${LOGDIR}"
+
+step() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+
+# ---------------------------------------------------------------- TLS cert --
+# postgres:18-alpine has no openssl CLI, so the self-signed pair is made here
+# and mounted; initdb-ssl.sh copies it into PGDATA with the perms postgres
+# demands. Regenerated only when missing.
+if [[ ! -f "${CERTDIR}/server.key" ]]; then
+  step "generating self-signed TLS cert for the repro postgres"
+  mkdir -p "${CERTDIR}"
+  openssl req -new -x509 -days 30 -nodes -text \
+    -out "${CERTDIR}/server.crt" -keyout "${CERTDIR}/server.key" \
+    -subj "/CN=postgres" >/dev/null 2>&1 || { echo "openssl failed"; exit 1; }
+  chmod 644 "${CERTDIR}/server.crt" "${CERTDIR}/server.key"
+fi
+
+# ------------------------------------------------------------------ images --
+build_binary() {
+  step "building the prod image (psycopg2-binary) — backend/Dockerfile, repo root context"
+  docker build -f "${REPO_ROOT}/backend/Dockerfile" -t archimedes-repro1632:binary "${REPO_ROOT}" \
+    >"${LOGDIR}/build-binary.log" 2>&1 \
+    || { echo "build failed — see ${LOGDIR}/build-binary.log"; exit 1; }
+}
+
+build_source() {
+  step "building the A/B image (psycopg2 from source)"
+  local ver
+  ver="$(docker run --rm archimedes-repro1632:binary python -c 'import psycopg2; print(psycopg2.__version__.split()[0])' | tr -d '\r')"
+  echo "matching psycopg2 version: ${ver}"
+  docker build --progress=plain -f "${HERE}/Dockerfile.psycopg2-source" \
+    --build-arg BASE_IMAGE=archimedes-repro1632:binary \
+    --build-arg "PSYCOPG2_VERSION=${ver}" \
+    -t archimedes-repro1632:source "${HERE}" \
+    >"${LOGDIR}/build-source.log" 2>&1 \
+    || { echo "build failed — see ${LOGDIR}/build-source.log"; exit 1; }
+}
+
+# ------------------------------------------------------------------- run 1 --
+run_variant() {
+  local variant="$1"
+  local image="archimedes-repro1632:${variant}"
+  local log="${LOGDIR}/run-${variant}.log"
+  local proj="${PROJECT}-${variant}"
+
+  step "running variant: ${variant}  (${DURATION_S}s budget) → ${log}"
+
+  # Drop this variant's previous verdict BEFORE running. Without it, a run that
+  # dies before writing one leaves the old file in place and the A/B summary
+  # reports a stale result as if it were this run's — the exact "trusted a
+  # signal for something it does not measure" failure this harness exists to
+  # avoid. Sibling variants' verdicts are deliberately left alone so `run.sh
+  # source` can still be summarised next to an earlier `run.sh binary`.
+  rm -f "${LOGDIR}/verdict-${variant}.txt"
+
+  REPRO_IMAGE="${image}" docker compose -p "${proj}" -f "${HERE}/docker-compose.repro.yml" down -v --remove-orphans >/dev/null 2>&1
+
+  local started ended rc
+  started="$(date +%s)"
+  REPRO_IMAGE="${image}" REPRO_DURATION_S="${DURATION_S}" \
+    docker compose -p "${proj}" -f "${HERE}/docker-compose.repro.yml" \
+    run --rm --no-TTY harness >"${log}" 2>&1
+  rc=$?
+  ended="$(date +%s)"
+
+  REPRO_IMAGE="${image}" docker compose -p "${proj}" -f "${HERE}/docker-compose.repro.yml" down -v --remove-orphans >/dev/null 2>&1
+
+  local elapsed=$(( ended - started ))
+  local writes execmany
+  writes="$(grep -o 'writes=[0-9]*' "${log}" | tail -1 | cut -d= -f2)"
+  writes="${writes:-0}"
+  execmany="$(grep -o 'do_executemany calls: [0-9]*' "${log}" | tail -1 | grep -o '[0-9]*$')"
+  execmany="${execmany:-$(grep -o 'executemany=[0-9]*' "${log}" | tail -1 | cut -d= -f2)}"
+  execmany="${execmany:-0}"
+
+  {
+    echo "variant        : ${variant}"
+    # Dated, because `run.sh source` prints this next to a binary verdict that
+    # may have been produced hours earlier.
+    echo "run finished   : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "exit code      : ${rc}   $( [[ ${rc} -eq 134 || ${rc} -eq 139 ]] && echo '<-- ABORT/SEGV' )"
+    echo "wall clock     : ${elapsed}s of ${DURATION_S}s budget"
+    echo "cache writes   : ${writes}"
+    # The load-bearing number: prod aborted INSIDE do_executemany. Zero here
+    # means the run never entered the frame under test, so "no crash" proves
+    # nothing at all.
+    echo "do_executemany : ${execmany}"
+    [[ "${execmany}" -eq 0 ]] && echo "                 ^^ ZERO — crash frame never entered; this run is a NON-RESULT"
+    # Read the count the harness itself computed. Counting the indented path
+    # lines instead over-reports 3x, because the fingerprint is printed three
+    # times per run (before import, after import, end of run) — a wrong number
+    # that looks authoritative.
+    echo -n "libssl copies  : "
+    grep -o 'mappings loaded: [0-9]*' "${log}" | tail -1 | grep -o '[0-9]*$' || echo "?"
+    if grep -q 'Fatal Python error' "${log}"; then
+      echo "CRASHED        : YES"
+      grep -n 'Fatal Python error' -A 25 "${log}" | head -40
+    else
+      echo "CRASHED        : no"
+    fi
+  } | tee "${LOGDIR}/verdict-${variant}.txt"
+}
+
+TARGET="${1:-both}"
+
+case "${TARGET}" in
+  binary) build_binary; run_variant binary ;;
+  source) build_binary; build_source; run_variant source ;;
+  both)   build_binary; build_source; run_variant binary; run_variant source ;;
+  *) echo "usage: $0 [binary|source|both]"; exit 2 ;;
+esac
+
+step "A/B summary"
+cat "${LOGDIR}"/verdict-*.txt


### PR DESCRIPTION
## Lane 1 — reproduction + A/B verdict for #1632

The #1725 flag is the tourniquet. This is the rig for the surgery: a harness that drives the real crash path in the real image, plus the A/B against the leading mechanism.

**Headline: the dual-OpenSSL condition is CONFIRMED PRESENT in the prod image, but this harness did NOT show it to be sufficient. Neither variant aborted in 30 minutes.** That is a non-repro, reported as a result — the hypothesis is neither confirmed nor killed.

### What the harness drives

The shipped code, not a mock of it:

```
paper_advance_loop            asyncio.to_thread → DEFAULT executor thread
  └─ replay → fetch_real_panel → _fetch_one
       └─ CachingMarketDataProvider.get_daily_ohlcv       ← real, shipped
            └─ read miss → inner fetch → _write_cached_ohlcv
                 └─ session.commit()  →  psycopg2 do_executemany  →  ABORT
```

Only the market-data vendor is substituted (a recorded 2600-bar OHLCV frame). Runs inside the image built from `backend/Dockerfile` — never bare-metal, because the bundled libssl only exists in the pip wheel — against a **TLS-enabled** `postgres:18-alpine`, concurrent with aiohttp TLS churn on a uvloop event loop.

Three fidelity points that were checked, not assumed:
- `pg_stat_ssl` confirms the libpq connection is real TLS: `ssl=True, TLSv1.3, TLS_AES_256_GCM_SHA384`. Prod's `DATABASE_URL` (`infra/outputs.tf`) carries no `sslmode`, so libpq's default `prefer` negotiates TLS against Aurora — the bundled OpenSSL is live, not merely resident. The repo's `localdb` postgres runs `ssl=off`, which would have left it untouched; hence the separate compose file.
- 287 C extensions loaded (prod: ~230), via `import archimedes.main`.
- `uvloop` installed, as `uvicorn[standard]` does in prod.

### Evidence 1 — how many libssl copies each variant loads

`openssl_inventory.py`, in-image, `/proc/self/maps` + `OpenSSL_version()` per mapping:

| | A: `psycopg2-binary` (prod) | B: psycopg2 from source |
| --- | --- | --- |
| libssl/libcrypto mappings | **5** | **2** |
| distinct OpenSSL builds | **2** | **1** |

Variant A, in one address space:

| library | build | origin |
| --- | --- | --- |
| `/usr/lib/*/libssl.so.3` + `libcrypto.so.3` | OpenSSL 3.5.6 | interpreter `_ssl` → aiohttp, web3, httpx, boto3 |
| `psycopg2_binary.libs/libssl-ad00b19a.so.3` + `libcrypto-a90fc9c6.so.3` | OpenSSL 3.5.6, *separate build, separate global state* | the wheel's bundled libpq → the Aurora TLS session |
| `psycopg2_binary.libs/libcrypto-6aa7cfbd.so.1.1.1k` | **OpenSSL 1.1.1k FIPS (2021)** | the wheel's bundled krb5/ldap stack |

So the condition psycopg2's docs warn about is real here, and a 2021-vintage OpenSSL 1.1.1 is riding along inside the wheel. Variant B loads only the system OpenSSL — which is what makes it a usable control.

### Evidence 2 — the A/B, 30 minutes each

Base `e43abe9f` (pre-#1725), `linux/arm64`:

| | A: `psycopg2-binary` | B: psycopg2 from source |
| --- | --- | --- |
| wall clock | 1823 s of 1800 s | 1815 s of 1800 s |
| cache writes | 3 664 | 4 794 |
| **`do_executemany`** | **1 685** (4 381 000 param rows) | **2 206** (5 735 600 param rows) |
| statement | `UPDATE asset_daily_bars` ×1685 | `UPDATE asset_daily_bars` ×2206 |
| `do_execute` | 13 415 | 17 546 |
| aiohttp TLS requests | 290 051 | 311 955 |
| errors | 0 | 0 |
| **aborted?** | **no** | **no** |

**Verdict: non-repro on both halves.** 1 685 passes through the exact frame prod aborted in, on a TLS libpq connection, concurrent with 290 k interpreter-side TLS requests, did not abort. What this *does* kill: the idea that the co-activity alone is sufficient on arm64 against a local postgres. The A/B cannot yet say whether the source build fixes anything, because there was nothing to fix in the control.

### The finding that narrows the search

The harness counts `do_executemany` and `do_execute` separately, and it changed the picture:

| `_write_cached_ohlcv` branch | what SQLAlchemy 2.0 emits | psycopg2 entry point |
| --- | --- | --- |
| new rows (`session.add`) | `INSERT … VALUES (…),(…) RETURNING id` via *insertmanyvalues* | `do_execute` |
| existing rows | `UPDATE asset_daily_bars SET … WHERE id = %(id)s` batched by PK | **`do_executemany`** |

Measured, 40 s: `REPRO_TICKER_MODE=rotate` (all-INSERT) → `do_executemany: 0`. Default `mixed` → 41 calls, all `UPDATE asset_daily_bars`.

**An insert-only loop never enters the crash frame at all.** So prod's abort is on the warm-cache **UPDATE** branch — re-writing a cache entry that already exists, not priming a cold one. Whoever carries this forward should aim there.

### Adversarial pass on the guards

Per the repo rule, each guard was shown to reject something before pushing.

1. **`do_executemany == 0` ⇒ NON-RESULT (exit 3), not "no crash."** Built the input that should trip it (`REPRO_TICKER_MODE=rotate`): harness logged `!!! do_executemany has NOT been called` and exited 3. **This guard caught two real defects in my own work** — (a) a `DefaultDialect.do_executemany` monkeypatch that never fired because `PGDialect_psycopg2` overrides the method, so the counter would have read a silent permanent zero while the run reported a reassuring "no crash"; (b) the INSERT/UPDATE split above.
2. **`configure_mitigation()` actually flips the shipped mitigation.** Mean `executemany` batch size is the observable: `=1` (default) → **2600 rows/call** (= `REPRO_BARS`, one batch per frame, pre-#1725 shape); `=0` → **433 rows/call**, under the 500-row cap. **First attempt failed the check**: `REPRO_DISABLE_MITIGATION` was not in `docker-compose.repro.yml`'s `environment:` block, so it never reached the container and the run reported the default while looking like it honoured the setting. Fixed, then re-verified in both directions.
3. **`libssl copies` in the verdict was over-reporting 3×** (it counted path lines across all three fingerprint dumps, printing 15 instead of 5). Now reads the count the harness itself computed.
4. **Stale verdict files could be reported as this run's.** A run that dies before writing one left the previous file in place. `run_variant` now deletes its own verdict first and stamps each with a UTC finish time.

### Fidelity gaps — state these alongside the non-repro

- **Architecture.** `linux/arm64` here; prod Fargate is `linux/amd64`. The wheel bundles OpenSSL on both, but the binaries differ. This is the biggest gap and the first thing to close.
- **Server.** Local `postgres:18-alpine` vs Aurora 18.3 across a VPC — different TLS peer, latency, idle-timeout behaviour.
- **Load shape.** No FastAPI request traffic, no LLM calls, no on-chain RPC.
- **The B image is not a pure one-variable swap.** Its `apt-get` layer also moves system OpenSSL 3.5.6 → 3.5.7 and libpq 170009 → 170011 — patch-level, but it would need ruling out before attributing any future difference to the psycopg2 flavour alone.

### Note for whoever writes the fix

`backend/Dockerfile`'s builder stage installs `gcc libpq-dev`, which is enough only because `psycopg2-binary` is a prebuilt wheel that never compiles. Switching the requirement to source-built psycopg2 without also adding **`libc6-dev`** fails the image build with `Python.h:23: fatal error: stdlib.h: No such file or directory`. Found the hard way; recorded in `Dockerfile.psycopg2-source`.

### Verification

- Unit suite on this branch: **5557 passed, 3 skipped, 2 deselected, 0 failed** (`pytest -m "not integration"`, repo root, env's pytest 9.0.3 / Python 3.12.13).
- `ruff check` + `ruff format --check` clean on `scripts/repro/issue-1632/`.
- `docker compose -f scripts/repro/issue-1632/docker-compose.repro.yml config -q` valid; `bash -n run.sh`, `sh -n initdb-ssl.sh` clean.
- Rebased onto current `main` (`131149aa`) after #1728 landed the mitigation in the function under test; the default `REPRO_DISABLE_MITIGATION=1` reproduces the pre-mitigation shape, confirmed by the 2600 rows/call batch size matching the original runs exactly.

### Not in this PR

No production code touched — this is `scripts/repro/issue-1632/` only. No merge; the real fix is a separate call.

Part of #1632
