### PR TITLE
[nginx][P0] Gated /app responses and the sign-in redirect are private, no-store — fixes the sign-in ping-pong

### DIFF
--- a/backend/tests/test_nginx_gated_responses_uncached.py
+++ b/backend/tests/test_nginx_gated_responses_uncached.py
@@ -1,0 +1,61 @@
+"""Session-dependent nginx responses must carry ``Cache-Control: private, no-store``.
+
+2026-09-01 sign-in outage: CloudFront's ``html`` cache policy (infra/cloudfront.tf)
+keys the cache WITHOUT cookies and caches for 60s. The gated ``/app/*`` locations
+returned an anonymous visitor's ``302 /sign-in`` with no ``Cache-Control``, so
+CloudFront cached it and replayed it to the very next *signed-in* request. The
+SPA then ping-ponged: AuthPage saw a valid session and jumped to ``/app/...``,
+CloudFront answered with the cached anonymous 302, and so on — 165 get-session
+calls in 45 minutes for one user. ``min_ttl = 0`` means an origin ``no-store``
+is honoured, which is what this test pins.
+
+Rule: every ``location`` that gates on ``auth_request /_auth_session``, and the
+``@sign_in`` redirect they fall back to, must set ``add_header Cache-Control
+"private, no-store" always;``. MUTATION: delete the header from any one of
+those blocks → this test goes red naming the block.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+NGINX_CONF = Path(__file__).resolve().parents[2] / "nginx" / "nginx.conf"
+_NO_STORE = re.compile(r'add_header\s+Cache-Control\s+"private,\s*no-store"\s+always;')
+
+
+def _location_blocks(conf: str) -> dict[str, str]:
+    """Map ``location <selector>`` → block body (brace-balanced, no nesting needed here)."""
+    blocks: dict[str, str] = {}
+    for m in re.finditer(r"^\s*location\s+([^{]+?)\s*\{", conf, re.M):
+        depth, i = 0, m.end() - 1
+        while i < len(conf):
+            if conf[i] == "{":
+                depth += 1
+            elif conf[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        blocks[m.group(1).strip()] = conf[m.end() : i]
+    return blocks
+
+
+def test_every_session_gated_location_and_the_sign_in_redirect_are_uncacheable() -> None:
+    conf = NGINX_CONF.read_text(encoding="utf-8")
+    blocks = _location_blocks(conf)
+    gated = [sel for sel, body in blocks.items() if "auth_request /_auth_session" in body]
+    assert gated, "no auth_request-gated locations found — the parser or the gate moved"
+    assert "@sign_in" in blocks, "the @sign_in redirect location is gone"
+    missing = [sel for sel in [*gated, "@sign_in"] if not _NO_STORE.search(blocks[sel])]
+    assert not missing, (
+        "session-dependent nginx responses without Cache-Control private,no-store — "
+        "CloudFront will cache an anonymous 302 and replay it to signed-in users: " + ", ".join(missing)
+    )
+
+
+def test_the_parser_sees_the_gate() -> None:
+    """Anti-vacuity: the gated set is the two /app locations, not an empty list."""
+    conf = NGINX_CONF.read_text(encoding="utf-8")
+    gated = sorted(sel for sel, body in _location_blocks(conf).items() if "auth_request /_auth_session" in body)
+    assert gated == ["= /app/insights", "^~ /app"], gated

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -282,6 +282,11 @@ server {
     location @sign_in {
         # Keep deep-link query args as top-level auth args; AuthPage safely
         # rebuilds and validates local /app destination after login.
+        # Session-dependent: CloudFront's html cache policy keys WITHOUT cookies and
+        # caches for 60s, so without this an anonymous visitor's 302 was replayed to
+        # the next signed-in request and the SPA ping-ponged sign-in <-> /app
+        # (2026-09-01 sign-in outage). Origin no-store wins over the policy TTL.
+        add_header Cache-Control "private, no-store" always;
         return 302 /sign-in?next=$uri&$args;
     }
 
@@ -361,6 +366,11 @@ server {
     # nginx at all.
     location = /app/insights {
         auth_request /_auth_session;
+        # Session-dependent: CloudFront's html cache policy keys WITHOUT cookies and
+        # caches for 60s, so without this an anonymous visitor's 302 was replayed to
+        # the next signed-in request and the SPA ping-ponged sign-in <-> /app
+        # (2026-09-01 sign-in outage). Origin no-store wins over the policy TTL.
+        add_header Cache-Control "private, no-store" always;
         error_page 401 = @sign_in;
         gzip off;
         root /usr/share/nginx/html;
@@ -371,6 +381,11 @@ server {
     # without a valid Better Auth session. FastAPI repeats authorization for APIs.
     location ^~ /app {
         auth_request /_auth_session;
+        # Session-dependent: CloudFront's html cache policy keys WITHOUT cookies and
+        # caches for 60s, so without this an anonymous visitor's 302 was replayed to
+        # the next signed-in request and the SPA ping-ponged sign-in <-> /app
+        # (2026-09-01 sign-in outage). Origin no-store wins over the policy TTL.
+        add_header Cache-Control "private, no-store" always;
         error_page 401 = @sign_in;
         gzip off;
         root /usr/share/nginx/html;


### PR DESCRIPTION
**Outage (2026-09-01, owner report: "I can't sign into the production site. It thrashes endlessly").**

**Mechanism, verified on prod.** CloudFront's `html` cache policy (`infra/cloudfront.tf`, `default_ttl = 60`, `cookie_behavior = "none"`) caches the anonymous `302 /sign-in?next=/app/generate&` that nginx's `auth_request` gate returns, keyed without cookies, and replays it to the next request **with** a valid session cookie:

```
GET /app/generate                              -> 302  x-cache: Miss from cloudfront
GET /app/generate                              -> 302  x-cache: Hit from cloudfront
GET /app/generate  (Cookie: __Secure-...=…)    -> 302  x-cache: Hit from cloudfront   # the bug
```

After sign-in, `AuthPage` sees the session and does `window.location.replace(next)`; CloudFront answers with the cached anonymous 302; the sign-in page loads, sees the session, jumps again. nginx access log for the owner's IP over 45 minutes: 2× `POST /api/auth/sign-in/email` 200, 3× gate 302, **165× `GET /api/auth/get-session`**, 162× `/api/features` (66 aborted) — the SPA ping-pong, page loads mostly served from cache. The backend saw no failing request at all.

**Fix.** `add_header Cache-Control "private, no-store" always;` on `@sign_in` and on both `auth_request`-gated locations (`= /app/insights`, `^~ /app`). `min_ttl = 0` on the html policy means the origin's `no-store` is honoured (cloudfront.tf's own note at ~L286). Session-dependent responses are never cached again, in either direction.

**Guard.** `backend/tests/test_nginx_gated_responses_uncached.py` parses `nginx.conf`, finds every location gating on `auth_request /_auth_session` plus `@sign_in`, and requires the header on each; an anti-vacuity test pins the gated set to exactly the two `/app` locations. Mutation (header removed from `^~ /app`):
```
E   ... CloudFront will cache an anonymous 302 and replay it to signed-in users: ^~ /app
1 failed, 1 passed
```
Restored: `2 passed`.

**Mitigation already applied on prod:** CloudFront invalidation `I9XCS33QBAVEUFMJRO9R0NJLAU` on `/app/*`, `/app`, `/sign-in*` (clears today's cached redirects; the next anonymous visit re-caches one until this ships).

**Structural follow-up (own PR, needs terraform apply):** a CloudFront behavior for `/app/*` and `/sign-in` on `CachingDisabled` with the `all_viewer` origin request policy, so a future nginx edit cannot reintroduce this.

Ships via the normal CI deploy (nginx image rebuilt). Do not merge — owner vets first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx