### PR TITLE
[infra] OIDC trust: follow the subject GitHub actually mints (id-qualified after the org rename)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,11 +113,26 @@
 #    config.
 #
 # 3. VERIFY OIDC TRUST POLICY IS LOCKED TO THIS REPO.
-#    The role trust policy must restrict token.actions.githubusercontent.com
-#    to `repo:a-apin/archimedes:*` (or tighter: `:ref:refs/heads/main`).
-#    Without that condition, any GitHub repo's Actions can assume the role.
+#    The role trust policy must restrict token.actions.githubusercontent.com to
+#    THIS repository on `:ref:refs/heads/main`. Without that condition, any
+#    GitHub repo's Actions can assume the role.
+#    The `sub` claim it must match is minted by GitHub in one of two shapes, and
+#    this repo currently gets the ID-QUALIFIED one:
+#        repo:aprin-labs/archimedes:ref:refs/heads/main                       (plain)
+#        repo:aprin-labs@284008417/archimedes@1236816811:ref:refs/heads/main   (id-qualified, current)
+#    The role trusts BOTH, so a GitHub-side toggle of that format cannot break
+#    deploys; main-only stays the rule. Incident 2026-09-01: after the org
+#    rename a-apin -> aprin-labs, a trust policy naming only the plain new name
+#    failed every deploy for ~3h with `Not authorized to perform
+#    sts:AssumeRoleWithWebIdentity` — the real subject was in CloudTrail, on the
+#    failed AssumeRoleWithWebIdentity event, as `userIdentity.userName`.
+#    Authoritative prefix:
+#      gh api repos/aprin-labs/archimedes/actions/oidc/customization/sub --jq .sub_claim_prefix
 #    Verify with: aws iam get-role --role-name archimedes-github-deploy
 #    and inspect AssumeRolePolicyDocument's Condition block.
+#    After ANY rename/transfer, re-point the role (it is NOT Terraform-managed —
+#    infra/scripts/setup-github-oidc.sh is the source of truth):
+#      AWS_PROFILE=<admin-profile> bash infra/scripts/setup-github-oidc.sh --apply
 
 name: Build, Push & Deploy
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -242,7 +242,7 @@ jobs:
         #
         # *** ACTION REQUIRED (Dan): add the `VITE_CIRCLE_CLIENT_KEY` repo
         # secret (Settings → Secrets and variables → Actions → Secrets, repo
-        # `a-apin/archimedes`) before the first real image build after this
+        # `aprin-labs/archimedes`) before the first real image build after this
         # PR merges — until then this build-arg resolves to an empty string
         # (same as today) and the wallet UI ships broken. ***
         #

--- a/docs/runbooks/docs-site-setup.md
+++ b/docs/runbooks/docs-site-setup.md
@@ -1,6 +1,6 @@
 # Docs Site — S3 + CloudFront at `docs.archimedes-arc.com`
 
-> **Status:** runbook. **Owner:** Dan Browne. **Updated:** 2026-08-31.
+> **Status:** runbook. **Owner:** Dan Browne. **Updated:** 2026-09-01.
 
 `docs/` **and the agent-generated `openwiki/` tree** are built into a static
 site by [`mkdocs.yml`](../../mkdocs.yml) (theme: mkdocs-material) and published
