### PR TITLE
[frontend] Don't claim ingested papers ⊂ the corpus manifest

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,7 @@ Owners: **Dan Browne** — contracts, on-chain, infrastructure, architecture. **
 | [`specs/component-interfaces-spec.md`](specs/component-interfaces-spec.md) | spec | Dan Browne | — | Component interfaces and the team work split. |
 | [`specs/ecosystem-design-spec.md`](specs/ecosystem-design-spec.md) | spec | Dan Browne | — | Marketplace/ecosystem design. Marketplace ships behind `PAYMENTS_DRY_RUN`. |
 | [`specs/xia-2026-protocols.md`](specs/xia-2026-protocols.md) | spec | Dan Browne | — | Xia et al. 2026 named protocols as implemented here. |
-| [`specs/architecture-page-design.md`](specs/architecture-page-design.md) | implemented | Dan Browne | 2026-07-28 | Design for the Architecture page, **implemented in PR #1192**. Should leave `specs/` for `architecture/` or `archive/` once #1192 merges, per `CONVENTIONS.md` § 1. |
+| [`specs/architecture-page-design.md`](specs/architecture-page-design.md) | implemented | Dan Browne | 2026-09-01 | Design for the Architecture page, **implemented in PR #1192**. Honesty card must not treat `corpus_db_count` as a subset of `corpus_papers`. Should leave `specs/` for `architecture/` or `archive/` once #1192 merges, per `CONVENTIONS.md` § 1. |
 | [`diagrams/strategy-passport-architecture.md`](diagrams/strategy-passport-architecture.md) | reference | Dan Browne | — | Passport architecture diagram + reference. |
 | [`bedrock-model-cost-comparison.md`](bedrock-model-cost-comparison.md) | reference | Dan Browne | — | Bedrock model costs, us-east-1 on-demand. LLM is `bedrock_converse` / `amazon.nova-micro-v1:0`. |
 | [`cost-estimates/generate-llm-costs.md`](cost-estimates/generate-llm-costs.md) | reference | Dan Browne | — | Per-generation LLM cost estimate. |

--- a/docs/specs/architecture-page-design.md
+++ b/docs/specs/architecture-page-design.md
@@ -2,7 +2,7 @@
 
 > **status:** implemented
 > **owner:** Dan Browne
-> **updated:** 2026-08-20
+> **updated:** 2026-09-01
 > **superseded-by:** —
 
 > **IMPLEMENTED 2026-07-28 in PR #1192.** This is no longer a proposal. The page described
@@ -87,7 +87,7 @@ Arc public testnet, and what is landing next, labeled as such.
 **Hero stat strip** (live-fetched; fallback "—"):
 - `{universe}` tradable synthetic assets *(from `/api/explore/assets`; ~281 today)*
 - `{contracts}` core contracts on Arc *(from `/api/config/contracts`; chain 5042002)*
-- `{papers}` research papers in the corpus manifest *(from corpus stats; caption: "manifest — see §What's real today")*
+- `{papers}` paper metadata records *(from `/health` `corpus_db_count`; caption names the Corpus page count — not a subset of a "manifest")*
 - 4 statistical gates before any strategy earns the badge
 
 ### 2 — The system, in one picture
@@ -238,8 +238,12 @@ production state today). Retrieved papers are
 embargo-filtered — nothing published after a decision point can inform it — and every citation
 carries its arXiv ID and content hash.
 
-**Honesty card (live-driven):** The corpus is being hydrated: `{ingested}` of the
-manifest papers are fully ingested and retrievable today *(live count from `/health`)*. The knowledge-graph
+**Honesty card (live-driven):** The papers table holds `{corpus_db_count}` metadata
+records (the Corpus page count). Generation currently loads `{corpus_papers}`. These are
+different populations — `corpus_papers` is `len(load_corpus())` and `corpus_db_count` is
+`COUNT(papers)` — not a completeness ratio of a committed manifest. Do not concatenate the
+two `/health` counts with a subset preposition: a subset cannot be larger than its
+superset. The knowledge-graph
 layer (citation graph over the corpus) is built by a pipeline that has not yet produced its
 first production artifact — the Corpus page shows exactly that, rather than a synthesized
 graph. Generation requires at least two relevant papers or it declines to run.

