### PR TITLE
test: enforce the org rename on live surfaces, not just sweep it (#1758)

### DIFF
--- a/backend/tests/test_canonical_repo_links.py
+++ b/backend/tests/test_canonical_repo_links.py
@@ -14,22 +14,42 @@ All three redirect to `aprin-labs/archimedes` today, and a redirect is a
 courtesy, not a guarantee — it breaks the moment any of the old names is
 re-claimed.
 
-Scope of the scan below, stated plainly: it polices the `archimedes-arcadia`
-substring, which covers both repository spellings. It does **not** yet police
-the bare `a-apin` org name, because `a-apin.github.io` is quoted on purpose by
-the docs-site guards (`test_docs_site.py`, `ui/test/docs-link.test.js`) to
-record what #1634 moved off. `CANONICAL_REPO` below is the name those failure
-messages point offenders at.
+Two scans live here, and they police different things.
+
+The first polices the `archimedes-arcadia` substring, which covers both
+*repository* spellings, across `LIVE_ROOTS`.
+
+The second polices the *organisation* rename (#1758). Adding a bare `a-apin` to
+`PRE_RENAME_NAMES` was never available: `a-apin.github.io` is quoted on purpose
+by the docs-site guards (`test_docs_site.py`, `ui/test/docs-link.test.js`'s
+`FORBIDDEN_HOSTS`, `docs-site/infra/main.tf`) to record the Pages host #1634
+moved off, and the OIDC and deploy notes quote "a-apin -> aprin-labs" to explain
+what the rename broke. So the second scan forbids the **repository pointer**
+`github.com/a-apin/` on live surfaces and leaves the *host* and the *rename
+narrative* alone.
+
+`CANONICAL_REPO` and `CANONICAL_ORG` are **documentation**. They are the names
+the failure messages point offenders at; no live surface is checked *against*
+them. That is precisely how #1758 was found — reverting `CANONICAL_REPO` to the
+pre-rename spelling left this file green, because a constant is a comment with a
+colon in it. **The scans are the enforcement.** `test_the_canonical_names_agree`
+keeps the two constants from contradicting each other, so the failure messages
+cannot start pointing at a dead redirect — but it proves nothing about any file
+in the repository. Only the scans do that.
 
 **Historical documents are deliberately exempt.** `docs/archive/`,
 `docs/handovers/` and `docs/audits/` record what was true at a point in time,
 and CLAUDE.md is explicit that superseded history is not rewritten. A handover
 saying "origin currently redirects to hackagora/archimedes-arcadia" was accurate
-when written and should stay that way. `submodules/` are separate repositories.
+when written and should stay that way. The org scan extends the same exemption
+to a **date in the filename** (`docs/plans/2026-08-30-*.md`,
+`docs/decisions/tooling-adoptions-2026-08.md`), and caps how far that can go.
+`submodules/` are separate repositories.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -114,3 +134,184 @@ def test_no_live_surface_names_the_pre_rename_repository(stale_name: str) -> Non
         f"'{CANONICAL_REPO}'. GitHub's redirect makes the stale link work, so nothing "
         "else catches this — that redirect breaks if the old name is ever re-claimed."
     )
+
+
+# ---------------------------------------------------------------------------
+# The organisation rename, 2026-09-01 (#1758)
+# ---------------------------------------------------------------------------
+
+CANONICAL_ORG = "aprin-labs"
+
+#: Assembled at runtime for the same reason as ``PRE_RENAME_NAMES``: this file
+#: quotes the stale spellings in prose so its failure messages can, and a guard
+#: that flags its own docstring is a guard nobody keeps.
+PRE_RENAME_ORG = "a-" + "apin"
+
+#: What is forbidden is the **repository pointer**, not the organisation name.
+#: ``<old org>.github.io`` is a *host* — the GitHub Pages origin #1634 moved off
+#: — and "old org -> new org" is a *rename narrative*; both are quoted on
+#: purpose and stay green. ``github.com/<old org>/<anything>`` is a link that
+#: only resolves while GitHub keeps redirecting, which is the thing that breaks.
+PRE_RENAME_REPO_POINTER = f"github.com/{PRE_RENAME_ORG}/"
+
+#: Files handed to a reader, or to a package manager, as current truth.
+ORG_LIVE_FILES = ("README.md", "SETUP.md", "CLAUDE.md", "AGENTS.md")
+
+#: Trees that ship: the app, the two published packages, the docs tree.
+ORG_LIVE_ROOTS = ("ui/src", "ui/public", "backend/archimedes", "cli", "mcp-server", "docs")
+
+ORG_EXEMPT_PARTS = ("archive", "handovers", "audits", "submodules", "node_modules", "dist", "build", ".git")
+
+#: Wider than ``SCANNED_SUFFIXES``: ``cli/pyproject.toml`` and
+#: ``mcp-server/pyproject.toml`` carry the ``Repository =`` URL that PyPI shows,
+#: and ``ui/public`` ships ``llms.txt`` / ``sitemap.xml`` / ``site.webmanifest``.
+ORG_SCANNED_SUFFIXES = SCANNED_SUFFIXES | {".toml", ".txt", ".html", ".css", ".xml", ".webmanifest"}
+
+#: A date in the filename marks a point-in-time record — a plan written on a
+#: day, a decision log for a month. Same principle as ``docs/archive/``: it was
+#: accurate when written, and CLAUDE.md is explicit that history is not
+#: rewritten. ``test_the_org_scan_exempts_only_point_in_time_records`` keeps
+#: this from becoming the loophole.
+_DATED_RECORD = re.compile(r"(?<!\d)\d{4}-\d{2}(?:-\d{2})?(?!\d)")
+
+#: Deliberate mentions of the pre-rename org that must stay green. These are the
+#: reason ``PRE_RENAME_NAMES`` could not simply grow a bare org entry (#1758).
+DELIBERATE_ORG_MENTIONS = (
+    # The Pages host #1634 moved off, quoted by the two docs-site guards.
+    "backend/tests/test_docs_site.py",
+    "ui/test/docs-link.test.js",
+    "docs-site/infra/main.tf",
+    # Incident narrative: the rename itself, and what it broke.
+    "docs/runbooks/docs-site-setup.md",
+    "infra/scripts/setup-github-oidc.sh",
+    ".github/workflows/deploy.yml",
+)
+
+
+def _is_point_in_time(relative: Path) -> bool:
+    return any(part in ORG_EXEMPT_PARTS for part in relative.parts) or bool(_DATED_RECORD.search(relative.name))
+
+
+def _org_walk(*, apply_exemptions: bool) -> list[Path]:
+    found: list[Path] = [REPO_ROOT / name for name in ORG_LIVE_FILES if (REPO_ROOT / name).is_file()]
+    for root in ORG_LIVE_ROOTS:
+        base = REPO_ROOT / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file() or path.suffix not in ORG_SCANNED_SUFFIXES:
+                continue
+            relative = path.relative_to(REPO_ROOT)
+            if apply_exemptions and _is_point_in_time(relative):
+                continue
+            found.append(path)
+    return found
+
+
+def _org_live_files() -> list[Path]:
+    return _org_walk(apply_exemptions=True)
+
+
+def _repo_pointer_offenders(paths: list[Path]) -> list[str]:
+    """Report ``path:line`` for every line pointing at the pre-rename org's repo."""
+    offenders: list[str] = []
+    for path in paths:
+        if path.resolve() == _SELF:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if PRE_RENAME_REPO_POINTER in line:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
+    return offenders
+
+
+def test_the_org_scan_reaches_the_live_surfaces() -> None:
+    """Guard on the guard: a walk that reached nothing would pass vacuously."""
+    scanned = {str(p.relative_to(REPO_ROOT)) for p in _org_live_files()}
+    assert len(scanned) > 400, f"only {len(scanned)} files scanned — the walk is broken"
+    for expected in (
+        "README.md",
+        "SETUP.md",
+        "CLAUDE.md",
+        "AGENTS.md",
+        # The published packages' metadata: this is what PyPI renders.
+        "cli/pyproject.toml",
+        "cli/README.md",
+        "mcp-server/pyproject.toml",
+        "mcp-server/README.md",
+        # The surface that actually rotted in #1434.
+        "ui/src/components/WalletConnect.jsx",
+        "backend/archimedes/main.py",
+        # A live doc that quotes the rename narrative and must stay green.
+        "docs/runbooks/docs-site-setup.md",
+    ):
+        assert expected in scanned, f"{expected} not scanned — the guard is blind"
+
+
+def test_the_org_scan_exempts_only_point_in_time_records() -> None:
+    """The date exemption must stay a footnote, not a way to park a stale link."""
+    scanned = {p.relative_to(REPO_ROOT) for p in _org_live_files()}
+    everything = {p.relative_to(REPO_ROOT) for p in _org_walk(apply_exemptions=False)}
+    skipped = everything - scanned
+    assert skipped, "nothing was exempted — the point-in-time filter is not running"
+    for relative in skipped:
+        assert _is_point_in_time(relative), f"{relative} was dropped for no stated reason"
+
+    dated_only = {r for r in skipped if not any(part in ORG_EXEMPT_PARTS for part in r.parts)}
+    assert len(dated_only) * 10 < len(scanned), (
+        f"{len(dated_only)} files are exempt on a dated filename alone against {len(scanned)} scanned. "
+        "The exemption is meant for a handful of plans and decision logs; at this ratio it is the loophole."
+    )
+
+
+def test_no_live_surface_points_at_the_pre_rename_org() -> None:
+    """#1758: the org rename must be enforced, not merely swept.
+
+    ``CANONICAL_REPO``/``CANONICAL_ORG`` are documentation — no assertion reads
+    them, which is exactly why reverting ``CANONICAL_REPO`` left this file green
+    and got #1758 filed. *This scan* is the enforcement.
+    """
+    offenders = _repo_pointer_offenders(_org_live_files())
+    assert not offenders, (
+        f"{sorted(offenders)} point at '{PRE_RENAME_REPO_POINTER}'. The canonical repository is "
+        f"'{CANONICAL_REPO}' under the '{CANONICAL_ORG}' organisation. GitHub's redirect makes the "
+        "stale link work today, so nothing else catches this — and the redirect dies the moment "
+        f"'{PRE_RENAME_ORG}' is re-claimed by anyone."
+    )
+
+
+@pytest.mark.parametrize("keep", DELIBERATE_ORG_MENTIONS)
+def test_deliberate_pre_rename_org_mentions_stay_green(keep: str) -> None:
+    """The host and the rename narrative are on purpose — the rule must let them through.
+
+    This is why #1758 was not a one-line addition to ``PRE_RENAME_NAMES``. Each
+    file here is checked with the *same* offender function the live scan uses,
+    so the pass is earned by the host-vs-repo distinction rather than by the
+    file happening to sit outside the scanned roots.
+    """
+    path = REPO_ROOT / keep
+    assert path.is_file(), f"{keep} is gone — update DELIBERATE_ORG_MENTIONS or restore the file"
+    assert PRE_RENAME_ORG in path.read_text(encoding="utf-8"), (
+        f"{keep} no longer mentions '{PRE_RENAME_ORG}'. If the mention was deliberately removed, "
+        "drop it from DELIBERATE_ORG_MENTIONS; otherwise this guard is no longer proving anything."
+    )
+    assert not _repo_pointer_offenders([path]), f"{keep} is a repo pointer, not a host or a narrative"
+
+
+def test_the_canonical_names_agree() -> None:
+    """The constants are documentation, but they may not be *wrong* documentation.
+
+    #1758's opening symptom: reverting `CANONICAL_REPO` to the pre-rename
+    spelling left this file green, because the failure messages were the only
+    reader. A guard that points offenders at a dead redirect is worse than one
+    that points at nothing.
+    """
+    assert CANONICAL_REPO.startswith(f"{CANONICAL_ORG}/"), (
+        f"CANONICAL_REPO ({CANONICAL_REPO!r}) is not under CANONICAL_ORG ({CANONICAL_ORG!r})"
+    )
+    assert PRE_RENAME_ORG not in CANONICAL_REPO, f"CANONICAL_REPO ({CANONICAL_REPO!r}) still names the pre-rename org"
+    for stale in PRE_RENAME_NAMES:
+        assert stale not in CANONICAL_REPO, f"CANONICAL_REPO ({CANONICAL_REPO!r}) names a pre-rename repository"


### PR DESCRIPTION
Closes #1758.

## Where this came from

The test-suite / dead-code audit decision package (`session-artifacts-2026-09-01/suite-deadcode-audit-decision-package.md`) reaches a one-paragraph verdict that this suite is "unusually honest — incident-pinned, adversarial self-tests", and §(C) PROTECTED INVENTORY puts the issue-pinned set off limits: **826 of 4,994 test functions carry an issue ref**, and `backend/tests/test_canonical_repo_links.py` (#1434) is one of them. #1758 is what happens when a protected guard is *documentation-shaped* rather than assertion-shaped: it names the right thing and enforces a narrower one. This PR adds enforcement to that file. It weakens nothing in it — the three existing tests are untouched, and the module still has every assertion it had before.

## The problem

`test_canonical_repo_links.py` polices `PRE_RENAME_NAMES = ("archimedes-arcadia",)` by substring scan. `CANONICAL_REPO` appeared only in its own definition and inside an assertion *message* — **no assertion read it**. So after #1755 swept `a-apin` out of the live tree, nothing stopped it coming back:

- a fresh `https://github.com/a-apin/archimedes` link on `main` passed the suite silently, and
- reverting `CANONICAL_REPO` itself to `"a-apin/archimedes"` also left the file green.

Neither is caught anywhere else. GitHub redirects the renamed org, so the link *resolves* — and `docs-gate.yml`'s link checker only verifies that links resolve. A redirect is a courtesy that dies the moment `a-apin` is re-claimed by anyone.

## Why it wasn't a one-liner

Adding a bare `a-apin` to `PRE_RENAME_NAMES` fails on a deliberate KEEP set. Two different things spell the old org:

| Spelling | What it is | Verdict |
|---|---|---|
| `a-apin.github.io` | the GitHub Pages **host** #1634 moved off | keep — quoted on purpose by the docs-site guards |
| `a-apin -> aprin-labs` | the **rename narrative** in the OIDC/deploy incident notes | keep — it explains what broke |
| `github.com/a-apin/…` | a **repository pointer** | forbid — this is the link that only works while the redirect lives |

So the new scan draws the host-vs-repo line rather than banning the org string.

## What changed

One file: `backend/tests/test_canonical_repo_links.py` (+205 / −7).

**The scan.** `PRE_RENAME_REPO_POINTER = "github.com/a-apin/"` over the live surfaces — `README.md`, `SETUP.md`, `CLAUDE.md`, `AGENTS.md`, `ui/src`, `ui/public`, `backend/archimedes`, `cli/`, `mcp-server/`, `docs/` — **550 files**. Offenders are reported as `file:line`. Suffixes are wider than the existing scan's on purpose: `cli/pyproject.toml` and `mcp-server/pyproject.toml` carry the `Repository =` URL **that PyPI renders**, and `ui/public` ships `llms.txt` / `sitemap.xml` / `site.webmanifest`.

**The exemption.** `docs/archive`, `docs/handovers`, `docs/audits` and any **date-stamped filename** (`docs/plans/2026-08-30-*.md`, `docs/decisions/tooling-adoptions-2026-08.md`) are point-in-time records — the same principle CLAUDE.md states about not rewriting superseded history. That is 11 files today. Because an exemption is exactly how a guard rots, `test_the_org_scan_exempts_only_point_in_time_records` re-walks without the filter, asserts every dropped file has a stated reason, and **caps date-only exemptions at under 10% of the scanned set**.

**The KEEP proof.** `test_deliberate_pre_rename_org_mentions_stay_green` runs the *same* offender function over `test_docs_site.py`, `ui/test/docs-link.test.js`, `docs-site/infra/main.tf`, `docs/runbooks/docs-site-setup.md`, `infra/scripts/setup-github-oidc.sh` and `.github/workflows/deploy.yml`. It passes because of the host-vs-repo rule, **not** because those files happen to sit outside the scanned roots — and it also asserts each file still *contains* the mention, so silently deleting the deliberate quote fails loudly instead of hollowing the guard out.

**The reported symptom.** `test_the_canonical_names_agree` asserts `CANONICAL_REPO` is under `CANONICAL_ORG` and names no pre-rename spelling. The constants stay documentation — nothing in the repo is checked *against* them — but they may not be *wrong* documentation, or the failure messages point offenders at a dead redirect. The docstring now says this outright: **the scans are the enforcement**.

## Adversarial pass — the guard shown red

Per the repo rule, the input that *should* fail was written first and confirmed red.

**1. Plant the repo pointer** (`https://github.com/a-apin/archimedes` appended to `README.md`, and `PlantedRepo = "https://github.com/a-apin/archimedes"` appended to `cli/pyproject.toml`):

```
backend/tests/test_canonical_repo_links.py:275: in test_no_live_surface_points_at_the_pre_rename_org
    assert not offenders, (
E   AssertionError: ['README.md:254', 'cli/pyproject.toml:65'] point at 'github.com/a-apin/'.
E   The canonical repository is 'aprin-labs/archimedes' under the 'aprin-labs' organisation.
E   GitHub's redirect makes the stale link work today, so nothing else catches this — and the
E   redirect dies the moment 'a-apin' is re-claimed by anyone.
E   assert not ['README.md:254', 'cli/pyproject.toml:65']

FAILED backend/tests/test_canonical_repo_links.py::test_no_live_surface_points_at_the_pre_rename_org
1 failed, 2 passed
```

Both plants restored; `git status` clean apart from the test file.

**2. Plant the KEEP spelling instead** — the host *and* the rename narrative, in a live surface (`README.md`):

```
Old docs host: https://a-apin.github.io/archimedes — the org rename a-apin -> aprin-labs moved it.
```

```
13 passed
```

Green. The distinction is real, not an accident of which roots are walked.

**3. Revert `CANONICAL_REPO`** to `"a-apin/archimedes"` — the exact edit that left this file green before:

```
backend/tests/test_canonical_repo_links.py:309: in test_the_canonical_names_agree
    assert CANONICAL_REPO.startswith(f"{CANONICAL_ORG}/"), (
E   AssertionError: CANONICAL_REPO ('a-apin/archimedes') is not under CANONICAL_ORG ('aprin-labs')
E   assert False
E    +  where False = <built-in method startswith of str object at 0x11fc38230>('aprin-labs/')

1 failed
```

Restored.

## Verification

| Check | Command | Result |
|---|---|---|
| The guard + the docs-site guard it must not break | `pytest backend/tests/test_canonical_repo_links.py backend/tests/test_docs_site.py -q -p no:cacheprovider` | **31 passed**, `EXIT=0` |
| On today's `main` (`03bff3dc`), before the plants | same file, 13 tests | **13 passed** — green, as required |
| `ruff format --check` | `ruff format --check backend/tests/test_canonical_repo_links.py` | `1 file already formatted`, `FORMAT_EXIT=0` |
| `ruff check` | `ruff check backend/tests/test_canonical_repo_links.py` | `All checks passed!`, `CHECK_EXIT=0` |
| Full unit suite | `pytest -m "not integration" -q -p no:cacheprovider` | **5654 passed, 4 skipped, 2 deselected** in 979s, `EXIT=0` (`/tmp/1758-org-guard-suite.log`) |

Deleted names: none — this PR deletes nothing. `grep -rn "test_canonical_repo_links\|PRE_RENAME_NAMES\|CANONICAL_REPO"` outside the file itself returns nothing, so no doc references need updating.

## Concerns for the reviewer

- **The date-stamped exemption is a judgement call.** It keeps the scan green on today's `main` without a sweep (that is #1755's lane, and one logical change per PR), and it is capped and asserted — but a future doc could dodge the guard by carrying a date in its name. Four live links sit behind it right now: `docs/plans/2026-08-30-paper-trading-reasoning-traces.md:8`, `docs/plans/2026-08-30-relations-phase2.md:8`, `docs/decisions/tooling-adoptions-2026-08.md:223,227`. If you would rather those be fixed than exempted, that is a separate sweep PR and I will file it.
- **`openwiki/` is out of scope** and carries four `github.com/a-apin/` links (`INSTRUCTIONS.md:286,293`, `rigor/documented-conflicts.md:34,67`). It is published content, so it is arguably a live surface; the issue's root list did not name it. Say the word and it goes in.
- **Scope is repo pointers only.** A bare `a-apin/archimedes` in prose (e.g. `gh pr view --repo a-apin/archimedes` in a runbook) is not caught. Catching it would collide with the incident narratives; the pointer form is what actually rots into a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
