### PR TITLE
[infra][deploy] Post-rollout probe: set +e so one timed-out sample cannot abort the step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -919,9 +919,9 @@ jobs:
           # With -e in force a single timed-out sample (curl exit 28) aborted
           # this whole step before `rc=$?` ran and before a single
           # `probe N/10` line was printed — the 2026-09-01 run 33553292497 went
-          # red that way with the rollout COMPLETED and the app serving the
-          # right version seconds later. Every failure below is handled
-          # explicitly through `fail`; nothing here may rely on -e.
+          # red that way with the rollout COMPLETED; the step never got to
+          # measure whether the app was answering. Every failure below is
+          # handled explicitly through `fail`; nothing here may rely on -e.
           set +e -uo pipefail
 
           PROBES=10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -914,7 +914,15 @@ jobs:
           # anything else, something other than this commit is serving.
           EXPECTED_VERSION: ${{ github.sha }}
         run: |
-          set -uo pipefail
+          # `set +e` is load-bearing: GitHub runs `run:` under `bash -e`, and
+          # `sample="$(curl ...)"` is an assignment whose exit status IS curl's.
+          # With -e in force a single timed-out sample (curl exit 28) aborted
+          # this whole step before `rc=$?` ran and before a single
+          # `probe N/10` line was printed — the 2026-09-01 run 33553292497 went
+          # red that way with the rollout COMPLETED and the app serving the
+          # right version seconds later. Every failure below is handled
+          # explicitly through `fail`; nothing here may rely on -e.
+          set +e -uo pipefail
 
           PROBES=10
           REQUIRED_STREAK=5


### PR DESCRIPTION
Part of #1760's fallout (the red on run 33553292497), and #1532's probe.

**Bug.** GitHub runs `run:` blocks under `bash -e`. The probe samples with `sample="$(curl ... --max-time 15 ...)"`, an assignment whose exit status is curl's — so a single timed-out sample (curl exit 28) aborts the whole step before `rc=$?` runs and before any `probe N/10` line is printed. Daniel caught the shape on #1760: exit 28 ~15s in, no probe lines, then the same URL 200 in under a second a minute later. The step's `set -uo pipefail` does not clear `-e`.

**Fix.** `set +e -uo pipefail` with a comment saying why it is load-bearing. Every failure in the step is already handled explicitly through `fail`; nothing relied on `-e`.

**Adversarial demo** — the probe body extracted from the workflow YAML with `yaml.safe_load`, edited only to `PROBES=2`, `REQUIRED_STREAK=1`, `--max-time 2`, `sleep 0`, run as `bash -e <body>` against a blackhole URL. Captured output, not paraphrased:

```
-- old body (origin/main) under bash -e:
Probing http://10.255.255.1:9/health — 2 samples, need the last 1 consecutive at 200 under 5s.
   exit=28        # aborted inside the first sample assignment; no probe line ever printed

-- new body under bash -e:
Probing http://10.255.255.1:9/health — 2 samples, need the last 1 consecutive at 200 under 5s.
probe  1/2: http=000 time=2.035643s curl_exit=28 -> NOT-OK (consecutive good: 0)
probe  2/2: http=000 time=2.012060s curl_exit=28 -> NOT-OK (consecutive good: 0)
::error::post-rollout answer probe: only 0 consecutive trailing samples answered 200 under 5s (needed 1). ECS reported the rollout COMPLETED, but the app is not answering
::error::post-rollout version check: could not read .version from http://10.255.255.1:9/health on the final probe (body was empty or not JSON). Cannot confirm which commi
   exit=1         # the explicit verdict, with the timings printed
```

(An earlier revision of this body quoted the demo before it had actually run — the harness used `timeout`, which macOS lacks, and both scripts exited 127. Re-run without it; the text above is the real capture.)

One line of behaviour, no change to what the probe asserts. `yaml.safe_load` clean. Does not touch the OIDC comment block that #1759 edits (different hunk).

Do not merge — owner vets first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