--- a/docs/specs/architecture-page-design.md
+++ b/docs/specs/architecture-page-design.md
@@ -240,10 +240,10 @@ carries its arXiv ID and content hash.
 
 **Honesty card (live-driven):** The papers table holds `{corpus_db_count}` metadata
 records (the Corpus page count). Generation currently loads `{corpus_papers}`. These are
-different populations — `corpus_papers` is `len(load_corpus())` and `corpus_db_count` is
-`COUNT(papers)` — not a completeness ratio of a committed manifest. Do not concatenate the
-two `/health` counts with a subset preposition: a subset cannot be larger than its
-superset. The knowledge-graph
+different populations — `corpus_papers` is `count_corpus_papers()` (embargo-filtered COUNT)
+and `corpus_db_count` is `COUNT(papers)` — not a completeness ratio of a committed
+manifest. Do not concatenate the two `/health` counts with a subset preposition: a subset
+cannot be larger than its superset. The knowledge-graph
 layer (citation graph over the corpus) is built by a pipeline that has not yet produced its
 first production artifact — the Corpus page shows exactly that, rather than a synthesized
 graph. Generation requires at least two relevant papers or it declines to run.

--- a/docs/specs/architecture-page-design.md
+++ b/docs/specs/architecture-page-design.md
@@ -240,10 +240,10 @@ carries its arXiv ID and content hash.
 
 **Honesty card (live-driven):** The papers table holds `{corpus_db_count}` metadata
 records (the Corpus page count). Generation currently loads `{corpus_papers}`. These are