@@ -79,6 +79,17 @@ which now includes the docs-site statements (`s3:ListBucket` /
 ./infra/scripts/setup-github-oidc.sh            # dry run — prints what it would do
 ./infra/scripts/setup-github-oidc.sh --apply
 ```
+
+> **Also re-run it after any org/repo rename or transfer.** The same script owns
+> the role's *trust* policy, and the OIDC `sub` claim GitHub mints carries the
+> repository's current identity — in this repo's case the **id-qualified** form
+> (`repo:aprin-labs@284008417/archimedes@1236816811:ref:refs/heads/main`), not
+> the plain `repo:ORG/REPO` one. On 2026-09-01 the `a-apin` → `aprin-labs`
+> rename broke every deploy for ~3h on
+> `Not authorized to perform sts:AssumeRoleWithWebIdentity`, docs-site publish
+> included. The dry run prints the exact subjects it will trust; compare them
+> against CloudTrail (`AssumeRoleWithWebIdentity` → `userIdentity.userName` on
+> the failed event). The script's own header has the full story.
 
 Skipping this does not break the build. It does **not** silently skip either:
 once the bucket exists, a role that cannot read it gets a 403 from

--- a/infra/README.md
+++ b/infra/README.md
@@ -212,7 +212,7 @@ so an admin can apply or audit it declaratively (audit #10 / issues #519, #526).
 ./scripts/setup-branch-protection.sh            # dry-run: print the payload, apply nothing
 ./scripts/setup-branch-protection.sh --apply    # apply (needs repo admin)
 ./scripts/setup-branch-protection.sh --verify    # print the currently-applied protection
-# or, raw:  gh api repos/a-apin/archimedes/branches/main/protection
+# or, raw:  gh api repos/aprin-labs/archimedes/branches/main/protection
 ```
 
 What it enforces: the two hard-block CI checks (`Backend — unit tests`, `Ruff — format +

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -373,10 +373,15 @@ resource "aws_iam_role_policy" "ecs_task_exec_command" {
 # ── IAM — extend the EXISTING CI deploy role with ECS deploy permissions ───
 # `archimedes-github-deploy` is deliberately NOT Terraform-managed (created
 # out-of-band by infra/scripts/setup-github-oidc.sh — see that script's own
-# "tighten once ECS exists" comment). This attaches a SEPARATE, additively-
-# named inline policy ("archimedes-ecs-deploy", distinct from the script's own
-# "archimedes-deploy" policy) so Terraform and the script each own a disjoint
-# policy name on the same role — no state fights, no clobbering.
+# "tighten once ECS exists" comment). That script, not Terraform, also owns the
+# role's TRUST policy: after any org/repo rename or transfer it must be re-run
+# (`--apply`) or every deploy fails at "Configure AWS credentials (OIDC)" —
+# incident 2026-09-01, written up in that script's header.
+#
+# This attaches a SEPARATE, additively-named inline policy
+# ("archimedes-ecs-deploy", distinct from the script's own "archimedes-deploy"
+# policy) so Terraform and the script each own a disjoint policy name on the
+# same role — no state fights, no clobbering.
 #
 # NOT wired into any CI workflow step yet (deploy.yml still only builds/pushes
 # to ECR — the box-pull path from build-chunk 1). This is the IAM

--- a/infra/scripts/setup-github-oidc.sh
+++ b/infra/scripts/setup-github-oidc.sh
@@ -8,10 +8,10 @@
 #
 # What this creates:
 #   1. An IAM OIDC identity provider for token.actions.githubusercontent.com
-#   2. A deploy role whose trust policy ONLY accepts ${GITHUB_ORG}/${GITHUB_REPO}
-#      on refs/heads/main (build-on-deploy), via sts:AssumeRoleWithWebIdentity.
-#      Re-run this after renaming or transferring the repo — see the note by
-#      GITHUB_ORG for why deploys break silently otherwise.
+#   2. A deploy role whose trust policy ONLY accepts THIS repository on
+#      refs/heads/main (build-on-deploy), via sts:AssumeRoleWithWebIdentity.
+#      "This repository" is not a string we get to choose — read THE SUBJECT
+#      GITHUB ACTUALLY MINTS below before editing anything here.
 #   3. A STARTER permissions policy (ECR push + SSM SendCommand + EC2 describe),
 #      plus the docs-site publish grants (#1634): sync into the
 #      docs-site/infra bucket and invalidate its CloudFront distribution.
@@ -24,23 +24,72 @@
 #   Resource "*" is the only valid form); `CreateInvalidation` is scoped to this
 #   account's distributions.
 #
+# ─── THE SUBJECT GITHUB ACTUALLY MINTS (incident 2026-09-01) ─────────────────
+# The trust policy matches the OIDC token's `sub` claim. GitHub mints that
+# claim; we only get to match it. It has TWO possible shapes:
+#
+#     repo:ORG/REPO:ref:refs/heads/main                      <- plain
+#     repo:ORG@<org-id>/REPO@<repo-id>:ref:refs/heads/main   <- id-qualified
+#
+# The id-qualified ("immutable subject") form names the numeric org and repo
+# IDs, so it survives renames. Which form a repository gets is a GitHub-side
+# setting, and the authoritative answer is the `sub_claim_prefix` field of
+#
+#     gh api repos/ORG/REPO/actions/oidc/customization/sub
+#
+# so this script ASKS rather than assumes, and writes BOTH forms into the trust
+# policy. Trusting both means a GitHub-side toggle in either direction cannot
+# break deploys; both are still pinned to refs/heads/main, so main-only remains
+# the rule and no other branch or repo gains anything.
+#
+# WHAT WENT WRONG. After the org rename a-apin -> aprin-labs, every production
+# deploy from 16:55Z to 20:04Z died at "Configure AWS credentials (OIDC)" with
+# `Not authorized to perform sts:AssumeRoleWithWebIdentity`. The trust policy
+# had already been corrected to the *plain* new name
+# (repo:aprin-labs/archimedes:ref:refs/heads/main) — and still failed, because
+# this repository mints the id-qualified form:
+#
+#     repo:aprin-labs@284008417/archimedes@1236816811:ref:refs/heads/main
+#
+# HOW TO SEE THE REAL SUBJECT (do this first, next time). CloudTrail, event
+# name AssumeRoleWithWebIdentity, errorCode AccessDenied: the subject GitHub
+# presented is `userIdentity.userName` on the failed event. That field is the
+# ground truth — compare it, character for character, against the subjects this
+# script prints in its dry run.
+#
+# OPERATOR RECIPE — after ANY repo rename, org rename, or transfer:
+#
+#     AWS_PROFILE=<admin-profile> bash infra/scripts/setup-github-oidc.sh
+#     AWS_PROFILE=<admin-profile> bash infra/scripts/setup-github-oidc.sh --apply
+#
+# (dry run first: it prints the exact subjects it will trust). Nothing else
+# re-points the role — `archimedes-github-deploy` is deliberately NOT
+# Terraform-managed (infra/ecs.tf), so this script is the source of truth.
+# Git keeps working throughout, because GitHub redirects clones and STS does
+# not, so deploys are the only thing that breaks — silently, before a byte is
+# built.
+#
 # DRY-RUN BY DEFAULT.  ./setup-github-oidc.sh   |   ./setup-github-oidc.sh --apply
-# Requires: AWS_PROFILE exported, aws CLI v2.
+# Requires: AWS_PROFILE exported, aws CLI v2. `gh` (authenticated) strongly
+# recommended — without it the sub prefix falls back to the plain form.
 set -euo pipefail
 
 # ─── Config ──────────────────────────────────────────────────────────────────
 # ACCOUNT_ID/REGION are not hardcoded — auto-detected from the active profile (override via env).
 ACCOUNT_ID="${ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)}"
 REGION="${AWS_REGION:-us-east-1}"
-# The OIDC `sub` claim carries the repository's CURRENT owner/name. Renaming or
-# transferring the repo changes the claim, the trust policy below stops matching,
-# and every deploy dies at "Configure AWS credentials (OIDC)" with
-# `Not authorized to perform sts:AssumeRoleWithWebIdentity` before a byte is built.
-# Git keeps working throughout, because GitHub redirects clones and STS does not.
+# The OIDC `sub` claim carries the repository's CURRENT identity. Renaming or
+# transferring the repo changes the claim, the trust policy below stops
+# matching, and every deploy dies at "Configure AWS credentials (OIDC)".
 # So: re-run this script after any rename. Override via env for a fork.
 GITHUB_ORG="${GITHUB_ORG:-aprin-labs}"
 GITHUB_REPO="${GITHUB_REPO:-archimedes}"
-DEPLOY_BRANCH_SUB="repo:${GITHUB_ORG}/${GITHUB_REPO}:ref:refs/heads/main"
+DEPLOY_REF="refs/heads/main"                            # main-only stays the rule
+PLAIN_SUB_PREFIX="repo:${GITHUB_ORG}/${GITHUB_REPO}"
+# Escape hatch: set this only when `gh` is unavailable AND you have read the
+# real prefix by hand (CloudTrail userIdentity.userName, minus the ":ref:..."
+# suffix, or the customization/sub API). Validated below like any other input.
+SUB_CLAIM_PREFIX="${SUB_CLAIM_PREFIX:-}"
 ROLE_NAME="archimedes-github-deploy"
 OIDC_URL="token.actions.githubusercontent.com"
 OIDC_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_URL}"
@@ -81,6 +130,73 @@ else
   echo "  skipped: gh unavailable or unauthenticated — cannot confirm ${GITHUB_ORG}/${GITHUB_REPO}"
 fi
 
+# ─── 0b. Resolve the sub prefix GitHub mints for THIS repo ───────────────────
+# The name is only half the subject: the prefix may be plain or id-qualified
+# (see the header). Ask GitHub; fall back loudly. Never guess quietly.
+say "OIDC subject prefix"
+if [ -n "$SUB_CLAIM_PREFIX" ]; then
+  echo "  using SUB_CLAIM_PREFIX from the environment: ${SUB_CLAIM_PREFIX}"
+elif command -v gh >/dev/null 2>&1 \
+     && SUB_CLAIM_PREFIX="$(gh api "repos/${GITHUB_ORG}/${GITHUB_REPO}/actions/oidc/customization/sub" --jq .sub_claim_prefix 2>/dev/null)" \
+     && [ -n "$SUB_CLAIM_PREFIX" ] && [ "$SUB_CLAIM_PREFIX" != "null" ]; then
+  echo "  GitHub reports sub_claim_prefix = ${SUB_CLAIM_PREFIX}"
+else
+  SUB_CLAIM_PREFIX="$PLAIN_SUB_PREFIX"
+  {
+    echo "  !! WARNING: could not read the sub prefix from GitHub (gh missing,"
+    echo "  !! unauthenticated, or the API call failed). Falling back to the PLAIN form:"
+    echo "  !!     ${PLAIN_SUB_PREFIX}"
+    echo "  !! If this repository mints the ID-QUALIFIED form"
+    echo "  !! (repo:ORG@<org-id>/REPO@<repo-id>) that fallback CANNOT match, and every"
+    echo "  !! deploy will fail at 'Configure AWS credentials (OIDC)'. Read the real"
+    echo "  !! subject from CloudTrail (AssumeRoleWithWebIdentity -> userIdentity.userName)"
+    echo "  !! or from"
+    echo "  !!     gh api repos/${GITHUB_ORG}/${GITHUB_REPO}/actions/oidc/customization/sub"
+    echo "  !! and re-run with SUB_CLAIM_PREFIX=<that value>."
+  } >&2
+fi
+
+# Validate before it reaches a trust policy. A prefix is matched with StringLike,
+# so a stray '*' would silently widen who may assume this role; anything that is
+# not this repository must not be written at all.
+_bad_prefix() {
+  echo "ERROR: refusing to write a trust policy for sub prefix '${SUB_CLAIM_PREFIX}'." >&2
+  echo "       $1" >&2
+  echo "       Expected 'repo:${GITHUB_ORG}/${GITHUB_REPO}' or the id-qualified" >&2
+  echo "       'repo:${GITHUB_ORG}@<org-id>/${GITHUB_REPO}@<repo-id>'." >&2
+  exit 1
+}
+case "$SUB_CLAIM_PREFIX" in
+  repo:*) ;;
+  *) _bad_prefix "It does not start with 'repo:'." ;;
+esac
+_sub_body="${SUB_CLAIM_PREFIX#repo:}"
+case "$_sub_body" in
+  "")            _bad_prefix "It is empty after 'repo:'." ;;
+  */*/*)         _bad_prefix "It has more than one '/' — that is not an owner/name pair." ;;
+  */*)           ;;
+  *)             _bad_prefix "It has no '/' — that is not an owner/name pair." ;;
+esac
+case "$_sub_body" in
+  *[!A-Za-z0-9._@/-]*) _bad_prefix "It contains a character outside [A-Za-z0-9._@/-] (a wildcard here would widen the trust policy)." ;;
+esac
+# Strip any '@<id>' qualifier from each segment, then the names must be OURS.
+_org_seg="${_sub_body%%/*}"; _repo_seg="${_sub_body#*/}"
+[ "${_org_seg%%@*}" = "$GITHUB_ORG" ] || _bad_prefix "Its owner segment is '${_org_seg}', not '${GITHUB_ORG}'."
+[ "${_repo_seg%%@*}" = "$GITHUB_REPO" ] || _bad_prefix "Its repo segment is '${_repo_seg}', not '${GITHUB_REPO}'."
+
+# Trust the resolved prefix AND the plain one (deduped when equal), both pinned
+# to main: a GitHub-side toggle of the immutable-subject format in either
+# direction then cannot break deploys.
+SUBJECTS=("${SUB_CLAIM_PREFIX}:ref:${DEPLOY_REF}")
+[ "$SUB_CLAIM_PREFIX" = "$PLAIN_SUB_PREFIX" ] || SUBJECTS+=("${PLAIN_SUB_PREFIX}:ref:${DEPLOY_REF}")
+echo "  subjects this run will trust (main only) — compare these character for"
+echo "  character against CloudTrail userIdentity.userName on a failed"
+echo "  AssumeRoleWithWebIdentity event:"
+for _s in "${SUBJECTS[@]}"; do echo "    - ${_s}"; done
+SUB_JSON=""
+for _s in "${SUBJECTS[@]}"; do SUB_JSON="${SUB_JSON:+${SUB_JSON},}\"${_s}\""; done
+
 # ─── 1. OIDC provider ─────────────────────────────────────────────────────────
 say "GitHub OIDC identity provider"
 if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$OIDC_ARN" >/dev/null 2>&1; then
@@ -90,7 +206,7 @@ else
 fi
 
 # ─── 2. Deploy role (trust scoped to main branch only) ────────────────────────
-say "Deploy role: ${ROLE_NAME} (trusts ${DEPLOY_BRANCH_SUB})"
+say "Deploy role: ${ROLE_NAME} (${#SUBJECTS[@]} trusted subject(s), main only)"
 cat > "$TMP/trust.json" <<JSON
 { "Version":"2012-10-17",
   "Statement":[{
@@ -99,9 +215,10 @@ cat > "$TMP/trust.json" <<JSON
     "Action":"sts:AssumeRoleWithWebIdentity",
     "Condition":{
       "StringEquals":{"${OIDC_URL}:aud":"sts.amazonaws.com"},
-      "StringLike":{"${OIDC_URL}:sub":"${DEPLOY_BRANCH_SUB}"}
+      "StringLike":{"${OIDC_URL}:sub":[${SUB_JSON}]}
     } }] }
 JSON
+$APPLY || { echo "  trust policy that would be written:"; sed 's/^/    /' "$TMP/trust.json"; }
 if aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
   echo "  role exists — updating trust policy"
   do_ "aws iam update-assume-role-policy --role-name $ROLE_NAME --policy-document file://$TMP/trust.json"


### PR DESCRIPTION
**Do not merge — owner vets first.**

## Incident (2026-09-01)

After the GitHub org rename `a-apin` → `aprin-labs`, **every production deploy from 16:55Z to 20:04Z** died at *Configure AWS credentials (OIDC)* with `Not authorized to perform sts:AssumeRoleWithWebIdentity`. Nothing was built; git kept working the whole time (GitHub redirects clones, STS does not), so the only symptom was a red deploy.

#1737 had already updated `setup-github-oidc.sh` to build `DEPLOY_BRANCH_SUB="repo:aprin-labs/archimedes:ref:refs/heads/main"`, that was applied to the role's trust policy — and it **still failed**. CloudTrail (`AssumeRoleWithWebIdentity`, `errorCode: AccessDenied`) showed the subject GitHub actually presents, in `userIdentity.userName`:

```
repo:aprin-labs@284008417/archimedes@1236816811:ref:refs/heads/main
```

the **id-qualified** ("immutable subject") form. Confirmed at the source:

```console
$ gh api repos/aprin-labs/archimedes/actions/oidc/customization/sub
{"use_default":true,"use_immutable_subject":false,"sub_claim_prefix":"repo:aprin-labs@284008417/archimedes@1236816811"}
```

`sub_claim_prefix` is the authoritative field. Deploys resumed once the role trusted both forms.

The real bug is not the string — it is that **we wrote the subject down as a constant when GitHub mints it and can change it under us.** This PR makes the script ask.

## What changed

`infra/scripts/setup-github-oidc.sh` (source of truth — the role is deliberately NOT Terraform-managed, `infra/ecs.tf` ~L374):

1. **Resolves the prefix from GitHub**: `gh api repos/${GITHUB_ORG}/${GITHUB_REPO}/actions/oidc/customization/sub --jq .sub_claim_prefix`. A `SUB_CLAIM_PREFIX=` env escape hatch exists for operators without `gh`. When it cannot ask, it falls back to the plain `repo:ORG/REPO` prefix behind a **loud multi-line warning** that names CloudTrail and the API call — never a quiet guess.
2. **Trusts BOTH forms.** The `StringLike` `sub` is now a **list**: `"<resolved-prefix>:ref:refs/heads/main"` and `"repo:ORG/REPO:ref:refs/heads/main"`, deduped when equal. A GitHub-side toggle of the immutable-subject format in **either** direction can no longer break deploys. Both entries are pinned to `:ref:refs/heads/main` — **main-only stays the rule**, no other branch or repo gains anything.
3. **Refuses to write a prefix that is not this repository** (new guard): must start with `repo:`, must be an owner/name pair, must contain only `[A-Za-z0-9._@/-]` (so a `*` cannot silently widen a `StringLike` condition or break out of the JSON), and after stripping any `@<id>` qualifier the segments must equal `aprin-labs` / `archimedes`.
4. **Header rewritten** with the two subject shapes, this incident, the CloudTrail field that reveals the truth (`userIdentity.userName` on the failed `AssumeRoleWithWebIdentity` event), and the operator recipe: after ANY rename/transfer run `AWS_PROFILE=<admin-profile> bash infra/scripts/setup-github-oidc.sh --apply`.
5. **Dry run prints the exact subjects AND the full trust policy** it would write, so a reviewer can compare against CloudTrail character for character before anything is applied.

The existing `--apply`/dry-run structure and the `gh repo view` nameWithOwner cross-check are unchanged.

Docs updated so the rule is not written down wrongly anywhere:

| File | What |
|---|---|
| `.github/workflows/deploy.yml` | "KNOWN SECURITY DEBT" #3 still said `repo:a-apin/archimedes:*`. Now: both subject shapes, which one this repo currently mints, the incident, the authoritative `gh api` call, and the re-run recipe. |
| `infra/ecs.tf` | The "NOT Terraform-managed" note now says the script also owns the **trust** policy and must be re-run after a rename. |
| `docs/runbooks/docs-site-setup.md` | The section that tells you to re-run the script for the docs-site grants now also tells you to re-run it after any rename, with the id-qualified subject and the CloudTrail pointer. |
| `infra/README.md` | Stale `gh api repos/a-apin/...` in the branch-protection snippet → `aprin-labs`. |

## Adversarial demo (mandatory)

All runs from the worktree with `AWS_PROFILE=ArchimedesDanAdmin`, **dry run only — `--apply` was never run, no IAM was touched.**

### 1. The OLD script would have printed only the subject that failed

```console
$ git show origin/main:infra/scripts/setup-github-oidc.sh > /tmp/old-setup-github-oidc.sh
$ AWS_PROFILE=ArchimedesDanAdmin bash /tmp/old-setup-github-oidc.sh
>>> DRY RUN — re-run with --apply to execute.

== Repo identity cross-check
  ok: GitHub reports aprin-labs/archimedes, matching the configured trust subject

== GitHub OIDC identity provider
  exists: arn:aws:iam::037613907429:oidc-provider/token.actions.githubusercontent.com

== Deploy role: archimedes-github-deploy (trusts repo:aprin-labs/archimedes:ref:refs/heads/main)
  role exists — updating trust policy
  + aws iam update-assume-role-policy --role-name archimedes-github-deploy --policy-document file://…/trust.json
```

`repo:aprin-labs/archimedes:ref:refs/heads/main` — **exactly the policy that produced the 3-hour outage**, and the dry run never shows the policy body, so a reviewer had nothing to compare against CloudTrail.

### 2. The NEW script prints the id-qualified subject too

```console
$ AWS_PROFILE=ArchimedesDanAdmin bash infra/scripts/setup-github-oidc.sh
>>> DRY RUN — re-run with --apply to execute.

== Repo identity cross-check
  ok: GitHub reports aprin-labs/archimedes, matching the configured trust subject

== OIDC subject prefix
  GitHub reports sub_claim_prefix = repo:aprin-labs@284008417/archimedes@1236816811
  subjects this run will trust (main only) — compare these character for
  character against CloudTrail userIdentity.userName on a failed
  AssumeRoleWithWebIdentity event:
    - repo:aprin-labs@284008417/archimedes@1236816811:ref:refs/heads/main
    - repo:aprin-labs/archimedes:ref:refs/heads/main

== GitHub OIDC identity provider
  exists: arn:aws:iam::037613907429:oidc-provider/token.actions.githubusercontent.com

== Deploy role: archimedes-github-deploy (2 trusted subject(s), main only)
  trust policy that would be written:
    { "Version":"2012-10-17",
      "Statement":[{
        "Effect":"Allow",
        "Principal":{"Federated":"arn:aws:iam::037613907429:oidc-provider/token.actions.githubusercontent.com"},
        "Action":"sts:AssumeRoleWithWebIdentity",
        "Condition":{
          "StringEquals":{"token.actions.githubusercontent.com:aud":"sts.amazonaws.com"},
          "StringLike":{"token.actions.githubusercontent.com:sub":["repo:aprin-labs@284008417/archimedes@1236816811:ref:refs/heads/main","repo:aprin-labs/archimedes:ref:refs/heads/main"]}
        } }] }
  role exists — updating trust policy
  + aws iam update-assume-role-policy --role-name archimedes-github-deploy --policy-document file://…/trust.json
```

### 3. Inputs that SHOULD fail the new guard, failing

Built the bad inputs on purpose and confirmed each is refused (exit 1) **before** anything is written:

```console
$ for bad in 'repo:*' 'repo:aprin-labs/*' 'repo:evil-org/archimedes' \
             'repo:aprin-labs@284008417/not-archimedes@1' \
             'repo:aprin-labs/archimedes","x":"*' 'aprin-labs/archimedes' 'repo:archimedes'; do
    SUB_CLAIM_PREFIX="$bad" AWS_PROFILE=ArchimedesDanAdmin bash infra/scripts/setup-github-oidc.sh >/dev/null 2>&1
    echo "exit=$? for '$bad'"
  done
exit=1 for 'repo:*'
exit=1 for 'repo:aprin-labs/*'
exit=1 for 'repo:evil-org/archimedes'
exit=1 for 'repo:aprin-labs@284008417/not-archimedes@1'
exit=1 for 'repo:aprin-labs/archimedes","x":"*'
exit=1 for 'aprin-labs/archimedes'
exit=1 for 'repo:archimedes'
```

with the reasons, e.g.

```
ERROR: refusing to write a trust policy for sub prefix 'repo:aprin-labs/*'.
       It contains a character outside [A-Za-z0-9._@/-] (a wildcard here would widen the trust policy).
       Expected 'repo:aprin-labs/archimedes' or the id-qualified
       'repo:aprin-labs@<org-id>/archimedes@<repo-id>'.

ERROR: refusing to write a trust policy for sub prefix 'repo:evil-org/archimedes'.
       Its owner segment is 'evil-org', not 'aprin-labs'.
```

The JSON-injection attempt (`repo:aprin-labs/archimedes","x":"*`) is refused by the same charset rule, so no crafted prefix can add a `Condition` key or a wildcard.

### 4. The gh-missing fallback is loud, not silent

```console
$ env -i HOME=$HOME PATH=/usr/bin:/bin ACCOUNT_ID=037613907429 bash infra/scripts/setup-github-oidc.sh
== Repo identity cross-check
  skipped: gh unavailable or unauthenticated — cannot confirm aprin-labs/archimedes

== OIDC subject prefix
  !! WARNING: could not read the sub prefix from GitHub (gh missing,
  !! unauthenticated, or the API call failed). Falling back to the PLAIN form:
  !!     repo:aprin-labs/archimedes
  !! If this repository mints the ID-QUALIFIED form
  !! (repo:ORG@<org-id>/REPO@<repo-id>) that fallback CANNOT match, and every
  !! deploy will fail at 'Configure AWS credentials (OIDC)'. Read the real
  !! subject from CloudTrail (AssumeRoleWithWebIdentity -> userIdentity.userName)
  !! or from
  !!     gh api repos/aprin-labs/archimedes/actions/oidc/customization/sub
  !! and re-run with SUB_CLAIM_PREFIX=<that value>.
```

(That run also proves bash 3.2 compatibility — it used `/bin/bash`, not Homebrew bash.)

### 5. Dedupe: if GitHub ever mints the plain form, one entry, not two

```console
$ SUB_CLAIM_PREFIX='repo:aprin-labs/archimedes' AWS_PROFILE=ArchimedesDanAdmin bash infra/scripts/setup-github-oidc.sh | grep StringLike
          "StringLike":{"token.actions.githubusercontent.com:sub":["repo:aprin-labs/archimedes:ref:refs/heads/main"]}
```

## Verification

- **The dry-run output matches the live role exactly** (read-only `get-role`), so applying this is a no-op today and self-correcting after the next rename:
  ```console
  $ aws iam get-role --role-name archimedes-github-deploy --query 'Role.AssumeRolePolicyDocument' --output json | jq -c '.Statement[0].Condition'
  {"StringEquals":{"token.actions.githubusercontent.com:aud":"sts.amazonaws.com"},"StringLike":{"token.actions.githubusercontent.com:sub":["repo:aprin-labs@284008417/archimedes@1236816811:ref:refs/heads/main","repo:aprin-labs/archimedes:ref:refs/heads/main"]}}
  ```
- The rendered trust policy parses as JSON (`jq`).
- `bash -n infra/scripts/setup-github-oidc.sh` clean. **`shellcheck` is not installed on this machine** — not run; happy to re-run if it is a gate.
- `terraform fmt -check infra/ecs.tf` ok (comment-only change).
- `deploy.yml` still parses as YAML (`yaml.safe_load`) — comment-only change.
- Docs gate: `docs_links.py` 1733 links, 0 broken; `docs_index.py` 174/174 indexed, 0 orphaned; staleness informational and unchanged.
- **No `--apply`, no IAM writes, no `gh api` writes.** Every AWS call in this session was read-only (`sts get-caller-identity`, `iam get-role`, `iam get-open-id-connect-provider`).

## Noted, deliberately out of scope

`.github/scripts/mkdocs_hooks.py` still rewrites out-of-tree doc links to `https://github.com/a-apin/archimedes/blob/main/...` (per `docs/runbooks/docs-site-setup.md` L210). Those survive on GitHub's rename redirect, so nothing is broken today, but it is the same stale-org class and wants its own PR — separate logical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx
