### PR TITLE
[test] Two money-path assertions that were blind: liquidity side-detection and multi-action charge amount

### DIFF
--- a/backend/tests/chain/test_chain_executor.py
+++ b/backend/tests/chain/test_chain_executor.py
@@ -134,7 +134,14 @@ class TestValidateTradeLiquidity:
             asyncio.run(executor._validate_trade_liquidity([trade]))
 
     def test_raises_on_low_reserves(self, executor, mock_loader):
-        """Pool with reserves below threshold → InsufficientLiquidityError."""
+        """Pool with reserves below threshold → InsufficientLiquidityError.
+
+        MUTATION: replace the side-detection at `executor.py` with an
+        unconditional ``usdc_reserve = r1 / 1e6`` — the fat synth reserve1
+        here would read as $1,000,000 and let the $0.10 pool through. This is
+        the token0 half of the side-detection pair; the token1 half is
+        ``test_raises_when_usdc_is_token1_and_thin`` below.
+        """
         trade = _make_trade()
         pool_addr = "0x38c3A5f52044a72C9cC11Ce621f1bfD7754BF8Bd"
         mock_loader.amm_router.functions.getPool.return_value.call = AsyncMock(return_value=pool_addr)
@@ -167,20 +174,66 @@ class TestValidateTradeLiquidity:
         asyncio.run(executor._validate_trade_liquidity([trade]))
 
     def test_usdc_as_token1(self, executor, mock_loader):
-        """When USDC is token1, reserve1 is the USDC-side reserve."""
+        """When USDC is token1, reserve1 is the USDC-side reserve.
+
+        MUTATION: replace the side-detection at `executor.py` with an
+        unconditional ``usdc_reserve = r0 / 1e6``.
+
+        The reserves here are deliberately on OPPOSITE sides of the $5
+        threshold once divided by 1e6, so this assertion can tell which
+        integer the executor read. Before this fixture change reserve0 was
+        500_000_000_000_000 — fat on both readings — and the whole chain
+        suite (336 tests) stayed green with the side-detection deleted.
+
+        Note the executor's ``/ 1e6`` is USDC-specific: the synth side is an
+        18-decimal token, so ``reserve0 / 1e6`` is not a dollar figure at all.
+        That is exactly why reading the wrong side is a money bug and why the
+        raw synth integer here is small — it is chosen to be distinguishable,
+        not to model a realistic synth balance.
+        """
         trade = _make_trade()
         pool_addr = "0xe0725Db0eC0e793Cde04Fa32BA21A4D211a5E685"
         mock_loader.amm_router.functions.getPool.return_value.call = AsyncMock(return_value=pool_addr)
 
         mock_pool = mock_loader.amm_pool.return_value
-        mock_pool.functions.reserve0.return_value.call = AsyncMock(return_value=500_000_000_000_000)  # synth
-        mock_pool.functions.reserve1.return_value.call = AsyncMock(return_value=10_000_000_000)  # USDC
+        # Synth side: misread as USDC this is $4.00, BELOW the $5 threshold.
+        mock_pool.functions.reserve0.return_value.call = AsyncMock(return_value=4_000_000)  # synth
+        mock_pool.functions.reserve1.return_value.call = AsyncMock(return_value=10_000_000_000)  # USDC = $10k
         mock_pool.functions.token0.return_value.call = AsyncMock(
             return_value="0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388"  # synth is token0
         )
 
-        # Should pass — USDC (token1) has $10k
+        # Should pass — USDC (token1) has $10k. Reading reserve0 instead raises.
         asyncio.run(executor._validate_trade_liquidity([trade]))
