### PR TITLE
[frontend] Generate leftovers: human 409 copy and pay-retry drill-in

### DIFF
--- a/ui/src/AuthenticatedApp.jsx
+++ b/ui/src/AuthenticatedApp.jsx
@@ -154,6 +154,7 @@ export default function AuthenticatedApp({
 					<Generate
 						onNavigate={navigateToPage}
 						onStageChange={setJourneyStage}
+						user={user}
 					/>
 				);
 			case "library":

--- a/ui/src/components/FreeGenerationBanner.jsx
+++ b/ui/src/components/FreeGenerationBanner.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiGet } from "../api";
 import { ACCOUNT_USAGE_ENDPOINT, deriveFreeGenerationView } from "../freeGenerations";
+import ResendVerificationControl from "./ResendVerificationControl";
 
 // Free-generation allowance banner + remaining-count chip (#1643).
 //
@@ -25,7 +26,7 @@ import { ACCOUNT_USAGE_ENDPOINT, deriveFreeGenerationView } from "../freeGenerat
 // free_generations_remaining: null because the ledger was unreadable, or the
 // free path is switched off (allowance <= 0). deriveFreeGenerationView in
 // ../freeGenerations.js owns that decision and is unit-tested directly.
-export default function FreeGenerationBanner() {
+export default function FreeGenerationBanner({ email }) {
 	const [view, setView] = useState(null);
 
 	useEffect(() => {
@@ -58,7 +59,10 @@ export default function FreeGenerationBanner() {
 			// without re-deriving the rule it is checking.
 			data-state={view.state}
 		>
-			<span>{view.message}</span>
+			<div>
+				<span>{view.message}</span>
+				{view.state === "locked" && <ResendVerificationControl email={email} />}
+			</div>
 			<span
 				className="caption"
 				style={{ flexShrink: 0, whiteSpace: "nowrap", color: "var(--text-3)" }}

--- a/ui/src/components/Generate.jsx
+++ b/ui/src/components/Generate.jsx
@@ -3,10 +3,12 @@ import GenerationStream from "./GenerationStream";
 import GenerationStatus from "./GenerationStatus";
 import ModelCostPanel from "./ModelCostPanel";
 import FreeGenerationBanner from "./FreeGenerationBanner";
+import ResendVerificationControl from "./ResendVerificationControl";
 import { SURPRISE_BRIEFS } from "../data/surpriseBriefs";
 import { pickSurpriseBrief } from "../data/pickSurpriseBrief";
 import { ASSET_GROUPS, SUPPORTED_ASSETS } from "../data/assetUniverse";
 import { apiGet, apiPostWithMeta } from "../api";
+import { deriveWalletGateView } from "../freeGenerations";
 import { getAddress } from "../config";
 import { listLinkedWallets } from "../linked-wallets";
 import { GENERATION_QUOTE_ENABLED } from "../featureFlags";
@@ -110,7 +112,7 @@ const RISK_PROFILES = [
 
 // ─────────────────────────────────────────────────────────────
 
-export default function Generate({ onNavigate, onStageChange }) {
+export default function Generate({ onNavigate, onStageChange, user }) {
 	// ── Brief form state ──
 	const [intent, setIntent] = useState("");
 	const [starting, setStarting] = useState(false);
@@ -165,6 +167,9 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// banner never survives a retry.
 	const [paymentStatus, setPaymentStatus] = useState(PAYMENT_STATUS.NONE);
 	const [paymentMessage, setPaymentMessage] = useState("");
+	// Human view of a 409 wallet_link_required — derived once from the error
+	// so the panel never dumps the agent/curl `detail.message` (#1658 leftover).
+	const [walletGateView, setWalletGateView] = useState(null);
 	// The parsed PAYMENT-REQUIRED requirements from the active 402 (or an
 	// error state if the header was missing/malformed/had no supported
 	// option) — see ../generateQuote.js's derivePaymentRequirements. Null
@@ -419,6 +424,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 	const resetPaymentStepState = () => {
 		setPaymentStatus(PAYMENT_STATUS.NONE);
 		setPaymentMessage("");
+		setWalletGateView(null);
 		setPaymentRequirements(null);
 		setPaymentRequirementsAt(0);
 		setPaywallQuoteRaw(null);
@@ -467,7 +473,9 @@ export default function Generate({ onNavigate, onStageChange }) {
 					setPaymentRequirements(derivePaymentRequirements(extractPaymentRequiredHeader(e.headers)));
 					setPaymentRequirementsAt(Date.now());
 				} else {
-					setPaymentMessage(paymentErrorMessage(e));
+					// 409 wallet_link_required. Same anti-dump rule as 402: the
+					// backend message names POST /api/... paths for agents.
+					setWalletGateView(deriveWalletGateView(e));
 				}
 			} else {
 				setStartError(startErrorMessage(e, "Failed to start generation"));
@@ -495,11 +503,17 @@ export default function Generate({ onNavigate, onStageChange }) {
 	// succeeded outright (paywall off), else the freshly parsed requirements.
 	const refreshPaymentRequirements = async () => {
 		try {
-			const { receipt: settledReceipt } = await submitStart();
+			const { data, receipt: settledReceipt } = await submitStart();
 			resetPaymentStepState();
 			setNoSettlementNotice(!settledReceipt);
 			if (GENERATION_QUOTE_ENABLED) fetchQuote();
 			fetchCredits();
+			// Same contract as startJob / finishStart: an accepted job takes
+			// the user into the stream. Returning null without this used to
+			// leave the armed pay button beside a quiet table-row update —
+			// the exact "reads as a failed start" shape enterStartedJob exists
+			// to close.
+			enterStartedJob(data);
 			return null;
 		} catch (e) {
 			const fresh = derivePaymentRequirements(extractPaymentRequiredHeader(e.headers));
@@ -666,9 +680,15 @@ export default function Generate({ onNavigate, onStageChange }) {
 			if (isActivationRefusal(e)) {
 				setPayStep("confirm");
 			} else {
-				setPaymentMessage(
-					paymentErrorMessage(e, e?.shortMessage || e?.message || "Payment failed — try again."),
-				);
+				const gate = deriveWalletGateView(e);
+				if (gate) {
+					setPaymentStatus(PAYMENT_STATUS.WALLET_LINK_REQUIRED);
+					setWalletGateView(gate);
+				} else {
+					setPaymentMessage(
+						paymentErrorMessage(e, e?.shortMessage || e?.message || "Payment failed — try again."),
+					);
+				}
 			}
 		} finally {
 			setPaying(false);
@@ -1147,7 +1167,7 @@ export default function Generate({ onNavigate, onStageChange }) {
 					    not have to touch the same lines. #1642 builds no gating
 					    logic — if this div is still empty, #1643 has not landed. */}
 					<div className="generate-gate-slot" data-generate-gate-slot>
-						<FreeGenerationBanner />
+						<FreeGenerationBanner email={user?.email} />
 					</div>
 
 					{/* `generate-submit-row` (not a bare flex utility chain) because
@@ -1174,7 +1194,8 @@ export default function Generate({ onNavigate, onStageChange }) {
 						>
 						{paymentStatus === PAYMENT_STATUS.WALLET_LINK_REQUIRED ? (
 							<div className="info-box warning" style={{ flex: 1 }}>
-								<strong>Wallet link required.</strong> {paymentMessage}
+								<strong>{walletGateView?.title ?? "Wallet link required"}.</strong>{" "}
+								{walletGateView?.message}
 								{payerMismatch && (
 									<p
 										className="caption mb-0"
@@ -1185,7 +1206,11 @@ export default function Generate({ onNavigate, onStageChange }) {
 										{shortAddr(payerMismatch.linked)}. Switch your wallet's
 										active account to that one, or link the connected one below.
 									</p>
-								)}{" "}
+								)}
+								{walletGateView?.offerResend && (
+									<ResendVerificationControl email={user?.email} />
+								)}
+								{" "}
 								<button
 									type="button"
 									onClick={() =>

--- a/ui/src/components/ResendVerificationControl.jsx
+++ b/ui/src/components/ResendVerificationControl.jsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { resendVerificationEmail } from "../auth-client";
+import { VERIFICATION_REQUESTED_MESSAGE } from "../freeGenerations";
+
+// On-demand verification resend for the Generate page (locked free-tier
+// banner + the 409 wallet-gate panel). Account Settings already has this
+// button; #1658 deferred the Generate-page copy to the #1642 redesign,
+// which landed without it. One control, two mount points, so the two
+// surfaces cannot drift on honesty (queued ≠ delivered).
+//
+// Renders nothing when there is no email to send to — a button that POSTs
+// an empty address would be a claim this control cannot keep.
+export default function ResendVerificationControl({ email }) {
+	const [status, setStatus] = useState("idle");
+	const [error, setError] = useState("");
+
+	if (!email) return null;
+
+	const send = async () => {
+		setStatus("sending");
+		setError("");
+		try {
+			await resendVerificationEmail(email, `${window.location.origin}/app`);
+			setStatus("sent");
+		} catch (err) {
+			setError(err?.message || "Could not request a verification email.");
+			setStatus("error");
+		}
+	};
+
+	return (
+		<div className="generate-resend" style={{ marginTop: 8 }}>
+			<button
+				type="button"
+				className="btn btn-outline btn-sm"
+				onClick={send}
+				disabled={status === "sending"}
+			>
+				{status === "sending" ? "Sending…" : "Resend verification email"}
+			</button>
+			{status === "sent" && (
+				<p className="caption mb-0" role="status" style={{ marginTop: 6 }}>
+					{VERIFICATION_REQUESTED_MESSAGE}
+				</p>
+			)}
+			{status === "error" && (
+				<p className="caption mb-0" role="alert" style={{ marginTop: 6 }}>
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/ui/src/freeGenerations.js
+++ b/ui/src/freeGenerations.js
@@ -130,3 +130,58 @@ export function deriveFreeGenerationView(usage) {
 				"No wallet needed until they run out.",
 	};
 }
+
+/**
+ * Honest copy after a resend click. Better Auth's send-verification-email
+ * returns `{status:true}` once the send is QUEUED, and the auth sidecar's
+ * mailer fail-softs (SES sandbox), so delivery is not a fact this UI can
+ * claim. Must stay in lockstep with AccountSettings.jsx's
+ * `VERIFICATION_REQUESTED_MESSAGE` — ui/test/free-generation-banner.test.js
+ * pins the two strings equal.
+ */
+export const VERIFICATION_REQUESTED_MESSAGE =
+	"Verification email requested — delivery isn't confirmed and may take a few minutes.";
+
+/**
+ * Turn a `409 wallet_link_required` /start error into what the Generate page
+ * shows a human.
+ *
+ * Two different dead ends share that status code (#1658). The backend
+ * `detail.message` names `POST /api/...` paths for agents; the interactive
+ * Generate page must not dump those (the same rule Generate.jsx already
+ * applies to 402 copy). `free_generations_locked_reason` is the discriminator
+ * the backend added for this; the UI was still rendering every 409 as
+ * "Wallet link required" plus the agent paragraph.
+ *
+ * Returns null when `err` is not that 409 — callers fall through to the
+ * generic start-error banner.
+ *
+ * @param {object|null|undefined} err — thrown by apiPostWithMeta
+ * @returns {{kind: string, title: string, message: string, offerResend: boolean}|null}
+ */
+export function deriveWalletGateView(err) {
+	if (!err || err.status !== 409 || err.detail?.reason !== "wallet_link_required") {
+		return null;
+	}
+
+	const locked = err.detail?.free_generations_locked_reason;
+	if (locked === LOCK_EMAIL_UNVERIFIED) {
+		return {
+			kind: "email_unverified",
+			title: "Verify your email to generate for free",
+			message:
+				"Verify your email to unlock free generations on this account — no wallet and no payment needed. Check your inbox for the link we sent when you signed up, or resend it below. You can also link a wallet and pay per run.",
+			offerResend: true,
+		};
+	}
+
+	// Exhausted, unknown lock, or a pre-D1 409 with no discriminator — the
+	// wallet path is the honest next step, never "verify your email".
+	return {
+		kind: "exhausted",
+		title: "Wallet link required",
+		message:
+			"Your free generations are used up. Link a wallet to keep generating — see the price below.",
+		offerResend: false,
+	};
+}

--- a/ui/test/free-generation-banner.test.js
+++ b/ui/test/free-generation-banner.test.js
@@ -5,7 +5,9 @@ import test from "node:test";
 import {
 	ACCOUNT_USAGE_ENDPOINT,
 	LOCK_EMAIL_UNVERIFIED,
+	VERIFICATION_REQUESTED_MESSAGE,
 	deriveFreeGenerationView,
+	deriveWalletGateView,
 } from "../src/freeGenerations.js";
 
 // Free-generation allowance banner (#1643).
@@ -259,8 +261,19 @@ test("Generate.jsx mounts the banner exactly once, and imports it as its own com
 	// feature's footprint there is one import + one element, and this test is
 	// what keeps it that way.
 	assert.match(generate, /import FreeGenerationBanner from "\.\/FreeGenerationBanner"/);
-	const mounts = generate.match(/<FreeGenerationBanner\s*\/>/g) || [];
+	const mounts = generate.match(/<FreeGenerationBanner\b[^>]*\/>/g) || [];
 	assert.equal(mounts.length, 1, `expected exactly one mount, found ${mounts.length}`);
+	assert.match(mounts[0], /email=\{user\?\.email\}/);
+});
+
+test("AuthenticatedApp threads the signed-in user into Generate so resend has an address", () => {
+	const authenticatedApp = readFileSync(
+		new URL("../src/AuthenticatedApp.jsx", import.meta.url),
+		"utf8",
+	);
+	const genMount = authenticatedApp.match(/<Generate\b[\s\S]*?\/>/);
+	assert.ok(genMount, "Generate mount missing from AuthenticatedApp");
+	assert.match(genMount[0], /user=\{user\}/);
 });
 
 test("Insights.jsx labels the two new funnel stages instead of showing raw keys", () => {
@@ -280,4 +293,118 @@ test("Insights.jsx labels the two new funnel stages instead of showing raw keys"
 		[...positions].sort((a, b) => a - b),
 		"CORE_FUNNEL_LABELS keys must follow the backend STAGES order",
 	);
+});
+
+// ── 409 wallet-gate panel: human copy, not the agent/curl paragraph (#1658 leftover)
+
+const AGENT_UNLOCK_409 = {
+	status: 409,
+	detail: {
+		reason: "wallet_link_required",
+		free_generations_locked_reason: LOCK_EMAIL_UNVERIFIED,
+		message:
+			"Two ways to generate. (1) Verify your email to unlock 3 free generations on this account — no wallet and no payment needed. We emailed a verification link when you signed up; POST /api/auth/send-verification-email re-sends it. (2) Or link a wallet now (POST /api/wallets/challenge → /api/wallets/verify), fund it with testnet USDC (the faucet currently requires a human), and pay per run. See GET /api/generate/quote for the price.",
+	},
+};
+
+const AGENT_EXHAUSTED_409 = {
+	status: 409,
+	detail: {
+		reason: "wallet_link_required",
+		free_generations_locked_reason: null,
+		message:
+			"Your free generations are used up. Generation now requires a linked, funded wallet. Link a wallet to your account (POST /api/wallets/challenge → /api/wallets/verify), fund it with testnet USDC (the faucet currently requires a human), then retry. See GET /api/generate/quote for the price.",
+	},
+};
+
+test("a 409 with email_unverified tells a human to verify, and never dumps POST /api/ paths", () => {
+	const view = deriveWalletGateView(AGENT_UNLOCK_409);
+	assert.equal(view.kind, "email_unverified");
+	assert.equal(view.offerResend, true);
+	assert.match(view.title, /Verify your email/i);
+	assert.match(view.message, /no wallet and no payment needed/i);
+	assert.doesNotMatch(view.title + view.message, /POST \/api\//);
+	assert.doesNotMatch(view.message, /wallets\/challenge/);
+	assert.doesNotMatch(view.message, /send-verification-email/);
+});
+
+test("a 409 with no lock (exhausted free tier) tells a human to link a wallet, not to verify", () => {
+	const view = deriveWalletGateView(AGENT_EXHAUSTED_409);
+	assert.equal(view.kind, "exhausted");
+	assert.equal(view.offerResend, false);
+	assert.match(view.title, /Wallet link required/i);
+	assert.match(view.message, /Link a wallet/i);
+	assert.doesNotMatch(view.message, /Verify your email/i);
+	assert.doesNotMatch(view.title + view.message, /POST \/api\//);
+});
+
+test("an unknown lock reason still offers the wallet path, never a fabricated verify instruction", () => {
+	const view = deriveWalletGateView({
+		status: 409,
+		detail: {
+			reason: "wallet_link_required",
+			free_generations_locked_reason: "region_blocked",
+			message: "POST /api/wallets/challenge",
+		},
+	});
+	assert.equal(view.kind, "exhausted");
+	assert.equal(view.offerResend, false);
+	assert.doesNotMatch(view.message, /Verify your email/i);
+	assert.doesNotMatch(view.message, /POST \/api\//);
+});
+
+test("deriveWalletGateView returns null for anything that is not the wallet-link 409", () => {
+	assert.equal(deriveWalletGateView(null), null);
+	assert.equal(deriveWalletGateView({ status: 402, detail: { reason: "payment_required" } }), null);
+	assert.equal(deriveWalletGateView({ status: 409, detail: { reason: "some_other_conflict" } }), null);
+	assert.equal(deriveWalletGateView({ status: 409 }), null);
+});
+
+test("Generate.jsx paints the 409 panel from deriveWalletGateView, not paymentErrorMessage", () => {
+	assert.match(generate, /deriveWalletGateView\(/);
+	assert.match(generate, /walletGateView\?\.title/);
+	assert.match(generate, /walletGateView\?\.message/);
+	assert.match(generate, /walletGateView\?\.offerResend/);
+	// The 409 branch used to interpolate paymentMessage, which is the agent
+	// paragraph. That interpolation must not survive in the wallet-gate panel.
+	const gateStart = generate.indexOf("PAYMENT_STATUS.WALLET_LINK_REQUIRED ?");
+	assert.ok(gateStart !== -1, "409 panel branch missing");
+	const gateEnd = generate.indexOf("PAYMENT_STATUS.DRY_RUN", gateStart);
+	const gateSlice = generate.slice(gateStart, gateEnd);
+	assert.doesNotMatch(gateSlice, /\{paymentMessage\}/);
+	assert.doesNotMatch(gateSlice, /paymentErrorMessage/);
+	assert.doesNotMatch(gateSlice, /POST \/api\//);
+});
+
+test("the locked banner mounts a resend control, gated on the locked state", () => {
+	assert.match(banner, /import ResendVerificationControl from "\.\/ResendVerificationControl"/);
+	assert.match(banner, /view\.state === ["']locked["'] && <ResendVerificationControl email=\{email\} \/>/);
+});
+
+test("resend success copy is honest — requested, not confirmed delivered — and matches Account Settings", () => {
+	const accountSettings = readFileSync(
+		new URL("../src/components/AccountSettings.jsx", import.meta.url),
+		"utf8",
+	);
+	const settingsMsg = accountSettings.match(
+		/const VERIFICATION_REQUESTED_MESSAGE = "([^"]+)"/,
+	);
+	assert.ok(settingsMsg, "AccountSettings honesty constant missing");
+	assert.equal(VERIFICATION_REQUESTED_MESSAGE, settingsMsg[1]);
+	assert.match(VERIFICATION_REQUESTED_MESSAGE, /requested/i);
+	assert.match(VERIFICATION_REQUESTED_MESSAGE, /(isn't|is not|not) confirmed/i);
+	assert.doesNotMatch(VERIFICATION_REQUESTED_MESSAGE, /email (was )?sent successfully/i);
+});
+
+test("ResendVerificationControl POSTs via the shared auth-client and renders nothing without an email", () => {
+	const control = readFileSync(
+		new URL("../src/components/ResendVerificationControl.jsx", import.meta.url),
+		"utf8",
+	);
+	assert.match(control, /resendVerificationEmail/);
+	assert.match(control, /from ["']\.\.\/auth-client["']/);
+	assert.match(control, /if \(!email\) return null/);
+	assert.match(control, /VERIFICATION_REQUESTED_MESSAGE/);
+	assert.doesNotMatch(control, /email (was )?sent successfully/i);
+	assert.doesNotMatch(control, /email has been sent/i);
 });

--- a/ui/test/payment-idempotency.test.js
+++ b/ui/test/payment-idempotency.test.js
@@ -44,7 +44,19 @@ test("every success path enters the started job's stream", () => {
 	// startJob path must all end in enterStartedJob — count the call sites.
 	const calls = generate.match(/enterStartedJob\(data\)/g) ?? [];
 	assert.ok(
-		calls.length >= 3,
-		`expected >=3 enterStartedJob(data) call sites (EOA, passkey, free path), found ${calls.length}`,
+		calls.length >= 4,
+		`expected >=4 enterStartedJob(data) call sites (EOA, passkey, free path, pay-panel refetch), found ${calls.length}`,
 	);
+});
+
+test("a pay-panel refetch that starts the job still enters the stream", () => {
+	// refreshPaymentRequirements's success path used to return null after
+	// submitStart without enterStartedJob — the user stayed on the form
+	// with the pay button re-armed, which reads as a failed start.
+	const fn = generate.match(
+		/const refreshPaymentRequirements = async \(\) => \{[\s\S]*?\n\t\};/,
+	);
+	assert.ok(fn, "refreshPaymentRequirements missing");
+	assert.match(fn[0], /enterStartedJob\(data\)/);
+	assert.match(fn[0], /const \{ data, receipt: settledReceipt \}/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two leftover Generate-page defects, both on the live path a single user takes to start a run and see the job:

1. **409 wallet-gate panel dumped agent/curl copy.** After #1658 the backend added `free_generations_locked_reason` so an unverified account and an exhausted free tier are different dead ends. The UI still rendered every 409 as **"Wallet link required"** plus `detail.message`, which names `POST /api/auth/send-verification-email` and `POST /api/wallets/challenge`. Same anti-dump rule Generate already applies to 402 copy. The panel now uses `deriveWalletGateView`: verify-email copy + resend when locked, wallet copy when exhausted. Resend also mounts on the locked free-generation banner (#1658 follow-up that #1642 did not pick up).

2. **A pay-panel refetch that actually started the job never entered the stream.** `refreshPaymentRequirements` called `submitStart`, then returned `null`; callers treated that as "started without payment" and `return`ed without `enterStartedJob`. That is the same "armed button beside a quiet table row reads as a failed start" shape the 2026-08-30 double-pay fix closed on the other success paths.

## Why

A full scan of open issues on 2026-09-01 found zero whose title/scope is the Generate page. #1642 / #1656, #1363 / #1388, and #872 are closed and were not reopened. These two are leftovers of those landings: #1658 explicitly deferred the human 409 + resend button to the #1642 redesign, which shipped layout only; the pay-retry hole is the one success path `enterStartedJob` missed.

## Issues

No open issue to close. Leftover of #1658 / #1643 (409 discriminator unused by the Generate panel; banner resend deferred) and of the double-pay `enterStartedJob` contract.

## Verification

```
cd ui && node --test test/free-generation-banner.test.js test/payment-idempotency.test.js test/generate-quote.test.js test/surprise-briefs.test.js test/webauthn-activation.test.js test/generation-credits.test.js
# 114 passed, 0 failed

cd ui && node --test test/*.test.js
# 911 passed, 0 failed

./node_modules/.bin/eslint src/components/Generate.jsx src/components/FreeGenerationBanner.jsx src/components/ResendVerificationControl.jsx src/freeGenerations.js src/AuthenticatedApp.jsx
# clean, exit 0
```

**Revert-demo (CLAUDE.md rule 3)** — each new test was shown failing against the unfixed code, then the fix restored:

- `deriveWalletGateView` mutated to echo `detail.message` (the leftover):
  - `a 409 with email_unverified…` → `exhausted` vs `email_unverified`
  - `a 409 with no lock…` → matched `POST /api/`
  - `an unknown lock reason…` → matched `POST /api/`
- `refreshPaymentRequirements` success path restored to `return null` without `enterStartedJob`:
  - `every success path enters the started job's stream` → `expected >=4 … found 3`
  - `a pay-panel refetch that starts the job still enters the stream` → `enterStartedJob(data)` missing from the function

## What was checked and left alone

Honest scan of `Generate.jsx`, `generateQuote.js`, `freeGenerations.js`, `POST /api/generate/start`, the live quote (`payment_required: true`, `$2.000000`, `dry_run: false`), and `/app/generate` (auth wall as designed). Not bugs, not in this PR:

- Surprise Me bank (124 entries, no-repeat picker, tests already pin empty/repeat).
- Job table polling (`GenerationStatus` 5s + remount on drill-back).
- `/start` error rendering (`startErrorMessage`, #1363 / #1388).
- Quote 402 signing path (held-requirements + activation-refusal confirm).
- Mobile-first layout from #1656 (base column, 900px grid, 44px targets).
- Quote-failure disabling submit (intentional: don't start a paid flow without a price; live quote is up).
- #1722 cookie-name (CLI/MCP `__Secure-` prefix; browser Generate is same-origin cookies).
- Vaults, marketplace, KG, paper-trading #1704/#1410, Landing truncation.

## Proves / does not prove

**Proves:** the two named Generate-page bugs above are fixed (human 409 + resend; pay-retry drill-in), with tests that fail against the unfixed code.

**Does not prove:** vaults, `paper_agent_trades`, marketplace.

## What a reviewer should push back on

- Resend is duplicated on the locked banner and the 409 panel. Deliberate: usage can fail (banner null) while `/start` still 409s with `email_unverified`.
- Exhausted-copy is a human paraphrase, not the backend faucet caveat verbatim. The 402 path already refuses to dump agent `detail.message`; this matches that rule. The wallet CTA still opens the existing connect-modal.
- No live signed-in click-through of verify-email → 202. SES verification is owner-owned (#1658 follow-up). The discriminator and the resend POST path are what this PR can pin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9256367c-0e62-4b86-9ef6-890d9e7d86b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9256367c-0e62-4b86-9ef6-890d9e7d86b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

