### PR TITLE
[infra][deploy] CloudFront invalidation step: set +e so its non-fatal warning path is reachable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1064,7 +1064,7 @@ jobs:
         # `terraform apply` in infra/ — until then this step logs a clear
         # warning and exits 0 rather than failing the deploy (an ECS deploy
         # that already succeeded and is serving traffic must not be marked
-        # failed over a CDN cache purge — see the non-`set -e`, explicit
+        # failed over a CDN cache purge — see the explicit `set +e` and the
         # exit-code handling below; the completion wait is likewise
         # non-fatal on timeout).
         env:
@@ -1079,7 +1079,12 @@ jobs:
           # (`terraform output -raw cloudfront_distribution_id`).
           CLOUDFRONT_DISTRIBUTION_ID: E34KG22GWPO075
         run: |
-          set -uo pipefail
+          # `set +e` is load-bearing here too (same class as the post-rollout probe):
+          # GitHub runs this under `bash -e`, and `OUTPUT="$(aws ...)"` is an assignment
+          # whose exit status is the CLI's, so a failed invalidation aborted the step
+          # BEFORE `RC=$?` and the deliberately non-fatal warning path below could run —
+          # turning a cache-purge hiccup into a red deploy that was already serving.
+          set +e -uo pipefail
           OUTPUT="$(aws cloudfront create-invalidation \
             --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
             --paths "/" "/?*" "/index.html*" 2>&1)"


### PR DESCRIPTION
Sibling of #1762, found by its adversarial pass. Same bug shape, opposite failure direction.

**Bug.** The step is designed to be non-fatal: a failed invalidation should print `::warning::` and `exit 0`, because the ECS deploy above it is already serving the new image. But it runs under GitHub's default `bash -e`, and `OUTPUT="$(aws cloudfront create-invalidation …)"` is an assignment whose exit status is the CLI's — so any CLI failure aborted the step before `RC=$?`, and the whole warning path (and the "Id could not be parsed" and waiter-timeout branches) was unreachable. A cache-purge hiccup reds a deploy that already took. The step's own comment promised "explicit exit-code handling"; it was not true.

**Fix.** `set +e -uo pipefail` with a comment saying why it is load-bearing; the stale "non-`set -e`" wording in the step's header comment corrected. One line of behaviour.

**Adversarial demo** (captured; step body extracted from the workflow via `yaml.safe_load`, run under `bash -e`, with an `aws` stub on PATH that prints AccessDenied and exits 254):
```
-- old: exit=254            # aborted at the assignment; no ::warning:: printed
-- new: exit=0
::warning::CloudFront invalidation failed (aws cli exit 254) — the ECS deploy above already succeeded and IS serving the new image …
```

`yaml.safe_load` clean. Touches only this step; the post-rollout probe fix is #1762 and the OIDC comment block is untouched.

Do not merge — owner vets first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx