### PR TITLE
[test] Guard: no tracked file may carry a git conflict marker

### DIFF
--- a/backend/tests/test_no_conflict_markers.py
+++ b/backend/tests/test_no_conflict_markers.py
@@ -1,0 +1,82 @@
+"""No git conflict marker may be tracked, anywhere.
+
+A ``>>>>>>> origin/main`` line sat inside ``strategy_fusion.py``'s ``_SPEC_CONTRACT``
+from ``bdb93547`` until #1744 removed it — i.e. inside BOTH proposer prompts, shipped
+to the model on every generation call — and nothing in ruff-gate, pre-commit, or
+quality-gate noticed, because a marker inside a string literal is valid Python.
+This test is the guard that was missing: it scans every tracked text file.
+
+Only the two unambiguous marker shapes are policed — a line beginning with
+``<<<<<<< `` or ``>>>>>>> `` (seven characters then a space; git always writes the
+side label after the space). The middle ``=======`` line is deliberately NOT
+policed: a bare ``=======`` is a legitimate Markdown/RST setext heading underline
+and appears in this repo's docs on purpose.
+
+Hermetic: reads the working tree of the files ``git ls-files`` reports, no network,
+no DB. MUTATION (run before pushing, per the adversarial-pass rule): append
+``>>>>>>> origin/main`` to any tracked ``.py`` or ``.md`` — this test must go red
+naming that file and line; remove it and it is green again.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_MARKER = re.compile(rb"^(<<<<<<< |>>>>>>> )")
+
+#: Tracked paths that are allowed to contain marker-shaped lines because they
+#: are ABOUT conflict markers (fixtures/tests). Keep this list short and named.
+_ALLOWED = {
+    "backend/tests/test_no_conflict_markers.py",
+}
+
+
+def _tracked_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout
+    return [REPO_ROOT / p.decode() for p in out.split(b"\0") if p]
+
+
+def _looks_binary(head: bytes) -> bool:
+    return b"\0" in head
+
+
+def _marker_hits(path: Path) -> list[str]:
+    try:
+        data = path.read_bytes()
+    except (FileNotFoundError, IsADirectoryError):  # gitlinks (submodules) and deleted-but-tracked
+        return []
+    if _looks_binary(data[:8192]):
+        return []
+    shown = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path.name
+    hits: list[str] = []
+    for lineno, line in enumerate(data.splitlines(), start=1):
+        if _MARKER.match(line):
+            hits.append(f"{shown}:{lineno}: {line[:60].decode('utf-8', 'replace')}")
+    return hits
+
+
+def test_no_tracked_file_contains_a_conflict_marker() -> None:
+    files = _tracked_files()
+    assert len(files) > 100, "git ls-files returned suspiciously few files — is this the repo root?"
+    hits = [h for p in files if str(p.relative_to(REPO_ROOT)) not in _ALLOWED for h in _marker_hits(p)]
+    assert not hits, (
+        "git conflict marker(s) are tracked — a merge was committed unresolved "
+        "(the bdb93547 class: this once shipped inside a live LLM prompt):\n  " + "\n  ".join(hits)
+    )
+
+
+def test_the_scan_is_not_vacuous(tmp_path: Path) -> None:
+    """The regex catches both marker shapes and ignores the setext underline."""
+    sample = tmp_path / "s.md"
+    sample.write_bytes(b"Title\n=======\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> origin/main\n")
+    hits = _marker_hits(sample)
+    assert [h.split(": ", 1)[1] for h in hits] == ["<<<<<<< HEAD", ">>>>>>> origin/main"]

--- a/backend/tests/test_no_conflict_markers.py
+++ b/backend/tests/test_no_conflict_markers.py
@@ -2,20 +2,28 @@
 
 A ``>>>>>>> origin/main`` line sat inside ``strategy_fusion.py``'s ``_SPEC_CONTRACT``
 from ``bdb93547`` until #1744 removed it — i.e. inside BOTH proposer prompts, shipped
-to the model on every generation call — and nothing in ruff-gate, pre-commit, or
-quality-gate noticed, because a marker inside a string literal is valid Python.
-This test is the guard that was missing: it scans every tracked text file.
+to the model on every generation call — and nothing blocking noticed, because a
+marker inside a string literal is valid Python, and the ``check-merge-conflict``
+pre-commit hook is advisory (pre-commit is not run in CI). This test is the guard
+that was missing: it scans every tracked text file.
 
-Only the two unambiguous marker shapes are policed — a line beginning with
-``<<<<<<< `` or ``>>>>>>> `` (seven characters then a space; git always writes the
-side label after the space). The middle ``=======`` line is deliberately NOT
-policed: a bare ``=======`` is a legitimate Markdown/RST setext heading underline
-and appears in this repo's docs on purpose.
+What counts as a marker: a line that BEGINS with seven-or-more ``<`` or seven-or-more
+``>``, followed by whitespace or end-of-line. Seven-or-more, not exactly seven,
+because git honours the ``conflict-marker-size`` attribute; whitespace-or-EOL, not
+"a space then a label", because ``git merge-file`` emits bare unlabeled markers. The
+middle ``=======`` line is deliberately NOT policed: a real conflict always carries
+the two outer markers, and a bare run of ``=`` is a legitimate Markdown/RST setext
+heading underline, so policing it would only add false positives.
 
-Hermetic: reads the working tree of the files ``git ls-files`` reports, no network,
-no DB. MUTATION (run before pushing, per the adversarial-pass rule): append
-``>>>>>>> origin/main`` to any tracked ``.py`` or ``.md`` — this test must go red
-naming that file and line; remove it and it is green again.
+The scan reads the WORKING TREE of every tracked path, so it also goes red in the
+middle of an unfinished ``git merge`` — the other honest reason to see it fail. There
+is no allowlist: this file itself contains no line-start marker, and an allowlist
+would be the one place a marker could hide.
+
+Hermetic: ``git ls-files`` plus file reads, no network, no DB. MUTATIONS (run before
+pushing): append ``>>>>>>> origin/main`` to any tracked ``.py`` or ``.md`` (or to this
+file) — red naming that file and line; a 32-char marker from ``conflict-marker-size``
+and a bare unlabeled ``<<<<<<<`` are red too; remove them and it is green again.
 """
 
 from __future__ import annotations
