### PR TITLE
Drop lepton demo from Product nav; retarget leftover archive pointers

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -62,7 +62,7 @@ current architecture — [`docs/architecture.md`](../architecture.md) is.
 | [`agora-2026-05/design.md`](agora-2026-05/design.md) | The original design document. |
 | [`agora-2026-05/infra-setup.md`](agora-2026-05/infra-setup.md) | Infrastructure and CI/CD setup as it stood at submission. |
 | [`agora-2026-05/chuan-architecture-survey.md`](agora-2026-05/chuan-architecture-survey.md) | Chuan's survey of `backend/archimedes/`. Predates the Chuan → Dan ownership transition. |
-| ``agora-2026-05/demo-script-pitch-deck-outline.md`` (routed to the private docs repo, 2026-08-19) | Demo script and pitch-deck outline. Current demo script: [`docs/demo-script-lepton.md`](../demo-script-lepton.md). |
+| ``agora-2026-05/demo-script-pitch-deck-outline.md`` (routed to the private docs repo, 2026-08-19) | Demo script and pitch-deck outline. Archived demo script: [`demo-script-lepton.md`](demo-script-lepton.md). |
 | [`agora-2026-05/portfolio-advisor-demo-cues.md`](agora-2026-05/portfolio-advisor-demo-cues.md) | 60-second Portfolio Advisor demo cue card. |
 | ``agora-2026-05/claude-design-prompts.md`` (routed to the private docs repo, 2026-08-19) | Design prompts used to generate the submission UI; routed because its slide prompts embed competitive comparisons, market-sizing figures, and judging strategy. |
 | [`agora-2026-05/traction-logging.md`](agora-2026-05/traction-logging.md) | `arc-canteen` traction-logging cheat sheet. |

--- a/docs/archive/agora-2026-05/portfolio-advisor-demo-cues.md
+++ b/docs/archive/agora-2026-05/portfolio-advisor-demo-cues.md
@@ -1,4 +1,4 @@
-> **ARCHIVED 2026-07-28 — historical. Current: [`docs/demo-script-lepton.md`](../../demo-script-lepton.md)**
+> **ARCHIVED 2026-07-28 — historical. See [`docs/archive/demo-script-lepton.md`](../demo-script-lepton.md)**
 >
 > May-2026 Agora demo cue sheet.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,6 @@ nav:
       - agent-api.md
       - specs/agent-native-onboarding-spec.md
       - asset-universe.md
-      - demo-script-lepton.md
 
   - Quant and rigor:
       - quant/README.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Lands the drop-not-retarget nav path from the #1735 review (danielscoffee): drop `demo-script-lepton.md` from mkdocs Product nav entirely (do **not** retarget to `archive/demo-script-lepton.md`, which would publish the June Linus-era script — vaults spoken as shipped — as a live Product page). Point the two leftover relatives at the archived file and stop calling it Current.

Product nav after the drop: `user-stories.md`, `agent-api.md`, `specs/agent-native-onboarding-spec.md`, `asset-universe.md`.

## Why

Owner review on #1735 asked for these three leftover-reference fixes so checks can go green. Retargeting the nav would republish retired branding on docs.archimedes-arc.com.

## Issues

Part of #1735. Does not close it.

## Verification

```
$ python3 .github/scripts/docs_links.py
links: scanned 1734 in 179 markdown files; broken 0 (0.0%)

$ python3 .github/scripts/docs_index.py
index: 174 docs under docs/; 174 indexed, 0 orphaned.

$ python3 -m pytest --noconftest backend/tests/test_docs_site.py::test_every_nav_target_exists backend/tests/test_public_branding_guard.py
3 passed
  test_every_nav_target_exists
  test_no_retired_branding_on_public_surfaces
  test_the_guard_actually_rejects_the_banned_phrase

$ mkdocs build --strict --site-dir _site
exit 0
  INFO: archive/demo-script-lepton.md exists in docs/ but is not in nav (same class as the rest of archive/; not a --strict warning)
```

No remaining pointer names the old `docs/demo-script-lepton.md` path. Guard tests were not weakened.

## What a reviewer should push back on

Anything that re-lists the lepton script on Product nav, or any copy rewrite of identity/tagline/spine (out of scope; already accepted on #1735).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c1746d1-1bec-425d-9ba1-217f3214efde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c1746d1-1bec-425d-9ba1-217f3214efde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

