### PR TITLE
test(ui): make hard-coded model mutation actually exercise the guard

### DIFF
--- a/ui/test/model-cost-line.test.js
+++ b/ui/test/model-cost-line.test.js
@@ -98,6 +98,18 @@ function priceLabelProblem(text) {
 	return null;
 }
 
+// `null` = no snapshot model name or id is a literal in the source; a string
+// = the problem. Shared by the property test and the mutation that must turn
+// it red — a check inlined only on the clean source cannot be shown to reject
+// a hard-coded model.
+function hardCodedModelProblem(src) {
+	for (const m of pricing.models) {
+		if (src.includes(m.name)) return `hard-codes model name ${m.name}`;
+		if (src.includes(m.model_id)) return `hard-codes model id ${m.model_id}`;
+	}
+	return null;
+}
+
 // ── 1. The header leads with the engine ───────────────────────────────────
 
 test("collapsed header names the engine before it quotes any price", () => {
@@ -169,16 +181,11 @@ test("no model name or id from the pricing snapshot is hard-coded in the card", 
 		pricing.models.length > 1,
 		"pricing snapshot is empty — this check would be vacuous",
 	);
-	for (const m of pricing.models) {
-		assert.ok(
-			!panel.includes(m.name),
-			`ModelCostPanel.jsx hard-codes the model name ${JSON.stringify(m.name)}. The card must name only the model /health reports as served (or the user's pick), never a literal — a literal keeps claiming that model after the backend moves off it.`,
-		);
-		assert.ok(
-			!panel.includes(m.model_id),
-			`ModelCostPanel.jsx hard-codes the model id ${JSON.stringify(m.model_id)} — same problem as a hard-coded name.`,
-		);
-	}
+	assert.equal(
+		hardCodedModelProblem(stripComments(panel)),
+		null,
+		"ModelCostPanel.jsx hard-codes a model name or id from the pricing snapshot. The card must name only the model /health reports as served (or the user's pick), never a literal — a literal keeps claiming that model after the backend moves off it.",
+	);
 });
 
 test("mutation: a hard-coded served model is rejected", () => {
@@ -188,8 +195,9 @@ test("mutation: a hard-coded served model is rejected", () => {
 		"Debate society over the research corpus",
 		`Debate society over the research corpus, served by ${recommended.provider} ${recommended.name}`,
 	);
-	assert.ok(
-		HARD_CODED.includes(recommended.name),
+	assert.equal(
+		hardCodedModelProblem(HARD_CODED),
+		`hard-codes model name ${recommended.name}`,
 		`writing ${JSON.stringify(recommended.name)} into the card is not caught by the hard-coded-model check — it is guarding nothing`,
 	);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Hoists the hard-coded-model check in `ui/test/model-cost-line.test.js` into a `null`-or-reason helper (`hardCodedModelProblem`) and points both the property test and the mutation at it, so the mutation actually exercises the guard.

No copy or component change. Stacked onto #1770 (`dbrowneup/ux-model-line`); do not close or merge that PR from this one.

## Why

Adversarial FIX-FIRST review on #1770 found two test-file defects:

1. **Vacuous mutation.** `"mutation: a hard-coded served model is rejected"` built `HARD_CODED` by splicing `recommended.name` into the source, then only asserted `HARD_CODED.includes(recommended.name)` — true by construction. It never ran the hard-coded-model property against `HARD_CODED`. Delete or weaken the real check (e.g. drop the `m.name` loop, keep only `m.model_id`) and the "mutation" still passed green.
2. **Nit: scan `stripComments(panel)`.** The property loop scanned raw `panel`, so a future comment mentioning a generic snapshot name (`Mistral Small`, `Nova Pro`) would false-fail.

Exact shape from the review: same idiom as `orderingProblem` / `priceLabelProblem` already in this file.

## Issues

Part of #1770 (FIX-FIRST comment: vacuous mutation + optional `stripComments` scan). Does **not** close #1770.

## Verification

| check | command | result |
| --- | --- | --- |
| guard | `cd ui && node --test test/model-cost-line.test.js` | **8 pass, 0 fail — exit 0** |
| mutation shown red | same command after deleting only the `m.name` line in `hardCodedModelProblem` | **7 pass, 1 fail — exit 1** (restored; not committed) |

The weakened-helper rejection (the input that *should* fail, and does):

```
✖ mutation: a hard-coded served model is rejected
  AssertionError: writing "Nova Micro" into the card is not caught by the
  hard-coded-model check — it is guarding nothing
  + actual   null
  - expected 'hard-codes model name Nova Micro'
```

That is the failure the previous `includes` assert could not produce. The property test still passed under the weakened helper — which is why the mutation has to assert the exact reason, not just "HARD_CODED contains the name we just wrote in."

No Python files touched; no `ModelCostPanel.jsx` copy change.

## What a reviewer should push back on

- This is a test-only fix-up for #1770. Merge this into `dbrowneup/ux-model-line`, then land #1770; do not merge this onto `main` ahead of #1770 unless you intend to stack it yourself.
- The PR-body copy defects on #1770 (false `Architecture.jsx` prior-art claim; unresolved pytest verification row) are **not** in this diff — they live in the #1770 description, not in the test file.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6894ade-3406-42e5-8b90-b368bcd568b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6894ade-3406-42e5-8b90-b368bcd568b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

