### PR TITLE
test(rigor): restore the `is None` claim in the num_trials correlation guard (audit P1-6)

### DIFF
--- a/backend/tests/test_num_trials_correlation_guard.py
+++ b/backend/tests/test_num_trials_correlation_guard.py
@@ -56,15 +56,15 @@ def test_guard_allows_the_real_num_trials_one_cohort_case():
     """Today's actual usage at all three call sites: num_trials=1 with a
     real, nonzero cohort-wide correlation. Must never raise — this is the
     documented-safe combination (E[max_N]=0 makes the correlation inert)."""
-    assert_self_contained_cohort_correlation(1, 0.73) is None
-    assert_self_contained_cohort_correlation(1, 0.0) is None
+    assert assert_self_contained_cohort_correlation(1, 0.73) is None
+    assert assert_self_contained_cohort_correlation(1, 0.0) is None
 
 
 def test_guard_allows_genuinely_self_contained_multi_trial_with_zero_correlation():
     """A strategy's OWN N-candidate generation pool or parameter-variant grid
     legitimately passes num_trials>1 — the guard must not block that, only
     the COMBINATION with a nonzero (cohort) correlation."""
-    assert_self_contained_cohort_correlation(35, 0.0) is None
+    assert assert_self_contained_cohort_correlation(35, 0.0) is None
 
 
 # ── 3. Wiring: all three call sites actually invoke the guard ──────────────


### PR DESCRIPTION
## Audit citation

**P1-6** in the test-suite/dead-code decision package (Phase 1 — zero-risk):

> **P1-6** | Hygiene: add missing `assert` keywords at `test_num_trials_correlation_guard.py:60-61,69`. This file is a PROTECTED adversarial guard — apply the repo's own rule: after editing, run the input that SHOULD fail and confirm it still does | Restores the `is None` claim | None if adversarial pass done

(Lines are **59-60 and 67** in current `main` — the audit's numbering was off by one; same three statements.)

## What changed

One file, three lines, test-only. No prod code touched.

```diff
 def test_guard_allows_the_real_num_trials_one_cohort_case():
-    assert_self_contained_cohort_correlation(1, 0.73) is None
-    assert_self_contained_cohort_correlation(1, 0.0) is None
+    assert assert_self_contained_cohort_correlation(1, 0.73) is None
+    assert assert_self_contained_cohort_correlation(1, 0.0) is None

 def test_guard_allows_genuinely_self_contained_multi_trial_with_zero_correlation():
-    assert_self_contained_cohort_correlation(35, 0.0) is None
+    assert assert_self_contained_cohort_correlation(35, 0.0) is None
```

These were bare expressions: Python evaluated `... is None` and threw the result away. The tests still exercised the guard (a raise would have propagated), so the **rejection** half of each test was real — what was blind is the **`is None`** half, i.e. the claim that the legitimate inputs return `None` rather than some other value.

This is not just an eyeball finding — `ruff check` flags all three on `main` today:

```
$ git show origin/main:backend/tests/test_num_trials_correlation_guard.py | ruff check --stdin-filename backend/tests/test_num_trials_correlation_guard.py -
B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
  --> backend/tests/test_num_trials_correlation_guard.py:59:5
B015 Pointless comparison at end of function scope. Did you mean to return the expression result?
  --> backend/tests/test_num_trials_correlation_guard.py:60:5
B015 Pointless comparison at end of function scope. Did you mean to return the expression result?
  --> backend/tests/test_num_trials_correlation_guard.py:67:5
```

After this PR, `ruff check --select B015 .` is clean **repo-wide** — this file held the only three.

Nothing was deleted, so the deleting-PR docs-grep rule does not bite; `grep -rn "test_num_trials_correlation_guard" .` returns zero references outside the file itself.

## Adversarial demo (the repo rule: show the guard red on what it must reject)

This file is a PROTECTED decouple-#2 adversarial guard (num_trials-provenance audit, 2026-08-03, V4). Three passes.

### 1. The guard rejects the forbidden input (direct, prod code unmodified)

`assert_self_contained_cohort_correlation(num_trials, average_correlation)` must reject `num_trials != 1` combined with a nonzero cohort-wide correlation:

```
$ python -c "<call the guard directly>"
DEMO 1 - the input the guard MUST reject (num_trials>1 + nonzero cohort correlation):
  g(25, 0.31)  -> RuntimeError: cohort-wide average_correlation=0.31 combined with num_trials=25 != 1 — this re-couples a curate...
  g(2, 1e-09)  -> RuntimeError: cohort-wide average_correlation=1e-09 combined with num_trials=2 != 1 — this re-couples a curate...
DEMO 1b - the legitimate inputs (must return None):
  g(1, 0.73)   -> None
  g(1, 0.0)    -> None
  g(35, 0.0)   -> None
```

### 2. MUTATION-A — the exact blindness this PR closes

Make the guard stop returning `None` (append `return False` to `_rigor_helpers.assert_self_contained_cohort_correlation`). **With this PR's asserts, the file goes red:**

```
backend/tests/test_num_trials_correlation_guard.py .FF....                [100%]
=================================== FAILURES ===================================
E   assert False is None
     +  where False = assert_self_contained_cohort_correlation(1, 0.73)
backend/tests/test_num_trials_correlation_guard.py:59: assert False is None
E   assert False is None
     +  where False = assert_self_contained_cohort_correlation(35, 0.0)
backend/tests/test_num_trials_correlation_guard.py:67: assert False is None
=========================== short test summary info ============================
FAILED ...::test_guard_allows_the_real_num_trials_one_cohort_case - assert False is None
FAILED ...::test_guard_allows_genuinely_self_contained_multi_trial_with_zero_correlation - assert False is None
========================= 2 failed, 5 passed in 2.94s ==========================
```

**With `main`'s bare expressions and the same mutation applied, the file is green** — that is the blind spot:

```
backend/tests/test_num_trials_correlation_guard.py .......                [100%]
========================= 7 passed, 1 warning in 1.52s =========================
```

### 3. MUTATION-B — the rejection half still guards (regression check on this edit)

Make the guard stop firing (`if False:` in place of `if num_trials != 1 and average_correlation != 0.0:`). Red, as it must be — my edit did not weaken it:

```
=========================== short test summary info ============================
FAILED ...::test_guard_rejects_num_trials_above_one_with_nonzero_cohort_correlation - Failed: DID NOT RAISE <class 'RuntimeError'>
==================== 1 failed, 6 passed, 1 warning in 1.57s ====================
```

Both mutations were reverted; `git status --porcelain` shows only the test file, and the whole-suite run below was made on the reverted tree.

## Verification (env pytest, worktree root, `-p no:cacheprovider`)

| Check | Command | Result |
|---|---|---|
| Target file | `pytest backend/tests/test_num_trials_correlation_guard.py -q` | **7 passed** · `EXIT=0` (`/tmp/p1-6-targeted.log`) |
| Full unit suite | `pytest -m "not integration" -q` | **5644 passed, 4 skipped, 2 deselected** in 813.80s (13:33) · `EXIT=0` (`/tmp/p1-6-assert-keywords-suite.log`) |
| `ruff format` | `ruff format backend/tests/test_num_trials_correlation_guard.py` | `1 file left unchanged` · exit 0 |
| `ruff format --check` (CI gate) | same file | `1 file already formatted` · exit 0 |
| `ruff check --select E9,F63,F7,F40,F82` (CI blocking gate) | same file | `All checks passed!` · exit 0 |
| `ruff check --select B015` | whole repo | `All checks passed!` · exit 0 (was 3 errors on `main`) |

ruff 0.15.13 — matches the pin in `.github/workflows/quality-gate.yml:197`.

## Concerns / notes for the vet

- **Not fixed here, deliberately (one logical change per PR):** the full `ruff check` on this file also reports a pre-existing `I001` (import block un-sorted — `from __future__` / stdlib / `pytest` grouping). It is identical on `main` and is *not* in CI's blocking subset (`quality-gate.yml` blocks on format + `E9,F63,F7,F40,F82` only; the broader `ruff check` is informational). Left alone so this PR's diff stays the three keywords.
- The full unit suite was run even though this is a tests-only change; it is green, so no interaction with the concurrently-edited files.
- `is None` on a `-> None` function is a slightly odd assertion shape, but it is the claim the file's docstring makes ("Must never raise") *plus* a pin on the return contract, and it is what caught MUTATION-A. Kept as written rather than rewritten to a bare call, so the diff stays minimal on a PROTECTED file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
