### PR TITLE
[strategy] Multi-paper utilization: make the paper→mechanism link explicit, validated, and durable

### DIFF
--- a/backend/archimedes/agents/debate_engine.py
+++ b/backend/archimedes/agents/debate_engine.py
@@ -797,14 +797,41 @@ def _rigor_verdict_dict(ev: Any) -> dict[str, Any]:
     }
 
 
-def _make_entry(candidate_id: str, proposal: Any, ev: Any, *, regime: str) -> _CandidateResult:
+def _make_entry(
+    candidate_id: str,
+    proposal: Any,
+    ev: Any,
+    *,
+    regime: str,
+    evidence_by_id: dict[str, dict[str, str]] | None = None,
+) -> _CandidateResult:
     """One leaderboard entry — a fully-populated ``_CandidateResult``.
 
     ``has_real_rigor=True`` (carries C-rigor's real backtest) so the downstream
     ``_patch_pbo`` and buy-and-hold gather correctly SKIP it (keyed on
     ``has_real_rigor``), preserving the CSCV PBO from ``evaluate_fusion_spec``.
+
+    ``evidence_by_id`` (#1739) is the ``{arxiv_id: {"title", "published"}}`` map
+    ``_propose_pool`` already built — the only place in the run that knows a
+    cited paper's TITLE. Without it every ``source_papers`` entry shipped
+    ``"title": ""`` and the Library card had nothing but an id to print.
+    Defaults to ``None`` (→ blank titles, the old behaviour) so the pure
+    ranking tests can call ``build_leaderboard`` without an evidence map.
     """
     spec = proposal.strategy_spec or {}
+    # (#1739) The server-filtered paper→mechanism map, keyed for the join
+    # below. First entry per id wins; a cited paper with no entry is carried
+    # with an empty mechanism, which is the honest "cited but unattributed"
+    # record (never dropped — dropping it would hide the shortfall).
+    mechanisms = getattr(proposal, "paper_mechanisms", None) or []
+    mech_by_id: dict[str, dict[str, Any]] = {}
+    for entry in mechanisms:
+        if not isinstance(entry, dict):
+            continue
+        arxiv_id = str(entry.get("arxiv_id", "") or "")
+        if arxiv_id and arxiv_id not in mech_by_id:
+            mech_by_id[arxiv_id] = entry
+    titles = evidence_by_id or {}
     # Real per-bar returns for the live gate (#788/#818, mirrors the fusion
     # path): without return_series, _persist_real_returns SKIPS the winner and
     # the passport reads "pending" forever even though C-rigor just ran a real
@@ -816,7 +843,15 @@ def _make_entry(candidate_id: str, proposal: Any, ev: Any, *, regime: str) -> _C
         strategy_name=proposal.strategy_name or "Debate candidate",
         thesis=proposal.thesis,
         asset_universe=list(spec.get("asset_universe", []) or []),
-        source_papers=[{"arxiv_id": a, "title": ""} for a in proposal.source_arxiv_ids],
+        source_papers=[
+            {
+                "arxiv_id": a,
+                "title": (titles.get(a) or {}).get("title", ""),
+                "mechanism": str((mech_by_id.get(a) or {}).get("mechanism", "") or ""),
+                "spec_elements": list((mech_by_id.get(a) or {}).get("spec_elements", []) or []),
+            }
+            for a in proposal.source_arxiv_ids
+        ],
         weights={},  # debate emits a DSL spec, not a static weight vector
         reasoning=proposal.fusion_reasoning or proposal.novelty_rationale or "",
         rigor_verdict=_rigor_verdict_dict(ev),
@@ -836,6 +871,11 @@ def _make_entry(candidate_id: str, proposal: Any, ev: Any, *, regime: str) -> _C
         # live agent runner later loads it to evaluate a deployed generated
         # strategy under its own signal rule instead of silently skipping it.
         strategy_spec=spec or None,
+        # (#1739) The budget-vs-used pair and the per-paper prose, carried onto
+        # the candidate instead of ending at a log line / a write-only field.
+        papers_offered=int(getattr(proposal, "papers_offered", 0) or 0),
+        distinct_mechanism_papers=int(getattr(proposal, "distinct_mechanism_papers", 0) or 0),
+        fusion_reasoning=str(getattr(proposal, "fusion_reasoning", "") or ""),
     )
 
 