+
+    def test_raises_when_usdc_is_token1_and_thin(self, executor, mock_loader):
+        """USDC as token1, reserve1 BELOW threshold, fat synth reserve0 → raise.
+
+        MUTATION: replace the side-detection at `executor.py` with an
+        unconditional ``usdc_reserve = r0 / 1e6``. The mutant reads the fat
+        synth side, computes a nonsense "$900,000,000.00" of USDC liquidity,
+        and lets a $2 pool through — a real trade sent into a pool that
+        cannot fill it.
+
+        The inverse (USDC as token0, thin reserve0, fat reserve1) is pinned by
+        ``test_raises_on_low_reserves`` above, which kills the mirror mutant
+        (``usdc_reserve = r1 / 1e6``). Together the two are the full 2x2.
+        """
+        trade = _make_trade()
+        pool_addr = "0xe0725Db0eC0e793Cde04Fa32BA21A4D211a5E685"
+        mock_loader.amm_router.functions.getPool.return_value.call = AsyncMock(return_value=pool_addr)
+
+        mock_pool = mock_loader.amm_pool.return_value
+        # Fat synth side (misread as USDC it would read $900,000,000.00)...
+        mock_pool.functions.reserve0.return_value.call = AsyncMock(return_value=900_000_000_000_000)  # synth
+        # ...but the actual USDC side holds $2.00, below the $5 threshold.
+        mock_pool.functions.reserve1.return_value.call = AsyncMock(return_value=2_000_000)  # USDC = $2
+        mock_pool.functions.token0.return_value.call = AsyncMock(
+            return_value="0xE745C07d7d32A1Ca0d6162A1c50e876619CF7388"  # synth is token0
+        )
+
+        with pytest.raises(InsufficientLiquidityError, match="below threshold"):
+            asyncio.run(executor._validate_trade_liquidity([trade]))
 
     def test_fails_closed_on_unexpected_error(self, executor, mock_loader):
         """Unexpected probe errors (RPC/ABI) fail closed — leg is skipped, not allowed.

--- a/backend/tests/marketplace/test_payments.py
+++ b/backend/tests/marketplace/test_payments.py
@@ -48,6 +48,20 @@ async def test_charge_zero_amount_is_paid_without_network():
 
 @pytest.mark.asyncio
 async def test_charge_success_path():
+    """The happy path, including the AMOUNT handed to circlekit.
+
+    MUTATION: `payments.py:141` -> `fee_to_price(min(action_count, 1), ...)`.
+
+    This test already passed action_count=2 but only asserted that settle was
+    awaited, so it never saw the price: the whole marketplace package (202
+    tests) stayed green while every multi-action tick under-charged to a
+    single action. `test_fee_to_price_basic` pins the helper, not this call
+    site — nothing connected the two until the assertions below.
+
+    All three circlekit legs are checked with the same string: require (the
+    402 the publisher advertises), verify, and settle. A price that drifts
+    between advertise and settle is its own money bug.
+    """
     middleware = MagicMock()
     middleware.require.return_value = {"status": 402, "headers": {}, "body": {}}
     middleware.verify = AsyncMock(return_value=MagicMock(is_valid=True))
@@ -73,6 +87,12 @@ async def test_charge_success_path():
         )
     assert ok is True
     middleware.settle.assert_awaited_once()
+
+    # 2 actions x 100 raw units (6-decimal USDC) = $0.000200, not $0.000100.
+    expected_price = "$0.000200"
+    assert middleware.require.call_args.args[0] == expected_price  # require(price, path)
+    assert middleware.verify.await_args.args[1] == expected_price  # verify(header, price)
+    assert middleware.settle.await_args.args[1] == expected_price  # settle(header, price)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Audit citation

§E items 1–2 of the test-suite / dead-code decision package (`session-artifacts-2026-09-01/suite-deadcode-audit-decision-package.md`), scheduled as **P1-5** in the Phase 1 table: *"The two mutation-killer one-liners (§E items 1–2): fixture fix in `test_chain_executor.py:169`, amount assertion in `test_payments.py:50`. Payoff: closes two proven-blind money-path seams."*

Both are **money-path** assertions that looked like coverage and were not: one decides whether a trade is sent into a pool that cannot fill it, the other decides how much a subscriber is charged.

Tests only — **no production code changed in this PR** (`git diff origin/main...HEAD -- backend/archimedes/` is empty). The prod files below were only mutated locally, in the worktree, to run the adversarial pass, and reverted before each commit.

## What changed

| File | Change |
|---|---|
| `backend/tests/chain/test_chain_executor.py` | Fixed the blind token1 fixture (L169) + added `test_raises_when_usdc_is_token1_and_thin`; named the mirror mutant in `test_raises_on_low_reserves`'s docstring |
| `backend/tests/marketplace/test_payments.py` | `test_charge_success_path` now asserts the price string handed to `require` / `verify` / `settle` |

### 1. AMM liquidity side-detection (`chain/executor.py:197`)

```python
usdc_reserve = r0 / 1e6 if chain_client.to_checksum(t0) == usdc_addr else r1 / 1e6
```

The suite could not tell **which reserve side** this read. The token1 fixture set the synth-side `reserve0` to `500_000_000_000_000`, which also clears the `$5` `MIN_HEALTHY_LIQUIDITY_USDC` threshold once divided by `1e6` — so both readings passed it.

The fix puts the two reserves on **opposite sides** of the threshold, so each test can only pass on one reading, and adds the raising case (fat synth `reserve0`, `$2` USDC `reserve1`). With the pre-existing `test_raises_on_low_reserves` covering the token0 half, the pair is the full 2x2:

| token0 | reserve0 (raw) | reserve1 (raw) | USDC side | expected | kills |
|---|---|---|---|---|---|
| USDC | `100_000` → $0.10 | `1_000_000_000_000` fat | reserve0, thin | raise | `= r1 / 1e6` |
| synth | `4_000_000` → $4.00 | `10_000_000_000` → $10k | reserve1, fat | pass | `= r0 / 1e6` |
| synth | `900_000_000_000_000` fat | `2_000_000` → $2.00 | reserve1, thin | raise | `= r0 / 1e6` |

Note the executor's `/ 1e6` is USDC-specific — the synth side is an 18-decimal token, so `reserve0 / 1e6` is not a dollar figure at all. That is precisely why reading the wrong side is a money bug, and why the raw synth integers here are chosen to be *distinguishable* rather than realistic. The docstrings say so.

### 2. Multi-action charge amount (`marketplace/payments.py:141`)

```python
price = fee_to_price(action_count, flat_fee_raw)
```

`test_charge_success_path` already passed `action_count=2`, but asserted only `ok is True` and `settle.assert_awaited_once()` — it never looked at the price. `test_fee_to_price_basic` pins the helper in isolation; nothing connected it to this call site.

It now asserts `"$0.000200"` (2 actions × 100 raw units of 6-decimal USDC) at all three circlekit legs — `require` (the 402 the publisher advertises), `verify`, and `settle` — which additionally pins that the advertised price and the settled price are the same string.

## Adversarial demo — the guards shown red on the input they reject

Both mutants were confirmed **green on `origin/main` first**, then confirmed **red** with these commits. Every prod mutation was reverted immediately after.

**Baseline — blind on `origin/main`:**

```
$ # executor.py:197 -> usdc_reserve = r0 / 1e6
$ pytest backend/tests/chain/ -q -p no:cacheprovider
336 passed, 2 skipped, 4 warnings in 11.30s
EXIT=0

$ # payments.py:141 -> fee_to_price(min(action_count, 1), flat_fee_raw)
$ pytest backend/tests/marketplace/ -q -p no:cacheprovider
202 passed, 1 warning in 35.98s
```

**After — red on exactly the input each guard rejects:**

```
$ # MUTANT A: executor.py:197 -> usdc_reserve = r0 / 1e6
$ pytest backend/tests/chain/test_chain_executor.py -q -p no:cacheprovider
FAILED ...::TestValidateTradeLiquidity::test_usdc_as_token1
  - archimedes.chain.executor.InsufficientLiquidityError: Pool 0xe0725Db0… (sTS...
FAILED ...::TestValidateTradeLiquidity::test_raises_when_usdc_is_token1_and_thin
  - Failed: DID NOT RAISE <class 'archimedes.chain.executor.InsufficientLiquidi...
2 failed, 44 passed, 1 warning in 2.02s

$ # MUTANT B (the mirror): executor.py:197 -> usdc_reserve = r1 / 1e6
$ pytest backend/tests/chain/test_chain_executor.py -q -p no:cacheprovider
FAILED ...::TestValidateTradeLiquidity::test_raises_on_low_reserves
  - Failed: DID NOT RAISE <class 'archimedes.chain.executor.InsufficientLiquidi...
1 failed, 45 passed, 1 warning in 2.08s

$ # MUTANT C: payments.py:141 -> fee_to_price(min(action_count, 1), flat_fee_raw)
$ pytest backend/tests/marketplace/ -q -p no:cacheprovider
FAILED backend/tests/marketplace/test_payments.py::test_charge_success_path
  - AssertionError: assert '$0.000100' == '$0.000200'
1 failed, 201 passed, 1 warning in 60.41s
```

The adversarial pass also caught a bug in **my own** first draft of the assertion: I read the price off `args[0]` of `verify`/`settle`, whose signature is `(header, price)`, and got `assert 'hdr' == '$0.000200'`. Fixed to `args[1]` before committing.

## Verification

```
$ pytest backend/tests/chain/ -q -p no:cacheprovider
337 passed, 2 skipped, 4 warnings          EXIT=0

$ pytest backend/tests/marketplace/test_payments.py -q -p no:cacheprovider
11 passed, 1 warning                        EXIT=0

$ ruff format && ruff check   # both touched files
1 file left unchanged / All checks passed!   RUFF_EXIT=0
```

Full unit suite (`pytest -m "not integration" -q -p no:cacheprovider`, log `/tmp/p1-5-money-assertions-suite.log`):

```
NOT RUN TO COMPLETION — abandoned at [ 40%], stuck inside
test_alembic_migrations.py (the file the same audit flags as 13.5% of the
suite, P1-4). Cause is box contention, not this change: eight sibling
agents were running the full unit suite concurrently on the same machine,
and one additional alembic test was completing per ~10 minutes. The run
was killed to stop adding to the contention.

Substituted, all green:
  $ pytest -m "not integration" -q -p no:cacheprovider --collect-only
  5649/5651 tests collected (2 deselected) in 8.10s     EXIT=0
```

**Deleting-PR blind spot:** nothing is deleted or renamed here, but `docs/` was grepped for every touched name anyway. `docs/specs/execution-trading-agent-society-spec.md:180,281` reference `_validate_trade_liquidity`, which is unchanged and still exists — no doc edits needed.

**PROTECTED tests:** none deleted or weakened. `test_raises_on_low_reserves` and `test_usdc_as_token1` were both *strengthened* (a fixture value moved so it can distinguish, assertions only added). The three tests now carry `MUTATION:` revert-demo docstrings per the repo convention, which makes them protected going forward.

## Concerns for the vet

0. **The full unit suite did not finish** (see above). I judged the marginal
   risk low — this PR adds assertions to two test files, changes no
   production code, no other test imports either file, and whole-suite
   collection is clean — but it is not the same as a green full run.
   Worth re-running `pytest -m "not integration"` when the box is quiet
   before merging.
1. `test_usdc_as_token1`'s synth `reserve0 = 4_000_000` is physically absurd for an 18-decimal token (4e-12 sTSLA). That is deliberate — it is the only way to make the two sides distinguishable given the executor divides *both* by `1e6` — and the docstring says so. If you'd rather the fixtures stay physically plausible, the alternative is to lower the threshold constant in the test or parametrize `MIN_HEALTHY_LIQUIDITY_USDC`; say the word and I'll switch.
2. These tests pin **side-detection, not pool-health policy**. A pool with a fat USDC side and a near-empty synth side passes, because the executor only checks the USDC side by design. That may itself be worth an issue — a one-sided pool cannot fill a buy — but changing it is a production behaviour change and out of scope for a test-only PR.
3. Asserting on `verify`/`settle` positionally (`await_args.args[1]`) couples the test to circlekit's call shape. It is the same coupling the surrounding tests already have, but a keyword-arg refactor in `charge()` would break it loudly rather than silently.

Two commits, one logical change each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
