### PR TITLE
[test][corpus] Isolate load_corpus tests from the 18k lifespan seed leak

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -48,6 +48,13 @@ os.environ["TESTING"] = "1"
 # one was; only its starting contents change (empty, like a fresh worktree).
 # `tests/db_isolation.redirect_to_tmp_sqlite` remains the right tool for
 # per-test isolation and layers on top of this unchanged.
+#
+# The remaining leak is that same per-process file: a TestClient / ASGI
+# lifespan still runs `seed_from_manifest()` into it (~18k rows). Tests that
+# call `load_corpus()` with `path=None` and expect the file fallback
+# (`test_loader_env_override`, `test_empty_db_falls_back_to_file_manifest`)
+# must isolate with `isolated_empty_sqlite`. Do not "fix" that by making
+# `ARCHIMEDES_CORPUS_MANIFEST` a production DB bypass.
 if not os.environ.get("DATABASE_URL"):
     _TEST_DB_DIR = tempfile.mkdtemp(prefix="archimedes-test-db-")
     atexit.register(shutil.rmtree, _TEST_DB_DIR, ignore_errors=True)

--- a/backend/tests/db_isolation.py
+++ b/backend/tests/db_isolation.py
@@ -16,6 +16,7 @@ the same process (see issue #1100).
 from __future__ import annotations
 
 from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from archimedes import db as archimedes_db
@@ -76,3 +77,18 @@ def redirect_to_tmp_sqlite(tmp_path: Path) -> Iterator[None]:
         archimedes_db.engine = orig_engine
         archimedes_db.SessionLocal = orig_session_local
         archimedes_db.DATABASE_URL = orig_database_url
+
+
+@contextmanager
+def isolated_empty_sqlite(tmp_path: Path) -> Iterator[None]:
+    """``with`` form of :func:`redirect_to_tmp_sqlite`.
+
+    Use this when a test calls ``load_corpus()`` with ``path=None`` and
+    therefore takes the DB-first branch. A sibling TestClient / ASGI lifespan
+    can have already seeded the process-global suite DB with the full
+    ~18k-row manifest (the 18752-vs-4 failure on Quality Gate). Redirecting
+    to an empty tmp sqlite lets the test measure the *file* fallback it
+    claims — ``ARCHIMEDES_CORPUS_MANIFEST`` is that fallback's location, not
+    a production DB bypass (issue #1640).
+    """
+    yield from redirect_to_tmp_sqlite(tmp_path)

--- a/backend/tests/test_corpus_loader_isolation.py
+++ b/backend/tests/test_corpus_loader_isolation.py
@@ -45,7 +45,7 @@ from archimedes import db as archimedes_db
 from archimedes.agents.strategy_fusion import load_corpus
 from archimedes.models.corpus_store import PaperRecord
 
-from tests.db_isolation import redirect_to_tmp_sqlite
+from tests.db_isolation import isolated_empty_sqlite, redirect_to_tmp_sqlite
 
 # Old enough to clear the 30-day Outcome Embargo in load_papers_from_db().
 _OLD = "2024-01-01"
@@ -202,3 +202,102 @@ class TestNoPathStillMeansDatabaseFirst:
 
         with _tmp_db(tmp_path):  # empty papers table
             assert [p.arxiv_id for p in load_corpus()] == ["4444.44444"]
+
+
+class TestFileFallbackSurvivesASeededSharedDatabase:
+    """The 18752-vs-4 / 18752-vs-0 Quality Gate leak.
+
+    TestClient / ASGI lifespan seeds the process-global suite DB with the
+    full manifest. ``load_corpus()`` with ``path=None`` then prefers that DB
+    over ``ARCHIMEDES_CORPUS_MANIFEST`` — which is correct in production
+    (issue #1640: the env var is the file-fallback location, not a DB
+    bypass) and wrong for the two tests that need an empty papers table to
+    measure the file path.
+
+    This plants a distinctive corpus on the *shared* engine (the lifespan
+    seed, in miniature), then runs those two shapes behind
+    ``isolated_empty_sqlite``. Drop the redirect and both fail with
+    ``len == N_PLANTED`` instead of 4 / 0. Cleanup is mandatory: planted
+    rows must not outlive the test and poison later files in the process.
+    """
+
+    N_PLANTED = 17  # not 4, not 0, not the real ~18k
+    _ID_PREFIX = "seedleak."
+
+    def _ids(self) -> list[str]:
+        return [f"{self._ID_PREFIX}{i:05d}" for i in range(self.N_PLANTED)]
+
+    def _plant_on_shared_engine(self) -> None:
+        archimedes_db.Base.metadata.create_all(bind=archimedes_db.engine)
+        with archimedes_db.get_session() as session:
+            for arxiv_id in self._ids():
+                session.add(_db_row(arxiv_id, f"leaked {arxiv_id}"))
+            session.commit()
+
+    def _unplant_from_shared_engine(self) -> None:
+        with archimedes_db.get_session() as session:
+            session.query(PaperRecord).filter(PaperRecord.arxiv_id.in_(self._ids())).delete(synchronize_session=False)
+            session.commit()
+
+    def test_loader_env_override_still_sees_four_after_the_shared_db_is_seeded(self, tmp_path, monkeypatch):
+        """The ``test_strategy_fusion.py::test_loader_env_override`` shape."""
+        four = _write_manifest(
+            tmp_path / "four.jsonl",
+            ["2401.00001", "2402.00002", "2403.00003", "2404.00004"],
+        )
+        monkeypatch.setenv("ARCHIMEDES_CORPUS_MANIFEST", str(four))
+        planted_ids = set(self._ids())
+        self._plant_on_shared_engine()
+        try:
+            # The leak is live: path=None prefers the shared DB (which may
+            # already hold a sibling lifespan's ~18k rows). If our planted
+            # ids are missing, isolation below is vacuous.
+            leaked = {p.arxiv_id for p in load_corpus()}
+            assert planted_ids <= leaked, "shared-DB plant did not occupy load_corpus()"
+            with isolated_empty_sqlite(tmp_path):
+                isolated = load_corpus()
+            assert len(isolated) == 4
+            assert not planted_ids & {p.arxiv_id for p in isolated}
+        finally:
+            self._unplant_from_shared_engine()
+
+    def test_empty_db_catalog_fallback_still_sees_zero_after_the_shared_db_is_seeded(self, tmp_path, monkeypatch):
+        """The ``test_papers_routes.py::test_empty_db_falls_back_to_file_manifest`` shape."""
+        import asyncio
+
+        from archimedes.api import papers_routes
+        from archimedes.models.chat import Base
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        monkeypatch.setenv("ARCHIMEDES_CORPUS_MANIFEST", str(tmp_path / "does-not-exist.jsonl"))
+        empty_engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(bind=empty_engine)
+        empty_session = sessionmaker(bind=empty_engine)()
+
+        class _Ctx:
+            def __enter__(self):
+                return empty_session
+
+            def __exit__(self, *args):
+                pass
+
+        monkeypatch.setattr(papers_routes, "get_session", lambda: _Ctx())
+        self._plant_on_shared_engine()
+        try:
+            leaked = asyncio.run(
+                papers_routes.list_papers(page=1, page_size=20, category=None, search=None, processed_only=True)
+            )
+            # Catalog's own session is empty; a non-zero total is load_corpus()
+            # reading the shared engine. May be N_PLANTED or N_PLANTED+~18k.
+            assert leaked["total"] >= self.N_PLANTED
+            with isolated_empty_sqlite(tmp_path):
+                isolated = asyncio.run(
+                    papers_routes.list_papers(page=1, page_size=20, category=None, search=None, processed_only=True)
+                )
+            assert isolated["total"] == 0
+            assert isolated["papers"] == []
+        finally:
+            empty_session.close()
+            empty_engine.dispose()
+            self._unplant_from_shared_engine()

--- a/backend/tests/test_papers_routes.py
+++ b/backend/tests/test_papers_routes.py
@@ -25,6 +25,8 @@ from archimedes.models.corpus_store import PaperRecord
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
+from tests.db_isolation import isolated_empty_sqlite
+
 
 @pytest.fixture
 def session():
@@ -111,7 +113,15 @@ class TestListPapersAuthorsFallback:
 
     def test_empty_db_falls_back_to_file_manifest(self, session, monkeypatch, tmp_path):
         """DB has zero rows — falls through to the file-manifest loader (which
-        genuinely has no author data), not an error."""
+        genuinely has no author data), not an error.
+
+        ``papers_routes.get_session`` is this test's empty in-memory sqlite,
+        but the last-resort fallback calls ``load_corpus()`` with no path,
+        which reads the *process-global* engine. A sibling TestClient /
+        lifespan seed of ~18k rows occupies that branch (18752-vs-0 on
+        Quality Gate). Isolate ``archimedes.db`` onto an empty tmp sqlite
+        so the missing-manifest fallback is what this assertion measures.
+        """
         from archimedes.api import papers_routes
 
         monkeypatch.setattr(papers_routes, "get_session", lambda: _ctx_session(session))
@@ -120,9 +130,10 @@ class TestListPapersAuthorsFallback:
         # whatever manifest happens to exist on this machine.
         monkeypatch.setenv("ARCHIMEDES_CORPUS_MANIFEST", str(tmp_path / "does-not-exist.jsonl"))
 
-        result = asyncio.run(
-            papers_routes.list_papers(page=1, page_size=20, category=None, search=None, processed_only=True)
-        )
+        with isolated_empty_sqlite(tmp_path):
+            result = asyncio.run(
+                papers_routes.list_papers(page=1, page_size=20, category=None, search=None, processed_only=True)
+            )
 
         assert result["total"] == 0
         assert result["papers"] == []

--- a/backend/tests/test_strategy_fusion.py
+++ b/backend/tests/test_strategy_fusion.py
@@ -40,6 +40,8 @@ from archimedes.agents.strategy_fusion import (
 )
 from archimedes.models.portfolio import RiskProfile
 
+from tests.db_isolation import isolated_empty_sqlite
+
 # ── Self-contained fixture corpus (frozen manifest schema) ──────
 
 _FIXTURE_ROWS = [
@@ -228,10 +230,17 @@ def test_loader_no_file_returns_empty(tmp_path):
     assert load_corpus(tmp_path / "does_not_exist.jsonl") == []
 
 
-def test_loader_env_override(monkeypatch, manifest):
+def test_loader_env_override(monkeypatch, manifest, tmp_path):
+    """path=None prefers a non-empty DB over ``ARCHIMEDES_CORPUS_MANIFEST``.
+
+    Isolate onto an empty papers table so this measures the 4-paper env
+    fixture, not a sibling TestClient/lifespan seed of ~18k rows
+    (18752-vs-4 on Quality Gate). The env var is the file-fallback
+    location, not a DB bypass — production still wants the DB.
+    """
     monkeypatch.setenv("ARCHIMEDES_CORPUS_MANIFEST", str(manifest))
-    # path=None → resolves via ARCHIMEDES_CORPUS_MANIFEST.
-    assert len(load_corpus()) == 4
+    with isolated_empty_sqlite(tmp_path):
+        assert len(load_corpus()) == 4
 
 
 # ── Deterministic steering / candidate selection ────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Test isolation so `test_loader_env_override` and `test_empty_db_falls_back_to_file_manifest` measure the file fallback they claim (4-paper env fixture; empty DB + missing manifest → 0 papers), even when a sibling TestClient / ASGI lifespan has seeded the process-global suite DB with the full ~18k corpus.

`load_corpus()` precedence is unchanged: an explicit `path` is authoritative; with `path=None` the DB still wins over `ARCHIMEDES_CORPUS_MANIFEST`. That env var remains the file-fallback location, not a production DB bypass.

## Why

Quality Gate on #1733 and #1740 failed:

- `test_strategy_fusion.py::test_loader_env_override` — `assert 18752 == 4`
- `test_papers_routes.py::test_empty_db_falls_back_to_file_manifest` — `assert 18752 == 0`

#1640 already moved the unset-`DATABASE_URL` default off the in-tree sqlite file. The remaining leak is that same *per-process* temp file: lifespan's `seed_from_manifest()` still writes the real manifest into it. `test_empty_db_falls_back_to_file_manifest` empties `papers_routes.get_session` but the last-resort fallback calls `load_corpus()` with no path, which reads the process-global engine.

Related to #1733 (same leak class). Does not close it. Does not touch #1740 (`_CORPUS_LOAD_LOCK`, `/health` COUNT).

## Issues

Related to #1733. Does not close #1733 or any issue.

## Verification

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
  python3 -m pytest \
  backend/tests/test_corpus_loader_isolation.py \
  backend/tests/test_strategy_fusion.py \
  backend/tests/test_papers_routes.py::TestListPapersAuthorsFallback -q
```

**60 passed** in 1.75s.

Hermetic (the two leaking tests):

```
env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend \
  python3 -m pytest \
  backend/tests/test_strategy_fusion.py::test_loader_env_override \
  backend/tests/test_papers_routes.py::TestListPapersAuthorsFallback::test_empty_db_falls_back_to_file_manifest -q
```

Both pass.

### Prove — a test that fails with the fix reverted

Drop `with isolated_empty_sqlite(tmp_path):` in `test_loader_env_override_still_sees_four_after_the_shared_db_is_seeded` (call `load_corpus()` against the planted shared DB):

```
FAILED test_loader_env_override_still_sees_four_after_the_shared_db_is_seeded
AssertionError: assert 17 == 4
```

Same class as `assert 18752 == 4`. Restored; the test passes. The plant-first assert (`planted_ids <= leaked`) fails if planting never occupied `load_corpus()`, so isolation cannot pass vacuously.

`ARCHIMEDES_CORPUS_MANIFEST` is still not a DB bypass: `test_env_manifest_does_not_bypass_a_populated_db` is unchanged and still reads the DB rows.

## What this does not prove

- **`load_corpus` production precedence.** Unchanged. DB-first with `path=None` is still load-bearing.
- **#1740.** Untouched. Does not serialize `load_corpus`, does not change `/health` to COUNT, does not touch `_CORPUS_LOAD_LOCK`.
- **#1733 request-path warmup.** Untouched. Does not add `REQUEST_PATH_WARMUP` to the fliplist.
- **`PAPER_ADVANCE_ENABLED`.** Untouched; stays false.
- **Vaults, KB pipeline, terraform `deployment_minimum_healthy_percent`.** Untouched.

## What a reviewer should push back on

- Lifespan still seeds the shared test DB when a TestClient runs. This PR isolates the two tests that measure file fallback; it does not skip `seed_from_manifest` under `TESTING`. A later TestClient still pays the 18k insert.
- The catalog test's `papers_routes.get_session` monkeypatch and `load_corpus`'s process-global engine are two different sessions. Isolating only one of them is how 18752-vs-0 happened; both have to be empty for the missing-manifest assertion to mean what it says.

Do not merge. Do not close #1733 or #1740. `PAPER_ADVANCE_ENABLED` stays false.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2e1013b-c63f-422b-82ce-1757847325cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2e1013b-c63f-422b-82ce-1757847325cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