@@ -26,13 +34,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-_MARKER = re.compile(rb"^(<<<<<<< |>>>>>>> )")
-
-#: Tracked paths that are allowed to contain marker-shaped lines because they
-#: are ABOUT conflict markers (fixtures/tests). Keep this list short and named.
-_ALLOWED = {
-    "backend/tests/test_no_conflict_markers.py",
-}
+_MARKER = re.compile(rb"^(<{7,}|>{7,})(\s|$)")
 
 
 def _tracked_files() -> list[Path]:
@@ -67,16 +69,30 @@ def _marker_hits(path: Path) -> list[str]:
 def test_no_tracked_file_contains_a_conflict_marker() -> None:
     files = _tracked_files()
     assert len(files) > 100, "git ls-files returned suspiciously few files — is this the repo root?"
-    hits = [h for p in files if str(p.relative_to(REPO_ROOT)) not in _ALLOWED for h in _marker_hits(p)]
+    hits = [h for p in files for h in _marker_hits(p)]
     assert not hits, (
-        "git conflict marker(s) are tracked — a merge was committed unresolved "
-        "(the bdb93547 class: this once shipped inside a live LLM prompt):\n  " + "\n  ".join(hits)
+        "git conflict marker(s) found in tracked files — either a merge was committed "
+        "unresolved (the bdb93547 class: this once shipped inside a live LLM prompt) or a "
+        "merge is still in progress in this working tree:\n  " + "\n  ".join(hits)
     )
 
 
 def test_the_scan_is_not_vacuous(tmp_path: Path) -> None:
-    """The regex catches both marker shapes and ignores the setext underline."""
+    """Every marker shape git can emit is caught; the setext underline is not."""
     sample = tmp_path / "s.md"
-    sample.write_bytes(b"Title\n=======\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> origin/main\n")
-    hits = _marker_hits(sample)
-    assert [h.split(": ", 1)[1] for h in hits] == ["<<<<<<< HEAD", ">>>>>>> origin/main"]
+    sample.write_bytes(
+        b"Title\n=======\n"  # setext underline: must NOT match
+        b"<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> origin/main\n"  # the default shape
+        b"<<<<<<<\nx\n>>>>>>>\n"  # git merge-file's unlabeled shape
+        b"<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< HEAD\ny\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> theirs\n"  # conflict-marker-size=32
+        b">>>>>>>text\n"  # not a git marker: no whitespace after the run
+    )
+    hits = [h.split(": ", 1)[1] for h in _marker_hits(sample)]
+    assert hits == [
+        "<<<<<<< HEAD",
+        ">>>>>>> origin/main",
+        "<<<<<<<",
+        ">>>>>>>",
+        "<" * 32 + " HEAD",
+        ">" * 32 + " theirs",
+    ]


### PR DESCRIPTION
Closes the class behind the `>>>>>>> origin/main` that shipped inside `strategy_fusion.py`'s live prompts from `bdb93547` until #1744 removed it. Nothing blocking caught it: a marker inside a string literal is valid Python, and the `check-merge-conflict` pre-commit hook in `.pre-commit-config.yaml` is **advisory** — pre-commit is not run in CI and was not run by whatever pushed that commit. This test runs in the blocking unit suite.

**What it checks.** Every tracked text file (`git ls-files -z`, binary-sniffed by a NUL in the first 8 KB) for a line beginning with `<<<<<<< ` or `>>>>>>> `. The middle `=======` is deliberately **not** policed: a bare `=======` is a legitimate Markdown/RST setext heading underline and this repo's docs use it. A second test pins that the regex catches both shapes and ignores the underline, so the scan cannot go vacuous.

**Adversarial demo** (captured):
```
$ printf '\n>>>>>>> origin/main\n' >> backend/archimedes/services/embargo_filter.py
$ pytest -q backend/tests/test_no_conflict_markers.py
E       backend/archimedes/services/embargo_filter.py:98: >>>>>>> origin/main
E   assert not ['backend/archimedes/services/embargo_filter.py:98: >>>>>>> origin/main']
1 failed, 1 passed
$ git checkout -- backend/archimedes/services/embargo_filter.py && pytest -q backend/tests/test_no_conflict_markers.py
2 passed
```

Today's tree is clean (the guard passes on `main`). Hermetic: no network, no DB; runs in ~2s. Requested by the Strategy Session after the #1744 cleanup.

Do not merge — owner vets first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx