### PR TITLE
[ux] Examples tab: stop presenting curated references as failures

### DIFF
--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -21,11 +21,31 @@ import {
   UNKNOWN_RIGOR_TITLE,
 } from '../rigorGateStatus.js'
 import { signClass } from '../signClass.js'
+import { metricsSourceNote } from '../metricsSource.js'
 import { strategies as ROADMAP_COPY } from '../roadmapCopyApp.js'
 
 // A compact "deployable at your level" chip for a library row, driven by the
 // strategy's min_passing_level (from the live gate) and the user's strictness.
 function DeployabilityChip({ deploy, level, gatePending }) {
+  // Vaults are out of the MVP cut (#1266) — and EVERY branch below answers a
+  // VAULT question. "deployable" / "needs level N" / "blocked" all grade a
+  // strategy against `/api/selection-bias/gate`, the same verdict the vault
+  // deploy gate reads (`api/vaults_routes.py::_deployable_levels`). With the
+  // roadmap flag off there is no vault to deploy into, so every one of those
+  // chips grades a strategy against a capability the shipped build does not
+  // have. On the Examples tab that is what put a red `blocked` pill on
+  // hand-curated reference implementations.
+  //
+  // Suppressing only the red branch was the other option, and it is worse: it
+  // would leave the green "deployable" claim standing on a surface where
+  // nothing can be deployed — the flattering half of a verdict kept and the
+  // rest hidden. The whole chip belongs to the flag, and comes back intact
+  // (blocked branch included) under VITE_ROADMAP_SURFACES=true.
+  //
+  // The gate FETCH is gated on the same flag in load() below: a hidden
+  // annotation that still costs the page its slowest request is the #1324
+  // defect, not a fix.
+  if (!ROADMAP_SURFACES_ENABLED) return null
   // #1645: the Library now renders rows as soon as the strategy list resolves,
   // without waiting for the (much slower) /api/selection-bias/gate call. During
   // that window there is no entry for this row yet — and a SILENTLY ABSENT chip
@@ -79,6 +99,20 @@ function DeployabilityChip({ deploy, level, gatePending }) {
 }
 
 const STATUS_ORDER = ['live', 'validated', 'candidate', 'retired']
+
+// A one-word provenance mark that rides directly under a row's headline
+// number. `metricsSourceNote` allow-lists only the sources that are NOT a run
+// made here (see ../metricsSource.js), so a real persisted backtest renders
+// unmarked and an unknown/absent value makes no claim in either direction.
+function MetricsSourceTag({ source }) {
+  const note = metricsSourceNote(source)
+  if (!note) return null
+  return (
+    <div style={{ fontSize: '0.68rem', color: 'var(--text-4)' }} title={note.title}>
+      {note.label}
+    </div>
+  )
+}
 
 function downloadStrategy(strategy, format) {
   let content, filename, type
@@ -329,6 +363,11 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
               (DSR conf=<MetricValue metric="dsr_p_value" value={s.dsr_p_value} row={s} surface="Library table" />)
             </div>
           )}
+          {/* Sharpe is the representative field of the whole display block —
+              the backend derives `display_metrics_source` from it because one
+              link of the fallback chain populates all of them — so one mark in
+              this cell describes the row's numbers, not four repeats. */}
+          <MetricsSourceTag source={s.display_metrics_source} />
         </td>
         <td className={`mono ${signClass(s.cagr)}`} style={{ textAlign: 'right' }}>
           <MetricValue metric="cagr" value={s.cagr} row={s} surface="Library table" />
@@ -593,7 +632,7 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
         <DeployabilityChip deploy={deploy} level={level} gatePending={gatePending} />
       </div>
       <div className="lib-card-stats">
-        <div><div className="caption">Sharpe</div><div className="mono"><MetricValue metric="sharpe_ratio" value={s.sharpe_ratio} row={s} surface="Library card" /></div></div>
+        <div><div className="caption">Sharpe</div><div className="mono"><MetricValue metric="sharpe_ratio" value={s.sharpe_ratio} row={s} surface="Library card" /></div><MetricsSourceTag source={s.display_metrics_source} /></div>
         <div><div className="caption">CAGR</div><div className={`mono ${signClass(s.cagr)}`}><MetricValue metric="cagr" value={s.cagr} row={s} surface="Library card" /></div></div>
         <div><div className="caption">Max DD</div><div className="mono negative"><MetricValue metric="max_drawdown" value={s.max_drawdown} row={s} surface="Library card" /></div></div>
         <div title={genCost.title}><div className="caption">Gen tokens</div><div className={genCost.measured ? 'mono' : 'caption'}>{genCost.label}</div></div>
@@ -895,7 +934,16 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
     // the 2026-08-30 external product review ("0 of 20 examples pass").
     const seedPromise = apiGet('/api/strategies/?limit=100')
     const genPromise = apiGet('/api/strategies/generated')
