### PR TITLE
[infra] Point the OIDC trust subject at the repo's current org

### DIFF
--- a/infra/scripts/setup-github-oidc.sh
+++ b/infra/scripts/setup-github-oidc.sh
@@ -8,8 +8,10 @@
 #
 # What this creates:
 #   1. An IAM OIDC identity provider for token.actions.githubusercontent.com
-#   2. A deploy role whose trust policy ONLY accepts a-apin/archimedes on
-#      refs/heads/main (build-on-deploy), assumed via sts:AssumeRoleWithWebIdentity.
+#   2. A deploy role whose trust policy ONLY accepts ${GITHUB_ORG}/${GITHUB_REPO}
+#      on refs/heads/main (build-on-deploy), via sts:AssumeRoleWithWebIdentity.
+#      Re-run this after renaming or transferring the repo — see the note by
+#      GITHUB_ORG for why deploys break silently otherwise.
 #   3. A STARTER permissions policy (ECR push + SSM SendCommand + EC2 describe),
 #      plus the docs-site publish grants (#1634): sync into the
 #      docs-site/infra bucket and invalidate its CloudFront distribution.
@@ -30,8 +32,14 @@ set -euo pipefail
 # ACCOUNT_ID/REGION are not hardcoded — auto-detected from the active profile (override via env).
 ACCOUNT_ID="${ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)}"
 REGION="${AWS_REGION:-us-east-1}"
-GITHUB_ORG="a-apin"
-GITHUB_REPO="archimedes"
+# The OIDC `sub` claim carries the repository's CURRENT owner/name. Renaming or
+# transferring the repo changes the claim, the trust policy below stops matching,
+# and every deploy dies at "Configure AWS credentials (OIDC)" with
+# `Not authorized to perform sts:AssumeRoleWithWebIdentity` before a byte is built.
+# Git keeps working throughout, because GitHub redirects clones and STS does not.
+# So: re-run this script after any rename. Override via env for a fork.
+GITHUB_ORG="${GITHUB_ORG:-aprin-labs}"
+GITHUB_REPO="${GITHUB_REPO:-archimedes}"
 DEPLOY_BRANCH_SUB="repo:${GITHUB_ORG}/${GITHUB_REPO}:ref:refs/heads/main"
 ROLE_NAME="archimedes-github-deploy"
 OIDC_URL="token.actions.githubusercontent.com"
@@ -49,6 +57,29 @@ do_() { printf '  + %s\n' "$*"; if $APPLY; then eval "$*"; fi; }
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 [ -n "$ACCOUNT_ID" ] || { echo "ERROR: could not resolve ACCOUNT_ID (set AWS_PROFILE / export ACCOUNT_ID)"; exit 1; }
 $APPLY && echo ">>> APPLY MODE — account ${ACCOUNT_ID}" || echo ">>> DRY RUN — re-run with --apply to execute."
+
+# ─── 0. The trust policy must name the repo GitHub will actually mint tokens for ──
+# A wrong org here is not a visible error: the role is written successfully and
+# every later deploy fails at the credentials step instead. `gh` knows the
+# canonical owner/name (a local git remote does not — it still resolves through
+# GitHub's rename redirect), so cross-check against it and refuse to write a
+# policy that cannot match. Skipped, not failed, when gh is missing or unauthed:
+# an absent optional tool should not block a valid run.
+say "Repo identity cross-check"
+if command -v gh >/dev/null 2>&1 && ACTUAL_REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" && [ -n "$ACTUAL_REPO" ]; then
+  if [ "$ACTUAL_REPO" = "${GITHUB_ORG}/${GITHUB_REPO}" ]; then
+    echo "  ok: GitHub reports ${ACTUAL_REPO}, matching the configured trust subject"
+  else
+    echo "ERROR: this script would trust 'repo:${GITHUB_ORG}/${GITHUB_REPO}:...', but GitHub" >&2
+    echo "       reports the repository as '${ACTUAL_REPO}'." >&2
+    echo "       The OIDC sub claim uses the name GitHub reports, so that policy could never" >&2
+    echo "       match and every deploy would fail at 'Configure AWS credentials (OIDC)'." >&2
+    echo "       Fix GITHUB_ORG/GITHUB_REPO (or export them) and re-run." >&2
+    exit 1
+  fi
+else
+  echo "  skipped: gh unavailable or unauthenticated — cannot confirm ${GITHUB_ORG}/${GITHUB_REPO}"
+fi
 
 # ─── 1. OIDC provider ─────────────────────────────────────────────────────────
 say "GitHub OIDC identity provider"


