### PR TITLE
[ux] Generate: the model card leads with the engine, not the per-token rate

### DIFF
--- a/ui/src/components/ModelCostPanel.jsx
+++ b/ui/src/components/ModelCostPanel.jsx
@@ -15,6 +15,16 @@ import pricing from '../data/modelPricing.json'
 //
 // `selectedModel` / `onSelectModel` lift the choice into the Generate flow. The
 // data is a snapshot (ui/src/data/modelPricing.json); the active row is live.
+//
+// COLLAPSED HEADER copy: it leads with what the engine IS (a debate society
+// over the research corpus — agents/debate_engine.py, the sole generation
+// pipeline) and only then quotes the per-token rate, labelled as the
+// provider's list price. The old header led with "Running <model> · $x in /
+// $y out per 1M tokens", which is true but reads as a bill on a page whose
+// first job is to tell you what you are about to run. The served model is
+// never a literal in this file — it comes from /health's `llm_model` and is
+// matched against the snapshot, so the card cannot name a model the backend
+// is not running. Guarded by ui/test/model-cost-line.test.js.
 
 const blended = (m) => m.input * 0.75 + m.output * 0.25
 const fmt = (x) => (x == null ? '—' : `$${x.toFixed(x < 1 ? 3 : 2)}`)
@@ -39,6 +49,11 @@ export default function ModelCostPanel({ selectedModel = null, onSelectModel }) 
   const active = rows.find((m) => m.model_id && m.model_id === activeModel)
   // The chosen model row (for the collapsed-header summary), if any.
   const chosen = rows.find((m) => m.model_id && m.model_id === selectedModel)
+  // The row whose published rate the collapsed header quotes: the user's pick
+  // if they made one, else the model /health reports as being served. Null
+  // when neither is known (or the served id is not in the snapshot) — the
+  // header then quotes no price at all rather than guessing one.
+  const priced = chosen || active
 
   // Free-tier-only selection. Premium rows are never selectable here.
   const selectable = (m) => Boolean(m.works_now && m.model_id && onSelectModel)
@@ -61,18 +76,28 @@ export default function ModelCostPanel({ selectedModel = null, onSelectModel }) 
         }}
       >
         <div>
-          <div className="label" style={{ marginBottom: 2 }}>Model &amp; cost</div>
+          <div className="label" style={{ marginBottom: 2 }}>Strategy engine</div>
+          {/* Lead line — WHAT you are running. The served model is read from
+              /health (activeModel) or the user's own pick; it is never a
+              literal here, so this line cannot name a model we are not
+              running. */}
           <div className="caption" style={{ color: 'var(--text-3)' }}>
+            Debate society over the research corpus
             {chosen ? (
-              <>Will run <strong style={{ color: 'var(--text-1)' }}>{chosen.provider} {chosen.name}</strong>
-                {' · '}{fmt(chosen.input)} in / {fmt(chosen.output)} out per 1M tokens</>
+              <>, next run served by <strong style={{ color: 'var(--text-1)' }}>{chosen.provider} {chosen.name}</strong></>
             ) : active ? (
-              <>Running <strong style={{ color: 'var(--text-1)' }}>{active.provider} {active.name}</strong>
-                {' · '}{fmt(active.input)} in / {fmt(active.output)} out per 1M tokens</>
+              <>, served by <strong style={{ color: 'var(--text-1)' }}>{active.provider} {active.name}</strong></>
             ) : activeModel ? (
-              <>Running <strong style={{ color: 'var(--text-1)' }}>{activeModel}</strong></>
+              <>, served by <strong style={{ color: 'var(--text-1)' }}>{activeModel}</strong></>
+            ) : null}
+          </div>
+          {/* Secondary line — the rate, explicitly labelled as the provider's
+              published list price so it does not read as your bill. */}
+          <div className="caption" style={{ color: 'var(--text-3)', marginTop: 2 }}>
+            {priced ? (
+              <>Provider list price{' · '}{fmt(priced.input)} in / {fmt(priced.output)} out per 1M tokens</>
             ) : (
-              <>Compare model costs across {rows.length} options on Bedrock</>
+              <>Compare provider list prices across {rows.length} models on Bedrock</>
             )}
           </div>
         </div>

--- a/ui/test/model-cost-line.test.js
+++ b/ui/test/model-cost-line.test.js
@@ -26,9 +26,14 @@
 //
 // Idiom is the repo's source-text one (oracle-copy.test.js,
 // roadmap-copy.test.js): `.jsx` is not importable under `node --test`, so the
-// component is read as text. Every check below is paired with a mutation that
-// must turn it red, so a check that stops checking anything fails loudly
-// instead of passing vacuously.
+// component is read as text. The three properties above are each computed by a
+// `null`-or-reason helper (`orderingProblem`, `priceLabelProblem`,
+// `hardCodedModelProblem`) and each is paired with a mutation test that feeds
+// the helper an input it must reject and asserts the exact reason — so a helper
+// that stops checking anything fails loudly instead of passing vacuously. The
+// two remaining tests (the /health wiring and the drill-in) are flat
+// `assert.match` regexes with no branch that can silently stop checking, so
+// they carry no paired mutation.
 
 import { readFileSync } from "node:fs";
 import assert from "node:assert/strict";
@@ -196,7 +201,7 @@ test("mutation: a hard-coded served model is rejected", () => {
 		`Debate society over the research corpus, served by ${recommended.provider} ${recommended.name}`,
 	);
 	assert.equal(
-		hardCodedModelProblem(HARD_CODED),
+		hardCodedModelProblem(stripComments(HARD_CODED)),
 		`hard-codes model name ${recommended.name}`,
 		`writing ${JSON.stringify(recommended.name)} into the card is not caught by the hard-coded-model check — it is guarding nothing`,
 	);

--- a/ui/test/model-cost-line.test.js
+++ b/ui/test/model-cost-line.test.js
@@ -98,6 +98,18 @@ function priceLabelProblem(text) {
 	return null;
 }
 
+// `null` = no snapshot model name or id is a literal in the source; a string
+// = the problem. Shared by the property test and the mutation that must turn
+// it red — a check inlined only on the clean source cannot be shown to reject
+// a hard-coded model.
+function hardCodedModelProblem(src) {
+	for (const m of pricing.models) {
+		if (src.includes(m.name)) return `hard-codes model name ${m.name}`;
+		if (src.includes(m.model_id)) return `hard-codes model id ${m.model_id}`;
+	}
+	return null;
+}
+
 // ── 1. The header leads with the engine ───────────────────────────────────
 
 test("collapsed header names the engine before it quotes any price", () => {
@@ -169,16 +181,11 @@ test("no model name or id from the pricing snapshot is hard-coded in the card", 
 		pricing.models.length > 1,
 		"pricing snapshot is empty — this check would be vacuous",
 	);
-	for (const m of pricing.models) {
-		assert.ok(
-			!panel.includes(m.name),
-			`ModelCostPanel.jsx hard-codes the model name ${JSON.stringify(m.name)}. The card must name only the model /health reports as served (or the user's pick), never a literal — a literal keeps claiming that model after the backend moves off it.`,
-		);
-		assert.ok(
-			!panel.includes(m.model_id),
-			`ModelCostPanel.jsx hard-codes the model id ${JSON.stringify(m.model_id)} — same problem as a hard-coded name.`,
-		);
-	}
+	assert.equal(
+		hardCodedModelProblem(stripComments(panel)),
+		null,
+		"ModelCostPanel.jsx hard-codes a model name or id from the pricing snapshot. The card must name only the model /health reports as served (or the user's pick), never a literal — a literal keeps claiming that model after the backend moves off it.",
+	);
 });
 
 test("mutation: a hard-coded served model is rejected", () => {
@@ -188,8 +195,9 @@ test("mutation: a hard-coded served model is rejected", () => {
 		"Debate society over the research corpus",
 		`Debate society over the research corpus, served by ${recommended.provider} ${recommended.name}`,
 	);
-	assert.ok(
-		HARD_CODED.includes(recommended.name),
+	assert.equal(
+		hardCodedModelProblem(HARD_CODED),
+		`hard-codes model name ${recommended.name}`,
 		`writing ${JSON.stringify(recommended.name)} into the card is not caught by the hard-coded-model check — it is guarding nothing`,
 	);
 });

--- a/ui/test/model-cost-line.test.js
+++ b/ui/test/model-cost-line.test.js
@@ -1,0 +1,248 @@
+// Claim + orientation guard for the Generate page's engine card
+// (ui/src/components/ModelCostPanel.jsx).
+//
+// Owner observation (screenshot, Generate page, under "Approve & Generate"):
+// the card read
+//
+//     MODEL & COST
+//     Running Amazon Nova Micro · $0.035 in / $0.140 out per 1M tokens
+//
+// Every word of that is true, but it leads with a billing rate on the one
+// surface whose first job is to tell a new user WHAT they are about to run.
+// The reworked header leads with the engine ("Strategy engine — debate
+// society over the research corpus, served by <model>") and keeps the rate as
+// a secondary line, labelled as the provider's published list price rather
+// than as the user's bill.
+//
+// This file pins three properties of that header:
+//
+//   1. it names the engine BEFORE it quotes any per-token price;
+//   2. the price is labelled as the provider's list price;
+//   3. it can never claim a model the backend is not running — no model name
+//      or model id from the pricing snapshot appears as a literal in the
+//      component, and the served model is still read from /health's
+//      `llm_model` through the shared fetchHealth cache, matched against the
+//      snapshot by `model_id` (the same source the card used before).
+//
+// Idiom is the repo's source-text one (oracle-copy.test.js,
+// roadmap-copy.test.js): `.jsx` is not importable under `node --test`, so the
+// component is read as text. Every check below is paired with a mutation that
+// must turn it red, so a check that stops checking anything fails loudly
+// instead of passing vacuously.
+
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const pricing = JSON.parse(
+	readFileSync(
+		new URL("../src/data/modelPricing.json", import.meta.url),
+		"utf8",
+	),
+);
+
+const panel = readFileSync(
+	new URL("../src/components/ModelCostPanel.jsx", import.meta.url),
+	"utf8",
+);
+
+// Comments are not copy. Without this, a `{/* ... list price ... */}` note
+// next to the markup would satisfy a check about what the user reads (it did,
+// on the first run of this file).
+function stripComments(text) {
+	return text.replace(/\{?\/\*[\s\S]*?\*\/\}?/g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+// ── The collapsed header: the toggle button's own subtree ──────────────────
+// Everything a user sees before they drill in lives between the toggle's
+// `aria-expanded={open}` and its `</button>`. Slicing it keeps the ordering
+// assertions honest: the drill-in table below quotes prices too, and a
+// whole-file index comparison would pass on a header that quoted nothing.
+function collapsedHeader(src) {
+	const start = src.indexOf("aria-expanded={open}");
+	const end = src.indexOf("</button>", start);
+	assert.ok(
+		start >= 0 && end > start,
+		"ModelCostPanel.jsx: could not find the collapsed header (the `aria-expanded={open}` toggle button) — this guard is reading the wrong region",
+	);
+	return stripComments(src.slice(start, end));
+}
+
+const header = collapsedHeader(panel);
+
+// `null` = header is well-ordered; a string = the problem, so the mutation
+// tests below can assert the exact rejection reason instead of "some error".
+function orderingProblem(text) {
+	const engine = text.search(/Strategy engine/);
+	const corpus = text.search(/[Dd]ebate society over the research corpus/);
+	const price = text.search(/per 1M tokens/);
+	if (engine < 0) return "header never names the strategy engine";
+	if (corpus < 0) return "header never says what the engine does";
+	if (price < 0) return "header quotes no per-token rate at all";
+	if (engine > price || corpus > price)
+		return "header quotes the per-token price before it names the engine";
+	return null;
+}
+
+// `null` = the rate is labelled as the provider's list price ahead of the
+// numbers; a string = the problem.
+function priceLabelProblem(text) {
+	// `\b` after "price" so the plural fallback line ("Compare provider list
+	// prices across N models") cannot stand in for the real label.
+	const label = text.search(/[Pp]rovider list price\b/);
+	const price = text.search(/per 1M tokens/);
+	if (price < 0) return "header quotes no per-token rate at all";
+	if (label < 0) return "the per-token rate is not labelled as a list price";
+	if (label > price)
+		return "the per-token rate appears before its list-price label";
+	return null;
+}
+
+// ── 1. The header leads with the engine ───────────────────────────────────
+
+test("collapsed header names the engine before it quotes any price", () => {
+	assert.equal(
+		orderingProblem(header),
+		null,
+		"ModelCostPanel.jsx's collapsed header must name the strategy engine (and what it does) before the per-token rate — the owner's screenshot showed the rate leading",
+	);
+});
+
+test("mutation: a price-led header is rejected", () => {
+	// (a) the literal pre-change header from the owner's screenshot.
+	const PRE_CHANGE = `<>Running <strong style={{ color: 'var(--text-1)' }}>{active.provider} {active.name}</strong>{' · '}{fmt(active.input)} in / {fmt(active.output)} out per 1M tokens</>`;
+	assert.equal(
+		orderingProblem(PRE_CHANGE),
+		"header never names the strategy engine",
+		"the ordering check no longer rejects the exact header this change replaced — it is guarding nothing",
+	);
+
+	// (b) the SHIPPED header, mechanically rotated so its price block leads.
+	// This is the reorder-only mutation: not one word changes, only the order.
+	const pricePos = header.search(/per 1M tokens/);
+	const reordered = header.slice(pricePos) + header.slice(0, pricePos);
+	assert.equal(
+		orderingProblem(reordered),
+		"header quotes the per-token price before it names the engine",
+		"reordering the shipped header so the price leads does not turn the ordering check red — it is guarding nothing",
+	);
+});
+
+// ── 2. The rate is labelled as the provider's list price ──────────────────
+
+test("the per-token rate is labelled as the provider's list price", () => {
+	assert.equal(
+		priceLabelProblem(header),
+		null,
+		"ModelCostPanel.jsx's collapsed header must label the per-token rate as the provider's list price, not present it as the user's bill",
+	);
+	assert.match(
+		header,
+		/Provider list price/,
+		"expected the literal 'Provider list price' label on the secondary line",
+	);
+});
+
+test("mutation: an unlabelled rate is rejected", () => {
+	// (a) the pre-change header from the owner's screenshot — a bare rate.
+	const PRE_CHANGE = `<>Running <strong>{active.provider} {active.name}</strong>{' · '}{fmt(active.input)} in / {fmt(active.output)} out per 1M tokens</>`;
+	assert.equal(
+		priceLabelProblem(PRE_CHANGE),
+		"the per-token rate is not labelled as a list price",
+		"the label check no longer rejects the exact header this change replaced — it is guarding nothing",
+	);
+
+	// (b) the SHIPPED header with only its label word swapped for a claim
+	// about the user's own bill.
+	const UNLABELLED = header.replace(/Provider list price/g, "Your cost");
+	assert.equal(
+		priceLabelProblem(UNLABELLED),
+		"the per-token rate is not labelled as a list price",
+		"stripping the list-price label does not turn the label check red — it is guarding nothing",
+	);
+});
+
+// ── 3. The card can only name the model it is actually being served by ────
+
+test("no model name or id from the pricing snapshot is hard-coded in the card", () => {
+	assert.ok(
+		pricing.models.length > 1,
+		"pricing snapshot is empty — this check would be vacuous",
+	);
+	for (const m of pricing.models) {
+		assert.ok(
+			!panel.includes(m.name),
+			`ModelCostPanel.jsx hard-codes the model name ${JSON.stringify(m.name)}. The card must name only the model /health reports as served (or the user's pick), never a literal — a literal keeps claiming that model after the backend moves off it.`,
+		);
+		assert.ok(
+			!panel.includes(m.model_id),
+			`ModelCostPanel.jsx hard-codes the model id ${JSON.stringify(m.model_id)} — same problem as a hard-coded name.`,
+		);
+	}
+});
+
+test("mutation: a hard-coded served model is rejected", () => {
+	const recommended = pricing.models.find((m) => m.recommended);
+	assert.ok(recommended, "pricing snapshot has no recommended model to mutate with");
+	const HARD_CODED = panel.replace(
+		"Debate society over the research corpus",
+		`Debate society over the research corpus, served by ${recommended.provider} ${recommended.name}`,
+	);
+	assert.ok(
+		HARD_CODED.includes(recommended.name),
+		`writing ${JSON.stringify(recommended.name)} into the card is not caught by the hard-coded-model check — it is guarding nothing`,
+	);
+});
+
+test("the served model is still read from /health's llm_model, matched by model_id", () => {
+	// The card's claim is only as good as its source. Keep it on the shared
+	// health cache (#1333) and on the id-equality lookup, so "served by X"
+	// tracks the backend instead of a snapshot guess.
+	assert.match(
+		panel,
+		/fetchHealth\(\)/,
+		"ModelCostPanel.jsx must read the served model through the shared fetchHealth() cache",
+	);
+	assert.match(
+		panel,
+		/setActiveModel\(d\?\.llm_model \|\| null\)/,
+		"the served model must come from /health's llm_model field",
+	);
+	assert.match(
+		panel,
+		/rows\.find\(\(m\) => m\.model_id && m\.model_id === activeModel\)/,
+		"the header's model row must be the snapshot row whose model_id equals the served model id",
+	);
+	// The rate quoted in the header is that row's (or the user's pick's) —
+	// never a constant.
+	assert.match(
+		panel,
+		/const priced = chosen \|\| active/,
+		"the header's quoted rate must come from the chosen or served row",
+	);
+	assert.doesNotMatch(
+		header,
+		/\$\d/,
+		"the collapsed header must not contain a literal dollar figure — the rate is formatted from the snapshot row",
+	);
+});
+
+// ── 4. The drill-in the header opens is still there ───────────────────────
+
+test("the header still drills in to the full model/cost table", () => {
+	assert.match(
+		panel,
+		/aria-expanded=\{open\}/,
+		"the collapsed header must remain an expand toggle",
+	);
+	assert.match(
+		panel,
+		/<table/,
+		"the drill-in must still render the full model cost table",
+	);
+	assert.match(
+		panel,
+		/\{pricing\.note\}/,
+		"the drill-in must still carry the pricing snapshot's own note",
+	);
+});


### PR DESCRIPTION
## The owner's observation

Screenshot of the Generate page, bottom — the card under **Approve & Generate**:

> **MODEL & COST**
> Running Amazon Nova Micro · $0.035 in / $0.140 out per 1M tokens

Every word of that is true. The problem is what it leads with: a billing rate,
on the one surface whose first job is to tell a new user *what they are about
to run*. And the number reads as the user's bill when it is actually the
provider's published on-demand list price out of the pricing snapshot.

## Root cause

`ui/src/components/ModelCostPanel.jsx` is, by construction, a cost-comparison
panel — the collapsed header was written as a one-line summary of the table
underneath it (`Running <model> · $x in / $y out per 1M tokens`), not as an
answer to "what engine am I running?". Nothing was wrong; the card was
answering a question the user had not asked yet.

## The change (copy only)

The collapsed header now leads with the engine and demotes the rate:

```
Strategy engine
Debate society over the research corpus, served by Amazon Nova Micro
Provider list price · $0.035 in / $0.140 out per 1M tokens
```

- **Lead line** — what the engine *is*. "Debate society over the research
  corpus" is the shipped pipeline, not a slogan: `agents/debate_engine.py` is
  the sole generation path (T1.1 Phase 3). Both halves of the phrase are the
  repo's existing wording, but the compound is new copy here:
  `Architecture.jsx:417` says *"Archimedes instead runs a **debate society** —
  the sole generation path"*, and `Architecture.jsx:224` describes that stage as
  *"proposer society drafts candidates from the research corpus and current
  market regime"*. The exact string *"debate society over the research corpus"*
  appears nowhere else in `ui/src` or `backend/archimedes` — this PR introduces
  it, compressing those two lines into one.
- **Secondary line** — the same numbers as before, now labelled **Provider
  list price** so it does not read as the viewer's bill.
- **Drill-in unchanged** — same expand toggle, same full model/cost table,
  same snapshot note, same free-tier-only selection.

Model-name honesty is preserved by construction: the served model is still read
from `/health`'s `llm_model` through the shared `fetchHealth()` cache and
matched to the snapshot by `model_id` (`priced = chosen || active`). No model
name or id appears as a literal anywhere in the component, so the card can only
name what the backend reports. When `/health` has not answered, the header
names no model and quotes no price.

Files: `ui/src/components/ModelCostPanel.jsx` (header block + comment),
`ui/test/model-cost-line.test.js` (new).

## Guard

`ui/test/model-cost-line.test.js` — the repo's source-text idiom
(`oracle-copy.test.js`, `roadmap-copy.test.js`); `.jsx` is not importable under
`node --test`. It slices the collapsed header out of the toggle button's own
subtree (so the price table below cannot satisfy it), strips comments (so a
`{/* ... list price ... */}` note cannot stand in for copy — that vacuity bit
me on the first run and is why `stripComments` exists), and checks:

1. the header names the engine, and what it does, **before** any per-token rate;
2. the rate carries the literal **Provider list price** label, ahead of the numbers;
3. no `name` or `model_id` from `modelPricing.json` is hard-coded in the component;
4. the served model still comes from `fetchHealth()` → `d?.llm_model` → `model_id` equality, and the header contains no literal dollar figure;
5. the expand toggle and the full table are still there.

Checks 1–3 are each computed by a `null`-or-reason helper (`orderingProblem`,
`priceLabelProblem`, `hardCodedModelProblem`) and each is paired with a mutation
test that feeds **the helper** an input it must reject and asserts the exact
reason — so a helper that stops checking anything fails loudly instead of
passing green. Checks 4 and 5 are flat `assert.match` regexes with no branch
that can silently stop checking, so they carry no paired mutation; the file
header says so rather than claiming blanket coverage.

## Folded in: #1777 (Daniel Reis)

The first review of this PR found that check 3's mutation test was **vacuous**:
it built `HARD_CODED` by splicing `recommended.name` into the source and then
only asserted `HARD_CODED.includes(recommended.name)` — true by construction,
and it never ran the guard. Weakening the real check left all 8 tests green.

#1777 (`cursor/hardcoded-model-mutation-68b7`, based on this branch) fixes it by
hoisting the check into `hardCodedModelProblem(src)` and pointing both the
property test and the mutation at it. Merged here as `db52bc88` with his
authorship intact (`633a06fa`, Cursor Agent). **#1777 needs no separate merge —
close it as merged-via-parent.**

Follow-up commit `fadd2864` on top: the file header claimed *"Every check below
is paired with a mutation that must turn it red"*, which was not true of checks
4 and 5 — narrowed to the three paired helpers, with the reason the other two
need none. Same commit feeds the mutation `stripComments(HARD_CODED)`, the same
comment-stripped source its property test uses, so the two cannot diverge if a
future comment in `ModelCostPanel.jsx` ever names a snapshot model.

## Adversarial demo — the guard shown red

Four mutations, each reverted; the committed files are the clean ones.

**Mutation 1 — reorder only.** Swap the two `<div>` blocks in the header so the
price leads. Not one word changes:

```
✖ collapsed header names the engine before it quotes any price
  AssertionError: ModelCostPanel.jsx's collapsed header must name the strategy
  engine (and what it does) before the per-token rate — the owner's screenshot
  showed the rate leading
  + actual   'header quotes the per-token price before it names the engine'
  - expected null
ℹ pass 7  ℹ fail 1  — exit 1
```

**Mutation 2 — claim a model we may not be running.** Write the served model in
as a literal (`, served by Amazon Nova Micro`) instead of reading `/health`:

```
✖ no model name or id from the pricing snapshot is hard-coded in the card
  AssertionError: ModelCostPanel.jsx hard-codes a model name or id from the
  pricing snapshot. The card must name only the model /health reports as served
  (or the user's pick), never a literal …
  actual: 'hard-codes model name Nova Micro'
  expected: null
ℹ pass 7  ℹ fail 1  — exit 1
```

**Mutation 3 — gut the guard, component untouched.** This is the pairing #1777
bought. Delete only the `m.name` branch from `hardCodedModelProblem` and leave
`ModelCostPanel.jsx` clean:

```
✔ no model name or id from the pricing snapshot is hard-coded in the card
✖ mutation: a hard-coded served model is rejected
  AssertionError: writing "Nova Micro" into the card is not caught by the
  hard-coded-model check — it is guarding nothing
  actual: null
  expected: 'hard-codes model name Nova Micro'
ℹ pass 7  ℹ fail 1  — exit 1
```

Before #1777, that exact weakening left **8 pass / 0 fail, exit 0** — the guard
was disabled and its own mutation test did not notice. That is the defect this
branch now closes.

**Mutation 4 — the `stripComments` probe.** Move `Provider list price` into a
JSX comment and change the rendered label to `Your cost`, so only a comment
carries the honest word:

```
✖ the per-token rate is labelled as the provider's list price
  AssertionError: ModelCostPanel.jsx's collapsed header must label the
  per-token rate as the provider's list price, not present it as the user's bill
  actual: 'the per-token rate is not labelled as a list price'
  expected: null
ℹ pass 7  ℹ fail 1  — exit 1
```

## Verification

Run on `fadd2864` (post-#1777-merge), in `.claude/worktrees` on this branch.

| check | command | result |
| --- | --- | --- |
| new guard | `cd ui && node --test test/model-cost-line.test.js` | 8 pass, 0 fail — **exit 0** |
| full ui suite | `cd ui && node --test` | 921 tests, 921 pass, 0 fail, 0 skipped — **exit 0** |
| eslint (touched) | `cd ui && npx eslint src/components/ModelCostPanel.jsx test/model-cost-line.test.js` | no output — **exit 0** |
| mutations 1–4 | see above | each 7 pass / 1 fail — **exit 1**, all reverted |
| corpus claim integrity | `pytest -p no:cacheprovider -q backend/tests/test_corpus_claim_integrity.py` | 26 passed, 1 warning — **exit 0** |
| full unit suite | `pytest -p no:cacheprovider -m "not integration" -q` | 5644 passed, 4 skipped, 2 deselected, 328 warnings in 988.02s (16:28) — **exit 0** |
| ruff | `ruff check backend` | not applicable — **0 `*.py` files in this diff** (`git diff --name-only` against the merge base = exactly the two `ui/` files). `ruff check backend` is red on this branch (37 errors) and identically red at the merge base for that reason, so CI's ruff ❌ is a pre-existing `main` condition, not this PR. |

The corpus-claim row is here because the new copy makes a corpus claim; it does
not trip `OVERCLAIM_PATTERNS` (which target embedding / semantic-retrieval / KG
claims, and this line makes none). Registering `ModelCostPanel.jsx` in that
test's `PUBLIC_SURFACES` tuple would widen the guard to cover this file — worth
doing, but it is guard-coverage hygiene rather than part of this copy fix, and
it deserves its own adversarial demo, so it is **not** in this diff.

## Known trade-off

The card's eyebrow went from "Model & cost" to "Strategy engine", so the word
"cost" no longer appears above the fold on the Generate page — costs are now one
line down under "Provider list price", and in the drill-in. That is the point of
the change, but it is a real discoverability trade and worth an owner glance at
the screenshot. "Strategy engine" is also ambiguous between the two engines
(`execution/__init__.py:15-16` — generation vs execution); this card is the
generation half. "Strategy generation engine" would disambiguate, at the cost of
a longer eyebrow. Owner's call; changing it means updating `/Strategy engine/`
in the guard too.

## Concurrency

Touches neither `dbrowneup/verdict-of-record-a`'s files (`Strategies.jsx`,
`StrategyPassport.jsx`, `strategies_routes.py`, passport writes) nor
`dbrowneup/reasoning-traces-surfaced`'s generation-stream/SSE code.
`ModelCostPanel.jsx` and `ui/test/model-cost-line.test.js` are not in either
branch's surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
