### PR TITLE
[product-truth] Library badge and rigor numbers come from the live gate, never the generation-time verdict (#1747)

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 from datetime import UTC
+from typing import TYPE_CHECKING
 
 import numpy as np
 from fastapi import APIRouter, Depends, Query, Request, Response
@@ -41,6 +42,12 @@ from archimedes.api.wallet_routes import get_linked_wallet_address
 from archimedes.models.strategy import Strategy, StrategyStatus
 from archimedes.services.live_rigor_gate import RigorGateVerdict
 from archimedes.services.rigor_evaluator import RigorGateResult
+
+if TYPE_CHECKING:
+    # Annotation only: `_live_generated_rigor` hands its caller the backtest row
+    # the gate graded. The runtime import stays inside that function, where the
+    # rest of the persisted-context reads already live.
+    from archimedes.models.backtest_store import BacktestResultRecord
 
 logger = logging.getLogger(__name__)
 
@@ -864,7 +871,7 @@ async def list_generated_strategies(
                 }
             verdicts = _live_generated_rigor(session, [i for i in page_ids if i in passports])
             for d in page:
-                verdict, rigor_result = verdicts.get(d["id"], (None, None))
+                verdict, rigor_result, graded_backtest = verdicts.get(d["id"], (None, None, None))
                 gate_status = verdict.status if verdict is not None else "pending"
                 d["rigor_gate_status"] = gate_status
                 # COUPLED to the four-state, never a separate stored boolean:
@@ -883,12 +890,17 @@ async def list_generated_strategies(
                 d["dsr_p_value"] = rigor_result.dsr_p_value if (graded and rigor_result) else None
                 d["pbo_score"] = rigor_result.pbo_score if (graded and rigor_result) else None
                 d["out_of_sample_sharpe"] = rigor_result.oos_sharpe if (graded and rigor_result) else None
-                # Display Sharpe is a descriptive backtest stat, not a gate
-                # output, so it comes from the passport row the gate re-graded —
-                # but it is still withheld unless that grading happened, so the
-                # headline number and the badge describe the same event.
-                passport = passports.get(d["id"])
-                d["sharpe_ratio"] = passport.sharpe_ratio if (graded and passport is not None) else None
+                # Display Sharpe is a descriptive backtest stat rather than a
+                # gate output, so it comes from the SAME `backtest_results` row
+                # the gate read its returns from — never from the denormalised
+                # `strategy_passports.sharpe_ratio`, which has no foreign key to
+                # backtest_results and routinely describes an older run (~155
+                # backtest rows per strategy; scripts/archive_backtest_results.py).
+                # Serving that column here printed a Sharpe of 1.4 beside a DSR
+                # computed from a series whose Sharpe was 0.031. Withheld unless
+                # the grading happened, so the headline number, the four rigor
+                # numbers and the badge all describe one event.
+                d["sharpe_ratio"] = graded_backtest.sharpe_ratio if (graded and graded_backtest is not None) else None
             # Citation truth: ``StrategyRecord.to_dict()`` returns source_papers
             # exactly as stored — arxiv_id, no title — so the Library card had no
             # real paper title to print and printed the generated strategy's own
@@ -1363,10 +1375,23 @@ def _passport_rigor_status(record, daily_returns: list[float]) -> tuple[str, boo
 
 def _live_generated_rigor(
     session, strategy_ids: list[str]
-) -> dict[str, tuple[RigorGateVerdict, RigorGateResult | None]]:
-    """LIVE four-state gate verdicts (+ the result each was reduced from) for a
-    page of GENERATED strategy ids — one ``run_rigor_gate`` per row, over that
-    row's OWN persisted returns and its OWN persisted grading context.
+) -> dict[str, tuple[RigorGateVerdict, RigorGateResult | None, BacktestResultRecord | None]]:
+    """LIVE four-state gate verdicts for a page of GENERATED strategy ids — one
+    ``run_rigor_gate`` per row, over that row's OWN persisted returns and its
+    OWN persisted grading context.
+
+    Each entry is ``(verdict, result, backtest_row)``. The third element is the
+    ``BacktestResultRecord`` the gate actually read its returns from — returned
+    rather than looked up again by the caller because the display Sharpe has to
+    describe THAT run and no other. ``latest_backtests_by_strategy`` and
+    ``get_all_daily_returns`` rank with the identical window
+    (``created_at DESC, id DESC``, backtest_repository.py), so the row handed
+    back here is the same physical row whose ``artifact_json`` produced
+    ``daily``. It is not ``strategy_passports.sharpe_ratio``: that column is a
+    denormalised snapshot with no foreign key to ``backtest_results`` (see
+    ``scripts/archive_backtest_results.py``, ~155 backtest rows per strategy),
+    so serving it beside these numbers prints a Sharpe from one run next to a
+    DSR from another.
 
     This is the batched form of ``selection_bias_routes._generated_strategy_rigor``
     (:676), and it is deliberately a re-use of that function's data path rather
@@ -1434,13 +1459,13 @@ def _live_generated_rigor(
         _rollback_quietly(session)
         return {}
 
-    graded: dict[str, tuple[RigorGateVerdict, RigorGateResult | None]] = {}
+    graded: dict[str, tuple[RigorGateVerdict, RigorGateResult | None, BacktestResultRecord | None]] = {}
     for sid in strategy_ids:
         daily = returns_by_id.get(sid) or []
         if len(daily) < _MIN_RETURNS_FOR_GATE:
             # Genuinely pre-backtest: the gate cannot run, so the badge is
             # "unknown". Never a boolean, and never the stored one.
-            graded[sid] = (RigorGateVerdict.pending(), None)
+            graded[sid] = (RigorGateVerdict.pending(), None, latest_by_id.get(sid))
             continue
         latest = latest_by_id.get(sid)
         num_trials, _num_trials_scope = _num_trials_for_generated_row(
@@ -1474,9 +1499,9 @@ def _live_generated_rigor(
             )
         except Exception as exc:  # pragma: no cover — defensive; gate-level failure
             logger.warning("generated badge: live gate failed for %s (→ pending): %s", sid, exc)
-            graded[sid] = (RigorGateVerdict.pending(), None)
+            graded[sid] = (RigorGateVerdict.pending(), None, latest)
             continue
-        graded[sid] = (RigorGateVerdict.from_result(result), result)
+        graded[sid] = (RigorGateVerdict.from_result(result), result, latest)
     return graded
 
 

--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -772,6 +772,16 @@ async def list_generated_strategies(
     canonical user; verified linked wallet handles legacy ``owner_wallet`` rows.
     Legacy ownerless rows remain invisible until purged (scripts/purge_orphan_generated.py)
     or published. Curated examples live on GET /api/strategies/ and stay public.
+
+    **The rigor badge on each row is a LIVE gate verdict (#1747)**, overlaid
+    below as ``rigor_gate_status`` (four-state) + ``passes_rigor_gate`` (the
+    fail-closed boolean coupled to it) + the four rigor numbers from that same
+    run. The row's own ``status`` and ``rigor_verdict`` are left on the wire
+    unchanged and are NOT the badge: they are the generation-time fusion
+    verdict, which is a different gate and is never re-derived after a backtest.
+    ``StrategyRecord.status`` is deliberately not written back — what the
+    synthesis gate thought is a fact worth keeping, and rewriting it has readers
+    (marketplace trending) outside this route.
     """
 
     from sqlalchemy import and_, or_
@@ -821,6 +831,64 @@ async def list_generated_strategies(
                 d["can_publish"] = r.id in publishable
                 d["generation_cost"] = costs.get(r.id)
                 page.append(d)
+            # ── Badge truth (#1747) ──────────────────────────────────────────
+            # `StrategyRecord.to_dict()` carries `status` and `rigor_verdict`,
+            # and BOTH are the GENERATION-TIME fusion verdict:
+            # `models/strategy_store.py` sets `status = "live" if
+            # rigor_verdict["passing"] else "rejected"` on the same write and
+            # nothing re-derives either after a backtest. The Library read them
+            # as its badge, so `status === 'live'` and `passes_rigor_gate ===
+            # true` were the SAME fact wearing two names — which is why the
+            # demotion rule the pill already had ("live" + gate failed →
+            # "Reference only") could never fire on this tab, and 21 rows the
+            # passport calls gate-failed rendered "Live ✓".
+            #
+            # Overlay a LIVE verdict instead. Not the stored
+            # `strategy_passports.passes_rigor_gate` either: that column is
+            # mixed-vintage (generation-time fusion verdict first, live re-grade
+            # only sometimes after) with no provenance column to tell the two
+            # apart — see `_live_generated_rigor`, which runs the same gate the
+            # Deploy ladder runs, batched for the page.
+            #
+            # Fail-closed by construction: a row with no `strategy_passports`
+            # row, or with too few persisted returns for the gate to run, is
+            # `pending`/None — never a boolean, and never green.
+            page_ids = [d["id"] for d in page]
+            passports = {}
+            if page_ids:
+                from archimedes.models.strategy_passport_record import StrategyPassportRecord
+
+                passports = {
+                    p.id: p
+                    for p in session.query(StrategyPassportRecord).filter(StrategyPassportRecord.id.in_(page_ids)).all()
+                }
+            verdicts = _live_generated_rigor(session, [i for i in page_ids if i in passports])
+            for d in page:
+                verdict, rigor_result = verdicts.get(d["id"], (None, None))
+                gate_status = verdict.status if verdict is not None else "pending"
+                d["rigor_gate_status"] = gate_status
+                # COUPLED to the four-state, never a separate stored boolean:
+                # `passes` is True only for "pass", and "pending" is not a
+                # boolean at all (a row nothing graded has no verdict to report,
+                # and `false` there would accuse it of failing).
+                d["passes_rigor_gate"] = None if gate_status == "pending" else (gate_status == "pass")
+                # The numbers come from the SAME gate run as the badge (#1187 /
+                # #868 rule, already enforced on the curated path in
+                # `_to_strategy_response`): a row that was not graded — pending,
+                # or degenerate, where the series carries no variance to grade —
+                # prints em-dashes, never the generation-time fusion verdict's
+                # DSR/PBO beside a non-pass pill.
+                graded = gate_status in ("pass", "fail")
+                d["deflated_sharpe_ratio"] = rigor_result.deflated_sharpe if (graded and rigor_result) else None
+                d["dsr_p_value"] = rigor_result.dsr_p_value if (graded and rigor_result) else None
+                d["pbo_score"] = rigor_result.pbo_score if (graded and rigor_result) else None
+                d["out_of_sample_sharpe"] = rigor_result.oos_sharpe if (graded and rigor_result) else None
+                # Display Sharpe is a descriptive backtest stat, not a gate
+                # output, so it comes from the passport row the gate re-graded —
+                # but it is still withheld unless that grading happened, so the
+                # headline number and the badge describe the same event.
+                passport = passports.get(d["id"])
+                d["sharpe_ratio"] = passport.sharpe_ratio if (graded and passport is not None) else None
             # Citation truth: ``StrategyRecord.to_dict()`` returns source_papers
             # exactly as stored — arxiv_id, no title — so the Library card had no
             # real paper title to print and printed the generated strategy's own
@@ -1291,6 +1359,125 @@ def _passport_rigor_status(record, daily_returns: list[float]) -> tuple[str, boo
     if record.sharpe_ratio is None:
         return "pending", True
     return ("pass" if bool(record.passes_rigor_gate) else "fail"), False
+
+
+def _live_generated_rigor(
+    session, strategy_ids: list[str]
+) -> dict[str, tuple[RigorGateVerdict, RigorGateResult | None]]:
+    """LIVE four-state gate verdicts (+ the result each was reduced from) for a
+    page of GENERATED strategy ids — one ``run_rigor_gate`` per row, over that
+    row's OWN persisted returns and its OWN persisted grading context.
+
+    This is the batched form of ``selection_bias_routes._generated_strategy_rigor``
+    (:676), and it is deliberately a re-use of that function's data path rather
+    than a second opinion about it: the same ``num_trials`` PROVENANCE rule
+    (``_num_trials_for_generated_row`` — a stored N is trusted only from a
+    pipeline that tracks its own selection pool), the same persisted
+    ``library_pbo`` with ``pbo_library_size`` left unset (no cohort-size
+    relaxation for a strategy that has no cohort), and the same look-ahead
+    triple from ``verdict_from_persisted_row`` (a retired ``self_attested``
+    boolean is a claim, not an audit, and does not deploy anything). Diverging
+    on any of those would let the Library badge and the Deploy gate disagree
+    about the same strategy — which is the #1747 defect one layer down.
+
+    **Why not the stored ``strategy_passports.passes_rigor_gate``.** That column
+    is MIXED-VINTAGE: its first writer is the generation-time FUSION verdict
+    (``generation_pipeline._persist_candidate`` writes
+    ``bool(c.rigor_verdict["passing"])``), and the post-backtest live re-grade
+    only replaces it when the refresh path actually reaches its write — both of
+    whose call sites swallow exceptions. There is no provenance column telling
+    the two apart, so reading it cannot distinguish "a gate ran and passed this"
+    from "a language model's synthesis-time score said passing". Running the
+    gate here is the only way the badge is a gate result.
+
+    **Cost, stated honestly.** ONE ``get_all_daily_returns`` and ONE
+    ``latest_backtests_by_strategy`` for the whole page — never per row — plus
+    one in-process ``run_rigor_gate`` per row that HAS enough persisted returns
+    to grade. The gate run is not cached (the returns are what a cache key would
+    have to be built from, and reading them is the expensive half — see
+    ``get_all_daily_returns``'s own note), so page cost scales with the number
+    of GRADEABLE rows on the page, bounded by this route's ``limit`` (<=200,
+    default 50). Rows with no persisted series cost nothing beyond the two
+    reads. Caching this per page is a real follow-up; serving a stale pass is
+    not an acceptable way to avoid it.
+
+    Any DB or gate failure degrades to ``pending`` for the affected rows — never
+    to a pass. Ids absent from the returned map are the caller's "no verdict"
+    case.
+    """
+    if not strategy_ids:
+        return {}
+
+    from archimedes.services.backtest_repository import (
+        get_all_daily_returns,
+        latest_backtests_by_strategy,
+    )
+    from archimedes.services.dsl_lookahead_audit import verdict_from_persisted_row
+
+    # The gate's own minimum, imported rather than re-typed as a literal 10:
+    # a badge that graded on fewer returns than the gate accepts would be a
+    # different gate wearing the same name.
+    from archimedes.services.live_rigor_gate import _MIN_RETURNS_FOR_GATE
+    from archimedes.services.rigor_evaluator import run_rigor_gate
+
+    try:
+        returns_by_id = get_all_daily_returns(session, strategy_ids) or {}
+        latest_by_id = latest_backtests_by_strategy(session, strategy_ids) or {}
+    except Exception as exc:  # pragma: no cover — defensive; DB-level failure
+        logger.warning(
+            "generated badge: persisted-context read failed (%s) — whole page → pending",
+            type(exc).__name__,
+        )
+        # A failed statement aborts the surrounding Postgres transaction; the
+        # rest of this request still has reads to do. (sqlite tolerates it,
+        # which is why this is written down rather than left to the suite.)
+        _rollback_quietly(session)
+        return {}
+
+    graded: dict[str, tuple[RigorGateVerdict, RigorGateResult | None]] = {}
+    for sid in strategy_ids:
+        daily = returns_by_id.get(sid) or []
+        if len(daily) < _MIN_RETURNS_FOR_GATE:
+            # Genuinely pre-backtest: the gate cannot run, so the badge is
+            # "unknown". Never a boolean, and never the stored one.
+            graded[sid] = (RigorGateVerdict.pending(), None)
+            continue
+        latest = latest_by_id.get(sid)
+        num_trials, _num_trials_scope = _num_trials_for_generated_row(
+            latest.backtest_engine if latest else None,
+            latest.num_trials_in_selection if latest else None,
+        )
+        look_ahead_passed, look_ahead_status, look_ahead_reason = verdict_from_persisted_row(
+            latest.look_ahead_audit_passed if latest else False,
+            latest.look_ahead_audit_source if latest else None,
+        )
+        try:
+            result = run_rigor_gate(
+                strategy_id=sid,
+                daily_returns=daily,
+                num_trials=num_trials,
+                # Persisted, per-row PBO — never a cohort recompute over other
+                # people's strategies. pbo_library_size stays unset on purpose
+                # (see _generated_strategy_rigor): the power-floor RELAXES
+                # criterion 4, and a single strategy has no cohort to earn that.
+                library_pbo=latest.pbo_score if latest else None,
+                look_ahead_audit_passed=look_ahead_passed,
+                look_ahead_status=look_ahead_status,
+                look_ahead_not_run_reason=look_ahead_reason,
+                # None on purpose: run_rigor_gate derives the in-sample
+                # denominator from the first 70% of this same series. Passing a
+                # full-sample Sharpe makes the OOS/IS cliff trivially passable.
+                in_sample_sharpe=None,
+                average_correlation=0.0,
+                # strictness_level intentionally omitted — the default IS the
+                # strictest level, which is the badge bar (#821).
+            )
+        except Exception as exc:  # pragma: no cover — defensive; gate-level failure
+            logger.warning("generated badge: live gate failed for %s (→ pending): %s", sid, exc)
+            graded[sid] = (RigorGateVerdict.pending(), None)
+            continue
+        graded[sid] = (RigorGateVerdict.from_result(result), result)
+    return graded
 
 
 def _passport_to_strategy_response(record, session=None, daily_returns=_RETURNS_NOT_PREFETCHED) -> StrategyResponse:

--- a/backend/tests/test_generated_badge_parity.py
+++ b/backend/tests/test_generated_badge_parity.py
@@ -30,7 +30,10 @@ What is pinned here:
   5. A genuinely passing series is still served ``pass`` / True: the fix must
      not have "fixed" the badge by never being green.
   6. The rigor NUMBERS come from the same gate run as the badge, and are absent
-     unless that run reached a pass/fail verdict.
+     unless that run reached a pass/fail verdict. The display Sharpe comes from
+     the same ``backtest_results`` row that run read its returns from — not from
+     ``strategy_passports.sharpe_ratio``, a denormalised snapshot with no
+     foreign key to ``backtest_results`` that routinely describes an older run.
   7. Page cost is constant in the number of rows — the passport read and the
      persisted-context reads are batched, never per row.
 
@@ -158,15 +161,30 @@ def _mk_passport(sid: str, *, passes_rigor_gate: bool = False, sharpe_ratio: flo
         session.commit()
 
 
-def _mk_backtest(sid: str, *, returns: list[float] | None, pbo: float | None = 0.05):
-    """Persist the row the live gate reads its returns and context from."""
+def _mk_backtest(
+    sid: str,
+    *,
+    returns: list[float] | None,
+    pbo: float | None = 0.05,
+    sharpe_ratio: float = 0.031,
+    content_hash: str | None = None,
+):
+    """Persist the row the live gate reads its returns and context from.
+
+    ``sharpe_ratio`` defaults to a value DISTINCT from every
+    ``strategy_passports.sharpe_ratio`` this file seeds (0.4 / 0.9 / 1.4 / 1.8),
+    so an assertion about the served display Sharpe can tell the two columns
+    apart. They are not the same number in prod either: the passport column is a
+    denormalised snapshot with no FK to ``backtest_results``.
+    """
     from archimedes.models.backtest_store import BacktestResultRecord
 
     with db.get_session() as session:
         session.add(
             BacktestResultRecord(
                 strategy_id=sid,
-                content_hash=f"bt_{sid}",
+                content_hash=content_hash or f"bt_{sid}",
+                sharpe_ratio=sharpe_ratio,
                 artifact_json=(
                     json.dumps({"results": [{"metrics": {"daily_returns": returns}}]}) if returns is not None else None
                 ),
@@ -357,7 +375,9 @@ async def test_rigor_numbers_come_from_the_live_run_not_the_stored_passport():
     assert g["deflated_sharpe_ratio"] != 0.87
     assert g["dsr_p_value"] != 0.99
     assert g["pbo_score"] == 0.05, "criterion-4 PBO is the persisted per-row value the deploy gate uses"
-    assert g["sharpe_ratio"] == 0.4, "display Sharpe is the graded passport's own number"
+    assert g["sharpe_ratio"] == 0.031, (
+        "display Sharpe is the GRADED backtest row's own number, not the passport snapshot (0.4)"
+    )
 
     u = rows[ungraded]
     assert u["rigor_gate_status"] == "pending"
@@ -369,6 +389,41 @@ async def test_rigor_numbers_come_from_the_live_run_not_the_stored_passport():
         "sharpe_ratio",
     ):
         assert u[field] is None, f"{field} must be absent on a row no gate graded"
+
+
+# ── 6b. The display Sharpe describes the run the gate graded ───────────────
+
+
+async def test_display_sharpe_is_the_graded_backtest_rows_own_number():
+    """The headline Sharpe must come from the SAME ``backtest_results`` row the
+    gate read its returns from — not ``strategy_passports.sharpe_ratio``.
+
+    That column is a denormalised snapshot with no foreign key to
+    ``backtest_results`` (``scripts/archive_backtest_results.py``: ~155 backtest
+    rows per strategy), so serving it prints a Sharpe from one run beside a DSR
+    computed from another. Seeded here as two backtest rows for one strategy: an
+    older PASSING series at Sharpe 9.9 and a newer FAILING one at 0.031, with a
+    passport snapshot of 1.4. Exactly one of those three numbers describes the
+    series the gate graded.
+    """
+    sid = "gen1747sharpevin"
+    _mk_strategy(sid, status="live", rigor_verdict={"passing": True})
+    _mk_passport(sid, passes_rigor_gate=True, sharpe_ratio=1.4)
+    # Older row first: same window (`created_at DESC, id DESC`) in
+    # get_all_daily_returns and latest_backtests_by_strategy, so the row
+    # inserted SECOND is the one both readers resolve to.
+    _mk_backtest(sid, returns=_passing_returns(), sharpe_ratio=9.9, content_hash=f"bt_{sid}_old")
+    _mk_backtest(sid, returns=_failing_returns(), sharpe_ratio=0.031, content_hash=f"bt_{sid}_new")
+
+    row = await _row(sid)
+    # The gate graded the NEWER series, so the badge is the newer verdict...
+    assert row["rigor_gate_status"] == "fail"
+    # ...and the Sharpe beside it is that same row's, not the passport's 1.4 and
+    # not the superseded run's 9.9.
+    assert row["sharpe_ratio"] == 0.031, (
+        f"served sharpe_ratio={row['sharpe_ratio']!r} — the display Sharpe and the rigor "
+        "numbers are describing two different backtest runs"
+    )
 
 
 # ── 7. Page cost is constant in the number of rows ─────────────────────────

--- a/backend/tests/test_generated_badge_parity.py
+++ b/backend/tests/test_generated_badge_parity.py
@@ -1,0 +1,430 @@
+"""GET /api/strategies/generated may never claim a rigor pass the gate did not give (#1747).
+
+The defect. ``list_generated_strategies`` returned ``StrategyRecord.to_dict()``
+and nothing else, so the Library's Generated tab took BOTH halves of its green
+badge from the same generation-time blob: ``status`` ("live") and
+``rigor_verdict["passing"]`` are written together by
+``models/strategy_store.py`` from the FUSION verdict and neither is ever
+re-derived after a backtest. The pill's own demotion arm — ``status === 'live'``
+AND the gate failed — was therefore structurally unreachable on that tab, and
+21 strategies whose own passport says "Reference only — gate failed" rendered
+"Live ✓".
+
+What is pinned here:
+
+  1. A row seeded exactly as prod holds it — ``StrategyRecord(status='live',
+     rigor_verdict={'passing': True})`` plus a passport row plus a healthy
+     persisted return series the LIVE gate fails — is served ``fail`` / False,
+     and agrees with ``GET /api/strategies/{id}`` for the same id.
+  2. A row with no ``strategy_passports`` row is ``pending`` / ``None`` — never
+     True, never False (nothing graded it, so "failed" would be a fresh lie).
+  3. **The stored column is not the source.** A row whose stored
+     ``strategy_passports.passes_rigor_gate`` is True, but whose live gate
+     fails, is served False. Overlaying the stored boolean instead of running
+     the gate passes tests 1 and 2 and fails this one — that is the whole point
+     of it. The column is mixed-vintage: its FIRST writer is the generation-time
+     fusion verdict (``generation_pipeline._persist_candidate``), and the live
+     re-grade replaces it only when the post-backtest refresh reaches its write.
+  4. A zero-variance persisted series is ``degenerate``, not ``fail`` and not
+     ``pending`` — it WAS evaluated, and there was nothing in it to grade.
+  5. A genuinely passing series is still served ``pass`` / True: the fix must
+     not have "fixed" the badge by never being green.
+  6. The rigor NUMBERS come from the same gate run as the badge, and are absent
+     unless that run reached a pass/fail verdict.
+  7. Page cost is constant in the number of rows — the passport read and the
+     persisted-context reads are batched, never per row.
+
+Hermetic (tmp-sqlite, no .env / network / Redis); DB fixture copies the
+``_use_tmp_db`` pattern from test_generated_citation_truth.py.
+
+Gate:
+  env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \\
+      backend/tests/test_generated_badge_parity.py -q -p no:cacheprovider
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import archimedes.db as db
+import numpy as np
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
+
+_W_OWNER = "0xAbC0000000000000000000000000000000000001"
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    """Point the DB at a FRESH temp sqlite (rebinds db.engine + db.SessionLocal).
+
+    db.engine/SessionLocal are built once at import, so setenv alone re-points
+    nothing — both have to be rebound to a per-test engine before init_db().
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'badge.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+# ── Return series with KNOWN live-gate verdicts ─────────────────────────────
+#
+# Deliberately not "a series that looks plausible": each is chosen because the
+# real ``run_rigor_gate`` gives it the verdict this file names, so a test that
+# claims "the live gate fails this" is checkable rather than asserted.
+
+
+def _failing_returns(n: int = 300) -> list[float]:
+    """Zero-drift noise: real variance, Sharpe ~0 → the live gate FAILS on DSR."""
+    return np.random.default_rng(7).normal(0.0, 0.01, n).tolist()
+
+
+def _passing_returns(n: int = 300) -> list[float]:
+    """Strong, non-degenerate → the live gate PASSES at the strictest level."""
+    return np.random.default_rng(42).normal(0.0018, 0.006, n).tolist()
+
+
+def _flat_returns(n: int = 300) -> list[float]:
+    """Zero variance → DEGENERATE: evaluated, and unevaluable."""
+    return [0.0] * n
+
+
+def _mk_strategy(
+    sid: str,
+    *,
+    status: str = "live",
+    rigor_verdict: dict | None = None,
+    owner: str = _W_OWNER,
+):
+    """The generation-time record, seeded the way the pipeline writes it."""
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with db.get_session() as session:
+        session.add(
+            StrategyRecord(
+                id=sid,
+                content_hash=("0x" + sid).ljust(66, "0"),
+                generation_method="fusion",
+                source_papers="[]",
+                strategy_name=f"Strategy {sid}",
+                thesis="test thesis",
+                asset_universe="[]",
+                risk_profile="moderate",
+                status=status,
+                rigor_verdict=json.dumps(rigor_verdict) if rigor_verdict is not None else None,
+                is_example=False,
+                owner_wallet=owner.lower(),
+                is_published=False,
+            )
+        )
+        session.commit()
+
+
+def _mk_passport(sid: str, *, passes_rigor_gate: bool = False, sharpe_ratio: float | None = 0.4):
+    from archimedes.models.strategy_passport_record import StrategyPassportRecord
+
+    with db.get_session() as session:
+        session.add(
+            StrategyPassportRecord(
+                id=sid,
+                content_hash=("0y" + sid).ljust(66, "0"),
+                generation_method="fusion",
+                methodology_summary="test",
+                asset_universe="[]",
+                status="live",
+                passes_rigor_gate=passes_rigor_gate,
+                sharpe_ratio=sharpe_ratio,
+                # The generation-time fusion numbers. Nothing may serve these
+                # beside a non-pass badge (#1187 / #868).
+                deflated_sharpe_ratio=0.87,
+                dsr_p_value=0.99,
+                pbo_score=0.02,
+                out_of_sample_sharpe=1.9,
+            )
+        )
+        session.commit()
+
+
+def _mk_backtest(sid: str, *, returns: list[float] | None, pbo: float | None = 0.05):
+    """Persist the row the live gate reads its returns and context from."""
+    from archimedes.models.backtest_store import BacktestResultRecord
+
+    with db.get_session() as session:
+        session.add(
+            BacktestResultRecord(
+                strategy_id=sid,
+                content_hash=f"bt_{sid}",
+                artifact_json=(
+                    json.dumps({"results": [{"metrics": {"daily_returns": returns}}]}) if returns is not None else None
+                ),
+                num_trials_in_selection=1,
+                pbo_score=pbo,
+                look_ahead_audit_passed=True,
+                look_ahead_audit_source=None,
+                source_pipeline="test",
+                backtest_engine=None,
+            )
+        )
+        session.commit()
+
+
+async def _generated_rows() -> list[dict]:
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["degraded"] is False, body["degraded_reason"]
+    return body["strategies"]
+
+
+async def _row(sid: str) -> dict:
+    rows = {r["id"]: r for r in await _generated_rows()}
+    assert sid in rows, f"{sid} missing from the generated list: {sorted(rows)}"
+    return rows[sid]
+
+
+async def _detail(sid: str) -> dict:
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/strategies/{sid}", cookies=_siwe_cookies(_W_OWNER))
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ── 1. The prod shape: synthesis said pass, the live gate says fail ─────────
+
+
+async def test_generation_time_pass_does_not_survive_a_failing_live_gate():
+    """The exact 21-row prod state, and the parity claim #1747 is about.
+
+    ``status='live'`` + ``rigor_verdict={'passing': True}`` is what the fusion
+    gate wrote; the persisted series is what the rigor gate actually has to
+    grade. The Library must report the second, and must not disagree with the
+    strategy's own detail page about it.
+    """
+    sid = "gen1747000000fail"
+    _mk_strategy(sid, status="live", rigor_verdict={"passing": True, "dsr": 0.8, "pbo": 0.02})
+    _mk_passport(sid, passes_rigor_gate=False, sharpe_ratio=0.4)
+    _mk_backtest(sid, returns=_failing_returns())
+
+    row = await _row(sid)
+    assert row["rigor_gate_status"] == "fail"
+    assert row["passes_rigor_gate"] is False
+
+    # The generation-time blob is still ON THE WIRE unchanged — the fix is a
+    # read-side overlay, not a rewrite of what the synthesis gate thought.
+    assert row["status"] == "live"
+    assert row["rigor_verdict"]["passing"] is True
+
+    # ...and the badge the Library renders now agrees with the badge the
+    # strategy's own passport page renders. Before the fix these were "Live ✓"
+    # and "Reference only — gate failed" for the same id.
+    detail = await _detail(sid)
+    assert row["passes_rigor_gate"] == detail["passes_rigor_gate"]
+    assert row["rigor_gate_status"] == detail["rigor_gate_status"]
+
+
+# ── 2. No passport row → nothing graded it ─────────────────────────────────
+
+
+async def test_row_without_a_passport_is_pending_not_a_boolean():
+    sid = "gen1747000pending"
+    _mk_strategy(sid, status="live", rigor_verdict={"passing": True})
+
+    row = await _row(sid)
+    assert row["rigor_gate_status"] == "pending"
+    assert row["passes_rigor_gate"] is None, (
+        "an ungraded row must carry no boolean at all — False would accuse it of failing a gate that never ran"
+    )
+
+
+async def test_passport_row_with_no_persisted_returns_is_pending():
+    """A passport exists but the backtest has not produced a series yet."""
+    sid = "gen1747000norets"
+    _mk_strategy(sid, status="live", rigor_verdict={"passing": True})
+    _mk_passport(sid, passes_rigor_gate=True, sharpe_ratio=1.4)
+
+    row = await _row(sid)
+    assert row["rigor_gate_status"] == "pending"
+    assert row["passes_rigor_gate"] is None
+
+
+# ── 3. The mutation-kill: the stored column is NOT the source ──────────────
+
+
+async def test_stored_passport_true_does_not_survive_a_failing_live_gate():
+    """Seeded so that overlaying ``strategy_passports.passes_rigor_gate``
+    instead of running the gate would serve True.
+
+    This is the assertion that separates "the badge is a gate result" from "the
+    badge is a stored boolean of unknown vintage". That column's first writer is
+    the generation-time fusion verdict, and there is no provenance column to
+    tell a fresh live verdict from a stale synthesis one — so reading it is
+    reading a claim, whichever value it happens to hold.
+    """
+    sid = "gen1747storedtru"
+    _mk_strategy(sid, status="live", rigor_verdict={"passing": True})
+    _mk_passport(sid, passes_rigor_gate=True, sharpe_ratio=1.4)
+    _mk_backtest(sid, returns=_failing_returns())
+
+    row = await _row(sid)
+    assert row["passes_rigor_gate"] is False, "the stored True must not reach the badge"
+    assert row["rigor_gate_status"] == "fail"
+
+    # And the DB column is untouched: this is a read-side overlay, not a
+    # write-back that would destroy the record of what the pipeline wrote.
+    from archimedes.services.passport_loader import get_passport
+
+    with db.get_session() as session:
+        assert get_passport(session, sid).passes_rigor_gate is True
+
+
+# ── 4. Degenerate is its own answer ────────────────────────────────────────
+
+
+async def test_zero_variance_series_is_degenerate_not_fail_or_pending():
+    sid = "gen1747000degen0"
+    _mk_strategy(sid, status="live", rigor_verdict={"passing": True})
+    _mk_passport(sid, passes_rigor_gate=True, sharpe_ratio=0.9)
+    _mk_backtest(sid, returns=_flat_returns())
+
+    row = await _row(sid)
+    assert row["rigor_gate_status"] == "degenerate", (
+        "a flat persisted series was evaluated and found unevaluable — that is neither 'pending' nor 'fail'"
+    )
+    assert row["passes_rigor_gate"] is False
+
+
+# ── 5. The badge can still be green when a gate says so ────────────────────
+
+
+async def test_live_gate_pass_is_served_as_a_pass():
+    """Inverse control. A fix that made everything non-green would satisfy every
+    assertion above and still be a lie."""
+    sid = "gen1747000000pas"
+    # status "rejected" on purpose: the SYNTHESIS gate rejected this one. The
+    # live gate is the authority, in both directions.
+    _mk_strategy(sid, status="rejected", rigor_verdict={"passing": False})
+    _mk_passport(sid, passes_rigor_gate=False, sharpe_ratio=1.8)
+    _mk_backtest(sid, returns=_passing_returns())
+
+    row = await _row(sid)
+    assert row["rigor_gate_status"] == "pass"
+    assert row["passes_rigor_gate"] is True
+
+
+# ── 6. The numbers come from the same run as the badge ─────────────────────
+
+
+async def test_rigor_numbers_come_from_the_live_run_not_the_stored_passport():
+    """Both directions of the #1187 rule on this route.
+
+    A graded row's DSR/PBO/OOS/dsr_p are the LIVE run's, so they cannot be the
+    generation-time fusion numbers seeded on the passport; an ungraded row's are
+    absent, so no row ever prints a confident statistic beside a non-verdict.
+    """
+    graded = "gen1747numsgrade"
+    _mk_strategy(graded, status="live", rigor_verdict={"passing": True})
+    _mk_passport(graded, passes_rigor_gate=True, sharpe_ratio=0.4)
+    _mk_backtest(graded, returns=_failing_returns())
+
+    ungraded = "gen1747numspend0"
+    _mk_strategy(ungraded, status="live", rigor_verdict={"passing": True, "dsr": 0.8})
+    _mk_passport(ungraded, passes_rigor_gate=True, sharpe_ratio=1.4)
+
+    rows = {r["id"]: r for r in await _generated_rows()}
+
+    g = rows[graded]
+    assert g["rigor_gate_status"] == "fail"
+    assert g["deflated_sharpe_ratio"] is not None
+    # The seeded passport/fusion values, which must NOT be what is served.
+    assert g["deflated_sharpe_ratio"] != 0.87
+    assert g["dsr_p_value"] != 0.99
+    assert g["pbo_score"] == 0.05, "criterion-4 PBO is the persisted per-row value the deploy gate uses"
+    assert g["sharpe_ratio"] == 0.4, "display Sharpe is the graded passport's own number"
+
+    u = rows[ungraded]
+    assert u["rigor_gate_status"] == "pending"
+    for field in (
+        "deflated_sharpe_ratio",
+        "dsr_p_value",
+        "pbo_score",
+        "out_of_sample_sharpe",
+        "sharpe_ratio",
+    ):
+        assert u[field] is None, f"{field} must be absent on a row no gate graded"
+
+
+# ── 7. Page cost is constant in the number of rows ─────────────────────────
+
+
+def _capture_sql(engine) -> tuple[list[str], object]:
+    """Attach a before_cursor_execute listener; return (statements, detach).
+
+    Same engine-boundary counter as test_publishable_strategy_ids.py — measuring
+    at the engine is what makes "batched" checkable rather than asserted.
+    """
+    statements: list[str] = []
+
+    def _on_exec(_conn, _cursor, statement, _params, _context, _executemany) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _on_exec)
+
+    def _detach() -> None:
+        event.remove(engine, "before_cursor_execute", _on_exec)
+
+    return statements, _detach
+
+
+def _selects_touching(statements: list[str], table: str) -> list[str]:
+    return [s for s in statements if s.lstrip().upper().startswith("SELECT") and table in s]
+
+
+async def _sql_for_page(n_rows: int, *, tag: str) -> list[str]:
+    for i in range(n_rows):
+        sid = f"gen1747{tag}{i:05d}"
+        _mk_strategy(sid, status="live", rigor_verdict={"passing": True})
+        _mk_passport(sid, passes_rigor_gate=False, sharpe_ratio=0.4)
+        _mk_backtest(sid, returns=_failing_returns())
+
+    statements, detach = _capture_sql(db.engine)
+    try:
+        rows = await _generated_rows()
+    finally:
+        detach()
+    assert len(rows) >= n_rows
+    return statements
+
+
+async def test_badge_overlay_is_batched_not_per_row():
+    """The passport read and the persisted-context reads must not scale with the
+    page. Compared at two page sizes rather than pinned to a magic number, so
+    the assertion survives an unrelated query being added elsewhere on the route
+    but cannot survive an N+1 in the overlay."""
+    small = await _sql_for_page(1, tag="cst")
+    small_passports = len(_selects_touching(small, "strategy_passports"))
+    small_backtests = len(_selects_touching(small, "backtest_results"))
+
+    big = await _sql_for_page(5, tag="cbg")  # 6 rows on the page now, not 1
+    assert len(_selects_touching(big, "strategy_passports")) == small_passports
+    assert len(_selects_touching(big, "backtest_results")) == small_backtests
+    # And the counter can actually see an N+1: it saw more than zero of each.
+    assert small_passports >= 1
+    assert small_backtests >= 1

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -21,6 +21,11 @@ import {
   UNKNOWN_RIGOR_TITLE,
 } from '../rigorGateStatus.js'
 import { signClass } from '../signClass.js'
+// The library status pill lives in a plain module so it can be executed by a
+// test (#1747) — `.jsx` is not importable under `node --test`. It consumes the
+// four-state rigor_gate_status, so a row nothing graded can no longer render a
+// green "Live".
+import { statusTag, statusLabel } from '../libraryStatus.js'
 import { strategies as ROADMAP_COPY } from '../roadmapCopyApp.js'
 
 // A compact "deployable at your level" chip for a library row, driven by the
@@ -114,21 +119,6 @@ function downloadStrategy(strategy, format) {
   const a = document.createElement('a')
   a.href = url; a.download = filename; a.click()
   URL.revokeObjectURL(url)
-}
-
-function statusTag(status, passesRigor) {
-  if (status === 'live' && passesRigor === false) return 'tag-muted'
-  if (status === 'live') return 'tag-positive'
-  if (status === 'validated') return 'tag-accent'
-  if (status === 'pending_backtest') return 'tag-warning'
-  return 'tag-muted'
-}
-
-function statusLabel(status, passesRigor) {
-  if (status === 'live' && passesRigor === false) return 'Reference only — gate failed'
-  if (status === 'pending_backtest') return 'Pending Backtest'
-  if (!status) return 'Candidate'
-  return status.charAt(0).toUpperCase() + status.slice(1)
 }
 
 // No local number formatter lives here any more. Every metric this file renders
@@ -289,10 +279,10 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
         <td>
           <div className="flex items-center gap-1.5 flex-wrap">
             <span
-              className={`tag ${statusTag(s.status, s.passes_rigor_gate)}`}
+              className={`tag ${statusTag(s.status, s.passes_rigor_gate, s.rigor_gate_status)}`}
               title={s.status === 'pending_backtest' ? 'Generated but the rigor gate has not scored real metrics yet — DSR / PBO / OOS Sharpe pending a backtest run.' : undefined}
             >
-              {statusLabel(s.status, s.passes_rigor_gate)}
+              {statusLabel(s.status, s.passes_rigor_gate, s.rigor_gate_status)}
             </span>
             {/* These UnoCSS icons render as a CSS mask on an empty <span>, so
                 without role/aria-label they contribute nothing to the
@@ -585,10 +575,10 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
       </div>
       <div className="lib-card-badges">
         <span
-          className={`tag ${statusTag(s.status, s.passes_rigor_gate)}`}
+          className={`tag ${statusTag(s.status, s.passes_rigor_gate, s.rigor_gate_status)}`}
           title={s.status === 'pending_backtest' ? 'Generated but the rigor gate has not scored real metrics yet — DSR / PBO / OOS Sharpe pending a backtest run.' : undefined}
         >
-          {statusLabel(s.status, s.passes_rigor_gate)}
+          {statusLabel(s.status, s.passes_rigor_gate, s.rigor_gate_status)}
         </span>
         <DeployabilityChip deploy={deploy} level={level} gatePending={gatePending} />
       </div>
@@ -742,11 +732,15 @@ function coerceGenerated(row) {
   // the title. Never row.created_at — that is when the STRATEGY was generated,
   // and printing it under a paper citation invented a publication date.
   const paperYear = typeof citedPaper?.resolved_year === 'number' ? citedPaper.resolved_year : null
-  // rigor_verdict is the real shape the backend persists (see
-  // StrategyRecord.to_dict() in backend/archimedes/models/strategy_store.py
-  // and generation_pipeline.py ~line 1272): {dsr, dsr_p_value, pbo,
-  // oos_sharpe, passing}. Read from there rather than nonexistent top-level
-  // fields — fall back to null only when rigor_verdict itself is absent.
+  // rigor_verdict is the GENERATION-TIME fusion verdict the backend persists on
+  // StrategyRecord ({dsr, dsr_p_value, pbo, oos_sharpe, passing}). It is NOT a
+  // rigor-gate result: a different gate produced it, at synthesis time, and
+  // nothing re-derives it after a backtest. #1747 — every rigor CLAIM this row
+  // renders (the pill, the check/X, DSR, PBO, OOS, dsr_p) now comes from the
+  // server's LIVE four-state verdict instead, and this blob is read for exactly
+  // one thing: whether any statistics exist at all, which decides the
+  // "rejected" → "pending_backtest" relabel below. Do not re-source a metric
+  // from it.
   const verdict = row.rigor_verdict || null
   const hasRealMetrics = verdict?.dsr != null || row.sharpe_ratio != null
   // Honest status mapping: the generation pipeline persists status="rejected"
@@ -772,19 +766,29 @@ function coerceGenerated(row) {
     methodology_summary: row.thesis || '',
     status: honestStatus,
     asset_universe: row.asset_universe || [],
-    sharpe_ratio: null,
+    // Served by /api/strategies/generated from the live gate run that produced
+    // the badge below, and served as null unless that run reached a pass/fail —
+    // so the numbers and the pill always describe the same event (#1747). They
+    // used to come from `verdict` (the synthesis blob above), which is how a row
+    // could print a passing DSR beside a "gate failed" pill.
+    sharpe_ratio: row.sharpe_ratio ?? null,
     cagr: null,
     max_drawdown: null,
     correlation_to_spy: null,
-    deflated_sharpe_ratio: verdict?.dsr ?? null,
-    pbo_score: verdict?.pbo ?? null,
-    out_of_sample_sharpe: verdict?.oos_sharpe ?? null,
+    deflated_sharpe_ratio: row.deflated_sharpe_ratio ?? null,
+    pbo_score: row.pbo_score ?? null,
+    out_of_sample_sharpe: row.out_of_sample_sharpe ?? null,
     paper_claimed_sharpe: null,
     backtest_start: null,
     backtest_end: null,
     is_backtest_placeholder: true,
-    passes_rigor_gate: verdict ? Boolean(verdict.passing) : null,
-    dsr_p_value: verdict?.dsr_p_value ?? null,
+    // The rigor badge. A LITERAL boolean from the server or nothing: `null` is
+    // the honest "no verdict", and the four-state below says which non-verdict
+    // it was. Anything looser — Boolean(...) over a missing field, or a fall
+    // back to the synthesis verdict's `passing` — manufactures a claim.
+    passes_rigor_gate: typeof row.passes_rigor_gate === 'boolean' ? row.passes_rigor_gate : null,
+    rigor_gate_status: row.rigor_gate_status ?? null,
+    dsr_p_value: row.dsr_p_value ?? null,
     // No real backtest has run yet on a pre-backtest hypothesis, so there is
     // no CI to report — honestly null, on the real field names (#1361).
     sharpe_ci_lower: null,

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -197,12 +197,12 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
   // #1358: a strategy with ZERO statistics computed must render as honestly
   // unknown, never as a failed rigor gate. rigor_gate_status is the
   // four-state badge curated/generated StrategyResponse rows carry
-  // ("pass"|"fail"|"pending"|"degenerate"); coerceGenerated's own rows don't
-  // set it at all but already encode the same "no verdict yet" case as
-  // passes_rigor_gate === null (see Strategies.jsx's coerceGenerated) — both
-  // checked so the same pending treatment applies on the Examples and
-  // Generated tabs alike. Checked BEFORE the true/false badge below so a
-  // pending row can never fall through to the "does not pass" X.
+  // ("pass"|"fail"|"pending"|"degenerate"); coerceGenerated sets it explicitly
+  // from the server's live verdict (#1747) and encodes the same "no verdict
+  // yet" case as passes_rigor_gate === null — both checked so the same pending
+  // treatment applies on the Examples and Generated tabs alike. Checked BEFORE
+  // the true/false badge below so a pending row can never fall through to the
+  // "does not pass" X.
   const isPending = s.rigor_gate_status === 'pending' || s.passes_rigor_gate == null
   // #1358 round-3: "degenerate" is the fourth state, and it belongs in the same
   // NEUTRAL bucket as pending — never the red "does not pass" X, because
@@ -781,7 +781,15 @@ function coerceGenerated(row) {
     paper_claimed_sharpe: null,
     backtest_start: null,
     backtest_end: null,
-    is_backtest_placeholder: true,
+    // A row the LIVE gate graded (pass|fail) is not a pre-backtest hypothesis:
+    // it has a persisted return series, which is the only thing the gate can
+    // grade. Left hardcoded `true`, metricDomain.absenceReason (:298-305) would
+    // title that row's empty CAGR / max-drawdown cells "PENDING — no backtest
+    // has run on this strategy yet" on the SAME row whose pill says the gate
+    // ran and failed. Before #1747 that pill was structurally unreachable here,
+    // so the self-contradiction could not occur; it is newly reachable.
+    // `pending` and `degenerate` stay `true` — for those the sentence is right.
+    is_backtest_placeholder: !(row.rigor_gate_status === 'pass' || row.rigor_gate_status === 'fail'),
     // The rigor badge. A LITERAL boolean from the server or nothing: `null` is
     // the honest "no verdict", and the four-state below says which non-verdict
     // it was. Anything looser — Boolean(...) over a missing field, or a fall

--- a/ui/src/libraryStatus.js
+++ b/ui/src/libraryStatus.js
@@ -1,0 +1,101 @@
+// The Library's status pill — class and label — in ONE importable module.
+//
+// #1747. These two functions used to be module-private in Strategies.jsx, so
+// nothing under ui/test/ could execute them (`.jsx` is not importable under
+// `node --test`, see ui/test/account-management.test.js) and the pill was
+// unpinned by any assertion. The rule they encode is a CLAIM about a strategy —
+// green means "this passed the rigor gate" — which makes it exactly the kind of
+// thing that must be tested by running it, not by reading the source.
+//
+// The rule, stated once:
+//
+//   A green pill requires an AFFIRMATIVE gate pass. It is not enough for the
+//   row's admin `status` to say "live". `status` on a generated row is written
+//   from the GENERATION-TIME fusion verdict and never re-derived after a
+//   backtest (backend/archimedes/models/strategy_store.py couples
+//   `status="live"` to `rigor_verdict["passing"]` on the same write), so before
+//   #1747 the Library's `status === 'live'` and its `passes_rigor_gate === true`
+//   were the same fact wearing two names — and the demotion arm below could
+//   never fire on the Generated tab. The backend now serves a LIVE four-state
+//   `rigor_gate_status` on those rows; this module consumes it.
+//
+// Four states, four different sentences. The one thing none of them may do is
+// claim something a gate did not say:
+//
+//   pass        → green "Live"                        (a gate ran and passed)
+//   fail        → muted "Reference only — gate failed" (a gate ran and failed)
+//   pending     → muted "Not yet graded"               (no gate ran — NOT a failure)
+//   degenerate  → muted "Unevaluable — flat returns"   (a gate ran; the series
+//                                                       had no variance to grade)
+//
+// `pending` deliberately does NOT get the "gate failed" label. Widening the
+// boolean test from `=== false` to `!== true` and leaving one label would have
+// been the smaller diff, and it would have put "Reference only — gate failed"
+// on the same row as the clock icon titled "Not yet evaluated — no backtest data
+// for the rigor gate to score" (Strategies.jsx) — one row asserting two
+// contradictory things, the failing one about a verdict nothing produced. That
+// is the #1358 defect class, re-committed.
+
+/** The demotion label, byte-identical to the literal in
+ *  ui/src/components/StrategyPassport.jsx.
+ *
+ *  The passport is NOT refactored onto this module: its `statusTag`/
+ *  `statusLabel` are near-duplicates, not duplicates — it maps `validated` to
+ *  green (the Library maps it to accent), maps `rejected`/`retired` to muted,
+ *  defaults unknown statuses to accent rather than muted, and has no
+ *  `pending_backtest` arm at all. Collapsing two different rules into one
+ *  "shared" function would have changed the passport's rendering as a side
+ *  effect of a Library fix. What MUST agree between the two surfaces is this
+ *  sentence, and ui/test/library-status.test.js pins that by reading the
+ *  passport's source. */
+export const GATE_FAILED_LABEL = "Reference only — gate failed";
+
+/** Ungraded, and saying so. Owner may prefer different copy — this is the
+ *  wording defaulted in #1747, not a decided product string. What it may not go
+ *  back to being is "Live" (a claim) or "gate failed" (a different claim). */
+export const NOT_GRADED_LABEL = "Not yet graded";
+
+/** #1184's fourth state: a persisted return series with zero variance — broken
+ *  data or a zero-trade backtest. Not "pending" (it WAS evaluated) and not
+ *  "failed" (there was nothing to grade). */
+export const DEGENERATE_LABEL = "Unevaluable — flat returns";
+
+/** Did a rigor gate affirmatively PASS this row?
+ *
+ * When the four-state verdict is on the wire it is the whole answer — including
+ * when it disagrees with the boolean, in which case the four-state wins and the
+ * row is not green. `null`/`undefined` means this payload carries no four-state
+ * (a caller or a build that predates it), and only then does the fail-closed
+ * boolean decide; `null` there is "no verdict", which is not a pass.
+ */
+export function isGatePass(passesRigor, rigorGateStatus) {
+	if (rigorGateStatus != null) return rigorGateStatus === "pass";
+	return passesRigor === true;
+}
+
+/** Pill CSS class for a library row. */
+export function statusTag(status, passesRigor, rigorGateStatus) {
+	// The only green-producing branch, and it is gated on an affirmative pass.
+	// Note this is NOT `passesRigor === false`: a row whose verdict never
+	// arrived has nothing to be green about either.
+	if (status === "live" && !isGatePass(passesRigor, rigorGateStatus)) return "tag-muted";
+	if (status === "live") return "tag-positive";
+	if (status === "validated") return "tag-accent";
+	if (status === "pending_backtest") return "tag-warning";
+	return "tag-muted";
+}
+
+/** Pill text for a library row. */
+export function statusLabel(status, passesRigor, rigorGateStatus) {
+	if (status === "live" && !isGatePass(passesRigor, rigorGateStatus)) {
+		// Order matters: each arm names what actually happened, so the most
+		// specific non-verdict is answered before the generic failure.
+		if (rigorGateStatus === "degenerate") return DEGENERATE_LABEL;
+		if (rigorGateStatus === "fail" || passesRigor === false) return GATE_FAILED_LABEL;
+		// "pending", and the no-four-state/no-boolean row: nothing graded this.
+		return NOT_GRADED_LABEL;
+	}
+	if (status === "pending_backtest") return "Pending Backtest";
+	if (!status) return "Candidate";
+	return status.charAt(0).toUpperCase() + status.slice(1);
+}

--- a/ui/test/library-status.test.js
+++ b/ui/test/library-status.test.js
@@ -27,6 +27,7 @@ import {
 	statusLabel,
 	statusTag,
 } from "../src/libraryStatus.js";
+import { absenceReason } from "../src/metricDomain.js";
 
 const strategies = readFileSync(
 	new URL("../src/components/Strategies.jsx", import.meta.url),
@@ -138,13 +139,18 @@ test("the rigor numbers no longer come from rigor_verdict either", () => {
 		"verdict?.dsr_p_value",
 	]) {
 		// `verdict?.dsr != null` (the hasRealMetrics probe, which decides a label
-		// relabel and never a metric) is the one permitted read.
-		const idx = strategies.indexOf(dead);
-		const permitted = idx !== -1 && strategies.slice(idx).startsWith("verdict?.dsr != null");
-		assert.ok(
-			idx === -1 || permitted,
-			`Strategies.jsx renders ${dead} — the fusion verdict's numbers beside a live-gate pill`,
-		);
+		// relabel and never a metric) is the one permitted read. EVERY occurrence
+		// is scanned, not just the first: `indexOf` alone made this loop vacuous
+		// for the one field that actually regresses, because the permitted probe
+		// sits ABOVE the return object — a re-sourced `deflated_sharpe_ratio:
+		// verdict?.dsr ?? null` further down would hide behind it.
+		let idx = -1;
+		while ((idx = strategies.indexOf(dead, idx + 1)) !== -1) {
+			assert.ok(
+				strategies.slice(idx).startsWith("verdict?.dsr != null"),
+				`Strategies.jsx renders ${dead} — the fusion verdict's numbers beside a live-gate pill`,
+			);
+		}
 	}
 });
 
@@ -171,5 +177,69 @@ test("both the desktop pill and the mobile lib-card call the shared helpers", ()
 		strategies.includes("from '../libraryStatus.js'"),
 		"Strategies.jsx must import the helpers rather than re-declaring them privately — " +
 			"module-private is how they went untested through #1747",
+	);
+});
+
+// ── The empty cells beside a graded pill ───────────────────────────────────
+
+test("a graded row's empty cells do not claim that no backtest has run", () => {
+	// coerceGenerated hardcoded `is_backtest_placeholder: true`, which
+	// absenceReason turns into "PENDING — no backtest has run on this strategy
+	// yet". On a row whose pill now says the gate RAN and failed, that is a
+	// same-row self-contradiction — and it is newly reachable, because before
+	// #1747 the "gate failed" pill could not appear on this tab at all.
+	const failRow = {
+		rigor_gate_status: "fail",
+		passes_rigor_gate: false,
+		is_backtest_placeholder: false,
+	};
+	assert.equal(absenceReason(failRow).state, "not_measured");
+	assert.ok(
+		!absenceReason(failRow).title.includes("no backtest has run"),
+		"a row the gate graded had a persisted return series to grade — " +
+			"its empty CAGR / drawdown cells are unmeasured, not pre-backtest",
+	);
+
+	const passRow = {
+		rigor_gate_status: "pass",
+		passes_rigor_gate: true,
+		is_backtest_placeholder: false,
+	};
+	assert.equal(absenceReason(passRow).state, "not_measured");
+
+	// The two states that ARE pre-backtest keep the pending sentence.
+	assert.equal(
+		absenceReason({
+			rigor_gate_status: "pending",
+			passes_rigor_gate: null,
+			is_backtest_placeholder: true,
+		}).state,
+		"pending",
+	);
+	assert.equal(
+		absenceReason({
+			rigor_gate_status: "degenerate",
+			passes_rigor_gate: false,
+			is_backtest_placeholder: true,
+		}).state,
+		"degenerate",
+	);
+});
+
+test("coerceGenerated derives is_backtest_placeholder from the gate verdict", () => {
+	// The executed check above only proves absenceReason behaves once the flag
+	// is right; this pins the flag Strategies.jsx actually sets, which
+	// `node --test` cannot import (.jsx).
+	assert.ok(
+		strategies.includes(
+			"is_backtest_placeholder: !(row.rigor_gate_status === 'pass' || row.rigor_gate_status === 'fail')",
+		),
+		"coerceGenerated is back to a hardcoded is_backtest_placeholder — a graded row's " +
+			"empty cells would again be titled 'no backtest has run on this strategy yet'",
+	);
+	assert.equal(
+		strategies.indexOf("is_backtest_placeholder: true"),
+		-1,
+		"the hardcoded literal is back on a row the live gate may have graded",
 	);
 });

--- a/ui/test/library-status.test.js
+++ b/ui/test/library-status.test.js
@@ -1,0 +1,175 @@
+// #1747: the Library's Generated tab rendered "Live ✓" on strategies whose own
+// passport says "Reference only — gate failed".
+//
+// The cause was that both halves of the badge came from the same generation-time
+// blob: the backend wrote StrategyRecord.status="live" and
+// rigor_verdict.passing=true on one write from the FUSION verdict, and
+// coerceGenerated read `passes_rigor_gate` back out of that same blob. The pill's
+// demotion arm (status "live" AND the gate failed) could therefore never fire —
+// the two inputs were one fact.
+//
+// These tests are of two kinds, on purpose:
+//   * EXECUTED — statusTag/statusLabel now live in a plain module
+//     (ui/src/libraryStatus.js) precisely so the rule can be RUN. It is a claim
+//     about a strategy; reading the source and hoping is not a check.
+//   * SOURCE-TEXT — for the wiring inside Strategies.jsx, which `node --test`
+//     cannot import (`.jsx` is not importable here; see
+//     ui/test/account-management.test.js). Same shape as
+//     ui/test/rigor-tristate.test.js.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+	DEGENERATE_LABEL,
+	GATE_FAILED_LABEL,
+	NOT_GRADED_LABEL,
+	statusLabel,
+	statusTag,
+} from "../src/libraryStatus.js";
+
+const strategies = readFileSync(
+	new URL("../src/components/Strategies.jsx", import.meta.url),
+	"utf8",
+);
+const passport = readFileSync(
+	new URL("../src/components/StrategyPassport.jsx", import.meta.url),
+	"utf8",
+);
+
+// ── The four states ────────────────────────────────────────────────────────
+
+test("pass: a gate that ran and passed is the only green pill", () => {
+	assert.equal(statusTag("live", true, "pass"), "tag-positive");
+	assert.equal(statusLabel("live", true, "pass"), "Live");
+});
+
+test("fail: a gate that ran and failed is muted, and says so", () => {
+	assert.equal(statusTag("live", false, "fail"), "tag-muted");
+	assert.equal(statusLabel("live", false, "fail"), GATE_FAILED_LABEL);
+});
+
+test("pending: nothing graded this row — not green, and NOT accused of failing", () => {
+	assert.equal(statusTag("live", null, "pending"), "tag-muted");
+	assert.equal(statusLabel("live", null, "pending"), NOT_GRADED_LABEL);
+	assert.notEqual(
+		statusLabel("live", null, "pending"),
+		GATE_FAILED_LABEL,
+		"a row the gate never ran on must not be labelled as having failed it — " +
+			"Strategies.jsx renders the clock 'Not yet evaluated' on this same row",
+	);
+});
+
+test("degenerate: evaluated, and unevaluable — its own sentence", () => {
+	assert.equal(statusTag("live", false, "degenerate"), "tag-muted");
+	assert.equal(statusLabel("live", false, "degenerate"), DEGENERATE_LABEL);
+});
+
+test("a row with no verdict at all is not green", () => {
+	// The gate-free seed shape: StrategyRecord rows written with status "live"
+	// and no rigor verdict of any kind (backend/archimedes/main.py seeds curated
+	// examples this way). Before #1747 this rendered a green "Live".
+	assert.equal(statusTag("live", null, null), "tag-muted");
+	assert.equal(statusLabel("live", null, null), NOT_GRADED_LABEL);
+});
+
+test("the four-state verdict outranks a disagreeing boolean", () => {
+	// Fail-closed: if the two ever disagree on the wire, the pill follows the
+	// verdict, never the boolean.
+	assert.equal(statusTag("live", true, "fail"), "tag-muted");
+	assert.equal(statusLabel("live", true, "fail"), GATE_FAILED_LABEL);
+});
+
+test("non-'live' statuses are untouched by this fix", () => {
+	// The #1747 change is scoped to the arm that produces a green claim. A
+	// curated candidate that fails the gate still reads "Candidate" — relabelling
+	// it would be a different product decision on a different tab.
+	assert.equal(statusTag("candidate", false, "fail"), "tag-muted");
+	assert.equal(statusLabel("candidate", false, "fail"), "Candidate");
+	assert.equal(statusTag("validated", true, "pass"), "tag-accent");
+	assert.equal(statusLabel("validated", true, "pass"), "Validated");
+	assert.equal(statusTag("pending_backtest", null, "pending"), "tag-warning");
+	assert.equal(statusLabel("pending_backtest", null, "pending"), "Pending Backtest");
+	assert.equal(statusLabel(null, null, null), "Candidate");
+});
+
+// ── One sentence, two surfaces ─────────────────────────────────────────────
+
+test("the demotion label is byte-identical to StrategyPassport.jsx's literal", () => {
+	// The two surfaces keep SEPARATE statusTag/statusLabel implementations
+	// (the passport maps `validated` to green and has no pending_backtest arm —
+	// they are near-duplicates, not duplicates, and merging them would change
+	// the passport's rendering as a side effect of a Library fix). What must not
+	// diverge is the sentence a user reads about the same strategy in two
+	// places, which is what #1747 was: "Live ✓" here, this string there.
+	assert.ok(
+		passport.includes(`"${GATE_FAILED_LABEL}"`),
+		`StrategyPassport.jsx no longer contains the exact literal "${GATE_FAILED_LABEL}" — ` +
+			"the Library and the passport have started describing the same verdict differently",
+	);
+});
+
+// ── Wiring inside Strategies.jsx ───────────────────────────────────────────
+
+test("coerceGenerated no longer sources the badge from rigor_verdict", () => {
+	assert.equal(
+		strategies.indexOf("verdict ? Boolean(verdict.passing)"),
+		-1,
+		"passes_rigor_gate is being read back out of the generation-time fusion verdict again — " +
+			"that blob is a different gate's output and is never re-derived after a backtest",
+	);
+	assert.ok(
+		strategies.includes(
+			"passes_rigor_gate: typeof row.passes_rigor_gate === 'boolean' ? row.passes_rigor_gate : null",
+		),
+		"the badge must be a LITERAL server boolean or null — a coercion manufactures a verdict",
+	);
+	assert.ok(
+		strategies.includes("rigor_gate_status: row.rigor_gate_status ?? null"),
+		"coerceGenerated must carry the four-state verdict through, or the pill has nothing to read",
+	);
+});
+
+test("the rigor numbers no longer come from rigor_verdict either", () => {
+	for (const dead of [
+		"verdict?.dsr",
+		"verdict?.pbo",
+		"verdict?.oos_sharpe",
+		"verdict?.dsr_p_value",
+	]) {
+		// `verdict?.dsr != null` (the hasRealMetrics probe, which decides a label
+		// relabel and never a metric) is the one permitted read.
+		const idx = strategies.indexOf(dead);
+		const permitted = idx !== -1 && strategies.slice(idx).startsWith("verdict?.dsr != null");
+		assert.ok(
+			idx === -1 || permitted,
+			`Strategies.jsx renders ${dead} — the fusion verdict's numbers beside a live-gate pill`,
+		);
+	}
+});
+
+test("both the desktop pill and the mobile lib-card call the shared helpers", () => {
+	const calls = strategies.match(
+		/statusTag\(s\.status, s\.passes_rigor_gate, s\.rigor_gate_status\)/g,
+	);
+	assert.equal(
+		calls?.length,
+		2,
+		"expected exactly two statusTag call sites (the table pill and the lib-card) " +
+			"passing the four-state verdict — a card that drops it renders a bare green Live on mobile",
+	);
+	const labels = strategies.match(
+		/statusLabel\(s\.status, s\.passes_rigor_gate, s\.rigor_gate_status\)/g,
+	);
+	assert.equal(labels?.length, 2);
+	assert.equal(
+		strategies.indexOf("statusTag(s.status, s.passes_rigor_gate)"),
+		-1,
+		"a call site is still on the two-argument form and cannot see the gate verdict",
+	);
+	assert.ok(
+		strategies.includes("from '../libraryStatus.js'"),
+		"Strategies.jsx must import the helpers rather than re-declaring them privately — " +
+			"module-private is how they went untested through #1747",
+	);
+});


### PR DESCRIPTION
Closes #1747.

## Root cause

The Library's Generated tab read a different verdict store from every other surface, and **both halves of its green badge came from the same generation-time blob**, which is why the tab's own honesty guard could never fire.

* `backend/archimedes/models/strategy_store.py:316-326` (and `:358-360` on insert) writes `status = "live" if rigor_verdict["passing"] else "rejected"` — one write, from the **fusion/synthesis** verdict. Nothing re-derives either field after a backtest.
* `backend/archimedes/api/strategies_routes.py:820-823` (`list_generated_strategies`) returned `r.to_dict()` — no live gate, no `strategy_passports` join.
* `ui/src/components/Strategies.jsx:750` `const verdict = row.rigor_verdict || null` → `:786` `passes_rigor_gate: verdict ? Boolean(verdict.passing) : null`.
* The pill demoted only on `status === 'live' && passesRigor === false` (`Strategies.jsx:120`, `:128`). On this tab both inputs were the *same fact*, so `live` + `false` was unreachable and 21 rows whose own passport says "Reference only — gate failed" rendered **Live ✓**.

Meanwhile `StrategyPassport.jsx` fetches `/api/strategies/{id}`, which for a generated id serves the passport row (`strategies_routes.py:1441`), and the leaderboard counts the same column — hence "0 of 19" on the board next to 21 green rows in the Library.

## What changed

**Backend — `backend/archimedes/api/strategies_routes.py`**

* New `_live_generated_rigor(session, ids)`: the **batched form of `selection_bias_routes._generated_strategy_rigor`** (`:676`). Same `num_trials` PROVENANCE rule (`_num_trials_for_generated_row`), same persisted per-row `library_pbo` with `pbo_library_size` deliberately unset, same look-ahead triple from `verdict_from_persisted_row`, `strictness_level` left at its default (the strictest = the badge bar). Diverging on any of those would let the Library badge and the Deploy ladder disagree about the same strategy.
* `list_generated_strategies` overlays, after the page is built and inside the same session: `rigor_gate_status` (four-state) and `passes_rigor_gate` **coupled to it** (`status == "pass"`), plus `deflated_sharpe_ratio` / `dsr_p_value` / `pbo_score` / `out_of_sample_sharpe` from **that same gate run** and `sharpe_ratio` from **the same `backtest_results` row that gate run read its returns from** (`_live_generated_rigor` returns it; `latest_backtests_by_strategy` and `get_all_daily_returns` rank with the identical `created_at DESC, id DESC` window, so it is one physical row) — all five served `None` unless the run reached `pass`/`fail`. No passport row, or fewer persisted returns than the gate accepts → `passes_rigor_gate: null`, `rigor_gate_status: "pending"`.
* **Not** the stored `strategy_passports.passes_rigor_gate`. That column is mixed-vintage: its first writer is the generation-time fusion verdict (`generation_pipeline._persist_candidate`), the live re-grade only replaces it when the post-backtest refresh reaches its write, and there is no provenance column to tell the two apart. Reading it is reading a claim, whichever value it holds. Demo 1 below is the mutation that proves this is not what the code does.
* `status` and `rigor_verdict` stay on the wire **unchanged** — the fix is a read-side overlay, not a rewrite of what the synthesis gate thought.

**UI**

* New `ui/src/libraryStatus.js` — `statusTag` / `statusLabel` / `isGatePass`, moved out of `Strategies.jsx` so a test can **run** them (`.jsx` is not importable under `node --test`; that is exactly how this rule went unpinned through #1747). Four states, four sentences: `pass` → green "Live"; `fail` → muted "Reference only — gate failed"; `pending`/absent → muted **"Not yet graded"**; `degenerate` → muted "Unevaluable — flat returns".
* Deliberately **not** the `!== true` widening. That is the smaller diff and it puts "Reference only — gate failed" on the same row as the clock icon titled "Not yet evaluated — no backtest data for the rigor gate to score" — one row asserting two contradictory things, the failing one about a verdict nothing produced (#1358's defect class). The `pending` arm gets its own label instead; only the pill *class* stops being green for a row with no affirmative pass.
* `StrategyPassport.jsx` is **not** refactored onto the new module. Its `statusTag`/`statusLabel` are near-duplicates, not duplicates — it maps `validated` to green (the Library maps it to accent), maps `rejected`/`retired` to muted, defaults unknown statuses to accent, and has no `pending_backtest` arm. Merging them would change the passport's rendering as a side effect of a Library fix. What must not diverge is the *sentence*, and the test pins that by reading the passport's source.
* `Strategies.jsx` `coerceGenerated`: `passes_rigor_gate` is taken **only** as a literal server boolean (else `null`), `rigor_gate_status` is carried through, and DSR/PBO/OOS/`dsr_p`/Sharpe now come from the server fields instead of `row.rigor_verdict` — otherwise the row would print the *other* gate's passing DSR beside a "gate failed" pill. `verdict` survives for exactly one thing: the `hasRealMetrics` probe that relabels `rejected` → `pending_backtest`.
* Both call sites take the four-state — the desktop table pill (`Strategies.jsx:282`) and the **mobile lib-card** (`:578`), which previously could render a bare green "Live" with no rigor icon beside it at all. A test asserts there are exactly two three-argument call sites and zero two-argument ones.

## Owner decisions I defaulted (all reversible, all yours)

1. **Ungraded label wording.** "Not yet graded". It is a placeholder, exported as `NOT_GRADED_LABEL` in one place. What it must not go back to being is "Live" (a claim) or "gate failed" (a different claim).
2. **Rows moving to the collapsed section.** `Strategies.jsx:1119-1121` partitions on `passes_rigor_gate === true / === false / == null`. Rows that flip to `false` drop into the collapsed **Rejected** section; rows that flip to `null` stay in the main table under "pending". That is honest, and it is also the Library visibly emptying out. Ships as-is unless you want the section renamed/expanded first.
3. **No write-back to `StrategyRecord.status`.** The alternative is writing the live re-grade back at `generation_pipeline.py:2041/:2232` so the record stops lying at rest. That destroys the record of what the synthesis gate thought and has readers outside this route (`marketplace_service.trending`). Left as a product/architecture call.
4. **Leaderboard's 2-state badge left for a follow-up.** `Leaderboard.jsx:190-198` has only pass/fail/no-backtest — a row the passport calls "unevaluable" is asserted there as "Gate failed". Same claims-must-be-true class, different surface, out of this diff.
5. **Curated Examples tab is touched too, on purpose.** A curated row with `STATUS = "live"` (5 of the 34 files) whose gate returns `pending` used to render a green "Live"; it now reads "Not yet graded". Same defect, same fix, one code path. Curated `candidate` / `validated` / `pending_backtest` rendering is unchanged — a test pins that.

## Review round 2 — commit `aecce416`

An independent verifier reproduced every claim in this PR and returned FIX-FIRST on four in-scope defects. All four are fixed in `aecce416`; the badge mechanism itself is unchanged.

**1. The display Sharpe did not come from the run the gate graded — and the comment said it did.** The gate reads its returns from the latest `backtest_results` row; the route was serving `strategy_passports.sharpe_ratio`, a denormalised snapshot with **no foreign key to `backtest_results`** (~155 backtest rows per strategy, per `scripts/archive_backtest_results.py`). Measured on a seeded row before the fix:

```
served sharpe_ratio  : 1.4      (strategy_passports column)
graded row's sharpe  : 0.031    (backtest_results — the row the gate actually read)
served DSR / OOS     : -2.606803 / -2.893566
```

A Sharpe of 1.4 printed beside a DSR of −2.61 computed from a series whose Sharpe is 0.031 — this PR's own stated invariant, broken. `_live_generated_rigor` now returns the `BacktestResultRecord` it graded as a third tuple element (it already held it at `:1445`, so this costs **no extra query**) and the route reads `sharpe_ratio` off that row.

**2. `ui/test/library-status.test.js` — the "rigor numbers" guard was VACUOUS for the DSR**, the one field that actually regresses. `strategies.indexOf(dead)` finds only the *first* occurrence, and for `verdict?.dsr` that is always the permitted `hasRealMetrics` probe at `Strategies.jsx:745`, so the loop body could never fail regardless of what appeared later in the file. Restoring `deflated_sharpe_ratio: verdict?.dsr ?? null` in `coerceGenerated` left the entire ui suite green. The loop now scans every occurrence. This also means the repo's adversarial-pass rule was **unmet** for that test in the first commit — it is met now (demo 5 below).

**3. `is_backtest_placeholder: true` put "no backtest has run" on a row whose pill says the gate ran and failed.** Listed as an open concern in round 1; it is a same-row self-contradiction, newly reachable because the "gate failed" pill was structurally unreachable on this tab before this PR. `metricDomain.absenceReason` (`metricDomain.js:298-305`) fires its pending branch on the literal, titling every empty CAGR / max-drawdown cell "PENDING — no backtest has run on this strategy yet". Now derived from the four-state: `pass`/`fail` → `false`; `pending`/`degenerate` keep `true`, where the sentence is true. Contained — on generated rows this field is read only by `absenceReason` (`Strategies.jsx:1244` scopes to `examples`; the `Leaderboard.jsx` / `StrategyPassport.jsx` reads are different payloads).

**4. `Strategies.jsx:200-202` — comment fix.** It said "coerceGenerated's own rows don't set it at all"; `coerceGenerated` now sets `rigor_gate_status` explicitly.

### Not changed, and why

* **The stored-column split is systematic, not incidental — the owner should know the size of it.** `_live_generated_rigor` routes look-ahead through `verdict_from_persisted_row` (which retires `self_attested`), while `generation_pipeline.py:2022-2029` passes `result.look_ahead_audit_passed` raw and supplies no `library_pbo`. So **every `self_attested` row will read `fail` in the Library and `pass` on its own passport page.** Measured split for one such row:

  ```
  LIBRARY /generated : passes=False status='fail'  DSR=-2.6068 PBO=0.05 p=0.0020 OOS=-2.894
  DETAIL  /{id}      : passes=True  status='pass'  DSR= 0.87   PBO=0.02 p=0.99   OOS= 1.900
  ```

  Not a reason to hold this PR: the Library is now the correct side, and it now agrees with `_generated_strategy_rigor` — the same path that already drives the Deploy ladder *on the passport page itself* (`StrategyPassport.jsx:410-419`), so the passport already contradicted itself before this change. Closing it is #1746's fix (a live overlay on the passport routes), which is a separate logical change.
* **A `StrategyRecord` with persisted returns but no `strategy_passports` row** is forced to `pending` even though the gate could grade it. Fail-closed, and `_persist_candidate` writes both rows, so it should be unreachable.
* **The route is `async def` and runs `run_rigor_gate` on the event loop.** Consistent with `list_strategies` at `:644`, authenticated, not new. A follow-up at most.

## Adversarial demos (guards-need-an-adversarial-pass)

**1. Restore the stored-column source** — `d["passes_rigor_gate"] = bool(passports[d["id"]].passes_rigor_gate) if d["id"] in passports else None`:

```
FAILED backend/tests/test_generated_badge_parity.py::test_passport_row_with_no_persisted_returns_is_pending - assert True is None
FAILED backend/tests/test_generated_badge_parity.py::test_stored_passport_true_does_not_survive_a_failing_live_gate - AssertionError: the stored True must not reach the badge
FAILED backend/tests/test_generated_badge_parity.py::test_zero_variance_series_is_degenerate_not_fail_or_pending - assert True is False
FAILED backend/tests/test_generated_badge_parity.py::test_live_gate_pass_is_served_as_a_pass - assert False is True
=================== 4 failed, 4 passed, 11 warnings in 4.27s ===================
```

**2. Restore `rigor_verdict.passing` in `coerceGenerated`** — `passes_rigor_gate: verdict ? Boolean(verdict.passing) : null`:

```
✖ coerceGenerated no longer sources the badge from rigor_verdict (1.167917ms)
  AssertionError [ERR_ASSERTION]: passes_rigor_gate is being read back out of the
  generation-time fusion verdict again — that blob is a different gate's output and
  is never re-derived after a backtest
  40825 !== -1
ℹ tests 11  ℹ pass 10  ℹ fail 1
```

**3. Restore the `=== false` guard** in `statusTag` — `if (status === "live" && passesRigor === false) return "tag-muted"`:

```
✖ pending: nothing graded this row — not green, and NOT accused of failing
  AssertionError: Expected values to be strictly equal:
    actual: 'tag-positive'   expected: 'tag-muted'
✖ a row with no verdict at all is not green
  AssertionError: Expected values to be strictly equal:
    actual: 'tag-positive'   expected: 'tag-muted'
✖ the four-state verdict outranks a disagreeing boolean
```

**4. Change the label string in one file** (em-dash → hyphen in `StrategyPassport.jsx` only):

```
✖ the demotion label is byte-identical to StrategyPassport.jsx's literal (0.513916ms)
  AssertionError [ERR_ASSERTION]: StrategyPassport.jsx no longer contains the exact
  literal "Reference only — gate failed" — the Library and the passport have started
  describing the same verdict differently
ℹ tests 11  ℹ pass 10  ℹ fail 1
```

**5. Round-2 fix (2) — re-source the DSR from the fusion verdict** in `coerceGenerated`: `deflated_sharpe_ratio: verdict?.dsr ?? null`. Green before the guard fix (924/924, EXIT=0 — the whole point); red now:

```
✖ the rigor numbers no longer come from rigor_verdict either (0.533542ms)
  AssertionError [ERR_ASSERTION]: Strategies.jsx renders verdict?.dsr — the fusion
  verdict's numbers beside a live-gate pill
ℹ tests 13  ℹ pass 12  ℹ fail 1
```

**6. Round-2 fix (1) — display Sharpe back to `strategy_passports.sharpe_ratio`**:

```
E   AssertionError: display Sharpe is the GRADED backtest row's own number, not the passport snapshot (0.4)
E   AssertionError: served sharpe_ratio=1.4 — the display Sharpe and the rigor numbers are describing two different backtest runs
FAILED backend/tests/test_generated_badge_parity.py::test_rigor_numbers_come_from_the_live_run_not_the_stored_passport
FAILED backend/tests/test_generated_badge_parity.py::test_display_sharpe_is_the_graded_backtest_rows_own_number
=================== 2 failed, 7 passed, 12 warnings in 4.02s ===================
```

**7. Round-2 fix (3) — `is_backtest_placeholder` back to the hardcoded `true`**:

```
✖ coerceGenerated derives is_backtest_placeholder from the gate verdict (0.454042ms)
  AssertionError [ERR_ASSERTION]: coerceGenerated is back to a hardcoded
  is_backtest_placeholder — a graded row's empty cells would again be titled
  'no backtest has run on this strategy yet'
ℹ tests 13  ℹ pass 12  ℹ fail 1
```

**8. Round-2 fix (3), executed half** — widen `metricDomain.absenceReason` to call a graded FAIL row pre-backtest (`row.passes_rigor_gate === false ||` added to the pending condition). Proves the executed assertion is live, not just the source-text one:

```
✖ a graded row's empty cells do not claim that no backtest has run (1.136583ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    actual: 'pending',   expected: 'not_measured'
ℹ tests 13  ℹ pass 12  ℹ fail 1
```

All eight mutations applied, run, and restored; working tree matches this commit (`git status` clean).

## Verification

```
$ env -i HOME=$HOME PATH=$PATH PYTHONPATH=backend python -m pytest \
    backend/tests/test_strategies_routes.py backend/tests/test_strategy_endpoints.py \
    backend/tests/test_passport_honesty.py backend/tests/test_passport_loader.py \
    backend/tests/test_api_routes.py backend/tests/test_generated_badge_parity.py \
    -q -p no:cacheprovider
155 passed, 13 warnings in 21.14s                                    EXIT=0

$ ... backend/tests/test_strategy_ownership.py test_generated_citation_truth.py \
      test_publishable_strategy_ids.py test_selection_bias_generated_gate.py \
      test_multipaper_passport.py test_brief_on_passport.py \
      test_reasoning_disclosure_gates.py test_sole_generation_route_guard.py
139 passed, 54 warnings in 13.72s                                    EXIT=0

$ cd ui && npm test
ℹ tests 926   ℹ pass 926   ℹ fail 0                                  EXIT=0

$ ruff format --check backend/archimedes/api/strategies_routes.py backend/tests/test_generated_badge_parity.py
2 files already formatted                                            EXIT=0
$ ruff check backend/tests/test_generated_badge_parity.py
All checks passed!                                                   EXIT=0
$ eslint ui/src/libraryStatus.js ui/src/components/Strategies.jsx ui/test/library-status.test.js
                                                                     EXIT=0
```

`ruff check` on `strategies_routes.py` reports one `SIM105` — pre-existing on `origin/main` in `_rollback_quietly`, verified by running the same check against `git show origin/main:...` inside the repo (same config). Not introduced here, not fixed here (one logical change per PR).

## Measured page cost

The overlay is **two SQL statements per page regardless of row count** (one `get_all_daily_returns`, one `latest_backtests_by_strategy`) plus one in-process `run_rigor_gate` per *gradeable* row, and `test_badge_overlay_is_batched_not_per_row` pins the constancy at the engine boundary (`before_cursor_execute`, same counter as `test_publishable_strategy_ids.py`) by comparing two page sizes:

| gradeable rows (300-pt series each) | wall | SQL statements on the request |
|---|---|---|
| 1 | 12 ms | 6 |
| 50 (route default limit) | 179 ms | 6 |

Measured at the engine boundary after a warm-up request (so app-lifespan DDL is not counted as page cost). Six is the whole request, auth and the citation/cost/publish reads included; the count does not move with N, which is the claim. Round 2 added no query — the graded `backtest_results` row was already loaded.

## Open concerns

* **The detail route still reads the stored column.** `GET /api/strategies/{id}` for a generated id serves `_passport_to_strategy_response`, i.e. `strategy_passports.passes_rigor_gate` (`strategies_routes.py:1441`). Badge parity holds for every row whose stored column agrees with the live gate — the pinned prod shape — but a row with a stale stored `True` and a failing live gate will now read `fail` in the Library and `pass` on its own passport page, and the four rigor numbers differ between the two routes for the same reason. **Round 2 established that this flip is systematic rather than incidental** — every `self_attested` look-ahead row is affected; see "Not changed, and why" above for the measured split and why it belongs to #1746 rather than here. `/api/leaderboard` reads the same stored column (`Leaderboard.jsx:194`/`:302`), also untouched.
* **`DeployabilityChip` is curated-only and left alone.** Its `deployMap` comes from `/api/selection-bias/gate`, whose LIST cohort is `_provider().list_strategies()` (`selection_bias_routes.py:307`), so `deployMap[generated_id]` is always undefined and the chip renders nothing on this tab. The one designed counter-signal is absent — noted, not changed.
* **The gate run is uncached.** The returns are what a cache key would have to be built from and reading them is the expensive half, so there is no free cache in front of it. At the measured ~3 ms/row this is affordable at the route's limit; a per-page memo is a real follow-up if the corpus grows.
* **The mobile lib-card still renders no rigor icon** (no check/X/clock/alert arms, unlike the desktop row). It can no longer render a bare green "Live" — it calls the same helpers — but it carries less signal than the table.

Do not merge — owner vets first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

