### PR TITLE
Serialize load_corpus; /health counts the corpus instead of loading it

### DIFF
--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -40,6 +40,7 @@ import json
 import logging
 import os
 import re
+import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -52,6 +53,10 @@ from archimedes.services.strategy_dsl import DSLError, validate_strategy_spec
 from archimedes.services.strategy_signal_evaluator import GLOBAL_ASSETS
 
 logger = logging.getLogger(__name__)
+
+# Serializes load_corpus's DB/file branch. See the comment inside load_corpus:
+# concurrent full-corpus ORM loads abort the interpreter (#1632, prod rev 214).
+_CORPUS_LOAD_LOCK = threading.Lock()
 
 # ── The three paper knobs (#1636) ───────────────────────────────────────────
 #
@@ -641,31 +646,41 @@ def load_corpus(path: Path | None = None) -> list[CorpusPaper]:
     if path is not None:
         return _load_corpus_from_file(path)
 
-    # DB path first
-    try:
-        from archimedes.services.corpus_service import load_papers_from_db
+    # Serialized: two threads running this branch CONCURRENTLY is the #1632
+    # abort. Prod rev 214 died with two executor threads both inside
+    # load_papers_from_db's session teardown (SQLAlchemy _detach_states /
+    # InstanceState._cleanup), piled up by abandoned /health corpus probes on a
+    # cold task. The lock makes the race unrepresentable for every caller —
+    # generation, warmers, anything — not just the probe path (which no longer
+    # loads at all; /health reads count_corpus_papers instead). The cost is a
+    # waiting thread, which is exactly the safe outcome: the interpreter never
+    # dies from waiting.
+    with _CORPUS_LOAD_LOCK:
+        # DB path first
+        try:
+            from archimedes.services.corpus_service import load_papers_from_db
 
-        db_rows = load_papers_from_db()
-        if db_rows:
-            papers = [
-                CorpusPaper(
-                    arxiv_id=r["arxiv_id"],
-                    title=r["title"],
-                    abstract=r["abstract"],
-                    primary_category=r.get("primary_category", ""),
-                    categories=tuple(r.get("categories", [])),
-                    published=r.get("published", ""),
-                )
-                for r in db_rows
-                if r.get("arxiv_id") and (r.get("title") or r.get("abstract"))
-            ]
-            logger.info("fusion: loaded %d corpus papers from DB", len(papers))
-            return papers
-    except Exception as exc:
-        logger.debug("fusion: DB corpus load failed, falling back to file: %s", exc)
+            db_rows = load_papers_from_db()
+            if db_rows:
+                papers = [
+                    CorpusPaper(
+                        arxiv_id=r["arxiv_id"],
+                        title=r["title"],
+                        abstract=r["abstract"],
+                        primary_category=r.get("primary_category", ""),
+                        categories=tuple(r.get("categories", [])),
+                        published=r.get("published", ""),
+                    )
+                    for r in db_rows
+                    if r.get("arxiv_id") and (r.get("title") or r.get("abstract"))
+                ]
+                logger.info("fusion: loaded %d corpus papers from DB", len(papers))
+                return papers
+        except Exception as exc:
+            logger.debug("fusion: DB corpus load failed, falling back to file: %s", exc)
 
-    # File fallback
-    return _load_corpus_from_file(path)
+        # File fallback
+        return _load_corpus_from_file(path)
 
 
 def _load_corpus_from_file(path: Path | None = None) -> list[CorpusPaper]:

--- a/backend/archimedes/main.py
+++ b/backend/archimedes/main.py
@@ -1030,9 +1030,9 @@ async def health(response: Response):
     """
     _no_store(response)
 
-    from archimedes.agents.strategy_fusion import fusion_enabled, load_corpus
+    from archimedes.agents.strategy_fusion import fusion_enabled
     from archimedes.chain.client import chain_client
-    from archimedes.services.corpus_service import get_corpus_meta, get_paper_count
+    from archimedes.services.corpus_service import count_corpus_papers, get_corpus_meta, get_paper_count
     from archimedes.services.health_cache import health_probe_cache
 
     async def _oracle_probe():
@@ -1121,11 +1121,17 @@ async def health(response: Response):
         # `absent=[]` renders corpus_papers: 0 — a plausible-looking number, and
         # the reason every one of these carries a `*_probe_state`: the state
         # field is what separates "we read zero" from "we could not read".
+        # A COUNT, never load_corpus: the full 18k-row ORM load here is what
+        # killed prod rev 214 — abandoned cold-boot probes piled concurrent
+        # loads into the executor until two raced in SQLAlchemy session
+        # teardown and aborted the interpreter (#1632). A scalar count holds
+        # no ORM state to race; load_corpus itself is additionally serialized
+        # behind _CORPUS_LOAD_LOCK for its real (generation) callers.
         health_probe_cache.probe(
             _CORPUS_PROBE,
-            _bounded_local_read(load_corpus),
+            _bounded_local_read(count_corpus_papers),
             budget_seconds=_LOCAL_PROBE_BUDGET_SECONDS,
-            absent=[],
+            absent=0,
         ),
         health_probe_cache.probe(
             _CORPUS_DB_PROBE,
@@ -1208,11 +1214,11 @@ async def health(response: Response):
     # every other field on the page.
     corpus_probe_fields: dict[str, object] = {}
     if isinstance(corpus_outcome, BaseException):
-        logger.warning("corpus load raised %s — reporting 0 papers", type(corpus_outcome).__name__)
-        corpus: list = []
+        logger.warning("corpus count raised %s — reporting 0 papers", type(corpus_outcome).__name__)
+        corpus_count: int = 0
         corpus_probe_fields = _probe_error_fields(_CORPUS_PROBE, corpus_outcome)
     else:
-        corpus = corpus_outcome.value or []
+        corpus_count = int(corpus_outcome.value or 0)
         corpus_probe_fields = corpus_outcome.payload_fields(_CORPUS_PROBE)
 
     _fusion_on = fusion_enabled()
@@ -1587,7 +1593,7 @@ async def health(response: Response):
         "human_count": human_count,
         "agent_count": agent_count,
         "real_users": real_users,
-        "corpus_papers": len(corpus),
+        "corpus_papers": corpus_count,
         "corpus_db_count": db_count,
         "corpus_source": corpus_source,
         "corpus_last_intake": corpus_last_intake,

--- a/backend/archimedes/services/corpus_service.py
+++ b/backend/archimedes/services/corpus_service.py
@@ -335,11 +335,15 @@ def get_paper_count() -> int:
 def count_corpus_papers(*, embargo_days: int = 30) -> int:
     """ORM-free count of the papers ``load_corpus`` would load — for /health.
 
-    Mirrors ``apply_outcome_embargo``'s rule in SQL: published strictly before
-    today − ``embargo_days``, empty ``published`` excluded (the Python filter
-    also drops *unparseable* dates, which SQL cannot check — ISO strings from
-    seeding make that delta zero in practice; if it ever drifts, the honest
-    direction is this count reading slightly high, never a fabricated low).
+    Mirrors ``apply_outcome_embargo``'s rule in SQL. That rule keeps a paper
+    whose date is *at most* ``embargo_days`` old (``pub <= cutoff``), and the
+    column holds either ``YYYY-MM-DD`` or a full ISO timestamp, so the SQL
+    form is ``published < day-after-cutoff`` (a timestamp on the cutoff day
+    sorts after the bare date but before the next day); empty ``published``
+    is excluded. The Python filter also drops *unparseable* dates, which SQL
+    cannot check — so the only permitted disagreement is this count reading
+    high by the unparseable rows, never a fabricated low. Both edges and that
+    delta are pinned by ``test_corpus_load_race_1632.py`` against a real table.
 
     Exists because the /health corpus probe used to call ``load_corpus`` — a
     full 18k-row ORM materialization per uncached check. On a cold task the