-    const gatePromise = apiGet('/api/selection-bias/gate')
+    // Deployability is a VAULT question and vaults are out of the MVP cut
+    // (#1266): DeployabilityChip returns null with the flag off, so an
+    // unconditional call here would spend the slowest request on the page
+    // (this route recomputes the whole cohort gate — ~8-10s, and 504-ing
+    // against prod on 2026-08-31) on an annotation nothing renders. Same
+    // ternary shape, and the same reason, as publishedPromise below: gating
+    // the render while still hitting the hidden API every load is the exact
+    // defect #1324 was filed against. The empty payload keeps every consumer
+    // downstream — deployMap, gateLoading, the gateError banner — unchanged.
+    const gatePromise = ROADMAP_SURFACES_ENABLED ? apiGet('/api/selection-bias/gate') : Promise.resolve({ strategies: [] })
     // Kept on one line deliberately: ui/test/routes.test.js's #1324 guard
     // anchors on this exact expression, and reformatting it would silently
     // disarm someone else's regression test rather than break it loudly.
@@ -1203,12 +1251,44 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
 
       {activeTab === 'examples' && (
         <>
+          {/* This tab is REFERENCE MATERIAL, and the intro has to say so before
+              the reader starts reading the rows as scores. The previous copy
+              ("see what a rigor-gate verdict looks like") invited exactly the
+              opposite reading, and the rows obliged: 34 hand-curated
+              implementations of published papers, each one carrying a red
+              failure pill next to numbers nobody re-ran here.
+
+              Three claims, each of which has to stay true:
+                1. what they are — reference implementations, to learn the card
+                   format; not fusion-engine output;
+                2. what a missing verdict means — a curated example is graded
+                   only once a backtest has actually been run for it (the live
+                   gate needs persisted returns), so "no verdict" is a state,
+                   not a failure, and the passport is where the verdict lives;
+                3. where the numbers come from — the mark under each row's
+                   Sharpe, driven by the API's own `display_metrics_source`
+                   (see ../metricsSource.js), so this paragraph never has to
+                   generalise about rows it cannot see. */}
           <div className="caption mb-3 text-[var(--text-3)] leading-relaxed">
-            <strong>Example strategies</strong> — hand-curated single-paper implementations
-            from published research. <em>Not</em> outputs of the fusion engine. Included
-            so you can read a strategy card, understand the metrics, and see what a
-            rigor-gate verdict looks like. They're also the candidate pool the curated-library
-            path of Generate picks and weights from.
+            <p style={{ marginBottom: 6 }}>
+              <strong>Example strategies</strong> — hand-curated reference implementations
+              of single published papers. They are here to be read: open one to learn the
+              card format — what each field means, which paper it came from, and where a
+              verdict appears once there is one. They are <em>not</em> outputs of the
+              fusion engine.
+            </p>
+            <p style={{ marginBottom: 6 }}>
+              They are <strong>not a scoreboard</strong>. A curated example is graded only
+              once a backtest has been run for it here; until then it carries no verdict,
+              and an absent verdict is not a failure. The numbers beside them are not all
+              measurements either: where a row's metrics trace to a stored fixture snapshot
+              rather than to a backtest run here, the row is marked <strong>fixture</strong>.
+              A strategy's passport is its verdict of record.
+            </p>
+            <p>
+              Generate's curated-library path picks and weights its candidates from this
+              same set.
+            </p>
           </div>
           {loading && <StrategyListSkeleton />}
           {/* Gated on !loadError, matching the Published branch below (#1356

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -1296,11 +1296,11 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
                 failure pill. Merged alone, this paragraph contradicts the pill two
                 inches below it, so land this after or with #1792.
 
-                This is an ORDERING constraint, not a conflict one: a 3-way merge
-                against that branch is clean (base=origin/main, git merge-file
-                EXIT=0, zero conflict markers). Do not "fix" it by softening the
-                copy — the copy is the correct end state; #1792 is what makes the
-                rows agree with it. */}
+                This is an ORDERING constraint, not a conflict one:
+                `git merge-tree --write-tree --name-only` of this branch against
+                origin/dbrowneup/verdict-of-record-a is EXIT=0 with no conflicted
+                paths. Do not "fix" it by softening the copy — the copy is the
+                correct end state; #1792 is what makes the rows agree with it. */}
             <p style={{ marginBottom: 6 }}>
               They are <strong>not a scoreboard</strong>. A curated example is graded only
               once a backtest has been run for it here; until then it carries no verdict,

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -1134,7 +1134,13 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
               signal — DeployabilityChip short-circuits to `null` for every
               row (:14), so every chip silently vanished (#1356). This banner
               is the visible signal that replaces that silence, near the
-              chips it describes. */}
+              chips it describes.
+
+              Scope note (this PR): with ROADMAP_SURFACES_ENABLED off, load()
+              no longer fetches /api/selection-bias/gate at all, so gateError
+              stays null and this banner cannot fire — there are no chips left
+              for it to describe. Banner and chips come back together under
+              VITE_ROADMAP_SURFACES=true. */}
           {gateError && (
             <div className="info-box warning mb-3">
               Deployability status unavailable: {gateError}. Chips below may not reflect the live gate.{' '}
@@ -1277,13 +1283,32 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
               verdict appears once there is one. They are <em>not</em> outputs of the
               fusion engine.
             </p>
+            {/* MERGE ORDER — depends on PR #1792 (dbrowneup/verdict-of-record-a).
+                The claim below ("until then it carries no verdict, and an absent
+                verdict is not a failure") is only true once #1792 lands.
+                statusLabel() (defined at :161 on this branch) still returns
+                'Reference only — gate failed' for
+                status === 'live' && passes_rigor_gate === false, and
+                passes_rigor_gate is the FAIL-CLOSED boolean: false for a pending
+                verdict too. #1792 replaces it with a four-state rigor_gate_status
+                and NOT_GRADED_LABEL = "Not yet graded" (ui/src/libraryStatus.js),
+                which is what stops an ungraded curated row from rendering a
+                failure pill. Merged alone, this paragraph contradicts the pill two
+                inches below it, so land this after or with #1792.
+
+                This is an ORDERING constraint, not a conflict one: a 3-way merge
+                against that branch is clean (base=origin/main, git merge-file
+                EXIT=0, zero conflict markers). Do not "fix" it by softening the
+                copy — the copy is the correct end state; #1792 is what makes the
+                rows agree with it. */}
             <p style={{ marginBottom: 6 }}>
               They are <strong>not a scoreboard</strong>. A curated example is graded only
               once a backtest has been run for it here; until then it carries no verdict,
               and an absent verdict is not a failure. The numbers beside them are not all
               measurements either: where a row's metrics trace to a stored fixture snapshot
-              rather than to a backtest run here, the row is marked <strong>fixture</strong>.
-              A strategy's passport is its verdict of record.
+              rather than to a backtest run here, the row is marked <strong>fixture</strong> —
+              or <strong>placeholder</strong>, where only the strategy module's declared
+              constants exist. A strategy's passport is its verdict of record.
             </p>
             <p>
               Generate's curated-library path picks and weights its candidates from this

--- a/ui/src/metricsSource.js
+++ b/ui/src/metricsSource.js
@@ -1,0 +1,62 @@
+/** Where a strategy row's headline numbers actually came from.
+ *
+ * `GET /api/strategies/` already serves this per row as
+ * `display_metrics_source` — the link of the backend's
+ * `s.real_* -> bt.* -> s.stub_*` display chain that supplied the numbers
+ * (`api/strategies_routes.py::_display_metrics_source`). The UI dropped the
+ * field, so a value carried on the strategy record and a value produced by a
+ * persisted backtest run rendered as the same black number in the same cell.
+ *
+ * That is the half of the Examples-tab problem the copy alone cannot fix: the
+ * curated examples are reference implementations, and the metrics beside them
+ * are values their records ship with. Saying so next to the number is the
+ * honest version of the sentence the tab's intro now makes.
+ *
+ * ALLOW-LIST, deliberately. Only the sources that are NOT a run made here get a
+ * mark; everything else — `persisted_backtest`, `unavailable`, an older API
+ * response with no such field at all — maps to `null` and the row says nothing.
+ * The two omissions are load-bearing:
+ *
+ *   - `persisted_backtest` is a real persisted backtest row. Marking it
+ *     "fixture" would be a fresh false claim, which is worse than the silence
+ *     this change is fixing.
+ *   - an absent/unknown value is not evidence of anything, so it earns no
+ *     label in either direction (a generated row reaches the table through
+ *     `coerceGenerated`, which does not carry the field).
+ */
+
+export const METRICS_SOURCE_NOTES = {
+	// `_display_metrics_source` returns this when `s.real_sharpe` is populated,
+	// and its own comment is explicit that this is NOT "measured": for the
+	// curated library those columns trace to the migrated backtest-fixture
+	// snapshot (`backend/tests/fixtures/backtest_fixtures_snapshot.json`,
+	// #1187), which predates the current DSR convention and gate threshold.
+	strategy_record: {
+		label: "fixture",
+		title:
+			"Fixture value — served from what the strategy record stores. For the " +
+			"curated example library these numbers trace to the backtest-fixture " +
+			"snapshot (#1187), not to a backtest run for this card.",
+	},
+	// The last link of the chain: the `BACKTEST_*` constants declared in the
+	// strategy module itself.
+	stub_placeholder: {
+		label: "placeholder",
+		title:
+			"Placeholder value — the BACKTEST_* constant declared in the strategy " +
+			"module. No backtest produced this number.",
+	},
+};
+
+/** `{label, title}` for a metric-provenance mark, or `null` for no claim.
+ *
+ * `Object.hasOwn`, not a bare lookup: the value arrives from an API payload, and
+ * `METRICS_SOURCE_NOTES["toString"]` would otherwise hand back an inherited
+ * `Object.prototype` member and render a mark for a source that has none.
+ */
+export function metricsSourceNote(source) {
+	if (typeof source !== "string") return null;
+	return Object.hasOwn(METRICS_SOURCE_NOTES, source)
+		? METRICS_SOURCE_NOTES[source]
+		: null;
+}

--- a/ui/test/curated-examples-copy.test.js
+++ b/ui/test/curated-examples-copy.test.js
@@ -25,7 +25,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { metricsSourceNote } from "../src/metricsSource.js";
+import { METRICS_SOURCE_NOTES, metricsSourceNote } from "../src/metricsSource.js";
 
 const strategies = readFileSync(
 	new URL("../src/components/Strategies.jsx", import.meta.url),
@@ -207,5 +207,56 @@ test("no mark claims the number was measured or verified", () => {
 		const { title } = metricsSourceNote(source);
 		assert.doesNotMatch(title, /\bmeasured\b/i);
 		assert.doesNotMatch(title, /\bverified\b/i);
+	}
+});
+
+// ── 6. The mark's vocabulary is the BACKEND's, and stays pinned to it ─────
+//
+// METRICS_SOURCE_NOTES' keys are bare string literals of what
+// `_display_metrics_source` returns. Renaming one there and in its own
+// backend/tests/test_metrics_provenance.py — the normal way such a rename
+// lands — leaves that file at 9 passed and, without this test, the whole UI
+// suite green, while every "fixture" mark silently stops rendering AND the
+// intro's promise that "the row is marked fixture" becomes false: fail-open
+// on the exact honesty signal this change exists to add. Same idiom as
+// ui/test/security-claims.test.js and account-deletion.test.js: read the
+// backend source from the UI suite.
+const routes = readFileSync(
+	new URL("../../backend/archimedes/api/strategies_routes.py", import.meta.url),
+	"utf8",
+);
+
+function displayMetricsSourceStates() {
+	const start = routes.indexOf("def _display_metrics_source(");
+	assert.notEqual(
+		start,
+		-1,
+		"_display_metrics_source not found — the mark's source is gone",
+	);
+	const end = routes.indexOf("\ndef ", start + 1);
+	const body = routes.slice(start, end === -1 ? undefined : end);
+	return new Set([...body.matchAll(/return "([a-z_]+)"/g)].map((m) => m[1]));
+}
+
+test("every marked source is a value the backend actually returns", () => {
+	const returned = displayMetricsSourceStates();
+	// Anti-vacuity: the backend's own four states must be found, or this is
+	// comparing against an empty set and pinning nothing.
+	for (const state of [
+		"strategy_record",
+		"persisted_backtest",
+		"stub_placeholder",
+		"unavailable",
+	]) {
+		assert.ok(
+			returned.has(state),
+			`_display_metrics_source no longer returns "${state}"`,
+		);
+	}
+	for (const key of Object.keys(METRICS_SOURCE_NOTES)) {
+		assert.ok(
+			returned.has(key),
+			`the UI marks "${key}" but no backend branch returns it — the mark is dead`,
+		);
 	}
 });

--- a/ui/test/curated-examples-copy.test.js
+++ b/ui/test/curated-examples-copy.test.js
@@ -1,0 +1,211 @@
+// Library → Examples must not present curated references as failures.
+//
+// The owner's screenshot of Examples (34): every hand-curated card carried
+// "Reference only — gate failed" AND a red `blocked` pill, beside metrics
+// nobody re-ran for that card. Two of those three are this file's subject
+// (the status pill is a separate change):
+//
+//   1. `blocked` is a DEPLOYABILITY verdict — DeployabilityChip grades a row
+//      against `/api/selection-bias/gate`, the same verdict the vault deploy
+//      gate reads (`api/vaults_routes.py::_deployable_levels`). Vaults are out
+//      of the MVP cut (#1266), so with ROADMAP_SURFACES_ENABLED off the pill
+//      grades references against a capability the shipped build does not have.
+//   2. the numbers beside them are the values the strategy record ships with;
+//      for the curated library those trace to the backtest-fixture snapshot
+//      (#1187), which the API already reports per row as
+//      `display_metrics_source` and the UI simply dropped.
+//
+// Idiom: source-text pins plus one real import, like corpus-kg-tab-gate.test.js
+// and library-loading.test.js (ui/package.json runs plain `node --test`; .jsx
+// is not importable). Every pattern below is shown rejecting its own pre-fix
+// input, so a pattern that silently stops matching anything fails loudly
+// instead of guarding nothing.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { metricsSourceNote } from "../src/metricsSource.js";
+
+const strategies = readFileSync(
+	new URL("../src/components/Strategies.jsx", import.meta.url),
+	"utf8",
+);
+
+// ── 1. The deployability chip is gated on the roadmap flag ───────────────
+
+// The gate must be the chip's FIRST statement: every branch after it (blocked,
+// not deployable, needs level N, deployable, checking…) is an answer to a vault
+// question, so none of them may be reached with the flag off.
+const CHIP_GATE =
+	/function DeployabilityChip\(\{ deploy, level, gatePending \}\) \{(?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\n)*[^\S\n]*if \(!ROADMAP_SURFACES_ENABLED\) return null/;
+
+// The chip exactly as it stood before this change — the input the guard exists
+// to reject. If CHIP_GATE ever matches this, it has stopped testing anything.
+const PRE_FIX_CHIP = `function DeployabilityChip({ deploy, level, gatePending }) {
+  // #1645: the Library now renders rows as soon as the strategy list resolves,
+  // without waiting for the (much slower) /api/selection-bias/gate call.
+  if (!deploy) {
+    if (!gatePending) return null
+`;
+
+test("DeployabilityChip renders nothing while the roadmap surfaces are off", () => {
+	assert.match(strategies, CHIP_GATE);
+	assert.doesNotMatch(
+		PRE_FIX_CHIP,
+		CHIP_GATE,
+		"the guard must reject the pre-fix chip — an ungated chip is the defect",
+	);
+});
+
+test("the flag this hangs on is genuinely off in a default build", async () => {
+	// import.meta.env is undefined under `node --test`, which is the unset
+	// case: this is what the shipped bundle does unless VITE_ROADMAP_SURFACES
+	// is exactly "true". Without this, the pattern above could be satisfied by
+	// a flag that is on everywhere.
+	const { ROADMAP_SURFACES_ENABLED } = await import("../src/featureFlags.js");
+	assert.equal(ROADMAP_SURFACES_ENABLED, false);
+});
+
+test("the blocked branch is gated, not deleted — it returns with the flag on", () => {
+	// Anti-goal: this change must not become "delete the failing pill". With
+	// VITE_ROADMAP_SURFACES=true the chip is whole, blocked branch included.
+	const gateIdx = strategies.indexOf("if (!ROADMAP_SURFACES_ENABLED) return null");
+	const blockedIdx = strategies.indexOf("if (deploy.blocked_by_floor) {");
+	assert.notEqual(gateIdx, -1, "no roadmap gate found in DeployabilityChip");
+	assert.notEqual(blockedIdx, -1, "the blocked_by_floor branch must survive");
+	assert.ok(
+		gateIdx < blockedIdx,
+		"the roadmap gate must precede the blocked branch, not replace it",
+	);
+});
+
+// ── 2. …and the hidden annotation costs nothing to fetch ─────────────────
+
+const GATED_FETCH =
+	/const gatePromise = ROADMAP_SURFACES_ENABLED \? apiGet\('\/api\/selection-bias\/gate'\) : Promise\.resolve\(\{ strategies: \[\] \}\)/;
+const PRE_FIX_FETCH = "const gatePromise = apiGet('/api/selection-bias/gate')";
+
+test("the deployability gate is not fetched when nothing renders it", () => {
+	// Same rule #1324 set for the hidden Published tab: gating the render while
+	// still hitting the hidden API on every load is not a fix. This route is
+	// the slowest request on the page (it recomputes the whole cohort gate).
+	assert.match(strategies, GATED_FETCH);
+	assert.doesNotMatch(
+		PRE_FIX_FETCH,
+		GATED_FETCH,
+		"the guard must reject the pre-fix unconditional fetch",
+	);
+});
+
+// ── 3. The Examples intro states the new identity ────────────────────────
+
+function examplesIntro() {
+	const start = strategies.indexOf("{activeTab === 'examples' && (");
+	assert.notEqual(start, -1, "could not find the Examples tab branch");
+	const end = strategies.indexOf("{loading && <StrategyListSkeleton />}", start);
+	assert.notEqual(end, -1, "could not bound the Examples intro");
+	// JSX comments stripped: these assertions are about the copy a READER sees.
+	// A `{/* ... */}` block explaining the change must not be able to satisfy a
+	// claim the rendered paragraph does not make (nor to trip the retired-claim
+	// check by quoting the sentence it retired).
+	return strategies.slice(start, end).replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+// The exact copy this replaced. Every REQUIRED assertion below must fail
+// against it, and the one RETIRED phrase must be found in it — otherwise these
+// patterns are pinning something the old copy already said.
+const PRE_FIX_INTRO = `<strong>Example strategies</strong> — hand-curated single-paper implementations
+from published research. <em>Not</em> outputs of the fusion engine. Included
+so you can read a strategy card, understand the metrics, and see what a
+rigor-gate verdict looks like. They're also the candidate pool the curated-library
+path of Generate picks and weights from.`;
+
+const REQUIRED_INTRO_CLAIMS = [
+	// what they are
+	/hand-curated reference implementations/,
+	// not graded until a backtest is actually run for them
+	/graded only\s*\n?\s*once a backtest has been run for it/,
+	/an absent verdict is not a failure/,
+	// where the verdict of record lives instead
+	/verdict of record/,
+	// where the numbers come from
+	/marked <strong>fixture<\/strong>/,
+];
+
+// The sentence that invited the reading this whole change exists to retract:
+// it told the reader the tab was a place to see verdicts, so the red pills
+// looked like the point rather than like a bug.
+const RETIRED_INTRO_CLAIM = /see what a\s*\n?\s*rigor-gate verdict looks like/;
+
+test("the Examples intro says what the examples are and are not", () => {
+	const intro = examplesIntro();
+	for (const claim of REQUIRED_INTRO_CLAIMS) {
+		assert.match(intro, claim);
+		assert.doesNotMatch(
+			PRE_FIX_INTRO,
+			claim,
+			`the old copy already satisfied ${claim} — that assertion guards nothing`,
+		);
+	}
+	assert.doesNotMatch(intro, RETIRED_INTRO_CLAIM);
+	assert.match(
+		PRE_FIX_INTRO,
+		RETIRED_INTRO_CLAIM,
+		"the retired-claim pattern no longer matches the copy it was written against",
+	);
+});
+
+test("the intro does not call the examples fusion output or a scoreboard", () => {
+	const intro = examplesIntro();
+	assert.match(intro, /<em>not<\/em> outputs of the\s*\n?\s*fusion engine/);
+	assert.match(intro, /<strong>not a scoreboard<\/strong>/);
+});
+
+// ── 4. The fixture mark rides next to the numbers ────────────────────────
+
+test("both the table row and the card mark where their numbers came from", () => {
+	const marks =
+		strategies.match(/<MetricsSourceTag source=\{s\.display_metrics_source\} \/>/g) ||
+		[];
+	assert.equal(
+		marks.length,
+		2,
+		"expected exactly one mark per rendered row — the table row and the card",
+	);
+	// The card's mark sits inside the Sharpe stat, i.e. beside a number, not
+	// off in the badge row where it would read as a status.
+	assert.match(
+		strategies,
+		/Sharpe<\/div><div className="mono"><MetricValue metric="sharpe_ratio"[\s\S]{0,200}<MetricsSourceTag source=\{s\.display_metrics_source\} \/>/,
+	);
+});
+
+// ── 5. …and the mark never overstates what it knows ──────────────────────
+
+test("only non-measured sources are marked", () => {
+	assert.equal(metricsSourceNote("strategy_record").label, "fixture");
+	assert.equal(metricsSourceNote("stub_placeholder").label, "placeholder");
+	// The load-bearing omission: a persisted backtest row IS a run. Marking it
+	// "fixture" would be a fresh false claim, worse than the silence this
+	// change fixes.
+	assert.equal(metricsSourceNote("persisted_backtest"), null);
+	// No data, an older payload, or a generated row (coerceGenerated does not
+	// carry the field) makes no claim in either direction.
+	for (const absent of ["unavailable", "", undefined, null, 42]) {
+		assert.equal(metricsSourceNote(absent), null);
+	}
+	// The lookup is own-property only: an API payload naming an inherited
+	// Object.prototype member must not conjure a mark out of the prototype.
+	for (const inherited of ["toString", "constructor", "__proto__"]) {
+		assert.equal(metricsSourceNote(inherited), null);
+	}
+});
+
+test("no mark claims the number was measured or verified", () => {
+	for (const source of ["strategy_record", "stub_placeholder"]) {
+		const { title } = metricsSourceNote(source);
+		assert.doesNotMatch(title, /\bmeasured\b/i);
+		assert.doesNotMatch(title, /\bverified\b/i);
+	}
+});

--- a/ui/test/library-loading.test.js
+++ b/ui/test/library-loading.test.js
@@ -97,9 +97,16 @@ test('the skeleton comes down without waiting for the deployability gate', () =>
     false,
     `the gate call must not be awaited before the rows paint; awaited: ${members.trim()}`,
   )
-  // The gate still runs, still lands, and still reports its own errors — this
-  // is a reordering, not a removal.
-  assert.match(strategies, /apiGet\('\/api\/selection-bias\/gate'\)/)
+  // The gate still runs — under VITE_ROADMAP_SURFACES=true — still lands, and
+  // still reports its own errors: this is a reordering, not a removal. The
+  // flag prefix is part of the pattern on purpose: the call now sits inside a
+  // `ROADMAP_SURFACES_ENABLED ? ... : Promise.resolve(...)` ternary, so a bare
+  // substring match is satisfied by a default build that never makes the
+  // request (0 hits for `selection-bias/gate` in the built chunk).
+  assert.match(
+    strategies,
+    /ROADMAP_SURFACES_ENABLED \? apiGet\('\/api\/selection-bias\/gate'\)/,
+  )
   assert.match(strategies, /setGateError\(/)
   // Its in-flight flag is cleared on BOTH outcomes: a rejected gate must reach
   // the error banner, never leave every chip on a permanent "checking…". The


### PR DESCRIPTION
## What the owner saw

Library → **Examples (34)**: every hand-curated card carried the pill
`Reference only — gate failed` **and** a red `blocked` pill, next to metrics.
Owner: *"lots of things don't look good."*

Under the new grading model — the passport is the verdict of record, and a
curated row is not graded until its backtest is actually run — the Examples tab
was presenting the reference library as 34 failures.

This PR takes the **copy** and the **`blocked` pill**. The
`Reference only — gate failed` pill is `statusTag` / `statusLabel`, which
PR #1792 (`dbrowneup/verdict-of-record-a`) owns; nothing here touches those
helpers, or `coerceGenerated`. See **Merge order** below — that is a hard
ordering constraint, not a nice-to-have.

## Root cause

`blocked` is not a research verdict — it is a **deployability** verdict.
`DeployabilityChip` (ui/src/components/Strategies.jsx) grades a row off
`/api/selection-bias/gate`, and `blocked_by_floor` is the same field the vault
deploy gate reads (`backend/archimedes/api/vaults_routes.py::_deployable_levels`).
Its own title says so: *"Fails an always-on correctness floor — cannot deploy at
any level."*

Vaults are out of the MVP cut (#1266, `ROADMAP_SURFACES_ENABLED`, off unless
`VITE_ROADMAP_SURFACES=true`). So the shipped build was grading hand-curated
reference implementations against a capability it does not have, in red, on the
one tab whose whole job is to teach the card format.

The metrics beside them have the same shape of problem, and the API already
knew: `GET /api/strategies/` serves `display_metrics_source` per row
(`strategies_routes.py::_display_metrics_source`), whose own comment says
`strategy_record` is **not** "measured" — for the curated library it traces to
the backtest-fixture snapshot (#1187). The UI dropped the field, so a fixture
value and a real persisted backtest rendered as the same black number.

## The change

**1. The deployability chip does not render unless `ROADMAP_SURFACES_ENABLED`.**
The *whole* chip, not just the red branch. Suppressing only `blocked` would
leave the green `deployable` claim standing on a surface where nothing can be
deployed — keeping the flattering half of a vault verdict and hiding the rest.
Every branch (`blocked` included) is intact and comes back with
`VITE_ROADMAP_SURFACES=true`; this is a gate, not a deletion, and there is a
test pinning that ordering.

**2. The gate fetch is gated on the same flag.** `/api/selection-bias/gate`
recomputes the whole cohort gate (the slowest request on the page, ~8-10s, and
504-ing against prod on 2026-08-31). Paying for it to annotate something that no
longer renders is the exact defect #1324 was filed against — same one-line
ternary as `publishedPromise`, and the empty payload leaves `deployMap`,
`gateLoading` and the `gateError` banner behaving exactly as before.

**3. The Examples intro is rewritten to the new identity** — reference
implementations to learn the card format; *not* fusion output; **not a
scoreboard**; graded only once a backtest has been run for it, so an absent
verdict is not a failure; a strategy's passport is its verdict of record; and
where the numbers come from (`fixture`, or `placeholder` where only the
strategy module's declared constants exist).

**4. `ui/src/metricsSource.js` (new)** turns `display_metrics_source` into a
one-word mark under the row's Sharpe (table + card): `fixture` for
`strategy_record`, `placeholder` for `stub_placeholder`.

Deliberately an **allow-list**, and the omissions are the honest part:
`persisted_backtest` is a real run and stays unmarked — marking it "fixture"
would be a fresh false claim, worse than the silence being fixed — and an
absent/unknown value (a generated row reaches the table through
`coerceGenerated`, which does not carry the field) makes no claim in either
direction. That is also why the intro says *"where a row's metrics trace to a
stored fixture snapshot rather than to a backtest run here, the row is marked
fixture"* rather than declaring every number on the tab a fixture: the paragraph
never generalises about rows it cannot see.

## Merge order — depends on PR #1792 (PR-A)

**Land this after or with #1792 (`dbrowneup/verdict-of-record-a`).**

This PR's intro copy — *"until then it carries no verdict, and an absent verdict
is not a failure"* — is only true once #1792 lands. `statusLabel(...)`
(Strategies.jsx:161, correctly untouched here) still returns
`'Reference only — gate failed'` for
`status === 'live' && passes_rigor_gate === false`, and `passes_rigor_gate` is
the **fail-closed** boolean: false for a `pending` verdict too. #1792 replaces
that with the four-state `rigor_gate_status` and
`NOT_GRADED_LABEL = "Not yet graded"` (`ui/src/libraryStatus.js`), which is what
stops an ungraded curated row from rendering a failure pill. **Merged alone,
this paragraph sits directly above 34 rows asserting the verdict it denies.**

This is an **ordering** constraint, not a conflict one:

```
git merge-tree --write-tree --name-only \
  origin/dbrowneup/ux-curated-examples-copy \
  origin/dbrowneup/verdict-of-record-a
-> EXIT=0, tree 656059e6, no conflicted paths   (217f8b8f vs b6b8b790)
```

`git merge-tree` against `origin/dbrowneup/reasoning-traces-surfaced` is clean
too (EXIT=0, 0 conflict markers). The dependency is
also recorded in the source, as a JSX comment immediately above the dependent
paragraph (Strategies.jsx, `MERGE ORDER — depends on PR #1792`), so it cannot be
lost when this body scrolls out of view.

The shared-file overlap with #1792 is textual proximity only: it owns
`statusTag` / `statusLabel` (~lines 118-131 on main); the hunks here are the
chip body (~line 28), a new component after `STATUS_ORDER`, the Sharpe cells,
the `gatePromise` line in `load()`, and the Examples intro.

## Adversarial demo — every guard shown red on the input it rejects

Guard file: `ui/test/curated-examples-copy.test.js` (10 tests, green on this
branch). Each pattern also carries in-file anti-vacuity: it is asserted to
*reject* its own pre-fix input, so a pattern that stops matching anything fails
loudly instead of guarding nothing. Beyond that, every defect was re-introduced
into the source and the guards run. **8 mutations, all red (exit 1), tree
restored after each (`git status --porcelain` clean).**

| # | mutation | suite | result |
| --- | --- | --- | --- |
| 1 | delete `if (!ROADMAP_SURFACES_ENABLED) return null` from `DeployabilityChip` | curated-examples-copy | pass 8 / **fail 2**, EXIT=1 |
| 2 | restore the pre-fix Examples intro copy | curated-examples-copy | pass 8 / **fail 2**, EXIT=1 |
| 3 | un-gate the `/api/selection-bias/gate` fetch | curated-examples-copy | pass 9 / **fail 1**, EXIT=1 |
| 4 | mark a real `persisted_backtest` as "fixture" | curated-examples-copy | pass 9 / **fail 1**, EXIT=1 |
| 5 | half-gate: move the flag check *below* the `!deploy` / "checking…" branch | curated-examples-copy | pass 9 / **fail 1**, EXIT=1 |
| 6 | drop the card's `MetricsSourceTag`, keep the table row's | curated-examples-copy | pass 9 / **fail 1**, EXIT=1 |
| 7 | rename `strategy_record` → `record_metrics` in the route **and** in `backend/tests/test_metrics_provenance.py` | curated-examples-copy | pass 9 / **fail 1**, EXIT=1 |
| 8 | un-gate the fetch (again), against the *tightened* neighbour guard | library-loading | pass 7 / **fail 1**, EXIT=1 |

Failure text for the two that pin the honesty signal itself:

```
# 7 — the rename lands "normally" everywhere else:
pytest backend/tests/test_metrics_provenance.py  ->  9 passed, EXIT=0   (green)

✖ every marked source is a value the backend actually returns
AssertionError [ERR_ASSERTION]: _display_metrics_source no longer returns "strategy_record"

# 4 — a real run must never be labelled a fixture:
✖ only non-measured sources are marked
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected
+ { label: 'fixture', title: 'x' }
- null
```

## Behavioural proof (the built bundle, not just the source text)

| build | `always-on correctness floor` in `dist/assets/Strategies-*.js` | `selection-bias/gate` |
| --- | --- | --- |
| default flags | **0** | **0** |
| `VITE_ROADMAP_SURFACES=true` | **1** | **1** |

The whole chip *and* the gate request are dead-code-eliminated in the shipped
build: the red pill cannot render and the page's slowest request is genuinely
not made. With the flag on, the `blocked` branch is back — gated, not deleted.

## Verification

| check | command | result |
| --- | --- | --- |
| new guard | `node --test test/curated-examples-copy.test.js` | tests 10 / pass 10 / fail 0, `EXIT=0` |
| full ui suite | `cd ui && node --test` | `tests 923 / pass 923 / fail 0`, `EXIT=0` |
| eslint (touched files) | `npx eslint src/components/Strategies.jsx src/metricsSource.js test/curated-examples-copy.test.js test/library-loading.test.js` | `EXIT=0` |
| ruff | `ruff check ui/` | "No Python files found", All checks passed, `EXIT=0` |
| routes/sitemap | `npm run check:routes` | orphans OK, sitemap OK, `EXIT=0` |
| vite build | `npm run build` (both flag states) | `EXIT=0` |
| backend behaviour this PR reads | `pytest -p no:cacheprovider -q backend/tests/test_metrics_provenance.py` | `9 passed`, `EXIT=0` |
| python unit suite | `pytest -m "not integration" -q -p no:cacheprovider` | `5644 passed, 4 skipped, 2 deselected in 951.01s`, `EXIT=0` — run at 8f05f165; **this PR touches zero Python files** (`git diff --name-only origin/main...HEAD` = 4 UI files), so it cannot be affected |

Pre-existing suites that pin this file still pass unchanged:
`rigor-tristate.test.js` (the pending / degenerate / blocked branch ordering
inside the chip), `fail-soft.test.js` (per-feed error state), `routes.test.js`
(#1324). `library-loading.test.js` still pins the chip signature and the
`gatePending` plumbing; its gate assertion is **tightened** by this PR (below).

## Review round — what changed after verification

Verdict was FIX-FIRST (2 required, 3 optional). All five applied; no defect
left open.

- **Required 1 — `ui/test/curated-examples-copy.test.js`.** `METRICS_SOURCE_NOTES`'
  keys are bare string literals of `_display_metrics_source`'s return values, and
  nothing pinned them. Renaming one in the route *and* in its own backend test —
  the normal way such a rename lands — left that file at 9 passed and the whole
  UI suite green while every `fixture` mark silently stopped rendering **and** the
  intro's promise that "the row is marked fixture" became false: fail-open on the
  exact honesty signal this PR adds. New guard reads the backend source from the
  UI suite (same idiom as `security-claims.test.js`, `account-deletion.test.js`),
  with an anti-vacuity check on all four backend states. Mutation 7 above.
- **Required 2 — merge-order dependency on #1792.** Now recorded in this body
  (**Merge order** section) and as a JSX comment at the dependent paragraph in
  `Strategies.jsx`.
- **Optional 3 — `ui/test/library-loading.test.js`.** Its comment ("the gate
  still runs, still lands") became false, and
  `assert.match(strategies, /apiGet\('\/api\/selection-bias\/gate'\)/)` was
  satisfied by the substring *inside* the new ternary — it would pass on a
  default build that never makes the call. Comment corrected and the assertion
  tightened to require the `ROADMAP_SURFACES_ENABLED ?` prefix. Mutation 8 above.
- **Optional 4 — `Strategies.jsx` intro.** It promised `fixture` while a row can
  render `placeholder` (`stub_placeholder`). One clause added.
- **Optional 5 — `Strategies.jsx` gateError banner comment.** It still claimed to
  be "the visible signal that replaces that silence"; with the flag off the gate
  is never fetched, so it cannot fire and there are no chips left for it to
  describe. Scope note added. Comment-only.

Part of #1436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
