### PR TITLE
[corpus] Comment-accuracy: name real KB entry points in run_kb_pipeline

### DIFF
--- a/backend/archimedes/scripts/run_kb_pipeline.py
+++ b/backend/archimedes/scripts/run_kb_pipeline.py
@@ -131,19 +131,48 @@ def run_pipeline(
     if str(kb_root) not in sys.path:
         sys.path.insert(0, str(kb_root))
 
-    # The actual functions live in:
-    #   papers_analysis.vectorize.embed_corpus(text_dir) → (np.ndarray, ids)
-    #   papers_analysis.cluster.cluster_embeddings(...) → dict[id, cluster]
-    #   papers_analysis.cluster.bertopic_labels(...)     → dict[cluster, label]
-    #   papers_analysis.knowledge_graph.extract_triples(text_dir) → list
-    #   papers_analysis.graph.aggregate(triples) → {nodes, edges}
+    # Real papers_analysis entry points (verified against the submodule pin;
+    # these are not a drop-in wiring job — see remaining-work notes below):
+    #   papers_analysis.vectorize.run_vectorize(
+    #       cache_dir, metadata_db, embeddings_dir, tfidf, specter2, …
+    #   ) → dict
+    #   papers_analysis.cluster.run_clustering(
+    #       embeddings, docs, sha256s, …
+    #   ) → dict
+    #   papers_analysis.cluster._extract_topic_records(topic_model)
+    #       → dict[int, dict]  # BERTopic labels; called from run_clustering,
+    #                          # not a standalone public API
+    #   papers_analysis.knowledge_graph.run_knowledge_graph(
+    #       db_path, out_dir, …, device="mps"
+    #   ) → None  # writes JSONL/GraphML/TTL to disk; does not return triples
+    #   papers_analysis.knowledge_graph.build_networkx_graph(...)
+    #       → nx.MultiDiGraph
+    #   papers_analysis.knowledge_graph.build_rdf_graph(G) → RDFLib Graph
+    # papers_analysis.graph.run_graph / papers_analysis.graph.build_graph exist
+    # but build a SPECTER2 cosine-similarity graph, not a KG from triples.
     #
-    # The canonical wiring (entry points, atomic-swap semantics, output schema)
-    # is documented in docs/corpus-architecture.md. The full implementation is
-    # gated behind REQUIRE_KB_PIPELINE_RUN because it pulls in ~6 GB of model
+    # Three mismatches remain before this skeleton can call those entry
+    # points (this is remaining work, not a wiring job — see #1090):
+    #   1. Data model. papers_analysis is built around data/metadata.db
+    #      (sqlite) plus data/embeddings/, both resolved relative to the
+    #      submodule. This runner and kb-integration-spec.md assume a
+    #      corpus_text_dir of text files and /srv/corpus-artifact/. There
+    #      is no adapter between them.
+    #   2. Identity. The submodule keys on sha256; Archimedes keys on
+    #      paper id. A mapping layer is required before any output can be
+    #      persisted to kg_entities / kg_relations.
+    #   3. Device. run_knowledge_graph defaults device="mps" and returns
+    #      None, writing to disk. On Fargate that has to be "cpu"
+    #      (infra/variables.tf already records GPU-appropriate compute as
+    #      out of scope there).
+    #
+    # The intended artifact layout (atomic-swap, output schema) is in
+    # docs/specs/kb-integration-spec.md § Pipeline invocation — that spec
+    # names modules and prose steps, not these functions. The real path is
+    # gated behind KB_PIPELINE_ENABLED because it pulls in ~6 GB of model
     # weights (SPECTER2, REBEL, SciSpacy) and runs meaningfully only inside
-    # the dedicated container. Once that container ships, set the flag and this
-    # NotImplementedError will be replaced with the real pipeline invocation.
+    # the dedicated container. Once that container ships, set the flag and
+    # this NotImplementedError will be replaced with the real invocation.
     raise NotImplementedError(
         "KB_PIPELINE_ENABLED set, but the full pipeline invocation is not yet wired. "
         "See docs/specs/kb-integration-spec.md § Pipeline invocation for the canonical shape. "


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Correct the `NotImplementedError` comment in `backend/archimedes/scripts/run_kb_pipeline.py` so it names the real `papers_analysis` entry points and the three structural mismatches that remain before the pipeline can be wired. Comment-accuracy only — the skeleton, the skip path, and `KB_PIPELINE_ENABLED` are unchanged.

## Why

The comment claimed five submodule functions that do not exist (`embed_corpus`, `cluster_embeddings`, `bertopic_labels`, `extract_triples`, `graph.aggregate`) and gated the real path behind `REQUIRE_KB_PIPELINE_RUN`, a flag that appears nowhere else. Anyone sizing #1090 from that comment would estimate a wiring job and find an integration project.

Verified against `submodules/KnowledgeBase/papers_analysis/` at the recorded pin, not from the issue's mapping:

| Named in the new comment | Confirmed `def` in |
| --- | --- |
| `vectorize.run_vectorize` | `vectorize.py` |
| `cluster.run_clustering` | `cluster.py` |
| `cluster._extract_topic_records` | `cluster.py` (BERTopic helper inside `run_clustering`; not a public labels API) |
| `knowledge_graph.run_knowledge_graph` | `knowledge_graph.py` (`device="mps"`, returns `None`) |
| `knowledge_graph.build_networkx_graph` / `build_rdf_graph` | `knowledge_graph.py` (not `graph.py`) |
| `graph.run_graph` / `graph.build_graph` | `graph.py` — SPECTER2 similarity graph, not KG aggregation |

Remaining work called out in the comment (not done here): data model (`metadata.db` + `data/embeddings/` vs `corpus_text_dir` / `/srv/corpus-artifact/`), identity (`sha256` vs paper id), device (`mps` default vs Fargate `cpu`).

## Issues

Part of #1738

## Verification

Invented names gone:

```
$ grep -n "embed_corpus\|cluster_embeddings\|bertopic_labels\|extract_triples\|graph.aggregate" backend/archimedes/scripts/run_kb_pipeline.py
(no matches)
```

Phantom flag gone:

```
$ grep -rn "REQUIRE_KB_PIPELINE_RUN" . --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=submodules
(no matches)
```

Every `papers_analysis.{mod}.{fn}` in the comment has a matching `^def {fn}` in `submodules/KnowledgeBase/papers_analysis/{mod}.py` (8/8). `NotImplementedError` and the `{"status": "skipped"}` path are still present. `KB_PIPELINE_ENABLED` wiring is untouched.

This is a comment-only change; a revert-the-fix regression test does not apply.

## What a reviewer should push back on

- If a named function is not actually the entry point you would call to finish #1090 — `_extract_topic_records` is a private helper; it is named because that is where BERTopic labels live, not as a public API.
- Scope: this PR does not implement the pipeline, delete the skeleton, or touch `KB_PIPELINE_ENABLED` / `PAPER_ADVANCE`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03c569bd-f731-4f17-b7c5-0e5d702b2e78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03c569bd-f731-4f17-b7c5-0e5d702b2e78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