@@ -935,6 +975,7 @@ def build_leaderboard(
     base_id: str,
     regime_force_abstain: bool = False,
     regime_reason: str = "",
+    evidence_by_id: dict[str, dict[str, str]] | None = None,
 ) -> list[_CandidateResult]:
     """Deterministic C-regime gate → C-null cull + rank → top-N leaderboard.
 
@@ -943,6 +984,11 @@ def build_leaderboard(
     market regime structurally overrides candidate consensus (Hierarchy-of-Truth).
     Otherwise: C-null cull → rank → leaderboard (leader keeps ``base_id``,
     alternatives get ``base_id_alt{n}``). Pure + deterministic — directly tested.
+
+    ``evidence_by_id`` (#1739) is threaded through to ``_make_entry`` purely so
+    a cited paper's TITLE reaches ``source_papers``; it never influences
+    ranking, culling, or the abstain paths. Optional, so the pure ranking tests
+    keep calling this with rigor results alone.
     """
     if regime_force_abstain:
         return [
@@ -966,7 +1012,13 @@ def build_leaderboard(
     # candidate set can't balloon when the pool is large.
     survivors = survivors[: _leaderboard_max()]
     return [
-        _make_entry(base_id if i == 0 else f"{base_id}_alt{i}", p, ev, regime=regime)
+        _make_entry(
+            base_id if i == 0 else f"{base_id}_alt{i}",
+            p,
+            ev,
+            regime=regime,
+            evidence_by_id=evidence_by_id,
+        )
         for i, (p, ev) in enumerate(survivors)
     ]
 
@@ -1102,6 +1154,7 @@ async def _run_debate_leaderboard(
         base_id=candidate_id,
         regime_force_abstain=regime_gate["force_abstain"],
         regime_reason=regime_gate["reason"],
+        evidence_by_id=evidence_by_id,
     )
     # Stamp the ONE transcript this run produced onto every entry (winner AND
     # the tail Considered Alternatives) — build_leaderboard is pure and knows

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -1022,6 +1022,40 @@ async def _persist_generation_cost(
         logger.warning("cost record: durable persist failed for job %s (non-blocking)", job_id, exc_info=True)
 
 
+def _passport_paper_refs(c: _CandidateResult) -> list[Any]:
+    """The passport's paper rows, with the attributed mechanism in ``contribution`` (#1739).
+
+    ``_persist_candidate`` and its two sibling passport rebuilds all built
+    ``PaperRef(arxiv_id=…, title=…)`` and nothing else, so ``contribution`` —
+    the column ``StrategyPassport.jsx`` renders as "per-paper contribution" —
+    had no writer at all and every generated row showed an em-dash. The
+    passport is what ``GET /strategies/{id}`` serves (``paper_refs``, not
+    ``StrategyRecord.source_papers``), and unlike the owner-only debate panel it
+    is public, so this is the only path on which the paper→mechanism link
+    reaches a reader of a published strategy.
+
+    ``contribution`` stays **None** for a cited paper whose ``spec_elements``
+    did not survive validation. The em-dash IS the unattributed record: writing
+    the model's unverified mechanism prose there would reinstate exactly the
+    laundering this issue removes, one column to the right.
+    """
+    from archimedes.models.paper_ref import PaperRef
+
+    refs: list[Any] = []
+    for p in c.source_papers or []:
+        if not isinstance(p, dict):
+            continue
+        mechanism = str(p.get("mechanism", "") or "").strip()
+        refs.append(
+            PaperRef(
+                arxiv_id=p.get("arxiv_id"),
+                title=p.get("title", ""),
+                contribution=mechanism if (mechanism and p.get("spec_elements")) else None,
+            )
+        )
+    return refs
+
+
 def _transcript_with_paper_record(c: _CandidateResult) -> list[dict[str, Any]]:
     """The candidate's transcript plus one trailing paper-attribution entry (#1739).
 
@@ -1037,12 +1071,15 @@ def _transcript_with_paper_record(c: _CandidateResult) -> list[dict[str, Any]]:
     turns sees an honest summary line rather than a blank card, and carries the
     machine-readable tally alongside it.
 
-    The prose is scrubbed here because ``sanitize_transcript`` only knows the
-    turn keys it was written for — writing unsanitized model text into this
-    table would re-open the leak its write-time sanitizer exists to close.
+    Both new keys carry MODEL prose — ``fusion_reasoning`` directly, and each
+    ``paper_verdicts`` row's ``discard_reasons``, which
+    ``_aggregate_paper_verdicts`` copies out of the raw debate turns. They are
+    scrubbed by ``sanitize_transcript``, which ``record_debate_transcript``
+    applies to everything written to this table; teaching the sanitizer the new
+    shape (rather than scrubbing at this one call site) is what keeps the
+    table's stated contract true — a raw read of ``transcript_json`` is already
+    safe, whoever wrote the row.
     """
-    from archimedes.models.debate_transcript import sanitize_debate_text
-
     transcript = list(c.debate_transcript or [])
     verdicts = c.debate_paper_verdicts or []
     reasoning = (c.fusion_reasoning or "").strip()
@@ -1061,7 +1098,7 @@ def _transcript_with_paper_record(c: _CandidateResult) -> list[dict[str, Any]]:
             "round": None,
             "verdict": summary,
             "paper_verdicts": verdicts,
-            "fusion_reasoning": sanitize_debate_text(reasoning),
+            "fusion_reasoning": reasoning,
         },
     ]
 
@@ -1795,13 +1832,10 @@ async def _persist_candidate(
 
             # Also write to the unified strategy_passports table (Issue #160)
             try:
-                from archimedes.models.paper_ref import PaperRef
                 from archimedes.models.strategy import StrategyPassport, StrategyStatus
                 from archimedes.services.passport_loader import ingest_passport
 
-                papers = [
-                    PaperRef(arxiv_id=p.get("arxiv_id"), title=p.get("title", "")) for p in (c.source_papers or [])
-                ]
+                papers = _passport_paper_refs(c)
                 # Map candidate regime to passport regime_tag
                 _regime_tag_map = {"bull": "bull", "bear": "bear"}
                 _regime_tag = _regime_tag_map.get(c.regime, "regime_neutral")
@@ -1915,14 +1949,13 @@ def _refresh_passport_real_metrics(
     """
     from datetime import date as _date
 
-    from archimedes.models.paper_ref import PaperRef
     from archimedes.models.strategy import StrategyPassport, StrategyStatus
     from archimedes.models.strategy_store import StrategyRecord
     from archimedes.services.passport_loader import ingest_passport
 
     record = session.query(StrategyRecord).filter_by(id=strategy_id).first()
     status_val = StrategyStatus(record.status) if record and record.status else StrategyStatus.CANDIDATE
-    papers = [PaperRef(arxiv_id=p.get("arxiv_id"), title=p.get("title", "")) for p in (c.source_papers or [])]
+    papers = _passport_paper_refs(c)
     regime_tag = {"bull": "bull", "bear": "bear"}.get(c.regime, "regime_neutral")
     passport = StrategyPassport(
         id=strategy_id,
@@ -2180,7 +2213,6 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
         from datetime import date as _date
 
         from archimedes.db import get_session
-        from archimedes.models.paper_ref import PaperRef
         from archimedes.models.strategy import StrategyPassport, StrategyStatus
         from archimedes.models.strategy_store import StrategyRecord
         from archimedes.services.backtest_mapper import canonical_artifact_hash
@@ -2266,7 +2298,7 @@ async def _backtest_and_persist(c: _CandidateResult, strategy_id: str, emit: _Em
             #    in-place update.
             record = session.query(StrategyRecord).filter_by(id=strategy_id).first()
             status_val = StrategyStatus(record.status) if record and record.status else StrategyStatus.CANDIDATE
-            papers = [PaperRef(arxiv_id=p.get("arxiv_id"), title=p.get("title", "")) for p in (c.source_papers or [])]
+            papers = _passport_paper_refs(c)
             _regime_tag_map = {"bull": "bull", "bear": "bear"}
             _regime_tag = _regime_tag_map.get(c.regime, "regime_neutral")
             passport = StrategyPassport(

--- a/backend/archimedes/agents/generation_pipeline.py
+++ b/backend/archimedes/agents/generation_pipeline.py
@@ -436,10 +436,24 @@ class _CandidateResult:
     # verdict}]`` over every paper that entered a proposer prompt. Computed by
     # ``debate_engine._aggregate_paper_verdicts`` (0 tokens) and stamped onto
     # every entry, same as the transcript. ``None`` on every non-debate path.
-    # NOT persisted: the transcript table's column holds the turn list and this
-    # issue explicitly carries no migration, so today this is an in-process +
-    # SSE-visible record only. Durable storage is follow-up work.
+    # (#1739) Now DURABLE: ``_persist_debate_transcripts`` appends it to the
+    # same ``debate_transcripts.transcript_json`` list the turns ride, so no
+    # migration was needed to stop it dying with the request.
     debate_paper_verdicts: list[dict[str, Any]] | None = None
+    # (#1739) The budget-vs-used pair, carried off the proposal instead of
+    # being left in a log line. ``papers_offered`` is how many papers were put
+    # in front of the proposer; ``distinct_mechanism_papers`` is how many of
+    # the CITED ones name a mechanism tied to an indicator the spec actually
+    # trades. Together they make ``len(source_arxiv_ids)`` readable: "2 of 30
+    # offered, 2 attributed" is a different claim from "5 cited, 1 attributed".
+    # Both 0 on every non-fusion path (fixture / buy-and-hold), which never saw
+    # a paper — 0 there means "no papers were offered", not "attribution failed".
+    papers_offered: int = 0
+    distinct_mechanism_papers: int = 0
+    # (#1739) The proposal's per-paper mechanism prose. ``reasoning`` above
+    # already falls back to ``novelty_rationale``, so it cannot be read as "the
+    # model named each paper's contribution"; this field is that text or "".
+    fusion_reasoning: str = ""
 
 
 def _is_deployable(c: _CandidateResult) -> bool:
@@ -1008,6 +1022,50 @@ async def _persist_generation_cost(
         logger.warning("cost record: durable persist failed for job %s (non-blocking)", job_id, exc_info=True)
 
 
+def _transcript_with_paper_record(c: _CandidateResult) -> list[dict[str, Any]]:
+    """The candidate's transcript plus one trailing paper-attribution entry (#1739).
+
+    ``debate_paper_verdicts`` was computed for free off the transcript we
+    already paid for and then thrown away at the end of the request — the run
+    that argued over 30 papers left no durable record of which ones it engaged
+    with. Same for ``fusion_reasoning``, the model's per-paper mechanism prose,
+    which ``_CandidateResult.reasoning`` collapses with ``novelty_rationale``.
+
+    Both ride the EXISTING ``transcript_json`` column as one extra list entry —
+    no migration, no new table, no schema change (#1739 carries none). The
+    entry keeps the turn shape (``role``/``verdict``) so a reader that walks
+    turns sees an honest summary line rather than a blank card, and carries the
+    machine-readable tally alongside it.
+
+    The prose is scrubbed here because ``sanitize_transcript`` only knows the
+    turn keys it was written for — writing unsanitized model text into this
+    table would re-open the leak its write-time sanitizer exists to close.
+    """
+    from archimedes.models.debate_transcript import sanitize_debate_text
+
+    transcript = list(c.debate_transcript or [])
+    verdicts = c.debate_paper_verdicts or []
+    reasoning = (c.fusion_reasoning or "").strip()
+    if not verdicts and not reasoning:
+        return transcript
+    engaged = sum(1 for v in verdicts if isinstance(v, dict) and v.get("verdict") != "unused")
+    summary = (
+        f"Paper attribution: {engaged} of {len(verdicts)} retrieved paper(s) were cited or "
+        f"discarded by name in this debate; {c.distinct_mechanism_papers} of "
+        f"{len(c.source_arxiv_ids)} cited paper(s) name a mechanism this strategy trades."
+    )
+    return [
+        *transcript,
+        {
+            "role": "attribution",
+            "round": None,
+            "verdict": summary,
+            "paper_verdicts": verdicts,
+            "fusion_reasoning": sanitize_debate_text(reasoning),
+        },
+    ]
+
+
 async def _persist_debate_transcripts(
     *,
     job_id: str,
@@ -1026,6 +1084,12 @@ async def _persist_debate_transcripts(
     from data already collected by the time this is called. Non-debate
     candidates (fusion, fixture, single-agent) carry ``debate_transcript=None``
     and are skipped — there is nothing to persist for them.
+
+    (#1739) Each row also carries the run's ``debate_paper_verdicts`` tally and
+    the proposal's ``fusion_reasoning``, appended by
+    :func:`_transcript_with_paper_record` as one extra entry on the same JSON
+    list the column already holds — so the per-paper record outlives the
+    request instead of being in-process + SSE-visible only.
 
     Best-effort, like the sibling :func:`_persist_generation_cost`: this runs
     after the winner's strategy row already landed, so a failure here must
@@ -1048,7 +1112,7 @@ async def _persist_debate_transcripts(
                     strategy_id=strategy_ids.get(c.candidate_id),
                     generation_id=job_id,
                     candidate_id=c.candidate_id,
-                    transcript=c.debate_transcript,
+                    transcript=_transcript_with_paper_record(c),
                 )
                 written += 1
             session.commit()

--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -1258,8 +1258,12 @@ class StrategyFusion:
                 validated_spec = None
 
         # (#1739) Paper→mechanism map, spec_elements half. ``indicators`` on the
-        # validated spec is exactly the alias set ``strategy_dsl`` checks
-        # ``parameter_variants`` keys against (strategy_dsl.py:269-274): an
+        # VALIDATED spec is exactly the alias set ``strategy_dsl`` checks
+        # ``parameter_variants`` keys against (strategy_dsl.py:269-274) — it is
+        # rebuilt from the entry/exit conditions (``sorted(all_indicators)``),
+        # so it is what the spec TRADES, not the ``indicators`` list the model
+        # declared alongside it. Checking the declared list would validate one
+        # self-report against another, which is the bug this issue is about: an
         # alias that entry/exit never uses is not part of what this spec
         # trades, so a paper "attributed" to it is not attributed at all. The
         # entry is KEPT with its claim and its id — only the unsupported

--- a/backend/archimedes/agents/strategy_fusion.py
+++ b/backend/archimedes/agents/strategy_fusion.py
@@ -858,6 +858,20 @@ class FusionProposal:
     # shortfall auditable instead of merely small. 0 on the non-fusion statuses
     # (disabled / insufficient_corpus / unparseable), where no prompt was built.
     papers_offered: int = 0
+    # (#1739) The paper→mechanism map: one entry per CITED paper the model
+    # could tie to a named mechanism AND to indicator aliases that literally
+    # appear in the validated spec's entry/exit conditions. Server-filtered in
+    # ``propose`` — an id the model invented, or a spec_element that is not in
+    # the spec, never survives into this list. Empty on every non-``ok``
+    # status, and empty on an ``ok`` proposal whose model emitted no map.
+    paper_mechanisms: list[dict[str, Any]] = field(default_factory=list)
+    # (#1739) How many of ``source_arxiv_ids`` survive that filter with at
+    # least one spec element attached. This is the honest read of "how many
+    # papers does this strategy actually trade the mechanism of", as opposed
+    # to ``len(source_arxiv_ids)``, which is the model's own claim. It LABELS,
+    # it never gates: a 5-citation / 1-mechanism proposal is still actionable,
+    # it just says so (#1636's honest-shortfall rule).
+    distinct_mechanism_papers: int = 0
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -908,11 +922,17 @@ position_sizing accepts NO other keys — a key outside that list is a hard \
 validation error, not an ignored field, so do not invent one. Do NOT emit any \
 field asserting the strategy's own correctness or look-ahead safety; the \
 platform derives that structurally from the spec and ignores anything you \
-claim about it. \
->>>>>>> origin/main
+claim about it.
 parameter_variants is OPTIONAL: a dict mapping indicator aliases to 2-8 numeric \
 values for CSCV overfitting detection (e.g. {"sma_200": [150, 175, 200, 225, 250]}). \
-Keys must reference indicators used in entry/exit conditions."""
+Keys must reference indicators used in entry/exit conditions.
+paper_mechanisms is a TOP-LEVEL field of the proposal, NOT a key inside \
+strategy_spec — do not emit it here. It maps each cited paper to the part of \
+this spec it produced: each entry's spec_elements must name indicator aliases \
+that actually appear in the spec's entry/exit conditions (the same rule \
+parameter_variants keys follow). An alias that is not in entry/exit is \
+dropped, and a cited paper left with no surviving spec_element counts as \
+UNATTRIBUTED."""
 
 
 _SYSTEM_PROMPT = (
@@ -933,6 +953,13 @@ downstream as evidence depth, so a fabricated mechanism launders weak \
 evidence into the provenance record.
 - Reference papers ONLY by an arxiv_id from the provided candidates. Never \
 invent a paper or an arxiv_id.
+- Every id in `source_arxiv_ids` MUST have a matching entry in \
+`paper_mechanisms` naming the one mechanism that paper contributes and the \
+`spec_elements` — indicator aliases that literally appear in the spec's \
+entry/exit conditions — it produced. If you cannot name the mechanism a paper \
+contributes to THIS spec, OMIT that id from `source_arxiv_ids` entirely; do \
+NOT pad the citation list with it and do not invent a mechanism for it. An \
+honest shorter list is correct; a longer one you cannot map is laundering.
 - OPTIMIZE FOR NOVELTY. The edge is the combination the literature has NOT \
 published. Published single-paper alpha decays post-publication (McLean & \
 Pontiff 2016) — your value is the non-obvious synthesis, not re-stating one \
@@ -953,6 +980,11 @@ as a synthesis constraint, not as a paper filter.
   "source_arxiv_ids": ["<arxiv_id from candidates>", "<another>", ...],
   "fusion_reasoning": "<what mechanism EACH cited paper contributes and how \
 they combine>",
+  "paper_mechanisms": [
+    {"arxiv_id": "<from source_arxiv_ids>",
+     "mechanism": "<the one mechanism THIS paper contributes>",
+     "spec_elements": ["<indicator alias used in entry/exit>", "..."]}
+  ],
   "novelty_rationale": "<why this specific combination is not already in the \
 literature>",
   "risk_notes": "<key risks + the pre-backtest / selection-bias caveat>",
@@ -1145,6 +1177,18 @@ class StrategyFusion:
         seen: set[str] = set()
         source_ids = [i for i in source_ids if not (i in seen or seen.add(i))]
 
+        # (#1739) Paper→mechanism map, id half — the SAME anti-hallucination
+        # shape as the valid_ids filter directly above: an entry naming a paper
+        # this proposal does not cite is dropped, never repaired. The
+        # spec_elements half runs further down, once there is a VALIDATED spec
+        # whose indicator aliases can be checked against.
+        cited_ids = set(source_ids)
+        paper_mechanisms: list[dict[str, Any]] = [
+            e
+            for e in (parsed.get("paper_mechanisms") or [])
+            if isinstance(e, dict) and str(e.get("arxiv_id", "")) in cited_ids
+        ]
+
         if len(source_ids) < MIN_PAPERS:
             logger.warning(
                 "fusion: model fused %d valid papers (<%d); declined",
@@ -1187,6 +1231,7 @@ class StrategyFusion:
             strategy_spec = _repair_spec(backend, brief, parsed)
         universe_source: str | None = None
         universe_gaps: list[str] = []
+        validated_spec = None
         if not isinstance(strategy_spec, dict):
             strategy_spec = None
         else:
@@ -1204,12 +1249,48 @@ class StrategyFusion:
             # model emission — must degrade to honest text-only HERE, not
             # surface later as a DSLError mid-evaluation/debate.
             try:
-                validate_strategy_spec(strategy_spec)
+                validated_spec = validate_strategy_spec(strategy_spec)
             except DSLError as exc:
                 logger.warning("fusion: strategy_spec failed DSL validation (%s) — falling back to text-only", exc)
                 strategy_spec = None
                 universe_source = None
                 universe_gaps = []
+                validated_spec = None
+
+        # (#1739) Paper→mechanism map, spec_elements half. ``indicators`` on the
+        # validated spec is exactly the alias set ``strategy_dsl`` checks
+        # ``parameter_variants`` keys against (strategy_dsl.py:269-274): an
+        # alias that entry/exit never uses is not part of what this spec
+        # trades, so a paper "attributed" to it is not attributed at all. The
+        # entry is KEPT with its claim and its id — only the unsupported
+        # element is stripped, the debate's keep-the-claim/strip-the-id honesty
+        # pattern (debate_engine.py:467-501) — and it then contributes 0 to the
+        # count. No validated spec (text-only fallback) → no aliases → every
+        # entry is unattributed, which is the honest read of a proposal that
+        # trades nothing yet.
+        valid_elements: set[str] = set(validated_spec.indicators) if validated_spec is not None else set()
+        paper_mechanisms = [
+            {
+                "arxiv_id": str(e.get("arxiv_id", "")),
+                "mechanism": str(e.get("mechanism", "") or "").strip(),
+                "spec_elements": [
+                    el for el in (e.get("spec_elements") or []) if isinstance(el, str) and el in valid_elements
+                ],
+            }
+            for e in paper_mechanisms
+        ]
+        distinct_mechanism_papers = len({e["arxiv_id"] for e in paper_mechanisms if e["spec_elements"]})
+        if distinct_mechanism_papers < len(source_ids):
+            # LABEL, never gate (#1636): a citation the model cannot tie to a
+            # traded indicator is recorded as unattributed, not deleted and not
+            # a reject. The pair is what makes "cites 5" readable.
+            logger.warning(
+                "fusion: paper→mechanism attribution — %d of %d cited paper(s) name a mechanism "
+                "tied to an indicator this spec actually trades; the remainder are recorded as "
+                "unattributed (labelled, never blocked)",
+                distinct_mechanism_papers,
+                len(source_ids),
+            )
 
         risk_notes = str(parsed.get("risk_notes", "")).strip()
         if universe_gaps:
@@ -1235,6 +1316,8 @@ class StrategyFusion:
             universe_source=universe_source,
             universe_gaps=universe_gaps,
             papers_offered=papers_offered,
+            paper_mechanisms=paper_mechanisms,
+            distinct_mechanism_papers=distinct_mechanism_papers,
         )
 
 

--- a/backend/archimedes/models/debate_transcript.py
+++ b/backend/archimedes/models/debate_transcript.py
@@ -24,10 +24,13 @@ therefore keyed to ``(generation_id, candidate_id)``, not to a strategy:
   "write failed".
 
 Sanitization happens at WRITE time, not read time (see ``sanitize_transcript``
-below): every string field of every turn is stripped of internal-jargon
-patterns before the JSON is serialized, so the stored column is never the
-place a leak has to be caught — a raw read of ``transcript_json`` is already
-safe.
+below): every model-written string in every entry is stripped of
+internal-jargon patterns before the JSON is serialized, so the stored column is
+never the place a leak has to be caught — a raw read of ``transcript_json`` is
+already safe. That contract binds the SANITIZER, not the callers: when the
+stored shape grows a key (#1636's dict claims, #1739's paper-attribution
+entry), the new key is taught to ``sanitize_transcript`` rather than scrubbed
+at one call site, or the next writer of that shape re-opens the leak.
 """
 
 from __future__ import annotations
@@ -99,6 +102,41 @@ def _sanitize_claim(claim: Any) -> Any:
     return claim
 
 
+#: Keys inside one ``paper_verdicts`` row (#1739) whose value is a LIST of
+#: model-written strings. ``title`` is deliberately NOT here: it is corpus
+#: metadata, not model prose, and the jargon patterns would mangle a real
+#: paper ("Phase-Type Models of ..." → "[redacted] Models of ...") — the same
+#: provenance reason ``arxiv_ids`` is left alone in ``_SCRUBBED_CLAIM_KEYS``.
+_SCRUBBED_VERDICT_LIST_KEYS = ("discard_reasons",)
+
+
+def _sanitize_paper_verdict(row: Any) -> Any:
+    """Scrub one per-paper verdict row (#1739).
+
+    ``debate_engine._aggregate_paper_verdicts`` builds these rows off the RAW
+    ``_debate_round`` output, so ``discard_reasons`` holds the bear's own
+    prose — the *same strings* that reach this table as ``discard[].reason``
+    and are scrubbed there by :func:`_sanitize_claim`. The tally used to die
+    with the request; now that it is durable, the rows have to be scrubbed on
+    the way in too, or the identical sentence lands unsanitized under a key the
+    sanitizer did not know about. That is the ``_sanitize_claim`` failure mode
+    exactly: a shape change re-opening the leak the write-time scrubber exists
+    to close.
+
+    ``arxiv_id`` / ``cited_by`` / ``discarded_by`` / ``verdict`` are engine
+    vocabulary rather than model text, and ``title`` is corpus metadata (see
+    ``_SCRUBBED_VERDICT_LIST_KEYS``); all pass through untouched.
+    """
+    if not isinstance(row, dict):
+        return row
+    out = dict(row)
+    for key in _SCRUBBED_VERDICT_LIST_KEYS:
+        value = out.get(key)
+        if isinstance(value, list):
+            out[key] = [sanitize_debate_text(v) if isinstance(v, str) else v for v in value]
+    return out
+
+
 def sanitize_transcript(transcript: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Apply :func:`sanitize_debate_text` to every string field of every turn.
 
@@ -108,6 +146,13 @@ def sanitize_transcript(transcript: list[dict[str, Any]]) -> list[dict[str, Any]
     ``round`` and the validated arXiv ids pass through untouched. A non-dict
     entry is dropped rather than raising, matching the "best-effort, never
     gates" posture of the debate round itself.
+
+    It also scrubs the two keys the paper-attribution entry adds (#1739):
+    ``paper_verdicts`` (per-paper rows carrying the bear's ``discard_reasons``)
+    and ``fusion_reasoning`` (the proposer's per-paper prose). Those are model
+    text arriving under keys no debate TURN has, and the module's contract is
+    that a raw read of ``transcript_json`` is already safe — so the sanitizer,
+    not the caller, is where the new shape has to be known.
     """
     sanitized: list[dict[str, Any]] = []
     for turn in transcript:
@@ -121,6 +166,12 @@ def sanitize_transcript(transcript: list[dict[str, Any]]) -> list[dict[str, Any]
             value = new_turn.get(key)
             if isinstance(value, list):
                 new_turn[key] = [_sanitize_claim(c) for c in value]
+        paper_verdicts = new_turn.get("paper_verdicts")
+        if isinstance(paper_verdicts, list):
+            new_turn["paper_verdicts"] = [_sanitize_paper_verdict(v) for v in paper_verdicts]
+        fusion_reasoning = new_turn.get("fusion_reasoning")
+        if isinstance(fusion_reasoning, str):
+            new_turn["fusion_reasoning"] = sanitize_debate_text(fusion_reasoning)
         sanitized.append(new_turn)
     return sanitized
 

--- a/backend/tests/test_multi_paper_utilization.py
+++ b/backend/tests/test_multi_paper_utilization.py
@@ -1,0 +1,443 @@
+"""Multi-paper utilization is checkable, not self-reported (#1739).
+
+Before this, a citation list was a claim with nothing behind it: a single-
+``sma_200`` crossover that named five papers passed ``is_actionable``,
+``_dsl_conformance_ok`` and ``validate_strategy_spec`` alike, and was
+hash-identical to the same spec citing one unrelated paper. Citation count
+reads downstream as evidence depth, so "5 papers" laundered a one-mechanism
+strategy — the exact move #1636 called "strictly worse than an honest 2".
+
+What is asserted here is the mapping, end to end:
+
+* ``paper_mechanisms`` ties each CITED id to a mechanism and to indicator
+  aliases that literally appear in the validated spec's entry/exit conditions.
+  An id the model invented is dropped (the ``valid_ids`` filter's shape); a
+  spec element the spec does not use is dropped (``strategy_dsl``'s
+  ``parameter_variants`` check, same ``all_indicators`` set).
+* ``distinct_mechanism_papers`` LABELS the result. It is never a gate: the
+  five-papers/one-mechanism spec still ships, it just says "1".
+* ``papers_offered`` / ``distinct_mechanism_papers`` / ``fusion_reasoning``
+  survive onto the candidate, into ``source_papers`` (with real titles), and
+  into the persisted ``debate_transcripts`` row — the four values that were
+  computed and then dropped.
+
+Hermetic: no ``.env``, no network, no Redis, no Docker. The corpus is built
+in-test, every LLM call is a stub, and the DB is tmp-file sqlite (fixture
+copied from ``test_generated_citation_truth.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import archimedes.agents.debate_engine as de
+import archimedes.db as db
+import pytest
+from archimedes.agents.generation_pipeline import (
+    _CandidateResult,
+    _persist_candidate,
+    _persist_debate_transcripts,
+)
+from archimedes.agents.strategy_fusion import CorpusPaper, FusionBrief, StrategyFusion
+from archimedes.api.generate_schemas import GenerateBrief
+from archimedes.api.strategies_routes import _resolve_source_papers
+from archimedes.models.debate_transcript import DebateTranscriptRecord
+
+# ── Fixture corpus: five real-shaped papers, distinct mechanisms ─────────────
+
+_PAPERS = [
+    CorpusPaper(
+        arxiv_id="2401.00001",
+        title="Cross-Sectional Equity Momentum with Regime Conditioning",
+        abstract="A regime-switching overlay on cross-sectional equity momentum.",
+        primary_category="q-fin.PM",
+        categories=("q-fin.PM",),
+        published="2024-01-05",
+    ),
+    CorpusPaper(
+        arxiv_id="2402.00002",
+        title="Treasury Yield Curve Carry and Macro Regimes",
+        abstract="A carry strategy on the treasury yield curve conditioned on macro states.",
+        primary_category="q-fin.PM",
+        categories=("q-fin.PM",),
+        published="2024-02-10",
+    ),
+    CorpusPaper(
+        arxiv_id="2403.00003",
+        title="Implied Volatility Surface Dynamics for Index Options",
+        abstract="Modelling implied volatility surface dynamics and variance risk premia.",
+        primary_category="q-fin.PR",
+        categories=("q-fin.PR",),
+        published="2024-03-15",
+    ),
+    CorpusPaper(
+        arxiv_id="2404.00004",
+        title="Trend Following Across Asset Classes",
+        abstract="Time-series momentum and moving-average crossovers across asset classes.",
+        primary_category="q-fin.PM",
+        categories=("q-fin.PM",),
+        published="2024-04-20",
+    ),
+    CorpusPaper(
+        arxiv_id="2405.00005",
+        title="Low-Volatility Anomalies in Equity Portfolios",
+        abstract="Realized-volatility sorting and the low-beta anomaly in equity portfolios.",
+        primary_category="q-fin.PM",
+        categories=("q-fin.PM",),
+        published="2024-05-25",
+    ),
+]
+
+_ALL_IDS = [p.arxiv_id for p in _PAPERS]
+
+# The adversarial spec from #1739: ONE mechanism (sma_200) in entry AND exit.
+# Anything a paper_mechanisms entry names other than "sma_200" is not part of
+# what this strategy trades.
+_SINGLE_MECHANISM_SPEC = {
+    "name": "Single-mechanism crossover",
+    "asset_universe": ["SPY"],
+    "rebalance_frequency": "monthly",
+    "entry": {"gt": ["close", "sma_200"]},
+    "exit": {"lt": ["close", "sma_200"]},
+    "position_sizing": {"type": "full_invested_when_in_market"},
+    "source_arxiv_ids": list(_ALL_IDS),
+    "indicators": ["sma_200"],
+}
+
+
+class _MechanismBackend:
+    """A stub proposer that cites all five papers and maps ``mechanisms`` of them.
+
+    ``model_id`` / ``served_model`` differ so the true-model honesty rule keeps
+    holding on this path too.
+    """
+
+    model_id = "claude-sonnet-4-20250514"
+    served_model = "glm-4.7"
+
+    def __init__(self, mechanisms: list[dict], *, source_ids: list[str] | None = None) -> None:
+        self._mechanisms = mechanisms
+        self._source_ids = list(source_ids if source_ids is not None else _ALL_IDS)
+
+    def complete(self, system: str, user: str) -> str:
+        # The prompt itself is asserted in test_strategy_fusion.py; this stub
+        # only has to answer in the proposal's output shape.
+        return json.dumps(
+            {
+                "strategy_name": "Single-mechanism crossover",
+                "thesis": "Pre-backtest hypothesis; empirical validation pending.",
+                "source_arxiv_ids": self._source_ids,
+                "fusion_reasoning": "Each cited paper is discussed by name.",
+                "novelty_rationale": "The combination is unpublished.",
+                "risk_notes": "Pre-backtest; the rigor gate still applies.",
+                "paper_mechanisms": self._mechanisms,
+                "strategy_spec": dict(_SINGLE_MECHANISM_SPEC),
+            }
+        )
+
+
+def _propose(monkeypatch, mechanisms, *, source_ids=None):
+    monkeypatch.setenv("ARCHIMEDES_FUSION_ENABLED", "1")
+    monkeypatch.delenv("ARCHIMEDES_CORPUS_MANIFEST", raising=False)
+    svc = StrategyFusion(
+        backend=_MechanismBackend(mechanisms, source_ids=source_ids),
+        corpus=list(_PAPERS),
+        candidates=list(_PAPERS),  # used verbatim — papers_offered == 5
+    )
+    return svc.propose(FusionBrief(asset_classes=[]))
+
+
+# ── DB fixture (copied from test_generated_citation_truth.py:41-53) ──────────
+
+
+@pytest.fixture
+def _use_tmp_db(tmp_path, monkeypatch):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'utilization.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+# ── 1. The mapping ──────────────────────────────────────────────────────────
+
+
+def test_unattributed_citation_does_not_count_as_a_mechanism_paper(monkeypatch, caplog):
+    """Citing five papers while naming spec elements for two is a 2, not a 5.
+
+    The citation list is NOT trimmed — #1636's rule is that an unattributable
+    paper is recorded as unattributed, never deleted (the debate's
+    keep-the-claim/strip-the-id pattern). The honest count travels beside it,
+    and the shortfall leaves a log line so it is auditable without re-reading
+    the proposal.
+    """
+    caplog.set_level(logging.WARNING, logger="archimedes.agents.strategy_fusion")
+    mechanisms = [
+        {"arxiv_id": "2401.00001", "mechanism": "trend filter", "spec_elements": ["sma_200"]},
+        {"arxiv_id": "2404.00004", "mechanism": "MA crossover", "spec_elements": ["sma_200"]},
+        # Cited, but the model could not tie them to anything this spec trades.
+        {"arxiv_id": "2402.00002", "mechanism": "carry", "spec_elements": []},
+        {"arxiv_id": "2403.00003", "mechanism": "vol surface", "spec_elements": []},
+        {"arxiv_id": "2405.00005", "mechanism": "low-vol anomaly", "spec_elements": []},
+    ]
+
+    proposal = _propose(monkeypatch, mechanisms)
+
+    assert proposal.status == "ok"
+    assert len(proposal.source_arxiv_ids) == 5, "the claim is kept, not trimmed"
+    assert proposal.distinct_mechanism_papers == 2
+    # The three unattributed papers are still ON the record, with their claim.
+    unattributed = [e for e in proposal.paper_mechanisms if not e["spec_elements"]]
+    assert {e["arxiv_id"] for e in unattributed} == {"2402.00002", "2403.00003", "2405.00005"}
+    assert all(e["mechanism"] for e in unattributed), "the claim survives; only the unsupported link is stripped"
+
+    lines = [r.getMessage() for r in caplog.records if "attribution" in r.getMessage()]
+    assert lines, "an under-attributed citation list must leave a WARNING"
+    assert "2 of 5" in lines[0]
+
+
+def test_spec_element_outside_the_spec_is_dropped(monkeypatch):
+    """``bollinger_20`` is not in entry/exit, so a paper "attributed" to it is not.
+
+    Mirrors ``strategy_dsl.py:269-274``, where a ``parameter_variants`` key
+    must reference an indicator alias the conditions actually use — same
+    ``all_indicators`` set, different key. Without it, ``spec_elements`` is
+    free text and the mapping proves nothing.
+    """
+    mechanisms = [
+        {"arxiv_id": "2401.00001", "mechanism": "trend filter", "spec_elements": ["sma_200"]},
+        {"arxiv_id": "2403.00003", "mechanism": "vol band", "spec_elements": ["bollinger_20"]},
+    ]
+
+    proposal = _propose(monkeypatch, mechanisms)
+
+    by_id = {e["arxiv_id"]: e for e in proposal.paper_mechanisms}
+    assert by_id["2403.00003"]["spec_elements"] == [], "an alias the spec never uses must not survive"
+    assert by_id["2403.00003"]["mechanism"] == "vol band", "the claim itself is kept, unlaundered"
+    assert by_id["2401.00001"]["spec_elements"] == ["sma_200"]
+    # It contributed nothing: only the sma_200 paper counts.
+    assert proposal.distinct_mechanism_papers == 1
+
+
+def test_single_mechanism_spec_claiming_five_papers_is_labelled_not_hidden(monkeypatch):
+    """#1739's adversarial case. It SHIPS — and it says "1".
+
+    ``distinct_mechanism_papers`` is deliberately not a gate: converting it into
+    a reject would fail generation instead of improving it, which #1636 ruled
+    out. An honest single-mechanism strategy is a legitimate outcome; a
+    single-mechanism strategy wearing five citations as evidence depth is not.
+    """
+    mechanisms = [
+        {"arxiv_id": "2401.00001", "mechanism": "200-day trend filter", "spec_elements": ["sma_200"]},
+        {"arxiv_id": "2402.00002", "mechanism": "carry", "spec_elements": []},
+        {"arxiv_id": "2403.00003", "mechanism": "variance risk premium", "spec_elements": []},
+        {"arxiv_id": "2404.00004", "mechanism": "time-series momentum", "spec_elements": []},
+        {"arxiv_id": "2405.00005", "mechanism": "low-vol anomaly", "spec_elements": []},
+    ]
+
+    proposal = _propose(monkeypatch, mechanisms)
+
+    assert proposal.is_actionable is True, "labelled, never rejected (#1636's honest-shortfall rule)"
+    assert len(proposal.source_arxiv_ids) == 5
+    assert proposal.distinct_mechanism_papers == 1
+    assert proposal.papers_offered == 5
+
+
+# ── 2. Survival onto the candidate ──────────────────────────────────────────
+
+
+def test_papers_offered_and_mechanism_count_survive_to_the_candidate():
+    """``_make_entry`` used to drop all three, plus the paper titles.
+
+    ``papers_offered`` was computed and logged, ``fusion_reasoning`` was folded
+    into ``reasoning`` (which falls back to ``novelty_rationale``, so it could
+    not be read as per-paper prose), and ``title`` was the literal ``""``.
+    """
+    from types import SimpleNamespace
+
+    from tests.test_debate_engine import _fake_ev
+
+    proposal = SimpleNamespace(
+        strategy_name="Single-mechanism crossover",
+        thesis="thesis",
+        source_arxiv_ids=["2401.00001", "2404.00004", "2402.00002"],
+        strategy_spec=dict(_SINGLE_MECHANISM_SPEC),
+        fusion_reasoning="Paper A gives the trend filter; paper D gives the crossover period.",
+        novelty_rationale="novelty",
+        is_actionable=True,
+        papers_offered=30,
+        distinct_mechanism_papers=2,
+        paper_mechanisms=[
+            {"arxiv_id": "2401.00001", "mechanism": "200-day trend filter", "spec_elements": ["sma_200"]},
+            {"arxiv_id": "2404.00004", "mechanism": "crossover period", "spec_elements": ["sma_200"]},
+            {"arxiv_id": "2402.00002", "mechanism": "carry", "spec_elements": []},
+        ],
+    )
+    evidence_by_id = {p.arxiv_id: {"title": p.title, "published": p.published} for p in _PAPERS}
+
+    entry = de._make_entry(
+        "cand_1",
+        proposal,
+        _fake_ev(cagr=0.2),
+        regime="neutral",
+        evidence_by_id=evidence_by_id,
+    )
+
+    assert entry.papers_offered == 30
+    assert entry.distinct_mechanism_papers == 2
+    assert entry.fusion_reasoning, "the per-paper mechanism prose must reach the candidate"
+    # …and the titles the evidence map already knew.
+    titles = {p["arxiv_id"]: p["title"] for p in entry.source_papers}
+    assert titles["2401.00001"] == "Cross-Sectional Equity Momentum with Regime Conditioning"
+    assert all(p["title"] for p in entry.source_papers), 'no citation ships with the literal ""'
+    mechanisms = {p["arxiv_id"]: p for p in entry.source_papers}
+    assert mechanisms["2404.00004"]["spec_elements"] == ["sma_200"]
+    assert mechanisms["2402.00002"]["spec_elements"] == [], "cited but unattributed, and it says so"
+
+
+# ── 3. Durability ───────────────────────────────────────────────────────────
+
+
+async def test_persisted_source_papers_carry_title_and_mechanism(_use_tmp_db):
+    """The enriched dicts ride the EXISTING ``source_papers`` JSON column.
+
+    No migration and no route change: ``upsert_strategy`` serializes whatever
+    dicts it is handed, and ``_resolve_source_papers`` does ``dict(paper)``, so
+    the extra keys reach the API response unchanged.
+    """
+    from archimedes.models.strategy_store import StrategyRecord
+
+    candidate = _CandidateResult(
+        candidate_id="cand_1",
+        strategy_name="Single-mechanism crossover",
+        thesis="thesis",
+        asset_universe=["SPY"],
+        source_papers=[
+            {
+                "arxiv_id": "2401.00001",
+                "title": "Cross-Sectional Equity Momentum with Regime Conditioning",
+                "mechanism": "200-day trend filter",
+                "spec_elements": ["sma_200"],
+            },
+            {
+                "arxiv_id": "2402.00002",
+                "title": "Treasury Yield Curve Carry and Macro Regimes",
+                "mechanism": "carry",
+                "spec_elements": [],
+            },
+        ],
+        weights={},
+        reasoning="r",
+        rigor_verdict={"passing": True, "dsr": 1.5},
+        passes_rigor=True,
+        generation_method="debate",
+        source_arxiv_ids=["2401.00001", "2402.00002"],
+        distinct_mechanism_papers=1,
+        papers_offered=5,
+        fusion_reasoning="Paper A gives the trend filter.",
+    )
+
+    strategy_id, _trace = await _persist_candidate(candidate, GenerateBrief(intent="momentum equities"))
+
+    with db.get_session() as session:
+        record = session.get(StrategyRecord, strategy_id)
+        stored = json.loads(record.source_papers)
+
+    assert len(stored) == 2
+    for paper in stored:
+        assert paper["title"], "a persisted citation must carry the real paper title"
+        assert "mechanism" in paper, "the paper→mechanism link must be durable, not request-scoped"
+
+    # The read path preserves both — nothing between the store and the API
+    # response strips the extra keys.
+    resolved = _resolve_source_papers(stored, {})
+    assert [p["mechanism"] for p in resolved] == ["200-day trend filter", "carry"]
+    assert all(p["resolved_title"] for p in resolved)
+    assert resolved[0]["spec_elements"] == ["sma_200"]
+
+
+async def test_debate_paper_verdicts_are_durable(_use_tmp_db):
+    """The per-paper tally outlives the request.
+
+    It was computed for free off a transcript we already paid for and then
+    thrown away — "in-process + SSE-visible only" — so a run that put 30 papers
+    in front of the proposers left no record of which ones it engaged with.
+    It now rides the same ``transcript_json`` list the turns ride: no
+    migration, no new table. ``unused`` rows are the point, not noise — they
+    are what makes "retrieved 5, argued over 2" readable.
+    """
+    verdicts = [
+        {
+            "arxiv_id": "2401.00001",
+            "title": "Cross-Sectional Equity Momentum with Regime Conditioning",
+            "cited_by": ["bull", "bear"],
+            "citations": 4,
+            "discarded_by": [],
+            "discard_reasons": [],
+            "verdict": "cited",
+        },
+        {
+            "arxiv_id": "2402.00002",
+            "title": "Treasury Yield Curve Carry and Macro Regimes",
+            "cited_by": [],
+            "citations": 0,
+            "discarded_by": ["bear"],
+            "discard_reasons": ["no distinct mechanism"],
+            "verdict": "discarded",
+        },
+        *(
+            {
+                "arxiv_id": p.arxiv_id,
+                "title": p.title,
+                "cited_by": [],
+                "citations": 0,
+                "discarded_by": [],
+                "discard_reasons": [],
+                "verdict": "unused",
+            }
+            for p in _PAPERS[2:]
+        ),
+    ]
+    candidate = _CandidateResult(
+        candidate_id="cand_1",
+        strategy_name="Single-mechanism crossover",
+        thesis="thesis",
+        asset_universe=["SPY"],
+        source_papers=[],
+        weights={},
+        reasoning="r",
+        rigor_verdict={"passing": True},
+        passes_rigor=True,
+        generation_method="debate",
+        source_arxiv_ids=["2401.00001", "2402.00002"],
+        distinct_mechanism_papers=1,
+        papers_offered=5,
+        fusion_reasoning="Paper A gives the trend filter; paper B contributes no distinct mechanism.",
+        debate_transcript=[{"role": "bull", "round": 1, "verdict": "act", "claims": ["c1"]}],
+        debate_paper_verdicts=verdicts,
+    )
+
+    await _persist_debate_transcripts(job_id="job-1", candidates=[candidate], strategy_ids={"cand_1": "strat-abc"})
+
+    with db.get_session() as session:
+        row = session.query(DebateTranscriptRecord).filter_by(generation_id="job-1").one()
+        stored = json.loads(row.transcript_json)
+
+    # The bull turn is untouched; the tally rides alongside it.
+    assert stored[0]["role"] == "bull"
+    attribution = [t for t in stored if t.get("paper_verdicts") is not None]
+    assert len(attribution) == 1, "exactly one attribution record per row"
+    persisted = attribution[0]["paper_verdicts"]
+
+    assert {v["arxiv_id"] for v in persisted} == set(_ALL_IDS), "every RETRIEVED paper, not just the cited ones"
+    by_id = {v["arxiv_id"]: v for v in persisted}
+    assert by_id["2401.00001"]["verdict"] == "cited"
+    assert by_id["2402.00002"]["discard_reasons"] == ["no distinct mechanism"]
+    assert [v["arxiv_id"] for v in persisted if v["verdict"] == "unused"] == _ALL_IDS[2:]
+    assert attribution[0]["fusion_reasoning"], "the per-paper prose is durable too"

--- a/backend/tests/test_multi_paper_utilization.py
+++ b/backend/tests/test_multi_paper_utilization.py
@@ -43,6 +43,7 @@ from archimedes.agents.strategy_fusion import CorpusPaper, FusionBrief, Strategy
 from archimedes.api.generate_schemas import GenerateBrief
 from archimedes.api.strategies_routes import _resolve_source_papers
 from archimedes.models.debate_transcript import DebateTranscriptRecord
+from archimedes.models.strategy_passport_record import StrategyPassportRecord
 
 # ── Fixture corpus: five real-shaped papers, distinct mechanisms ─────────────
 
@@ -94,6 +95,14 @@ _ALL_IDS = [p.arxiv_id for p in _PAPERS]
 # The adversarial spec from #1739: ONE mechanism (sma_200) in entry AND exit.
 # Anything a paper_mechanisms entry names other than "sma_200" is not part of
 # what this strategy trades.
+#
+# ``indicators`` carries a DECOY. ``validate_strategy_spec`` ignores the key the
+# model emits and rebuilds the list from the entry/exit conditions
+# (``indicators=sorted(all_indicators)``), so a spec can DECLARE an alias it
+# never trades — which is the same self-report problem, one field over. The
+# decoy is what makes the spec_elements check falsifiable: validating against
+# the model's declared list instead of the derived one would let
+# ``bollinger_20`` through, and the test below would still be green without it.
 _SINGLE_MECHANISM_SPEC = {
     "name": "Single-mechanism crossover",
     "asset_universe": ["SPY"],
@@ -102,7 +111,7 @@ _SINGLE_MECHANISM_SPEC = {
     "exit": {"lt": ["close", "sma_200"]},
     "position_sizing": {"type": "full_invested_when_in_market"},
     "source_arxiv_ids": list(_ALL_IDS),
-    "indicators": ["sma_200"],
+    "indicators": ["sma_200", "bollinger_20"],
 }
 
 
@@ -209,6 +218,11 @@ def test_spec_element_outside_the_spec_is_dropped(monkeypatch):
     must reference an indicator alias the conditions actually use — same
     ``all_indicators`` set, different key. Without it, ``spec_elements`` is
     free text and the mapping proves nothing.
+
+    The alias set has to be the DERIVED one (``StrategySpec.indicators``, built
+    from entry/exit) and not the ``indicators`` list the model wrote: the
+    fixture declares ``bollinger_20`` there and trades it nowhere, so checking
+    the declared list would validate one self-report against another.
     """
     mechanisms = [
         {"arxiv_id": "2401.00001", "mechanism": "trend filter", "spec_elements": ["sma_200"]},
@@ -361,6 +375,24 @@ async def test_persisted_source_papers_carry_title_and_mechanism(_use_tmp_db):
     assert all(p["resolved_title"] for p in resolved)
     assert resolved[0]["spec_elements"] == ["sma_200"]
 
+    # …and the PASSPORT, which is what GET /strategies/{id} actually serves —
+    # `strategy_passports.paper_refs`, not `StrategyRecord.source_papers`. The
+    # debate panel that carries the attribution summary is owner-only, so this
+    # is the only path on which a public reader sees the link at all.
+    # `contribution` is the column StrategyPassport.jsx renders; it had no
+    # writer before this, so every generated row showed an em-dash.
+    with db.get_session() as session:
+        passport = session.get(StrategyPassportRecord, strategy_id)
+        refs = {r.arxiv_id: r for r in passport.paper_refs}
+
+    assert refs["2401.00001"].title == "Cross-Sectional Equity Momentum with Regime Conditioning"
+    assert refs["2401.00001"].contribution == "200-day trend filter"
+    # The unattributed citation keeps its row and its title, and its
+    # contribution stays NULL — the em-dash IS the honest record. Writing the
+    # unvalidated mechanism prose there would launder it one column over.
+    assert refs["2402.00002"].title == "Treasury Yield Curve Carry and Macro Regimes"
+    assert refs["2402.00002"].contribution is None
+
 
 async def test_debate_paper_verdicts_are_durable(_use_tmp_db):
     """The per-paper tally outlives the request.
@@ -441,3 +473,82 @@ async def test_debate_paper_verdicts_are_durable(_use_tmp_db):
     assert by_id["2402.00002"]["discard_reasons"] == ["no distinct mechanism"]
     assert [v["arxiv_id"] for v in persisted if v["verdict"] == "unused"] == _ALL_IDS[2:]
     assert attribution[0]["fusion_reasoning"], "the per-paper prose is durable too"
+
+
+async def test_persisted_paper_verdicts_do_not_leak_internal_jargon(_use_tmp_db):
+    """Making the tally durable must not walk model prose past the sanitizer.
+
+    ``debate_transcript``'s contract is that sanitization happens at WRITE
+    time, so "a raw read of ``transcript_json`` is already safe". The tally's
+    ``discard_reasons`` are copied by ``_aggregate_paper_verdicts`` out of the
+    RAW ``_debate_round`` turns — the same sentences that reach this table as
+    ``discard[].reason``, which ``_sanitize_claim`` scrubs. Persisting the
+    tally under a key the sanitizer did not know about would re-open that leak
+    by a shape change: precisely the regression ``_sanitize_claim`` was written
+    for after claims went from strings to dicts.
+
+    Titles are the deliberate exception and are asserted here too: they are
+    corpus metadata, not model text, and blanket-scrubbing them would mangle a
+    real paper ("Phase-Locked …" → "[redacted] …"), which is the same reason
+    validated arXiv ids are left alone.
+    """
+    leak = "rejected: blocked on the T3.5 cutover until Phase-4 lands"
+    candidate = _CandidateResult(
+        candidate_id="cand_1",
+        strategy_name="Single-mechanism crossover",
+        thesis="thesis",
+        asset_universe=["SPY"],
+        source_papers=[],
+        weights={},
+        reasoning="r",
+        rigor_verdict={"passing": True},
+        passes_rigor=True,
+        generation_method="debate",
+        source_arxiv_ids=["2401.00001"],
+        distinct_mechanism_papers=1,
+        papers_offered=5,
+        fusion_reasoning="Paper A gives the trend filter; the carry leg is deferred to the T3.5 cutover.",
+        # The identical sentence on BOTH paths: the turn's discard reason (long
+        # sanitized) and the tally row's discard_reasons (the new key).
+        debate_transcript=[
+            {
+                "role": "bear",
+                "round": 1,
+                "verdict": "hold",
+                "claims": [],
+                "discard": [{"arxiv_id": "2402.00002", "reason": leak}],
+            }
+        ],
+        debate_paper_verdicts=[
+            {
+                "arxiv_id": "2402.00002",
+                "title": "Phase-Locked Cycles in Commodity Futures",
+                "cited_by": [],
+                "citations": 0,
+                "discarded_by": ["bear"],
+                "discard_reasons": [leak],
+                "verdict": "discarded",
+            }
+        ],
+    )
+
+    await _persist_debate_transcripts(job_id="job-1", candidates=[candidate], strategy_ids={"cand_1": "strat-abc"})
+
+    with db.get_session() as session:
+        row = session.query(DebateTranscriptRecord).filter_by(generation_id="job-1").one()
+        raw = row.transcript_json
+
+    assert "T3.5" not in raw, "a raw read of transcript_json must already be safe (module docstring)"
+    assert "cutover" not in raw.lower()
+    assert "Phase-4" not in raw
+
+    stored = json.loads(raw)
+    attribution = next(t for t in stored if t.get("paper_verdicts") is not None)
+    tally = attribution["paper_verdicts"][0]
+    # Scrubbed, not dropped — the discard is still on the record, and so is the
+    # id that carries its provenance.
+    assert tally["discard_reasons"] == ["rejected: blocked on the [redacted] [redacted] until [redacted] lands"]
+    assert tally["arxiv_id"] == "2402.00002"
+    assert tally["verdict"] == "discarded"
+    # The corpus title is untouched: scrubbing it would redact a real paper.
+    assert tally["title"] == "Phase-Locked Cycles in Commodity Futures"


### PR DESCRIPTION
## What & why

`Closes #1739`

A generation run puts up to 80 paper-slots in front of the proposers, and since #1636 the debate genuinely argues over named papers — but **nothing connected the papers a strategy cited to the mechanism it traded.** `is_actionable` counted list length, `source_arxiv_ids` was filtered only for set membership, `validate_strategy_spec` accepted `source_arxiv_ids: []`, and `_canonical_spec_hash` deliberately excludes citations. A single-`sma_200` crossover claiming five papers passed every check and was hash-identical to the same spec citing one unrelated paper. On the passport, citation count reads as evidence depth — the exact laundering #1636 named as "strictly worse than an honest 2".

This makes the mapping explicit, validated, and durable, on today's lexical corpus. **It labels; it never gates.**

## What changed

**`strategy_fusion.py`**
- Deleted the `>>>>>>> origin/main` merge-conflict marker at `:912`. It sat inside `_SPEC_CONTRACT`, therefore inside **both** `_SYSTEM_PROMPT` and `_SPEC_REPAIR_SYSTEM`, and shipped on every proposer call (introduced by `bdb93547`).
- Output schema gains `paper_mechanisms: [{arxiv_id, mechanism, spec_elements}]`, with the hard rule stated: an id whose mechanism cannot be named is **omitted from `source_arxiv_ids`**, not padded in. The `_SPEC_CONTRACT` half states that `paper_mechanisms` is a top-level proposal field, *not* a spec key (so the repair prompt, which emits only the spec, is not misled) and that `spec_elements` follow the same alias rule `parameter_variants` keys do.
- `FusionProposal` gains `paper_mechanisms` and `distinct_mechanism_papers`.
- `propose()` filters both halves server-side: entries whose `arxiv_id` is not in `source_ids` are dropped (the `valid_ids` anti-hallucination shape, right beside it); `spec_elements` that are not an indicator alias in the **validated** spec's `indicators` are dropped (reusing `all_indicators`, `strategy_dsl.py:269-274`). The entry is kept with its claim and its id — only the unsupported link is stripped, the keep-the-claim/strip-the-id pattern from `debate_engine.py:467-501`. `distinct_mechanism_papers = len({e["arxiv_id"] for e in kept if e["spec_elements"]})`, with a WARNING when it is below `len(source_ids)`.

**`generation_pipeline.py`** — `_CandidateResult` gains `papers_offered`, `distinct_mechanism_papers`, `fusion_reasoning`. `_persist_debate_transcripts` attaches the run's `debate_paper_verdicts` tally and `fusion_reasoning` to the persisted row as one extra entry on the JSON list the `transcript_json` column already holds (no migration, no new table). The stale `# NOT persisted…` comment on `debate_paper_verdicts` is corrected rather than left to read false.

**`debate_engine.py`** — `_make_entry` populates the three fields and builds `source_papers` as `{arxiv_id, title, mechanism, spec_elements}`, with the title coming from `evidence_by_id` (previously the literal `""`). `evidence_by_id` is threaded through `build_leaderboard` as an optional keyword, so the pure ranking tests keep calling it unchanged; it never influences ranking, culling, or the abstain paths.

**`backend/tests/test_multi_paper_utilization.py`** — new, hermetic (no `.env`, no network, no Redis, tmp-file sqlite; DB fixture copied from `test_generated_citation_truth.py:41-53`).

No migration. No new route. No new LLM call. No UI change.

## Acceptance criteria

**Conflict marker gone from the live prompts** — run against unmodified `main` first, as the issue asks:

```
# unmodified main
$ cd backend && .../python -c "...assert '>>>>>>>' not in _SYSTEM_PROMPT and ... _SPEC_REPAIR_SYSTEM; print('OK')"
Traceback (most recent call last):
  File "<string>", line 4, in <module>
AssertionError
$ grep -rn '>>>>>>>' backend/archimedes/
backend/archimedes/agents/strategy_fusion.py:912:>>>>>>> origin/main

# this branch
$ cd backend && .../python -c "... print('OK')"
OK
$ grep -rn '>>>>>>>' backend/archimedes/
(no output)
```

**The six named tests** — plus one added in review (the sanitizer guard, below)

```
$ .../pytest -q backend/tests/test_multi_paper_utilization.py
collected 7 items
backend/tests/test_multi_paper_utilization.py .......                    [100%]
7 passed, 1 warning in 2.42s
```

**Suite green + the pinned baseline goes up, with all 84 still passing**

```
$ .../pytest --collect-only -q backend/tests/test_strategy_fusion.py backend/tests/test_debate_engine.py
84 tests collected                       # unchanged — no existing test was edited
$ .../pytest --collect-only -q <those two> backend/tests/test_multi_paper_utilization.py
91 tests collected                       # 84 -> 91

$ .../pytest -q <those two> + the 4 guard files named in the anti-goals
127 passed, 7 warnings in 16.53s

$ .../pytest -m "not integration"
5632 passed, 4 skipped, 2 deselected, 327 warnings in 545.64s (0:09:05)     # exit code 0
```

Guard files named in the anti-goals, run explicitly and green inside the 127 above: `test_sole_generation_route_guard.py`, `test_generate_schemas_depth_drift.py`, `test_debate_transcript_persistence.py`, `test_generated_citation_truth.py`.

**Anti-goals, checked mechanically**

```
$ git diff -U0 | grep '^+' | grep -niE "semantic|embedding|knowledge graph|kg_entities|kg_relations|cluster_id|sentence-transformers|SPECTER"
(no output — none of that vocabulary is introduced anywhere in the diff)
$ git status --porcelain backend/migrations/
(empty — no Alembic revision added)
$ git diff --stat
 backend/archimedes/agents/debate_engine.py       |  59 ++-
 backend/archimedes/agents/generation_pipeline.py | 120 ++++-
 backend/archimedes/agents/strategy_fusion.py     |  95 +++-
 backend/archimedes/models/debate_transcript.py   |  59 ++-
```
`services/paper_rag.py`, `_RERANK_MAX_TEXTS`, `analytics-engine/`, `api/generate_schemas.py`, `_HASH_IGNORED_SPEC_KEYS` and the four paper constants are all untouched. `distinct_mechanism_papers` has no `raise` and no reject path — grep the diff for `DebateUnavailable`: absent.

**Lint** — `ruff format --check` clean on all five files; `ruff check` clean on the four I touched with new code. The two `SIM905` hits `ruff check` reports on `generation_pipeline.py` are **pre-existing on `main`** (verified against the unmodified checkout: `Found 2 errors`) and are in word-list constants my diff does not touch.

## Adversarial pass

Per *guards-need-an-adversarial-pass*: every guard was run against code that should fail it, and does.

### a. Every new test against unmodified `main`

```
$ cd <main worktree> && .../pytest -q backend/tests/test_multi_paper_utilization.py
collected 6 items
FFFFFF                                                                   [100%]

test_unattributed_citation_does_not_count_as_a_mechanism_paper
E   AttributeError: 'FusionProposal' object has no attribute 'distinct_mechanism_papers'
test_spec_element_outside_the_spec_is_dropped
E   AttributeError: 'FusionProposal' object has no attribute 'paper_mechanisms'
test_single_mechanism_spec_claiming_five_papers_is_labelled_not_hidden
E   AttributeError: 'FusionProposal' object has no attribute 'distinct_mechanism_papers'
test_papers_offered_and_mechanism_count_survive_to_the_candidate
E   TypeError: _make_entry() got an unexpected keyword argument 'evidence_by_id'
test_persisted_source_papers_carry_title_and_mechanism
E   TypeError: _CandidateResult.__init__() got an unexpected keyword argument 'distinct_mechanism_papers'
test_debate_paper_verdicts_are_durable
E   TypeError: _CandidateResult.__init__() got an unexpected keyword argument 'distinct_mechanism_papers'

6 failed, 1 warning in 1.80s
```

Those are *absence* failures, which prove the feature is new but not that the checks bite. So each guard was also mutated **on this branch**, one at a time, and the mutation reverted after:

### b. MUT-A — accept any `spec_elements` value (drop the `all_indicators` check)

`if isinstance(el, str) and el in valid_elements` → `if isinstance(el, str)`

```
E   assert ['bollinger_20'] == []
    "an alias the spec never uses must not survive"
1 failed, 1 passed, 4 deselected
```

### c. MUT-B — count every mechanism entry, attributed or not

`len({… if e["spec_elements"]})` → `len({… for e in paper_mechanisms})`

```
E   AssertionError: assert 5 == 2   test_unattributed_citation_does_not_count_as_a_mechanism_paper
E   AssertionError: assert 5 == 1   test_single_mechanism_spec_claiming_five_papers_is_labelled_not_hidden
2 failed, 4 deselected
```

That is the exact laundering the issue describes — five papers reported as five mechanisms — and it is now a red test.

### d. MUT-C — revert the `_make_entry` copy (the issue asks for this one by name)

Restored `source_papers=[{"arxiv_id": a, "title": ""} …]` and removed the three field copies.

```
E   AssertionError: assert 0 == 30
    assert entry.papers_offered == 30
1 failed, 5 deselected
```

### e. MUT-D — persist the bare transcript (drop the attribution record)

`transcript=_transcript_with_paper_record(c)` → `transcript=c.debate_transcript`

```
E   assert 0 == 1
    "exactly one attribution record per row"
1 failed, 5 deselected
```

### f. MUT-E — read path drops the enrichment

`_resolve_source_papers`' `entry = dict(paper)` → a fixed `{arxiv_id, title}` projection.

```
assert [p["mechanism"] for p in resolved] == ["200-day trend filter", "carry"]
1 failed, 5 deselected
```

## Review follow-up (2nd commit `b70da92`)

Three things came out of review. All three are in the second commit; the first commit is unchanged.

### 1. BLOCKER — unsanitized model prose reached the durable transcript

`_transcript_with_paper_record` scrubbed `fusion_reasoning` at the call site but wrote `debate_paper_verdicts` **verbatim**. Those rows carry `discard_reasons`, which `_aggregate_paper_verdicts` copies straight out of the **raw** `_debate_round` turns — so the identical bear sentence that gets scrubbed on its way in as `discard[].reason` landed unscrubbed under the new `paper_verdicts` key. `sanitize_transcript` only knew `verdict` / `claims` / `discard`.

That breaks the contract `debate_transcript.py:26-30` states outright ("a raw read of `transcript_json` is already safe"), and it is exactly the regression class the `_sanitize_claim` comment at `:82-89` names: a **shape change** re-opening the leak the write-time sanitizer exists to close. It is served to owners by `GET /strategies/{id}/debate`, which has no read-time net, by design.

Fixed where the contract lives — in `sanitize_transcript`, not at the one call site, so any future writer of that shape is covered too:

* `paper_verdicts` rows get their `discard_reasons` scrubbed (`_sanitize_paper_verdict`).
* `fusion_reasoning` is scrubbed there rather than at the attach point.
* `title` is deliberately **not** scrubbed: it is corpus metadata, not model prose, and `Phase-\w*` would redact a real paper ("Phase-Locked Cycles …" → "[redacted] Cycles …"). Same provenance reason validated `arxiv_ids` are left alone in `_SCRUBBED_CLAIM_KEYS`.

New guard: **`test_persisted_paper_verdicts_do_not_leak_internal_jargon`** — the same jargon sentence on both paths, asserted against the RAW `transcript_json` string.

**MUT-F — the pre-fix behaviour** (`sanitize_transcript` does not know `paper_verdicts`):

```
E   AssertionError: a raw read of transcript_json must already be safe (module docstring)
E   assert 'T3.5' not in '[{"claims":...y trades."}]'
1 failed, 6 deselected
```

**MUT-I — over-correct the other way** (scrub every string in the row, titles included):

```
E   AssertionError: assert '[redacted] C...odity Futures' == 'Phase-Locked...odity Futures'
1 failed, 1 passed, 5 deselected
```

### 2. The link never reached the surface #1739 named (reviewer's call)

`GET /strategies/{id}` serves the passport — `strategy_passports.paper_refs` — not `StrategyRecord.source_papers`, and the debate panel carrying the attribution summary is **owner-only**, so a public passport never showed it. All three passport constructors built `PaperRef(arxiv_id=…, title=…)` and nothing else, so `contribution` (the column `StrategyPassport.jsx` renders as "per-paper contribution") had **no writer at all** and every generated row was an em-dash.

One `_passport_paper_refs(c)` helper now feeds all three sites. It writes the named mechanism into `contribution` **only when `spec_elements` survived validation**, and leaves it `None` otherwise — the em-dash *is* the unattributed record; writing unvalidated prose there would launder the same claim one column over. The column already exists (`PassportPaperRef.contribution`), `_build_paper_refs` already passes it through, and `PaperRefResponse` already serves it: **no schema change, no migration, no UI change**. Titles now reach the passport too (they used to be `""`).

`test_persisted_source_papers_carry_title_and_mechanism` was extended past `StrategyRecord` to assert the passport row, per the review.

**MUT-G — the old constructor** (`contribution=None`):

```
E   AssertionError: assert None == '200-day trend filter'
1 failed, 6 deselected
```

**MUT-H — write the mechanism regardless of whether `spec_elements` survived**:

```
E   AssertionError: assert 'carry' is None
1 failed, 6 deselected
```

### 3. The `spec_elements` guard was not falsifiable

`validate_strategy_spec` rebuilds `indicators` from the entry/exit conditions (`indicators=sorted(all_indicators)`) and **ignores** the `indicators` list the model declares. But the test fixture declared exactly `["sma_200"]`, so validating the *declared* list instead of the *derived* one passed the test anyway — the guard could not tell the two apart, which is the same self-report problem this issue is about, one field over.

The fixture now declares a `bollinger_20` it never trades. Checking the model's own list is now red:

**MUT-J — `valid_elements = set((strategy_spec or {}).get("indicators") or [])`**:

```
E   assert ['bollinger_20'] == []
    "an alias the spec never uses must not survive"
1 failed, 6 deselected
```

Every earlier mutation (MUT-A→E) and the fails-on-`main` run were re-run against the final tree: 7 failed on `436cc1a0` (`AttributeError` / `TypeError` — absence), and each mutation still turns its guard red.

## Reviewer notes

- **`distinct_mechanism_papers` is not a gate, deliberately.** `test_single_mechanism_spec_claiming_five_papers_is_labelled_not_hidden` asserts `is_actionable is True` *and* `distinct_mechanism_papers == 1`. An honest single-mechanism strategy ships with an honest count; turning this into a reject would fail generation instead of improving it, which #1636 ruled out.
- **One judgement call worth naming:** the tally rides `transcript_json` as an extra list entry with `role: "attribution"` and a plain-sentence `verdict`. `StrategyReasoning.jsx` maps every entry to a card, so a keyless entry would render as a blank one; giving it a real summary sentence means the existing renderer shows something honest with **zero UI changes**. Both of its model-prose keys are scrubbed inside `sanitize_transcript` itself — see the review follow-up below, which is where the first version of this got it wrong.
- **Residual the spec does not cover** (flagging, not fixing — out of scope here): a model that names the *same* alias for all five papers would still score `distinct_mechanism_papers == 5`. The check as specified validates that each claimed element is real, not that the five claims are distinct from each other. Worth its own issue if it shows up in live output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqgq6BzkRzuDrUL34xqZj7