### PR DESCRIPTION
## What

Points the generated OIDC trust subject at `aprin-labs/archimedes`, makes the org and repo env-overridable, and adds a cross-check that refuses to write a trust policy naming a repo GitHub does not report.

One file: `infra/scripts/setup-github-oidc.sh`.

## Why

The repository was renamed. GitHub mints the OIDC token with the repo's current name, so the `sub` claim is now `repo:aprin-labs/archimedes:ref:refs/heads/main` while the trust policy still requires `repo:a-apin/archimedes:...`. STS refuses, and every deploy since has died at "Configure AWS credentials (OIDC)" before building anything. Four consecutive failures, prod 18 commits behind. Full evidence in #1736.

Git kept working throughout, because GitHub redirects clones and STS does not. That gap is why the rename and the deploy failures don't look connected, so the reason is now written next to `GITHUB_ORG` rather than left to be rediscovered.

**This PR alone does not unblock deploys.** The trust policy lives in IAM, not in the tree, and the role is deliberately not Terraform-managed (`infra/ecs.tf:374`). After this merges, the role still has to be updated in account `037613907429`:

```bash
aws iam update-assume-role-policy --role-name archimedes-github-deploy \
  --policy-document file://trust.json
```

Re-running `infra/scripts/setup-github-oidc.sh --apply` does exactly that and nothing else — the role exists, so the script takes its update branch.

## Issues

Closes #1736

## Verification

The cross-check has to be shown rejecting something, so here it is running against both values. `ACCOUNT_ID` is passed in because the script auto-detects it from the AWS profile and I have no credentials.

```
$ ACCOUNT_ID=000000000000 bash infra/scripts/setup-github-oidc.sh
== Repo identity cross-check
  ok: GitHub reports aprin-labs/archimedes, matching the configured trust subject
exit=0

$ ACCOUNT_ID=000000000000 GITHUB_ORG=a-apin bash infra/scripts/setup-github-oidc.sh
== Repo identity cross-check
ERROR: this script would trust 'repo:a-apin/archimedes:...', but GitHub
       reports the repository as 'aprin-labs/archimedes'.
       The OIDC sub claim uses the name GitHub reports, so that policy could never
       match and every deploy would fail at 'Configure AWS credentials (OIDC)'.
       Fix GITHUB_ORG/GITHUB_REPO (or export them) and re-run.
exit=1
```

The rejected value is the one currently live in IAM, so the guard reproduces the outage rather than describing it.

Generated subject is correct:

```
$ ACCOUNT_ID=037613907429 bash infra/scripts/setup-github-oidc.sh | grep 'Deploy role:'
== Deploy role: archimedes-github-deploy (trusts repo:aprin-labs/archimedes:ref:refs/heads/main)
```

`bash -n infra/scripts/setup-github-oidc.sh` is clean. Script is dry-run by default and untouched on that point.

## What a reviewer should push back on

- **The cross-check skips instead of failing when `gh` is absent or unauthenticated.** I read that as correct for an optional tool, but it does mean a run on a box without `gh` gets no protection. Argument for hard-failing if you disagree.
- **I left the old org accepted nowhere.** A rename redirect does not apply to OIDC claims, so a second `StringLike` entry for `a-apin` would be dead weight. Say so if you want it kept anyway during the transition.
- **Scope.** 76 files still name `a-apin`, including `CANONICAL_REPO` in `backend/tests/test_canonical_repo_links.py`. All of those work via redirect and none block deploys, so they are deliberately not in this PR. Flagged at the bottom of #1736 and worth its own issue — that test is supposed to catch stale repo names and structurally cannot catch this one.
- Whether the failure-mode comment by `GITHUB_ORG` is too long. I'd rather over-explain a silent failure than under-explain it.