-different populations — `corpus_papers` is `count_corpus_papers()` (embargo-filtered COUNT)
-and `corpus_db_count` is `COUNT(papers)` — not a completeness ratio of a committed
-manifest. Do not concatenate the two `/health` counts with a subset preposition: a subset
-cannot be larger than its superset. The knowledge-graph
+different populations — `corpus_papers` is `count_corpus_papers()` (embargo-mirrored SQL
+COUNT, published by `/health`) and `corpus_db_count` is `COUNT(papers)` — not a completeness
+ratio of a committed manifest. Do not concatenate the two `/health` counts with a subset
+preposition: a subset cannot be larger than its superset. The knowledge-graph
 layer (citation graph over the corpus) is built by a pipeline that has not yet produced its
 first production artifact — the Corpus page shows exactly that, rather than a synthesized
 graph. Generation requires at least two relevant papers or it declines to run.

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -870,7 +870,7 @@ function CorpusSection({ health, healthError }) {
 			) : (
 				<p className="body mb-4">
 					Generation starts from a corpus of quantitative-finance research —{" "}
-					{fmtNum(health.corpus_db_count)} paper metadata records spanning
+					{fmtNum(health.corpus_papers)} embargo-eligible papers spanning
 					statistical finance, portfolio math, market microstructure, and
 					agentic AI. At generate time, retrieval runs in two stages: a
 					keyword/asset-class filter, then a relevance rerank against your brief,

--- a/ui/src/components/Architecture.jsx
+++ b/ui/src/components/Architecture.jsx
@@ -15,6 +15,12 @@ import { fetchHealth } from "../health";
 import flowDiagramSrc from "../assets/flow-diagram.svg";
 import { ROADMAP_SURFACES_ENABLED } from "../featureFlags.js";
 import { architecture as ROADMAP_COPY } from "../roadmapCopy.js";
+import {
+	CORPUS_HERO_CAPTION,
+	CORPUS_HERO_LABEL,
+	formatCorpusHonestyCounts,
+	formatCorpusLedgerCounts,
+} from "../corpusCountCopy.js";
 
 function fmtNum(n) {
 	return typeof n === "number" ? n.toLocaleString() : n;
@@ -147,15 +153,11 @@ function HeroStrip({
 				caption="live on Arc testnet"
 			/>
 			<StatTile
-				label="Research papers in the corpus manifest"
-				value={health?.corpus_papers}
+				label={CORPUS_HERO_LABEL}
+				value={health?.corpus_db_count}
 				loading={healthLoading}
 				failed={healthError}
-				caption={
-					health
-						? `${fmtNum(health.corpus_db_count)} ingested and retrievable today`
-						: ""
-				}
+				caption={health ? CORPUS_HERO_CAPTION : ""}
 			/>
 			<StatTile
 				label="Strategies on the public leaderboard"
@@ -837,7 +839,7 @@ function MarketplaceSection() {
 
 // ── §9 — The research corpus ───────────────────────────────────────────
 // Every retrieval claim on this panel is driven off /health, never asserted
-// statically — see #778. Two things this panel must NOT imply. (1) That a
+// statically — see #778. Three things this panel must NOT imply. (1) That a
 // vector index sits behind the corpus: the papers schema carries text only,
 // and /health says so directly now (#1488) — corpus_embedded_at_rest is false,
 // while paper_rerank_model_live carries the narrower process-local fact of
@@ -845,6 +847,9 @@ function MarketplaceSection() {
 // (2) That a knowledge graph exists: corpus_kg_built is false and the
 // graph/KG endpoints 503. backend/tests/test_corpus_claim_integrity.py
 // scans this file for both claim-shapes.
+// (3) That corpus_db_count ⊂ corpus_papers (or the reverse). They are
+// different populations — see ../corpusCountCopy.js. Never concatenate them
+// with "of the".
 
 function CorpusSection({ health, healthError }) {
 	const loading = !health && !healthError;
@@ -864,8 +869,8 @@ function CorpusSection({ health, healthError }) {
 				</p>
 			) : (
 				<p className="body mb-4">
-					Generation starts from a corpus of quantitative-finance research — a{" "}
-					{fmtNum(health.corpus_papers)}-paper arXiv manifest spanning
+					Generation starts from a corpus of quantitative-finance research —{" "}
+					{fmtNum(health.corpus_db_count)} paper metadata records spanning
 					statistical finance, portfolio math, market microstructure, and
 					agentic AI. At generate time, retrieval runs in two stages: a
 					keyword/asset-class filter, then a relevance rerank against your brief,
@@ -894,10 +899,8 @@ function CorpusSection({ health, healthError }) {
 					</p>
 				) : (
 					<p className="caption" style={{ color: "var(--text-3)" }}>
-						{fmtNum(health.corpus_db_count)} of the{" "}
-						{fmtNum(health.corpus_papers)} manifest papers are fully ingested
-						and retrievable today. The knowledge-graph layer (citation graph
-						over the corpus){" "}
+						{formatCorpusHonestyCounts(health, fmtNum)} The knowledge-graph
+						layer (citation graph over the corpus){" "}
 						{health.corpus_kg_built
 							? "has produced its first artifact"
 							: "has not yet produced its first production artifact"}{" "}
@@ -1102,8 +1105,7 @@ function HonestyLedger({ health, healthError, agentStatus, agentStatusError }) {
 									<>
 										<LedgerStatus tone="live">Live</LedgerStatus> — keyword +
 										MiniLM rerank, scored per request;{" "}
-										{fmtNum(health.corpus_db_count)} of{" "}
-										{fmtNum(health.corpus_papers)} papers hydrated
+										{formatCorpusLedgerCounts(health, fmtNum)}
 									</>
 								) : (
 									<>

--- a/ui/src/corpusCountCopy.js
+++ b/ui/src/corpusCountCopy.js
@@ -8,10 +8,16 @@
 //   corpus_db_count  = COUNT(papers) — metadata records; the Corpus page
 //                      reports the same number. The committed JSONL seed is
 //                      the floor; intake can grow the table past it.
-//   corpus_papers    = count_corpus_papers() — embargo-filtered scalar
-//                      COUNT on papers (`published < day-after-cutoff`,
-//                      blank excluded). Still ≤ corpus_db_count by
-//                      construction (same table, one extra WHERE). The
+//   corpus_papers    = count_corpus_papers() published by /health — scalar
+//                      COUNT of papers the generation surface would load,
+//                      with the Xia Outcome Embargo cutoff mirrored in SQL
+//                      (`published != '' AND published < day-after-cutoff`).
+//                      Same meaning as before; no longer a full
+//                      load_corpus() materialization. Still ≤
+//                      corpus_db_count by construction (same table, one
+//                      extra WHERE). On the day #1740 deploys the number
+//                      may read slightly higher than the old strict-`<`
+//                      Python filter (papers exactly 30 days old). The
 //                      user-facing "Generation currently loads N" still
 //                      means the size of the corpus generation would load.
 //

--- a/ui/src/corpusCountCopy.js
+++ b/ui/src/corpusCountCopy.js
@@ -1,0 +1,74 @@
+// Honest labels for the two /health corpus counts on /architecture.
+//
+// Live defect (2026-09-01): the page rendered
+//   "18,907 of the 18,752 manifest papers are fully ingested and retrievable today"
+// by concatenating corpus_db_count and corpus_papers with "of the". A subset
+// cannot be larger than its superset. Those fields are different populations:
+//
+//   corpus_db_count  = COUNT(papers) — metadata records; the Corpus page
+//                      reports the same number. The committed JSONL seed is
+//                      the floor; intake can grow the table past it.
+//   corpus_papers    = len(load_corpus()) — the generation surface. On the
+//                      DB path that is embargo-filtered (Xia Outcome Embargo);
+//                      on file fallback it is valid JSONL rows. /health does
+//                      not say which path ran.
+//
+// The UI cannot prove a subset relationship from /health, so this module
+// never emits "X of the Y" / "fully ingested" / "hydrated" completeness
+// copy. Extracted from Architecture.jsx so the live 18,907-vs-18,752
+// sentence is unit-testable without a DOM (same shape as paperCopy.js /
+// generateQuote.js). See #778 for the broader corpus claim-integrity rule.
+
+/**
+ * The live counts that produced the dishonest sentence. Frozen as the
+ * regression input — not as a number the UI may quote.
+ */
+export const LIVE_DEFECT_COUNTS = {
+	corpus_papers: 18752,
+	corpus_db_count: 18907,
+};
+
+export const LIVE_DEFECT_SENTENCE =
+	"18,907 of the 18,752 manifest papers are fully ingested and retrievable today";
+
+export const CORPUS_HERO_LABEL = "Paper metadata records";
+
+export const CORPUS_HERO_CAPTION =
+	"the Corpus page count — metadata + abstracts, not a knowledge graph";
+
+/**
+ * True iff `text` is the banned ingested-of-manifest subset claim.
+ *
+ * Matches the live sentence and any "N of the M manifest papers are fully
+ * ingested" variant (with or without thousands separators). Also matches
+ * the ledger's sibling "N of M papers hydrated". Does not match honest
+ * copy that names the two populations without a subset preposition.
+ */
+export function claimsIngestedSubsetOfManifest(text) {
+	if (typeof text !== "string" || text.length === 0) return false;
+	return (
+		/\d[\d,]* of the \d[\d,]* manifest papers/i.test(text) ||
+		/\d[\d,]* of(?: the)? \d[\d,]* papers hydrated/i.test(text) ||
+		/\bfully ingested and retrievable\b/i.test(text)
+	);
+}
+
+/**
+ * Honesty-note count sentence. Names both live fields as different
+ * populations. Never uses "of the" / "fully ingested" / "hydrated".
+ */
+export function formatCorpusHonestyCounts(health, fmtNum) {
+	const records = fmtNum(health.corpus_db_count);
+	const generation = fmtNum(health.corpus_papers);
+	return (
+		`The papers table holds ${records} metadata records — the same count the Corpus page reports. ` +
+		`Generation currently loads ${generation}. These are different populations, not a completeness ratio of a committed manifest.`
+	);
+}
+
+/**
+ * Ledger retrieval-row count. One population, one label — no denominator.
+ */
+export function formatCorpusLedgerCounts(health, fmtNum) {
+	return `${fmtNum(health.corpus_db_count)} paper metadata records`;
+}

--- a/ui/src/corpusCountCopy.js
+++ b/ui/src/corpusCountCopy.js
@@ -77,8 +77,10 @@ export function formatCorpusHonestyCounts(health, fmtNum) {
 }
 
 /**
- * Ledger retrieval-row count. One population, one label — no denominator.
+ * Ledger retrieval-row count. Retrieval scores the embargo-filtered
+ * generation surface (`corpus_papers`), not the full papers-table count.
+ * One population, one label — no denominator.
  */
 export function formatCorpusLedgerCounts(health, fmtNum) {
-	return `${fmtNum(health.corpus_db_count)} paper metadata records`;
+	return `${fmtNum(health.corpus_papers)} embargo-eligible papers scored`;
 }

--- a/ui/src/corpusCountCopy.js
+++ b/ui/src/corpusCountCopy.js
@@ -8,14 +8,18 @@
 //   corpus_db_count  = COUNT(papers) — metadata records; the Corpus page
 //                      reports the same number. The committed JSONL seed is
 //                      the floor; intake can grow the table past it.
-//   corpus_papers    = len(load_corpus()) — the generation surface. On the
-//                      DB path that is embargo-filtered (Xia Outcome Embargo);
-//                      on file fallback it is valid JSONL rows. /health does
-//                      not say which path ran.
+//   corpus_papers    = count_corpus_papers() — embargo-filtered scalar
+//                      COUNT on papers (`published < day-after-cutoff`,
+//                      blank excluded). Still ≤ corpus_db_count by
+//                      construction (same table, one extra WHERE). The
+//                      user-facing "Generation currently loads N" still
+//                      means the size of the corpus generation would load.
 //
-// The UI cannot prove a subset relationship from /health, so this module
-// never emits "X of the Y" / "fully ingested" / "hydrated" completeness
-// copy. Extracted from Architecture.jsx so the live 18,907-vs-18,752
+// corpus_papers ≤ corpus_db_count by construction, but they are still
+// different populations (embargoed COUNT vs full table), not a
+// completeness ratio of a committed manifest — so this module never
+// emits "X of the Y" / "fully ingested" / "hydrated" copy.
+// Extracted from Architecture.jsx so the live 18,907-vs-18,752
 // sentence is unit-testable without a DOM (same shape as paperCopy.js /
 // generateQuote.js). See #778 for the broader corpus claim-integrity rule.
 

--- a/ui/test/corpus-count-copy.test.js
+++ b/ui/test/corpus-count-copy.test.js
@@ -1,0 +1,216 @@
+// Claim-integrity guard for /architecture corpus counts.
+//
+// Live defect: https://archimedes-arc.com/architecture simultaneously claimed
+// "18,752 RESEARCH PAPERS IN THE CORPUS MANIFEST / 18,907 ingested and
+// retrievable today" and "18,907 of the 18,752 manifest papers are fully
+// ingested and retrievable today". A subset cannot be larger than its
+// superset. The Corpus page independently reports "18,907 paper metadata
+// records".
+//
+// The two /health fields are different populations, not a completeness
+// ratio of a committed manifest:
+//   corpus_db_count = COUNT(papers)  (Corpus page)
+//   corpus_papers   = len(load_corpus())  (generation surface)
+//
+// Same idiom as oracle-copy.test.js / ipfs-pinning-copy.test.js: the
+// formatter is unit-tested against the live numbers, and Architecture.jsx
+// is scanned so the old template cannot return. Anti-vacuity: the detector
+// must still reject the live sentence, otherwise it is guarding nothing.
+//
+// Hermetic: no network, no DOM, no `.env`.
+
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	CORPUS_HERO_CAPTION,
+	CORPUS_HERO_LABEL,
+	LIVE_DEFECT_COUNTS,
+	LIVE_DEFECT_SENTENCE,
+	claimsIngestedSubsetOfManifest,
+	formatCorpusHonestyCounts,
+	formatCorpusLedgerCounts,
+} from "../src/corpusCountCopy.js";
+
+function repoFile(rel) {
+	return new URL(`../${rel}`, import.meta.url);
+}
+
+const architecture = readFileSync(repoFile("src/components/Architecture.jsx"), "utf8");
+const spec = readFileSync(repoFile("../docs/specs/architecture-page-design.md"), "utf8");
+
+const usFmt = (n) => (typeof n === "number" ? n.toLocaleString("en-US") : n);
+
+// The pre-fix concatenator — what Architecture.jsx used to do with the two
+// /health fields. Kept here so the detector's anti-vacuity case is the
+// exact production sentence, not a paraphrase.
+function preFixHonestyNote({ corpus_papers, corpus_db_count }, fmtNum) {
+	return `${fmtNum(corpus_db_count)} of the ${fmtNum(corpus_papers)} manifest papers are fully ingested and retrievable today`;
+}
+
+function preFixLedgerNote({ corpus_papers, corpus_db_count }, fmtNum) {
+	return `${fmtNum(corpus_db_count)} of ${fmtNum(corpus_papers)} papers hydrated`;
+}
+
+test("the detector rejects the live 18,907-of-the-18,752 sentence", () => {
+	assert.equal(claimsIngestedSubsetOfManifest(LIVE_DEFECT_SENTENCE), true);
+	assert.equal(
+		claimsIngestedSubsetOfManifest(preFixHonestyNote(LIVE_DEFECT_COUNTS, usFmt)),
+		true,
+		"detector must reject the exact concatenator the live page used",
+	);
+	assert.equal(
+		claimsIngestedSubsetOfManifest(preFixLedgerNote(LIVE_DEFECT_COUNTS, usFmt)),
+		true,
+		"detector must reject the ledger's 'N of M papers hydrated' sibling",
+	);
+});
+
+test("the detector is not a match-anything: honest copy is allowed", () => {
+	const honest = formatCorpusHonestyCounts(LIVE_DEFECT_COUNTS, usFmt);
+	assert.equal(claimsIngestedSubsetOfManifest(honest), false);
+	assert.equal(
+		claimsIngestedSubsetOfManifest("the Corpus page count — metadata + abstracts"),
+		false,
+	);
+});
+
+test("ingested-of-manifest copy cannot have ingested > manifest (live counts)", () => {
+	const honest = formatCorpusHonestyCounts(LIVE_DEFECT_COUNTS, usFmt);
+	assert.equal(
+		claimsIngestedSubsetOfManifest(honest),
+		false,
+		"live 18907-vs-18752 must not render as ingested ⊂ manifest",
+	);
+	assert.doesNotMatch(honest, /\bof the\b/);
+	assert.doesNotMatch(honest, /fully ingested/i);
+	assert.doesNotMatch(honest, /hydrated/i);
+	assert.match(honest, /18,907/);
+	assert.match(honest, /18,752/);
+	assert.match(honest, /different populations/);
+	assert.match(honest, /metadata records/);
+});
+
+test("even when the numbers would make a subset look plausible, still no 'of the'", () => {
+	// Swapped: 18,752 ingested of 18,907 would look arithmetically fine and
+	// still be a false completeness claim — they are different populations.
+	const swapped = formatCorpusHonestyCounts(
+		{ corpus_papers: 18907, corpus_db_count: 18752 },
+		usFmt,
+	);
+	assert.equal(claimsIngestedSubsetOfManifest(swapped), false);
+	assert.doesNotMatch(swapped, /\bof the\b/);
+	assert.doesNotMatch(swapped, /fully ingested/i);
+});
+
+test("equal counts still do not get subset copy — equality is not ingestion completeness", () => {
+	const equal = formatCorpusHonestyCounts(
+		{ corpus_papers: 18907, corpus_db_count: 18907 },
+		usFmt,
+	);
+	assert.equal(claimsIngestedSubsetOfManifest(equal), false);
+	assert.doesNotMatch(equal, /\bof the\b/);
+});
+
+test("the ledger formatter names one population, with no denominator", () => {
+	const ledger = formatCorpusLedgerCounts(LIVE_DEFECT_COUNTS, usFmt);
+	assert.equal(claimsIngestedSubsetOfManifest(ledger), false);
+	assert.equal(ledger, "18,907 paper metadata records");
+	assert.doesNotMatch(ledger, /\bof\b/);
+	assert.doesNotMatch(ledger, /hydrated/i);
+});
+
+// ── Architecture.jsx wiring + the old template must be gone ──────────────
+
+const BANNED_SOURCE_PATTERNS = [
+	[
+		"honesty_of_the_manifest",
+		/of the\{\s*" "\s*\}\s*\n?\s*\{fmtNum\(health\.corpus_papers\)\} manifest papers are fully ingested/,
+		'{fmtNum(health.corpus_db_count)} of the{" "}{fmtNum(health.corpus_papers)} manifest papers are fully ingested',
+	],
+	[
+		"fully_ingested_and_retrievable",
+		/fully ingested\s+and retrievable today/,
+		"fully ingested and retrievable today",
+	],
+	[
+		"ledger_papers_hydrated",
+		/papers hydrated/,
+		"{fmtNum(health.corpus_db_count)} of {fmtNum(health.corpus_papers)} papers hydrated",
+	],
+	[
+		"hero_corpus_papers_as_manifest",
+		/label="Research papers in the corpus manifest"/,
+		'label="Research papers in the corpus manifest"',
+	],
+	[
+		"hero_value_is_corpus_papers",
+		/value=\{health\?\.corpus_papers\}/,
+		"value={health?.corpus_papers}",
+	],
+	[
+		"body_n_paper_arxiv_manifest",
+		/health\.corpus_papers\)\}-paper arXiv manifest/,
+		"{fmtNum(health.corpus_papers)}-paper arXiv manifest",
+	],
+];
+
+test("every banned source pattern still rejects the pre-fix literal", () => {
+	for (const [name, pattern, example] of BANNED_SOURCE_PATTERNS) {
+		assert.match(
+			example,
+			pattern,
+			`pattern ${name} no longer rejects its canonical example — it is guarding nothing`,
+		);
+	}
+});
+
+test("Architecture.jsx no longer concatenates ingested-of-manifest copy", () => {
+	for (const [name, pattern] of BANNED_SOURCE_PATTERNS) {
+		assert.doesNotMatch(
+			architecture,
+			pattern,
+			`Architecture.jsx still contains banned corpus subset copy (${name})`,
+		);
+	}
+});
+
+test("splicing the live concatenator back into Architecture.jsx fails the source scan", () => {
+	// The unfixed page. Proves the scan is not passing because it never
+	// looks: putting the live sentence's JSX back must trip honesty_of_the_manifest.
+	const spliced = architecture.replace(
+		"formatCorpusHonestyCounts(health, fmtNum)",
+		'{fmtNum(health.corpus_db_count)} of the{" "}{fmtNum(health.corpus_papers)} manifest papers are fully ingested',
+	);
+	assert.notEqual(spliced, architecture, "splice must actually change Architecture.jsx");
+	const honesty = BANNED_SOURCE_PATTERNS.find(([name]) => name === "honesty_of_the_manifest")[1];
+	assert.match(
+		spliced,
+		honesty,
+		"the source scan must fail against the live concatenator — otherwise it would have passed on the unfixed page",
+	);
+});
+
+test("Architecture.jsx drives the hero off corpus_db_count and the honest helper", () => {
+	assert.match(architecture, /from "\.\.\/corpusCountCopy\.js"/);
+	assert.match(architecture, /formatCorpusHonestyCounts/);
+	assert.match(architecture, /formatCorpusLedgerCounts/);
+	assert.match(architecture, /CORPUS_HERO_LABEL/);
+	assert.match(architecture, /CORPUS_HERO_CAPTION/);
+	assert.match(architecture, /value=\{health\?\.corpus_db_count\}/);
+	assert.match(architecture, new RegExp(`label=\\{CORPUS_HERO_LABEL\\}`));
+	assert.doesNotMatch(architecture, /ingested and retrievable today/);
+});
+
+test("the design spec no longer teaches '{ingested} of the {manifest}'", () => {
+	assert.doesNotMatch(spec, /of the\s*\n?manifest papers are fully ingested/);
+	assert.doesNotMatch(spec, /\{ingested\} of the/);
+});
+
+test("hero caption is not a second count posing as a subset", () => {
+	assert.doesNotMatch(CORPUS_HERO_CAPTION, /\d/);
+	assert.doesNotMatch(CORPUS_HERO_CAPTION, /of the/);
+	assert.match(CORPUS_HERO_CAPTION, /Corpus page count/);
+	assert.equal(CORPUS_HERO_LABEL, "Paper metadata records");
+});

--- a/ui/test/corpus-count-copy.test.js
+++ b/ui/test/corpus-count-copy.test.js
@@ -116,7 +116,7 @@ test("equal counts still do not get subset copy — equality is not ingestion co
 test("the ledger formatter names one population, with no denominator", () => {
 	const ledger = formatCorpusLedgerCounts(LIVE_DEFECT_COUNTS, usFmt);
 	assert.equal(claimsIngestedSubsetOfManifest(ledger), false);
-	assert.equal(ledger, "18,907 paper metadata records");
+	assert.equal(ledger, "18,752 embargo-eligible papers scored");
 	assert.doesNotMatch(ledger, /\bof\b/);
 	assert.doesNotMatch(ledger, /hydrated/i);
 });
@@ -153,6 +153,11 @@ const BANNED_SOURCE_PATTERNS = [
 		"body_n_paper_arxiv_manifest",
 		/health\.corpus_papers\)\}-paper arXiv manifest/,
 		"{fmtNum(health.corpus_papers)}-paper arXiv manifest",
+	],
+	[
+		"generation_starts_from_db_count",
+		/Generation starts from[\s\S]{0,120}corpus_db_count/,
+		"Generation starts from a corpus … {fmtNum(health.corpus_db_count)} paper metadata records",
 	],
 ];
 

--- a/ui/test/corpus-count-copy.test.js
+++ b/ui/test/corpus-count-copy.test.js
@@ -10,7 +10,7 @@
 // The two /health fields are different populations, not a completeness
 // ratio of a committed manifest:
 //   corpus_db_count = COUNT(papers)  (Corpus page)
-//   corpus_papers   = count_corpus_papers()  (embargo-filtered COUNT; ≤ db_count)
+//   corpus_papers   = count_corpus_papers()  (/health; embargo-mirrored SQL COUNT; ≤ db_count)
 //
 // Same idiom as oracle-copy.test.js / ipfs-pinning-copy.test.js: the
 // formatter is unit-tested against the live numbers, and Architecture.jsx

--- a/ui/test/corpus-count-copy.test.js
+++ b/ui/test/corpus-count-copy.test.js
@@ -10,7 +10,7 @@
 // The two /health fields are different populations, not a completeness
 // ratio of a committed manifest:
 //   corpus_db_count = COUNT(papers)  (Corpus page)
-//   corpus_papers   = len(load_corpus())  (generation surface)
+//   corpus_papers   = count_corpus_papers()  (embargo-filtered COUNT; ≤ db_count)
 //
 // Same idiom as oracle-copy.test.js / ipfs-pinning-copy.test.js: the
 // formatter is unit-tested against the live numbers, and Architecture.jsx


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`/architecture` no longer concatenates `corpus_db_count` and `corpus_papers` as "N of the M manifest papers are fully ingested". The two `/health` fields are different populations; the hero now shows the Corpus page's metadata-record count, and the honesty note names both numbers without a subset preposition.

Follow-up (`6bae29a7`, after dbrowneup FIX-FIRST review): generation body and ledger retrieval row now read `corpus_papers` ("embargo-eligible papers"), not `corpus_db_count`. Banned-source guard covers wiring generation back to the papers-table count.

Follow-up records #1740: `corpus_papers` is `count_corpus_papers()` (embargo-filtered scalar COUNT), not `len(load_corpus())`. User-facing "Generation currently loads N" in the honesty note is unchanged.

## Why

Live https://archimedes-arc.com/architecture (measured 2026-09-01 against `GET /health`) claimed both:

- **18,752** RESEARCH PAPERS IN THE CORPUS MANIFEST / **18,907** ingested and retrievable today
- **18,907 of the 18,752** manifest papers are fully ingested and retrievable today

A subset cannot be larger than its superset. The Corpus page independently reports **18,907 paper metadata records**.

The hunch that 18,752 was a hardcoded manifest count is **false**. Both numbers are live from `/health`:

| Field | Live value (pre-#1740 deploy) | What it actually is |
| --- | --- | --- |
| `corpus_papers` | 18,752 | `count_corpus_papers()` as of #1740 (`0570f16e`) — embargo-filtered scalar `COUNT(papers)` (`published < day-after-cutoff`, blank excluded). Still ≤ `corpus_db_count` by construction. Generation and retrieval copy use this field. |
| `corpus_db_count` | 18,907 | `COUNT(papers)` — metadata records. Same count the Corpus page reports. Hero tile only. |

The page labeled the smaller number "manifest" and the larger number "ingested of the manifest". They are not a completeness ratio, and "fully ingested" over-claims metadata rows as hydration.

## Issues

See #778 (corpus claim-integrity — related; this does not close it).

No dedicated issue for this live copy contradiction.

## Verification

```
$ cd ui && node --test test/corpus-count-copy.test.js
# tests 12
# pass 12
```

**Guard rejects the live sentence** (the input that should fail, before the honest formatter):

```
LIVE_DEFECT_SENTENCE banned? true
LIVE_DEFECT_SENTENCE: 18,907 of the 18,752 manifest papers are fully ingested and retrievable today
honest banned? false
honest: The papers table holds 18,907 metadata records — the same count the Corpus page reports. Generation currently loads 18,752. These are different populations, not a completeness ratio of a committed manifest.
```

Ledger formatter on the live defect counts: `18,752 embargo-eligible papers scored`.

**Source scan fails if the live concatenator is spliced back** — `splicing the live concatenator back into Architecture.jsx fails the source scan` (test 9). `generation_starts_from_db_count` rejects wiring "Generation starts from" to `corpus_db_count`.

## What a reviewer should push back on

- Hero still keys off `corpus_db_count` (Corpus page population). Generation/retrieval now key off `corpus_papers`.
- Honesty-note sentence still names both populations without "of the".

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5f10b76-c0b1-48a4-b8e7-50b8ac935b02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5f10b76-c0b1-48a4-b8e7-50b8ac935b02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