@@ -350,11 +354,13 @@ def count_corpus_papers(*, embargo_days: int = 30) -> int:
     """
     from datetime import date, timedelta
 
-    cutoff = (date.today() - timedelta(days=embargo_days)).isoformat()
+    # apply_outcome_embargo keeps pub <= today - embargo_days; as a string
+    # bound over "YYYY-MM-DD[Thh:mm:ssZ]" values that is `< the following day`.
+    first_excluded_day = (date.today() - timedelta(days=embargo_days - 1)).isoformat()
     with get_session() as session:
         return (
             session.query(func.count(PaperRecord.arxiv_id))
-            .filter(PaperRecord.published != "", PaperRecord.published < cutoff)
+            .filter(PaperRecord.published != "", PaperRecord.published < first_excluded_day)
             .scalar()
             or 0
         )

--- a/backend/archimedes/services/corpus_service.py
+++ b/backend/archimedes/services/corpus_service.py
@@ -332,6 +332,34 @@ def get_paper_count() -> int:
         return session.query(func.count(PaperRecord.arxiv_id)).scalar() or 0
 
 
+def count_corpus_papers(*, embargo_days: int = 30) -> int:
+    """ORM-free count of the papers ``load_corpus`` would load — for /health.
+
+    Mirrors ``apply_outcome_embargo``'s rule in SQL: published strictly before
+    today − ``embargo_days``, empty ``published`` excluded (the Python filter
+    also drops *unparseable* dates, which SQL cannot check — ISO strings from
+    seeding make that delta zero in practice; if it ever drifts, the honest
+    direction is this count reading slightly high, never a fabricated low).
+
+    Exists because the /health corpus probe used to call ``load_corpus`` — a
+    full 18k-row ORM materialization per uncached check. On a cold task the
+    probe blows its budget, is abandoned-but-running, and the next checks pile
+    more loads into the executor until two race in SQLAlchemy session teardown
+    and abort the interpreter (#1632, prod rev 214). A scalar COUNT holds no
+    ORM state to race and returns in milliseconds.
+    """
+    from datetime import date, timedelta
+
+    cutoff = (date.today() - timedelta(days=embargo_days)).isoformat()
+    with get_session() as session:
+        return (
+            session.query(func.count(PaperRecord.arxiv_id))
+            .filter(PaperRecord.published != "", PaperRecord.published < cutoff)
+            .scalar()
+            or 0
+        )
+
+
 def get_corpus_meta() -> dict | None:
     """Return the singleton corpus_meta row as a dict, or None."""
     with get_session() as session:

--- a/backend/tests/test_corpus_load_race_1632.py
+++ b/backend/tests/test_corpus_load_race_1632.py
@@ -22,7 +22,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-
 from archimedes.agents import strategy_fusion
 
 
@@ -41,9 +40,7 @@ class TestLoadCorpusIsSerialized:
             time.sleep(0.05)  # wide-open window: unlocked, 4 threads WILL overlap here
             with gauge:
                 in_flight -= 1
-            return [
-                {"arxiv_id": "2401.00001", "title": "t", "abstract": "a", "published": "2024-01-01"}
-            ]
+            return [{"arxiv_id": "2401.00001", "title": "t", "abstract": "a", "published": "2024-01-01"}]
 
         import archimedes.services.corpus_service as corpus_service
 
@@ -64,10 +61,9 @@ class TestLoadCorpusIsSerialized:
 class TestHealthProbeDoesNotLoadTheCorpus:
     @pytest.fixture()
     def client(self):
-        from fastapi.testclient import TestClient
-
         from archimedes.main import app
         from archimedes.services.health_cache import health_probe_cache
+        from fastapi.testclient import TestClient
 
         health_probe_cache.clear()
         with TestClient(app) as c:

--- a/backend/tests/test_corpus_load_race_1632.py
+++ b/backend/tests/test_corpus_load_race_1632.py
@@ -59,19 +59,17 @@ class TestLoadCorpusIsSerialized:
 
 
 class TestHealthProbeDoesNotLoadTheCorpus:
-    @pytest.fixture()
-    def client(self):
+    # ASGITransport, NOT TestClient: entering TestClient's context manager runs
+    # the app's startup lifespan, whose background corpus seed writes ~18k rows
+    # into the shared test DB and poisons every empty-DB test that runs after
+    # this one in the same process. Precedent: test_health_always_answers.py's
+    # _get_health, which exists for exactly this reason.
+    async def test_health_reports_the_count_and_never_calls_load_corpus(self, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        import archimedes.services.corpus_service as corpus_service
         from archimedes.main import app
         from archimedes.services.health_cache import health_probe_cache
-        from fastapi.testclient import TestClient
-
-        health_probe_cache.clear()
-        with TestClient(app) as c:
-            yield c
-        health_probe_cache.clear()
-
-    def test_health_reports_the_count_and_never_calls_load_corpus(self, monkeypatch, client):
-        import archimedes.services.corpus_service as corpus_service
 
         def _forbidden(*_a, **_k):  # pragma: no cover - the guard IS the failure
             raise AssertionError(
@@ -82,9 +80,14 @@ class TestHealthProbeDoesNotLoadTheCorpus:
         monkeypatch.setattr(strategy_fusion, "load_corpus", _forbidden)
         monkeypatch.setattr(corpus_service, "count_corpus_papers", lambda **_k: 1234)
 
-        resp = client.get("/health")
-        assert resp.status_code == 200
-        assert resp.json()["corpus_papers"] == 1234
+        health_probe_cache.clear()
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.get("/health")
+            assert resp.status_code == 200
+            assert resp.json()["corpus_papers"] == 1234
+        finally:
+            health_probe_cache.clear()
 
 
 class TestCountMatchesTheEmbargoRule:

--- a/backend/tests/test_corpus_load_race_1632.py
+++ b/backend/tests/test_corpus_load_race_1632.py
@@ -20,8 +20,12 @@ from __future__ import annotations
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import date, timedelta
 
+import pytest
 from archimedes.agents import strategy_fusion
+
+from tests.db_isolation import redirect_to_tmp_sqlite
 
 
 class TestLoadCorpusIsSerialized:
@@ -89,23 +93,67 @@ class TestHealthProbeDoesNotLoadTheCorpus:
 
 
 class TestCountMatchesTheEmbargoRule:
-    def test_sql_count_agrees_with_the_python_filter(self, monkeypatch):
-        """The COUNT and apply_outcome_embargo answer identically on the same rows."""
-        from datetime import date, timedelta
+    """``count_corpus_papers`` answers what the old probe's ``len(load_corpus())`` did.
 
-        from archimedes.services.embargo_filter import apply_outcome_embargo
+    Driven against a real ``papers`` table (tmp-file sqlite via
+    ``tests/db_isolation``), never a Python list checked against itself: the
+    SQL COUNT and ``load_papers_from_db`` — whose rows go through
+    ``apply_outcome_embargo`` — must agree on the SAME stored rows, including
+    both edges of the embargo boundary.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_db(self, tmp_path):
+        yield from redirect_to_tmp_sqlite(tmp_path)
+
+    @staticmethod
+    def _seed(rows: list[tuple[str, str]]) -> None:
+        from archimedes.db import get_session
+        from archimedes.models.corpus_store import PaperRecord
+
+        with get_session() as session:
+            for arxiv_id, published in rows:
+                session.add(PaperRecord(arxiv_id=arxiv_id, title=f"t {arxiv_id}", abstract="a", published=published))
+            session.commit()
+
+    def test_sql_count_agrees_with_load_papers_from_db_on_both_embargo_edges(self):
+        from archimedes.services.corpus_service import count_corpus_papers, load_papers_from_db
+
+        def day(n: int) -> str:
+            return (date.today() - timedelta(days=n)).isoformat()
+
+        self._seed(
+            [
+                ("old.1", day(40)),
+                ("edge.in", day(30)),  # exactly embargo_days old: apply_outcome_embargo KEEPS it (<=)
+                ("edge.in.ts", day(30) + "T23:59:59Z"),  # same day, arXiv's timestamp form
+                ("edge.out", day(29)),  # one day inside the embargo: dropped
+                ("fresh.1", day(10)),
+                ("blank", ""),  # no date: dropped, fail closed
+            ]
+        )
+
+        loaded = load_papers_from_db(embargo_days=30, apply_decay=False)
+        assert sorted(p["arxiv_id"] for p in loaded) == ["edge.in", "edge.in.ts", "old.1"]
+
+        # THE assertion: the scalar the probe reports IS the size of the corpus
+        # generation would load. Mutations that fail it: `<` for `<=` at the
+        # cutoff (reads 1 low on the edge day), dropping the != '' clause
+        # (reads 1 high), comparing against today instead of the cutoff.
+        assert count_corpus_papers(embargo_days=30) == len(loaded) == 3
+
+    def test_an_unparseable_date_can_only_make_the_count_read_high(self):
+        """The documented delta: SQL cannot parse, so garbage that sorts as old is counted.
+
+        ``apply_outcome_embargo`` drops it (fail closed). The honest direction
+        for a health number is over-reporting by the unparseable rows — never a
+        fabricated low — and this pins that the delta is exactly those rows.
+        """
+        from archimedes.services.corpus_service import count_corpus_papers, load_papers_from_db
 
         old = (date.today() - timedelta(days=40)).isoformat()
-        fresh = (date.today() - timedelta(days=10)).isoformat()
-        rows = [
-            {"arxiv_id": "a1", "published": old},
-            {"arxiv_id": "a2", "published": fresh},  # inside the embargo → dropped
-            {"arxiv_id": "a3", "published": ""},  # unparseable → dropped (fail closed)
-        ]
-        kept = apply_outcome_embargo(rows, embargo_days=30)
-        assert [r["arxiv_id"] for r in kept] == ["a1"]
+        self._seed([("old.1", old), ("garbage.old", "1999-99-99"), ("garbage.new", "9999-99-99")])
 
-        # The SQL mirror: published != "" AND published < cutoff.
-        cutoff = (date.today() - timedelta(days=30)).isoformat()
-        sql_kept = [r for r in rows if r["published"] and r["published"] < cutoff]
-        assert [r["arxiv_id"] for r in sql_kept] == ["a1"]
+        loaded = load_papers_from_db(embargo_days=30, apply_decay=False)
+        assert [p["arxiv_id"] for p in loaded] == ["old.1"]
+        assert count_corpus_papers(embargo_days=30) == len(loaded) + 1  # garbage.old, and only it

--- a/backend/tests/test_corpus_load_race_1632.py
+++ b/backend/tests/test_corpus_load_race_1632.py
@@ -1,0 +1,114 @@
+"""The #1632 abort class: concurrent corpus loads racing in session teardown.
+
+Prod rev 214 died (exit 139, tick OFF) with faulthandler showing two executor
+threads simultaneously inside ``load_corpus`` → ``load_papers_from_db``, one in
+SQLAlchemy ``_detach_states``, one in ``InstanceState._cleanup`` — piled up by
+abandoned /health corpus probes on a cold task ("abandoning the call (6 in
+flight)"). Two guards keep the class dead:
+
+1. ``load_corpus`` is serialized behind ``_CORPUS_LOAD_LOCK`` — the race is
+   unrepresentable for any pair of callers.
+2. The /health corpus probe never calls ``load_corpus`` at all — it reads
+   ``count_corpus_papers`` (a scalar COUNT with no ORM state to race).
+
+Each guard is exercised against the input that killed prod: real concurrency
+for (1), a live /health request for (2).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from archimedes.agents import strategy_fusion
+
+
+class TestLoadCorpusIsSerialized:
+    def test_concurrent_loaders_never_overlap(self, monkeypatch):
+        """Four threads through load_corpus: the DB read runs strictly one-at-a-time."""
+        in_flight = 0
+        max_in_flight = 0
+        gauge = threading.Lock()
+
+        def slow_db_load():
+            nonlocal in_flight, max_in_flight
+            with gauge:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            time.sleep(0.05)  # wide-open window: unlocked, 4 threads WILL overlap here
+            with gauge:
+                in_flight -= 1
+            return [
+                {"arxiv_id": "2401.00001", "title": "t", "abstract": "a", "published": "2024-01-01"}
+            ]
+
+        import archimedes.services.corpus_service as corpus_service
+
+        monkeypatch.setattr(corpus_service, "load_papers_from_db", slow_db_load)
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(lambda _: strategy_fusion.load_corpus(), range(4)))
+
+        assert all(len(r) == 1 for r in results)
+        # THE assertion: with _CORPUS_LOAD_LOCK removed this reads 2..4 —
+        # verified by reverting the lock before this file was pushed.
+        assert max_in_flight == 1, (
+            f"load_corpus ran {max_in_flight} DB loads concurrently — the #1632 "
+            "session-teardown race is representable again"
+        )
+
+
+class TestHealthProbeDoesNotLoadTheCorpus:
+    @pytest.fixture()
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from archimedes.main import app
+        from archimedes.services.health_cache import health_probe_cache
+
+        health_probe_cache.clear()
+        with TestClient(app) as c:
+            yield c
+        health_probe_cache.clear()
+
+    def test_health_reports_the_count_and_never_calls_load_corpus(self, monkeypatch, client):
+        import archimedes.services.corpus_service as corpus_service
+
+        def _forbidden(*_a, **_k):  # pragma: no cover - the guard IS the failure
+            raise AssertionError(
+                "/health called load_corpus — the full-ORM load the #1632 "
+                "abort piled up. The probe must read count_corpus_papers."
+            )
+
+        monkeypatch.setattr(strategy_fusion, "load_corpus", _forbidden)
+        monkeypatch.setattr(corpus_service, "count_corpus_papers", lambda **_k: 1234)
+
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["corpus_papers"] == 1234
+
+
+class TestCountMatchesTheEmbargoRule:
+    def test_sql_count_agrees_with_the_python_filter(self, monkeypatch):
+        """The COUNT and apply_outcome_embargo answer identically on the same rows."""
+        from datetime import date, timedelta
+
+        from archimedes.services.embargo_filter import apply_outcome_embargo
+
+        old = (date.today() - timedelta(days=40)).isoformat()
+        fresh = (date.today() - timedelta(days=10)).isoformat()
+        rows = [
+            {"arxiv_id": "a1", "published": old},
+            {"arxiv_id": "a2", "published": fresh},  # inside the embargo → dropped
+            {"arxiv_id": "a3", "published": ""},  # unparseable → dropped (fail closed)
+        ]
+        kept = apply_outcome_embargo(rows, embargo_days=30)
+        assert [r["arxiv_id"] for r in kept] == ["a1"]
+
+        # The SQL mirror: published != "" AND published < cutoff.
+        cutoff = (date.today() - timedelta(days=30)).isoformat()
+        sql_kept = [r for r in rows if r["published"] and r["published"] < cutoff]
+        assert [r["arxiv_id"] for r in sql_kept] == ["a1"]

--- a/backend/tests/test_corpus_load_race_1632.py
+++ b/backend/tests/test_corpus_load_race_1632.py
@@ -21,7 +21,6 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-import pytest
 from archimedes.agents import strategy_fusion
 
 
@@ -65,11 +64,10 @@ class TestHealthProbeDoesNotLoadTheCorpus:
     # this one in the same process. Precedent: test_health_always_answers.py's
     # _get_health, which exists for exactly this reason.
     async def test_health_reports_the_count_and_never_calls_load_corpus(self, monkeypatch):
-        from httpx import ASGITransport, AsyncClient
-
         import archimedes.services.corpus_service as corpus_service
         from archimedes.main import app
         from archimedes.services.health_cache import health_probe_cache
+        from httpx import ASGITransport, AsyncClient
 
         def _forbidden(*_a, **_k):  # pragma: no cover - the guard IS the failure
             raise AssertionError(

--- a/backend/tests/test_health_always_answers.py
+++ b/backend/tests/test_health_always_answers.py
@@ -498,7 +498,10 @@ _INJECTED_STALL_SECONDS = 30.0
 # refactor that stops going through it fails these tests loudly instead of
 # silently testing nothing. Internals are never patched.
 _LOCAL_READS = [
-    ("archimedes.agents.strategy_fusion.load_corpus", "corpus"),
+    # #1632/#1740: the corpus probe boundary moved from load_corpus (a full
+    # 18k-row ORM materialization whose abandoned-probe pileup aborted prod
+    # rev 214) to an ORM-free scalar count. Same stall semantics, safe read.
+    ("archimedes.services.corpus_service.count_corpus_papers", "corpus"),
     ("archimedes.services.corpus_service.get_paper_count", "corpus_db"),
     ("archimedes.services.corpus_service.get_corpus_meta", "corpus_meta"),
     ("archimedes.services.paper_rag.paper_rag_health", "paper_rag"),
@@ -550,7 +553,7 @@ def _fast_local_reads():
     from archimedes.services.paper_rag import PaperRAGHealth
 
     with (
-        patch("archimedes.agents.strategy_fusion.load_corpus", lambda *_a, **_k: [{"id": "p1"}]),
+        patch("archimedes.services.corpus_service.count_corpus_papers", lambda *_a, **_k: 1),
         patch("archimedes.services.corpus_service.get_paper_count", lambda *_a, **_k: 7),
         patch("archimedes.services.corpus_service.get_corpus_meta", lambda *_a, **_k: {"source": "db"}),
         patch(
@@ -573,7 +576,7 @@ class TestTheSixLocalReadsAreBoundedToo:
     """#1594: a stalled LOCAL read must not hold the endpoint either.
 
     MUTATION for every case below: restore the plain synchronous calls
-    (``corpus = load_corpus()``, the ``try: db_count = get_paper_count()``
+    (``corpus_count = count_corpus_papers()``, the ``try: db_count = get_paper_count()``
     block, and the three ``*_health()`` try-blocks) under the concurrent gather.
     Each test then blocks the event loop for the full 30s and fails on the
     budget assertion — including the ones whose read is "just a local DB query".


### PR DESCRIPTION
Part of #1632 — the actual crash mechanism, caught by faulthandler on prod rev 214 (exit 139, tick OFF, one OpenSSL mapped — the dual-OpenSSL hypothesis is falsified).

## The mechanism (full traceback on #1632)

Two `_HEALTH_PROBE_EXECUTOR` threads simultaneously inside `load_corpus` → `load_papers_from_db`, one in SQLAlchemy `_detach_states`, one in `InstanceState._cleanup`. The pileup is narrated by the task's own log: the cold-boot corpus probe blows its 0.8s budget, is abandoned-but-running, and successive health checks stack more full 18k-row ORM loads — `abandoning the call (1 in flight)` … `(6 in flight)` — until two race in C-level teardown and abort the interpreter.

## The fix

- `strategy_fusion.load_corpus` serializes its DB/file branch behind `_CORPUS_LOAD_LOCK` — the race becomes unrepresentable for **every** caller; a waiting thread is the safe outcome.
- The /health corpus probe now reads `count_corpus_papers()` — an ORM-free scalar COUNT mirroring the embargo cutoff in SQL (`published != '' AND published < today−30d`). Nothing heavy left for abandoned probes to pile onto, and `corpus_papers` stays the same honest post-embargo number. The one delta from the Python filter (SQL can't detect *unparseable* dates) can only read high, never fabricate low, and is zero on seeded data.

Side effect worth naming: /health stops paying an 18,907-row ORM load per uncached check — a real chunk of the cold-task health latency (#1713's neighborhood).

## Adversarial demos (both run before push)

Lock removed (`with _CORPUS_LOAD_LOCK:` → `if True:`):
```
FAILED backend/tests/test_corpus_load_race_1632.py::TestLoadCorpusIsSerialized::test_concurrent_loaders_never_overlap
AssertionError: load_corpus ran 4 DB loads concurrently — the #1632 session-teardown race is representable again
```
Probe reverted to `load_corpus`:
```
FAILED backend/tests/test_corpus_load_race_1632.py::TestHealthProbeDoesNotLoadTheCorpus::test_health_reports_the_count_and_never_calls_load_corpus
AssertionError: /health called load_corpus — the full-ORM load the #1632 abort piled up.
```
Restored: 3 passed. Plus a count-vs-python-filter agreement test on the embargo rule.

## Not claimed

This does not close #1632 — the tourniquet stays until this soaks (and the re-enable of the tick in #1728's isolated child is owner-scheduled). No behavior change for generation callers beyond serialization; no cache added (embargo/decay filtering stays per-call fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7

## Review follow-up (Daniel, 2026-09-01) — `6bfda2e9`

- **`TestCountMatchesTheEmbargoRule` was self-referential.** It now seeds a real `papers` table (tmp sqlite via `tests/db_isolation.redirect_to_tmp_sqlite`) and asserts `count_corpus_papers(embargo_days=30) == len(load_papers_from_db(embargo_days=30, apply_decay=False))` on the same stored rows — the size of the corpus generation would load, which is what `/health` used to report through `len(load_corpus())`.
- **That found a real edge bug.** `apply_outcome_embargo` KEEPS a paper exactly `embargo_days` old (`pub <= cutoff`) and the column holds either `YYYY-MM-DD` or arXiv's full timestamp; the SQL used a strict `< cutoff` on the bare date, so both edge-day forms were dropped and the count read low. Bound is now `published < (day after cutoff)`.

| mutation on the final tree | new test |
|---|---|
| strict `< cutoff` (the pre-fix code) | `assert 1 == 3` |
| `<= cutoff` on the bare date only | `assert 2 == 3` |
| drop the `!= ""` clause | `assert 4 == 3` |

- **The five stall tests** were red only on `54181ecc`; `145977c8` moved the `_LOCAL_READS` corpus row to `count_corpus_papers`, so the stall injector wraps the read `/health` actually makes. Same stall semantics at the new boundary; nothing moved off corpus.
- The documented delta — SQL cannot parse, so garbage that sorts as old is counted — is pinned as exactly that (`test_an_unparseable_date_can_only_make_the_count_read_high`): reads high by the unparseable rows, never low.
- `origin/main` merged in (#1745 does not intersect). Full suite on the union head: `5631 passed, 4 skipped, 2 deselected`, exit 0.
