### PR TITLE
[frontend] Landing hero is visible in every animation state: the entrance no longer starts at opacity 0 (#1750)

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -6323,16 +6323,48 @@ body:has(.public-site) {
 	color: var(--accent-text, var(--accent));
 }
 
+/* The hero's resting appearance must come from the cascade, never from a
+   retained animation value — issue #1750.
+
+   What broke: this keyframe declared only a `from` frame and both rules below
+   used `animation-fill-mode: both`. `both` adds the backwards fill (the first
+   frame, opacity 0, applied before the animation starts) *and* the forwards
+   fill (the last frame, applied after it ends) — and with no `to` frame the
+   last frame is one the UA synthesises from the element's underlying style.
+   Nothing in the hero declares an opacity of its own (the only `opacity` in
+   this whole block was the `from` frame), so opacity 0 was the only value the
+   stylesheet ever stated, and the hero's visibility depended entirely on the
+   animation running to completion *and* on that implicit frame resolving to 1.
+   When it didn't, the hero's children painted at opacity 0 over
+   `.public-hero__stage`'s own `--public-stage` (#0c0c11) — the solid black
+   void in #1750.
+
+   The two halves of the fix, and what each one buys:
+   • an explicit `to` frame: the end state is stated, so a forwards fill can
+     never resolve to an implicit frame the UA has to synthesise.
+   • `backwards` instead of `both`: no forwards fill at all, so once the
+     animation is over the element is drawn from its own cascade — where
+     opacity is 1 — rather than from a value the animation left behind.
+   Together: with the animation absent, idle, or finished, the hero is visible.
+   opacity 0 remains only *while* the animation is running (the ≤120ms delay
+   window and the fade itself), which is the animation doing its job.
+
+   Guard: ui/test/public-hero-visible-at-rest.test.js. */
 @keyframes public-arrive {
 	from {
 		opacity: 0;
 		transform: translateY(10px);
 	}
+
+	to {
+		opacity: 1;
+		transform: none;
+	}
 }
 
 @media (prefers-reduced-motion: no-preference) {
 	.public-hero__copy > * {
-		animation: public-arrive 360ms both;
+		animation: public-arrive 360ms backwards;
 	}
 
 	.public-hero__copy > :nth-child(2) {
@@ -6345,7 +6377,20 @@ body:has(.public-site) {
 
 	.public-hero__copy > :nth-child(4),
 	.public-product-frame {
-		animation: public-arrive 400ms 120ms both;
+		animation: public-arrive 400ms 120ms backwards;
+	}
+}
+
+/* Belt and braces. The rules above already sit inside a
+   `prefers-reduced-motion: no-preference` block, so a reduce preference never
+   applies them today — this block states the intent anyway, so that hoisting
+   the animation out of that media query (or adding another `public-arrive`
+   user outside it) cannot silently hand reduced-motion visitors an entrance
+   animation, and an opacity-0 entry state, that they asked not to have. */
+@media (prefers-reduced-motion: reduce) {
+	.public-hero__copy > *,
+	.public-product-frame {
+		animation: none;
 	}
 }
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -6323,41 +6323,43 @@ body:has(.public-site) {
 	color: var(--accent-text, var(--accent));
 }
 
-/* The hero's resting appearance must come from the cascade, never from a
-   retained animation value — issue #1750.
+/* The hero must be visible in every animation state, by construction — issue
+   #1750.
 
-   What broke: this keyframe declared only a `from` frame and both rules below
-   used `animation-fill-mode: both`. `both` adds the backwards fill (the first
-   frame, opacity 0, applied before the animation starts) *and* the forwards
-   fill (the last frame, applied after it ends) — and with no `to` frame the
-   last frame is one the UA synthesises from the element's underlying style.
-   Nothing in the hero declares an opacity of its own (the only `opacity` in
-   this whole block was the `from` frame), so opacity 0 was the only value the
-   stylesheet ever stated, and the hero's visibility depended entirely on the
-   animation running to completion *and* on that implicit frame resolving to 1.
-   When it didn't, the hero's children painted at opacity 0 over
-   `.public-hero__stage`'s own `--public-stage` (#0c0c11) — the solid black
-   void in #1750.
+   What broke: this keyframe entered from `opacity: 0`, and nothing else in the
+   hero declares an opacity at all — the only `opacity` anywhere in the hero
+   block was that `from` frame. So opacity 0 was the only opacity the
+   stylesheet ever stated for the eyebrow, `#public-hero-title`, the lede, the
+   CTA row and the product screenshot, and the hero was visible only as a
+   consequence of the animation actually running. Every state that holds the
+   first frame paints the hero at opacity 0 over `.public-hero__stage`'s own
+   near-black `--public-stage` (#0c0c11): the before phase, and — the one that
+   never ends — a play-pending animation whose start time never resolves,
+   which is what a suspended document timeline in a background tab, a bfcache
+   restore before the first style commit, or a compositor stall produce. That
+   is the solid black void in #1750.
 
-   The two halves of the fix, and what each one buys:
-   • an explicit `to` frame: the end state is stated, so a forwards fill can
-     never resolve to an implicit frame the UA has to synthesise.
-   • `backwards` instead of `both`: no forwards fill at all, so once the
-     animation is over the element is drawn from its own cascade — where
-     opacity is 1 — rather than from a value the animation left behind.
-   Together: with the animation absent, idle, or finished, the hero is visible.
-   opacity 0 remains only *while* the animation is running (the ≤120ms delay
-   window and the fade itself), which is the animation doing its job.
+   No fill mode fixes that. `backwards` and `both` are *defined* as applying
+   the first frame throughout the before phase, and `none`/`forwards` do not
+   help either: three of the five animated elements have no delay, so their
+   pending hold time lands on active time 0 — which is the `from` frame again.
+   The fill mode only ever changed the far end, where the underlying value is
+   opacity 1 already.
+
+   The fix is to take opacity out of the entrance entirely. The hero animates
+   `transform` only, so its opacity is 1 in every state there is: pending,
+   before phase, active, finished, idle, cancelled, reduced motion, a stale
+   bundle, a stylesheet that failed to load. An entrance that never starts now
+   leaves the hero sitting 10px low and completely readable. The fade is gone
+   — that is the accepted cost; the slide stays.
 
    Guard: ui/test/public-hero-visible-at-rest.test.js. */
 @keyframes public-arrive {
 	from {
-		opacity: 0;
 		transform: translateY(10px);
 	}
 
 	to {
-		opacity: 1;
 		transform: none;
 	}
 }
@@ -6381,12 +6383,14 @@ body:has(.public-site) {
 	}
 }
 
-/* Belt and braces. The rules above already sit inside a
-   `prefers-reduced-motion: no-preference` block, so a reduce preference never
-   applies them today — this block states the intent anyway, so that hoisting
-   the animation out of that media query (or adding another `public-arrive`
-   user outside it) cannot silently hand reduced-motion visitors an entrance
-   animation, and an opacity-0 entry state, that they asked not to have. */
+/* Reduced motion gets no entrance at all — a motion-preference courtesy, not
+   a visibility guard. It changes nothing today: the rules above already sit
+   inside a `prefers-reduced-motion: no-preference` block, so a `reduce`
+   preference never applies them. It is written down so that hoisting the
+   animation out of that media query, or adding another `public-arrive` user
+   outside it, cannot silently hand reduced-motion visitors a slide they asked
+   not to have. Since the entrance no longer touches opacity, deleting this
+   block could not reintroduce #1750. */
 @media (prefers-reduced-motion: reduce) {
 	.public-hero__copy > *,
 	.public-product-frame {

--- a/ui/test/public-hero-visible-at-rest.test.js
+++ b/ui/test/public-hero-visible-at-rest.test.js
@@ -1,26 +1,48 @@
 /**
  * Issue #1750 — the landing hero rendered as a solid black void.
  *
- * The hero's children carry no opacity of their own; the only opacity the
- * stylesheet stated was `from { opacity: 0 }` in the `public-arrive` keyframe,
- * and both rules that used it asked for `animation-fill-mode: both`. `both`
- * means "apply the first frame before the animation starts AND the last frame
- * after it ends" — so opacity 0 was the hero's stylesheet-supplied resting
- * value, and whether anyone ever saw the headline depended on the animation
- * running and on a `to` frame the UA had to synthesise because none was
- * written. Over `.public-hero__stage`'s near-black `--public-stage` (#0c0c11),
- * a hero that loses that bet is a black rectangle.
+ * The hero's own rules declare no opacity. The only opacity the stylesheet
+ * ever stated for that content was `from { opacity: 0 }` in the
+ * `public-arrive` entrance, so the headline, lede, CTA row and product
+ * screenshot were visible only as a consequence of that animation running.
+ * Every state that holds an animation's first frame therefore painted the
+ * hero at opacity 0 over `.public-hero__stage`'s near-black `--public-stage`
+ * (#0c0c11) — including the one state that never ends, a play-pending
+ * animation whose start time never resolves.
  *
- * These are source-text checks against ui/src/App.css. They cannot prove what
- * a browser paints; what they pin is the invariant that made the void
- * possible — that the hero must not depend on an animation for its resting
- * appearance:
- *   1. the keyframe states where it ends, and it ends visible;
- *   2. any rule that keeps a forwards fill (`forwards`/`both`) may only do so
- *      while that explicit, visible end frame exists;
- *   3. reduced-motion visitors get `animation: none`, not a shortened fade;
- *   4. no rule that uses the animation writes an at-rest `opacity: 0` back
- *      into the cascade.
+ * No fill mode closes that. `backwards`/`both` are *defined* as applying the
+ * first frame through the before phase, and `none`/`forwards` leave the
+ * zero-delay elements holding active time 0, which is the first frame again.
+ * The fix, and the invariant these checks pin, is structural: **the hero's
+ * opacity is 1 in every state, because no rule and no keyframe that reaches
+ * the hero ever states otherwise.** Pending, before phase, active, finished,
+ * idle, cancelled, reduced motion, a stale bundle, a stylesheet that failed
+ * to load — all opacity 1.
+ *
+ * These are source-text checks over ui/src/App.css. They cannot prove what a
+ * browser paints; what they prove is that the stylesheet never asks for an
+ * invisible hero.
+ *
+ *   1. `@keyframes public-arrive` contains no `opacity` token at all, and
+ *      still animates something (so an emptied keyframe cannot pass it).
+ *   2. No rule targeting the hero hides it — opacity below 1, `visibility:
+ *      hidden`/`collapse`, `display: none`, or `content-visibility`. Checked
+ *      in every context, media queries included, because a rule that hides
+ *      the hero at one viewport width is #1750 at that width.
+ *   3. Every keyframe named by an animation on a hero rule is opacity-free —
+ *      not just `public-arrive`. This is not a passenger of check 1: adding
+ *      `animation: some-other-fade` (whose keyframes fade from 0) to
+ *      `.public-hero__copy > *` reddens 3 alone.
+ *
+ * Each check also asserts that it actually looked at something — that the
+ * keyframe exists, that the hero selectors still match rules, that the two
+ * known animation users are still there. A rename or a deletion makes this
+ * file fail loudly rather than pass over an empty set.
+ *
+ * Not checked, deliberately: reduced motion. The `@media (prefers-reduced-
+ * motion: reduce)` block in App.css is now a motion-preference courtesy, not
+ * a visibility guard — with opacity gone from the entrance, deleting it could
+ * not reintroduce #1750, so asserting on it here would be a passenger.
  */
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -28,14 +50,35 @@ import test from "node:test";
 
 const raw = readFileSync(new URL("../src/App.css", import.meta.url), "utf8");
 
-// Blank comments out (preserving length and newlines, so offsets and line
-// numbers stay true) — prose about `animation` must never read as a rule.
+// Blank comments out, preserving length and newlines so offsets and line
+// numbers stay true — prose about `opacity` must never read as a declaration.
 const css = raw.replace(/\/\*[\s\S]*?\*\//g, (match) =>
 	match.replace(/[^\n]/g, " "),
 );
 
 const NAME = "public-arrive";
-const FILL_KEYWORDS = new Set(["none", "forwards", "backwards", "both"]);
+
+/**
+ * Selectors that carry the hero's visible content. The `(?![\w-])` boundary
+ * keeps `.public-product-frame` from swallowing `.public-product-frame__bar`
+ * (whose chrome legitimately hides a span on narrow screens) while still
+ * matching `.public-product-frame img` and `.public-hero__copy > :nth-child`.
+ */
+const HERO_SELECTORS = [
+	".public-hero",
+	".public-hero__stage",
+	".public-hero__copy",
+	".public-product-frame",
+	// The headline is styled through `.public-hero h1` today and has no rule of
+	// its own, so this one is scanned rather than required — it is here so an
+	// id-targeted rule cannot slip a hide past the scan later.
+	"#public-hero-title",
+];
+
+/** Of those, the ones that must still match a rule or the scan is vacuous. */
+const REQUIRED_SELECTORS = HERO_SELECTORS.filter(
+	(token) => token !== "#public-hero-title",
+);
 
 const lineOf = (index) => css.slice(0, index).split("\n").length;
 
@@ -52,149 +95,181 @@ function blockAt(openIndex) {
 	throw new Error(`src/App.css: unbalanced braces from line ${lineOf(openIndex)}`);
 }
 
-/** Flat `selector { declarations }` pairs inside a block that does not nest. */
-function flatRules(body) {
-	return [...body.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((match) => ({
-		selector: match[1].replace(/\s+/g, " ").trim(),
-		declarations: match[2],
-	}));
+/**
+ * Every leaf rule in the sheet, with the at-rules it nests inside. App.css is
+ * a flat stylesheet (rules and @media/@keyframes blocks, no CSS nesting), so
+ * a leaf block's text is its declaration list.
+ */
+function leafRules() {
+	const rules = [];
+	const stack = [];
+	let buffer = "";
+	for (let i = 0; i < css.length; i += 1) {
+		const char = css[i];
+		if (char === "{") {
+			stack.push({ prelude: buffer.replace(/\s+/g, " ").trim(), at: i });
+			buffer = "";
+		} else if (char === "}") {
+			const frame = stack.pop();
+			assert.ok(frame, `src/App.css:${lineOf(i)}: unbalanced closing brace`);
+			if (buffer.trim()) {
+				rules.push({
+					selector: frame.prelude,
+					context: stack.map((outer) => outer.prelude).join(" / "),
+					declarations: buffer,
+					line: lineOf(frame.at),
+				});
+			}
+			buffer = "";
+		} else buffer += char;
+	}
+	assert.equal(stack.length, 0, "src/App.css: unbalanced braces");
+	return rules;
 }
 
-function keyframesBody(name) {
-	const at = css.search(new RegExp(`@keyframes\\s+${name}\\s*\\{`));
-	assert.notEqual(
-		at,
-		-1,
-		`src/App.css: @keyframes ${name} is gone. If the hero's entrance was ` +
-			`retired, delete this guard in the same change; do not leave it ` +
-			`passing on an animation that no longer exists.`,
-	);
-	return blockAt(css.indexOf("{", at));
-}
+const rules = leafRules();
 
-/** Every rule whose own declarations name the animation. */
-function rulesUsing(name) {
-	const declaration = new RegExp(
-		`animation(?:-name)?\\s*:[^;{}]*\\b${name}\\b[^;{}]*`,
-		"g",
-	);
-	return [...css.matchAll(declaration)].map((match) => {
-		const open = css.lastIndexOf("{", match.index);
-		const start =
-			Math.max(css.lastIndexOf("}", open), css.lastIndexOf("{", open - 1)) + 1;
-		return {
-			selector: css.slice(start, open).replace(/\s+/g, " ").trim(),
-			declarations: blockAt(open),
-			shorthand: match[0].replace(/\s+/g, " ").trim(),
+const keyframes = new Map(
+	[...css.matchAll(/@keyframes\s+([\w-]+)\s*\{/g)].map((match) => [
+		match[1],
+		{
+			body: blockAt(match.index + match[0].length - 1),
 			line: lineOf(match.index),
-		};
-	});
-}
-
-/** The fill mode a rule ends up with: longhand wins, else the shorthand. */
-function fillModeOf(rule) {
-	const longhand = rule.declarations.match(
-		/animation-fill-mode\s*:\s*([a-zA-Z-]+)/,
-	);
-	if (longhand) return longhand[1].toLowerCase();
-	const fromShorthand = rule.shorthand
-		.split(/[\s:]+/)
-		.map((token) => token.toLowerCase())
-		.filter((token) => token !== NAME && FILL_KEYWORDS.has(token));
-	// A CSS shorthand takes the fill mode from its last such keyword.
-	return fromShorthand.at(-1) ?? "none";
-}
-
-const frames = flatRules(keyframesBody(NAME)).map((frame) => ({
-	offsets: frame.selector
-		.split(",")
-		.map((offset) => offset.trim().toLowerCase())
-		.filter(Boolean),
-	declarations: frame.declarations,
-}));
-const endFrame = frames.find(
-	(frame) => frame.offsets.includes("to") || frame.offsets.includes("100%"),
+		},
+	]),
 );
-const endsVisible = Boolean(endFrame) && /opacity\s*:\s*1\b/.test(endFrame.declarations);
-const users = rulesUsing(NAME);
 
-test(`@keyframes ${NAME} states an end frame, and it ends visible`, () => {
-	assert.ok(
-		endFrame,
-		`src/App.css: @keyframes ${NAME} has no \`to\` (or \`100%\`) frame. With ` +
-			`only a \`from { opacity: 0 }\` frame the end state is implicit — the ` +
-			`browser has to synthesise it from the element's underlying style — so ` +
-			`nothing in the stylesheet ever says the hero is visible. Write the ` +
-			`end state: \`to { opacity: 1; transform: none; }\`. (#1750)`,
+const MISSING =
+	`src/App.css: @keyframes ${NAME} is gone. If the hero's entrance was ` +
+	`retired, delete this guard in the same change; do not leave it passing ` +
+	`over an animation that no longer exists. (#1750)`;
+
+const targetsHero = (selector) =>
+	HERO_SELECTORS.some((token) =>
+		new RegExp(`${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![\\w-])`).test(
+			selector,
+		),
 	);
-	assert.ok(
-		endsVisible,
-		`src/App.css: the \`to\` frame of @keyframes ${NAME} does not set ` +
-			`\`opacity: 1\`. The frame the hero finishes on has to be a visible ` +
-			`one. (#1750)`,
+
+const heroRules = rules.filter((rule) => targetsHero(rule.selector));
+
+/** Declarations that make an element, or its text, unpaintable. */
+const HIDING = [
+	{
+		pattern: /opacity\s*:\s*(-?[\d.]+%?)/g,
+		hides: (value) =>
+			Number.parseFloat(value) / (value.endsWith("%") ? 100 : 1) < 1,
+		why: "the hero must never be less than fully opaque — that is #1750",
+	},
+	{
+		pattern: /visibility\s*:\s*(hidden|collapse)\b/g,
+		hides: () => true,
+		why: "a hidden hero is #1750 with a different property",
+	},
+	{
+		pattern: /display\s*:\s*(none)\b/g,
+		hides: () => true,
+		why: "a hero that is not laid out is a hero nobody reads",
+	},
+	{
+		pattern: /content-visibility\s*:\s*(hidden|auto)\b/g,
+		hides: () => true,
+		why: "a skipped subtree paints nothing, which is #1750 by another route",
+	},
+];
+
+test(`@keyframes ${NAME} animates transform only — no opacity anywhere in it`, () => {
+	const frame = keyframes.get(NAME);
+	assert.ok(frame, MISSING);
+	assert.doesNotMatch(
+		frame.body,
+		/\bopacity\b/,
+		`src/App.css:${frame.line}: @keyframes ${NAME} mentions \`opacity\`. The ` +
+			`hero has no opacity of its own, so any opacity in this entrance is ` +
+			`the only opacity the stylesheet states for the headline, lede, CTAs ` +
+			`and screenshot — and a pending or stalled animation holds its first ` +
+			`frame forever, under every fill mode. Animate \`transform\` only, so ` +
+			`a broken entrance leaves the hero 10px low and readable rather than ` +
+			`invisible. (#1750)`,
 	);
 	assert.match(
-		endFrame.declarations,
-		/transform\s*:\s*none\b/,
-		`src/App.css: the \`to\` frame of @keyframes ${NAME} does not reset ` +
-			`\`transform\`, so a forwards fill would leave the hero holding the ` +
-			`10px entrance offset. (#1750)`,
+		frame.body,
+		/\btransform\s*:/,
+		`src/App.css:${frame.line}: @keyframes ${NAME} no longer animates ` +
+			`\`transform\`, so this check would pass over an empty keyframe. If ` +
+			`the entrance changed shape, update this guard deliberately. (#1750)`,
 	);
 });
 
-test("no public-arrive rule keeps a forwards fill without a visible end frame", () => {
-	assert.ok(
-		users.length >= 2,
-		`src/App.css: expected the hero copy and the product frame to use ` +
-			`${NAME}; found ${users.length} rule(s). Update this guard along with ` +
-			`the hero if that changed on purpose.`,
-	);
-	const covered = users.map((rule) => rule.selector).join(" ");
-	assert.match(covered, /public-hero__copy/, "hero copy no longer animates");
-	assert.match(covered, /public-product-frame/, "product frame no longer animates");
-
-	for (const rule of users) {
-		const fill = fillModeOf(rule);
-		if (fill !== "forwards" && fill !== "both") continue;
+test("no rule targeting the hero hides it", () => {
+	for (const token of REQUIRED_SELECTORS) {
 		assert.ok(
-			endsVisible,
-			`src/App.css:${rule.line}: \`${rule.selector}\` uses ` +
-				`\`${rule.shorthand}\` — a \`${fill}\` fill holds the animation's ` +
-				`last frame after it ends — but @keyframes ${NAME} has no \`to\` ` +
-				`frame ending at \`opacity: 1\`. That is exactly #1750: the hero's ` +
-				`resting appearance is supplied by an animation whose end state ` +
-				`nothing states. Either write the end frame, or drop to ` +
-				`\`backwards\` so the element rests on its own cascade.`,
+			heroRules.some((rule) => rule.selector.includes(token)),
+			`src/App.css: no rule matches \`${token}\` any more. This guard scans ` +
+				`the hero by selector; a rename leaves it scanning nothing. Update ` +
+				`HERO_SELECTORS in the same change. (#1750)`,
 		);
+	}
+
+	for (const rule of heroRules) {
+		for (const { pattern, hides, why } of HIDING) {
+			for (const match of rule.declarations.matchAll(pattern)) {
+				assert.ok(
+					!hides(match[1]),
+					`src/App.css:${rule.line}: \`${rule.selector}\`` +
+						(rule.context ? ` (inside ${rule.context})` : "") +
+						` declares \`${match[0].replace(/\s+/g, " ")}\` — ${why}. The ` +
+						`hero sits on a near-black stage; anything that stops it ` +
+						`painting is the black void the issue reports. (#1750)`,
+				);
+			}
+		}
 	}
 });
 
-test("reduced motion turns the hero entrance off rather than shortening it", () => {
-	const reduceBodies = [...css.matchAll(/@media[^{]*\{/g)]
-		.filter((match) => /prefers-reduced-motion\s*:\s*reduce/.test(match[0]))
-		.map((match) => blockAt(match.index + match[0].length - 1));
-	const silenced = reduceBodies
-		.flatMap(flatRules)
-		.filter((rule) => /animation(?:-name)?\s*:\s*none\b/.test(rule.declarations))
-		.map((rule) => rule.selector)
-		.join(" ");
-	const explain =
-		"src/App.css: under `prefers-reduced-motion: reduce` the hero must get " +
-		"`animation: none`. A global `animation-duration: 0.01ms !important` is " +
-		"not the same thing — it still runs an animation, and an animation that " +
-		"has not started yet is an animation holding opacity 0. (#1750)";
-	assert.match(silenced, /public-hero__copy/, explain);
-	assert.match(silenced, /public-product-frame/, explain);
-});
+test("every animation the hero runs comes from an opacity-free keyframe", () => {
+	assert.ok(keyframes.has(NAME), MISSING);
 
-test("no public-arrive rule writes an at-rest opacity: 0 into the cascade", () => {
-	for (const rule of users) {
-		assert.doesNotMatch(
-			rule.declarations,
-			/opacity\s*:\s*0(?![.\d%])/,
-			`src/App.css:${rule.line}: \`${rule.selector}\` declares ` +
-				`\`opacity: 0\` outside the keyframe, which makes invisible the ` +
-				`hero's resting state again no matter what the animation does. (#1750)`,
-		);
+	const animated = heroRules.filter((rule) =>
+		/animation(?:-name)?\s*:/.test(rule.declarations),
+	);
+	const arriveUsers = animated.filter((rule) =>
+		new RegExp(`\\b${NAME}\\b`).test(rule.declarations),
+	);
+	const covered = arriveUsers.map((rule) => rule.selector).join(" ");
+	assert.match(
+		covered,
+		/public-hero__copy/,
+		`src/App.css: no hero-copy rule runs ${NAME} any more; this guard would ` +
+			`have nothing to check. (#1750)`,
+	);
+	assert.match(
+		covered,
+		/public-product-frame/,
+		`src/App.css: the product frame no longer runs ${NAME}; this guard would ` +
+			`have nothing to check. (#1750)`,
+	);
+
+	for (const rule of animated) {
+		const named = [
+			...rule.declarations.matchAll(/animation(?:-name)?\s*:([^;}]*)/g),
+		]
+			.flatMap((match) => match[1].split(/[\s,]+/))
+			.map((token) => token.trim())
+			.filter((token) => keyframes.has(token));
+
+		for (const name of new Set(named)) {
+			assert.doesNotMatch(
+				keyframes.get(name).body,
+				/\bopacity\b/,
+				`src/App.css:${rule.line}: \`${rule.selector}\` runs ` +
+					`@keyframes ${name} (defined at line ${keyframes.get(name).line}), ` +
+					`which animates \`opacity\`. Nothing in the hero declares an ` +
+					`opacity of its own, so that keyframe's first frame becomes the ` +
+					`hero's appearance for as long as the animation is pending — ` +
+					`indefinitely, if its start time never resolves. Animate ` +
+					`\`transform\` only. (#1750)`,
+			);
+		}
 	}
 });

--- a/ui/test/public-hero-visible-at-rest.test.js
+++ b/ui/test/public-hero-visible-at-rest.test.js
@@ -1,0 +1,200 @@
+/**
+ * Issue #1750 — the landing hero rendered as a solid black void.
+ *
+ * The hero's children carry no opacity of their own; the only opacity the
+ * stylesheet stated was `from { opacity: 0 }` in the `public-arrive` keyframe,
+ * and both rules that used it asked for `animation-fill-mode: both`. `both`
+ * means "apply the first frame before the animation starts AND the last frame
+ * after it ends" — so opacity 0 was the hero's stylesheet-supplied resting
+ * value, and whether anyone ever saw the headline depended on the animation
+ * running and on a `to` frame the UA had to synthesise because none was
+ * written. Over `.public-hero__stage`'s near-black `--public-stage` (#0c0c11),
+ * a hero that loses that bet is a black rectangle.
+ *
+ * These are source-text checks against ui/src/App.css. They cannot prove what
+ * a browser paints; what they pin is the invariant that made the void
+ * possible — that the hero must not depend on an animation for its resting
+ * appearance:
+ *   1. the keyframe states where it ends, and it ends visible;
+ *   2. any rule that keeps a forwards fill (`forwards`/`both`) may only do so
+ *      while that explicit, visible end frame exists;
+ *   3. reduced-motion visitors get `animation: none`, not a shortened fade;
+ *   4. no rule that uses the animation writes an at-rest `opacity: 0` back
+ *      into the cascade.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const raw = readFileSync(new URL("../src/App.css", import.meta.url), "utf8");
+
+// Blank comments out (preserving length and newlines, so offsets and line
+// numbers stay true) — prose about `animation` must never read as a rule.
+const css = raw.replace(/\/\*[\s\S]*?\*\//g, (match) =>
+	match.replace(/[^\n]/g, " "),
+);
+
+const NAME = "public-arrive";
+const FILL_KEYWORDS = new Set(["none", "forwards", "backwards", "both"]);
+
+const lineOf = (index) => css.slice(0, index).split("\n").length;
+
+/** Contents of the block whose opening brace is at `openIndex`. */
+function blockAt(openIndex) {
+	let depth = 0;
+	for (let i = openIndex; i < css.length; i += 1) {
+		if (css[i] === "{") depth += 1;
+		else if (css[i] === "}") {
+			depth -= 1;
+			if (depth === 0) return css.slice(openIndex + 1, i);
+		}
+	}
+	throw new Error(`src/App.css: unbalanced braces from line ${lineOf(openIndex)}`);
+}
+
+/** Flat `selector { declarations }` pairs inside a block that does not nest. */
+function flatRules(body) {
+	return [...body.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((match) => ({
+		selector: match[1].replace(/\s+/g, " ").trim(),
+		declarations: match[2],
+	}));
+}
+
+function keyframesBody(name) {
+	const at = css.search(new RegExp(`@keyframes\\s+${name}\\s*\\{`));
+	assert.notEqual(
+		at,
+		-1,
+		`src/App.css: @keyframes ${name} is gone. If the hero's entrance was ` +
+			`retired, delete this guard in the same change; do not leave it ` +
+			`passing on an animation that no longer exists.`,
+	);
+	return blockAt(css.indexOf("{", at));
+}
+
+/** Every rule whose own declarations name the animation. */
+function rulesUsing(name) {
+	const declaration = new RegExp(
+		`animation(?:-name)?\\s*:[^;{}]*\\b${name}\\b[^;{}]*`,
+		"g",
+	);
+	return [...css.matchAll(declaration)].map((match) => {
+		const open = css.lastIndexOf("{", match.index);
+		const start =
+			Math.max(css.lastIndexOf("}", open), css.lastIndexOf("{", open - 1)) + 1;
+		return {
+			selector: css.slice(start, open).replace(/\s+/g, " ").trim(),
+			declarations: blockAt(open),
+			shorthand: match[0].replace(/\s+/g, " ").trim(),
+			line: lineOf(match.index),
+		};
+	});
+}
+
+/** The fill mode a rule ends up with: longhand wins, else the shorthand. */
+function fillModeOf(rule) {
+	const longhand = rule.declarations.match(
+		/animation-fill-mode\s*:\s*([a-zA-Z-]+)/,
+	);
+	if (longhand) return longhand[1].toLowerCase();
+	const fromShorthand = rule.shorthand
+		.split(/[\s:]+/)
+		.map((token) => token.toLowerCase())
+		.filter((token) => token !== NAME && FILL_KEYWORDS.has(token));
+	// A CSS shorthand takes the fill mode from its last such keyword.
+	return fromShorthand.at(-1) ?? "none";
+}
+
+const frames = flatRules(keyframesBody(NAME)).map((frame) => ({
+	offsets: frame.selector
+		.split(",")
+		.map((offset) => offset.trim().toLowerCase())
+		.filter(Boolean),
+	declarations: frame.declarations,
+}));
+const endFrame = frames.find(
+	(frame) => frame.offsets.includes("to") || frame.offsets.includes("100%"),
+);
+const endsVisible = Boolean(endFrame) && /opacity\s*:\s*1\b/.test(endFrame.declarations);
+const users = rulesUsing(NAME);
+
+test(`@keyframes ${NAME} states an end frame, and it ends visible`, () => {
+	assert.ok(
+		endFrame,
+		`src/App.css: @keyframes ${NAME} has no \`to\` (or \`100%\`) frame. With ` +
+			`only a \`from { opacity: 0 }\` frame the end state is implicit — the ` +
+			`browser has to synthesise it from the element's underlying style — so ` +
+			`nothing in the stylesheet ever says the hero is visible. Write the ` +
+			`end state: \`to { opacity: 1; transform: none; }\`. (#1750)`,
+	);
+	assert.ok(
+		endsVisible,
+		`src/App.css: the \`to\` frame of @keyframes ${NAME} does not set ` +
+			`\`opacity: 1\`. The frame the hero finishes on has to be a visible ` +
+			`one. (#1750)`,
+	);
+	assert.match(
+		endFrame.declarations,
+		/transform\s*:\s*none\b/,
+		`src/App.css: the \`to\` frame of @keyframes ${NAME} does not reset ` +
+			`\`transform\`, so a forwards fill would leave the hero holding the ` +
+			`10px entrance offset. (#1750)`,
+	);
+});
+
+test("no public-arrive rule keeps a forwards fill without a visible end frame", () => {
+	assert.ok(
+		users.length >= 2,
+		`src/App.css: expected the hero copy and the product frame to use ` +
+			`${NAME}; found ${users.length} rule(s). Update this guard along with ` +
+			`the hero if that changed on purpose.`,
+	);
+	const covered = users.map((rule) => rule.selector).join(" ");
+	assert.match(covered, /public-hero__copy/, "hero copy no longer animates");
+	assert.match(covered, /public-product-frame/, "product frame no longer animates");
+
+	for (const rule of users) {
+		const fill = fillModeOf(rule);
+		if (fill !== "forwards" && fill !== "both") continue;
+		assert.ok(
+			endsVisible,
+			`src/App.css:${rule.line}: \`${rule.selector}\` uses ` +
+				`\`${rule.shorthand}\` — a \`${fill}\` fill holds the animation's ` +
+				`last frame after it ends — but @keyframes ${NAME} has no \`to\` ` +
+				`frame ending at \`opacity: 1\`. That is exactly #1750: the hero's ` +
+				`resting appearance is supplied by an animation whose end state ` +
+				`nothing states. Either write the end frame, or drop to ` +
+				`\`backwards\` so the element rests on its own cascade.`,
+		);
+	}
+});
+
+test("reduced motion turns the hero entrance off rather than shortening it", () => {
+	const reduceBodies = [...css.matchAll(/@media[^{]*\{/g)]
+		.filter((match) => /prefers-reduced-motion\s*:\s*reduce/.test(match[0]))
+		.map((match) => blockAt(match.index + match[0].length - 1));
+	const silenced = reduceBodies
+		.flatMap(flatRules)
+		.filter((rule) => /animation(?:-name)?\s*:\s*none\b/.test(rule.declarations))
+		.map((rule) => rule.selector)
+		.join(" ");
+	const explain =
+		"src/App.css: under `prefers-reduced-motion: reduce` the hero must get " +
+		"`animation: none`. A global `animation-duration: 0.01ms !important` is " +
+		"not the same thing — it still runs an animation, and an animation that " +
+		"has not started yet is an animation holding opacity 0. (#1750)";
+	assert.match(silenced, /public-hero__copy/, explain);
+	assert.match(silenced, /public-product-frame/, explain);
+});
+
+test("no public-arrive rule writes an at-rest opacity: 0 into the cascade", () => {
+	for (const rule of users) {
+		assert.doesNotMatch(
+			rule.declarations,
+			/opacity\s*:\s*0(?![.\d%])/,
+			`src/App.css:${rule.line}: \`${rule.selector}\` declares ` +
+				`\`opacity: 0\` outside the keyframe, which makes invisible the ` +
+				`hero's resting state again no matter what the animation does. (#1750)`,
+		);
+	}
+});


### PR DESCRIPTION
Closes #1750.

**Reworked.** The first attempt on this branch changed `animation-fill-mode` from `both` to `backwards` and added an explicit `to` frame. An **independent verifier** pulled it apart and found it inert: it changes what a spec-compliant browser paints in *zero* of the four states it claimed to fix, and leaves the one state that produces the reported black void untouched. The owner accepted that analysis. This is the rework.

## Why the fill-mode story was wrong

Nothing in the hero declares an `opacity` of its own — I grepped the whole hero block, and the only `opacity` in it was the keyframe's `from` frame. So the element's *underlying* computed opacity is 1, and CSS Animations L1 §3 says a missing `to` frame is synthesised from exactly that underlying value. Which means the old `both` forwards-fill was already holding **opacity 1** at the end.

The verifier's phase × fill-mode table, before vs. after that first attempt:

| state | before (`both`, implicit `to`) | after (`backwards`, explicit `to`) |
| --- | --- | --- |
| before phase / play-pending (hold time 0) | **0** (the backwards half of `both`) | **0** — unchanged |
| `prefers-reduced-motion: reduce` | 1 (the rules live inside `no-preference`) | 1 — unchanged |
| interrupted: paused/frozen mid-active | partial (→ 0 at the head) | unchanged; cancelled → idle = 1 either way |
| hidden tab → shown | finished before hide → 1; suspended at t=0 → **0** | identical |
| finished | forwards fill of the implicit frame = **1** | no fill = **1** |

Active-phase interpolation was byte-identical too — the implicit `to` resolves to `opacity 1 / transform none`, which is precisely the explicit `to` that was added. Same computed animation, before and after.

The only state that rests at 0 is the before/pending phase, and `backwards` is *defined* as filling it.

## The actual bug, and the ruling

**`from { opacity: 0 }` is the whole bug**, and no fill mode reaches it:

- `backwards` and `both` apply the first frame throughout the before phase, by definition.
- `none` and `forwards` do not help either: three of the five animated elements have **no delay**, so their play-pending hold time lands on active time 0 — which is the `from` frame again.

So any state where the animation is applied but its start time never resolves — a background-tab load with a suspended WebKit document timeline, a bfcache/tab-snapshot restore before the first style commit, a compositor stall — paints the hero at opacity 0 over `.public-hero__stage`'s near-black `--public-stage` (`#0c0c11`). Indefinitely. That is the reported symptom exactly: DOM present, assets fetched, no console errors, a solid black rectangle.

`@starting-style` is not the escape it looks like — a CSS transition is spec'd with `fill: backwards` as well, so a play-pending transition holds the same opacity 0.

**Owner ruling: the hero is fail-visible by construction.** Opacity comes out of the entrance entirely. The `translateY(10px)` → `none` slide stays; **the fade is dropped, and that cost is accepted.**

```css
@keyframes public-arrive {
	from { transform: translateY(10px); }
	to   { transform: none; }
}
```

The hero's opacity is now 1 in **every** state there is: pending, before phase, active, finished, idle, cancelled, reduced motion, a stale bundle, a stylesheet that failed to load. An entrance that never starts leaves the hero sitting 10px low and completely readable.

Built CSS confirms it: `public-arrive{0%{transform:translateY(10px)}to{transform:none}`.

The two rules keep `backwards` (now immaterial — the first frame is a transform, and holding it is the intended entrance offset). The `@media (prefers-reduced-motion: reduce)` block stays, relabelled plainly as what it is: **a motion-preference courtesy, not a visibility guard.** It changes nothing today (the animation rules already sit inside `no-preference`), and since the entrance no longer touches opacity, deleting it could not reintroduce #1750.

I also confirmed no rule anywhere in `App.css` matching `.public-hero`, `.public-hero__stage`, `.public-hero__copy`, `.public-product-frame` or `#public-hero-title` declares `opacity: 0`, `visibility: hidden`, `display: none`, or any `content-visibility`. (`.public-product-frame__bar span:last-child { display: none }` at :8692 is the frame's chrome on narrow screens, not the frame.)

## Guard, rewritten — `ui/test/public-hero-visible-at-rest.test.js`

The verifier found the old guard green on the reported symptom itself: adding `opacity: 0` to `.public-hero__copy` passed 4/4, as did a 999999ms delay and a fill-mode longhand injected in a separate rule. It only ever inspected the rules that *named* the animation.

The rewrite pins the structural invariant instead of a fill mode. Three checks, all over `ui/src/App.css` source text (comments blanked out first, so prose about `opacity` can never read as a declaration):

1. `@keyframes public-arrive` contains **no `opacity` token at all**, and still animates something — so an emptied keyframe cannot pass it.
2. **No rule targeting the hero hides it** — opacity below 1, `visibility: hidden`/`collapse`, `display: none`, `content-visibility`. Checked in every context, **media queries included**, because a rule that hides the hero at one viewport width is #1750 at that width. A full leaf-rule walker replaces the old "rules that name the animation" scan.
3. **Every keyframe named by an animation on a hero rule is opacity-free** — not just `public-arrive`.

On the verifier's vacuity points:

- Each check asserts it **actually looked at something**: the keyframe exists, each required hero selector still matches a rule, both known `public-arrive` users are still present. A rename or a deletion fails loudly rather than passing over an empty set. (This caught a real thing while I wrote it — `#public-hero-title` has no rule of its own, it is styled through `.public-hero h1`, so it is scanned but not required.)
- **No passengers.** The old check 2 could only fail after check 1 had already failed (`endsVisible` was module-level and check 1 already asserted it) — it is gone. So is the reduced-motion assertion, for the same reason: with opacity out of the entrance, that block is no longer load-bearing for visibility, and asserting on it here would be a second passenger. Check 3 is *not* a passenger of check 1: mutation D below reddens it alone.

### Mutations — every check red on its own, none vacuous

Each applied to the fixed CSS one at a time, then restored (pristine md5 re-verified after the run).

```
A  restore `from { opacity: 0 }` in @keyframes public-arrive
✖ @keyframes public-arrive animates transform only — no opacity anywhere in it
✔ no rule targeting the hero hides it
✖ every animation the hero runs comes from an opacity-free keyframe
ℹ pass 1   ℹ fail 2   exit code: 1
  AssertionError: src/App.css:6357: @keyframes public-arrive mentions `opacity`. The hero
  has no opacity of its own, so any opacity in this entrance is the only opacity the
  stylesheet states for the headline, lede, CTAs and screenshot — and a pending or stalled
  animation holds its first frame forever, under every fill mode. Animate `transform` only,
  so a broken entrance leaves the hero 10px low and readable rather than invisible. (#1750)
  AssertionError: src/App.css:6369: `.public-hero__copy > *` runs @keyframes public-arrive
  (defined at line 6357), which animates `opacity`. …

B  `opacity: 0` added to `.public-hero__copy > *`   ← the mutation the old guard passed
✔ @keyframes public-arrive animates transform only — no opacity anywhere in it
✖ no rule targeting the hero hides it
✔ every animation the hero runs comes from an opacity-free keyframe
ℹ pass 2   ℹ fail 1   exit code: 1
  AssertionError: src/App.css:6368: `.public-hero__copy > *` (inside @media
  (prefers-reduced-motion: no-preference)) declares `opacity: 0` — the hero must never be
  less than fully opaque — that is #1750. The hero sits on a near-black stage; anything
  that stops it painting is the black void the issue reports. (#1750)

C  @keyframes public-arrive deleted entirely   ← must fail loudly, not pass vacuously
✖ @keyframes public-arrive animates transform only — no opacity anywhere in it
✔ no rule targeting the hero hides it
✖ every animation the hero runs comes from an opacity-free keyframe
ℹ pass 1   ℹ fail 2   exit code: 1
  AssertionError: src/App.css: @keyframes public-arrive is gone. If the hero's entrance was
  retired, delete this guard in the same change; do not leave it passing over an animation
  that no longer exists. (#1750)   [both failures carry this message]

D  a DIFFERENT opacity-fading keyframe applied to the hero copy   ← check 3 alone
✔ @keyframes public-arrive animates transform only — no opacity anywhere in it
✔ no rule targeting the hero hides it
✖ every animation the hero runs comes from an opacity-free keyframe
ℹ pass 2   ℹ fail 1   exit code: 1
  AssertionError: src/App.css:6374: `.public-hero__copy > *` runs @keyframes
  public-soft-fade (defined at line 6367), which animates `opacity`. …

E  `opacity: 0` on `.public-product-frame` inside @media (max-width: 980px)
✔ @keyframes public-arrive animates transform only — no opacity anywhere in it
✖ no rule targeting the hero hides it
✔ every animation the hero runs comes from an opacity-free keyframe
ℹ pass 2   ℹ fail 1   exit code: 1
  AssertionError: src/App.css:8463: `.public-product-frame` (inside @media
  (max-width: 980px)) declares `opacity: 0` — the hero must never be less than fully
  opaque — that is #1750. …

F  `.public-hero__copy` renamed away   ← the vacuity trip
✔ @keyframes public-arrive animates transform only — no opacity anywhere in it
✖ no rule targeting the hero hides it
✖ every animation the hero runs comes from an opacity-free keyframe
ℹ pass 1   ℹ fail 2   exit code: 1
  AssertionError: src/App.css: no rule matches `.public-hero__copy` any more. This guard
  scans the hero by selector; a rename leaves it scanning nothing. Update HERO_SELECTORS in
  the same change. (#1750)
  AssertionError: src/App.css: no hero-copy rule runs public-arrive any more; this guard
  would have nothing to check. (#1750)
```

## Tests

```
ui suite, node --test:  ℹ tests 916   ℹ pass 916   ℹ fail 0    exit code: 0
npx eslint test/public-hero-visible-at-rest.test.js            exit code: 0
npm run lint                                                   exit code: 0
npm run build                                                  exit code: 0
```

(916, not the previous 917: the old guard had four checks and one was the passenger described above; the rewrite has three.)

## Residual — stated, not hidden

- **The trigger on the owner's iPhone is unconfirmed.** This removes the *dependency* — the hero can no longer rest, stall, or start invisible — but it does not prove *why* the entrance failed to complete on that particular load. I have no way to render the page; the confirming screenshot is the owner's to take.
- **A stale-bundle check is still worth doing before closing #1750.** Compare the CSS hash actually served by CloudFront against the one in the current build output. If the black void was a stale cached bundle, this fix does not reach it until that bundle expires — and that would be a different issue with a different remedy.
- Also unrejected by this change: correcting the record on the first commit here, whose message claimed the hero was "invisible in every other state." That was false. Finished, idle and reduced-motion all resolved to opacity 1 under the old CSS. The verifier caught it; the new commit message says so plainly.

**Do not merge — owner vets first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx
