### PR TITLE
test(paper_rag): pin the TF-IDF-named tests to the TF-IDF path (audit P1-3)

### DIFF
--- a/backend/tests/services/test_paper_rag.py
+++ b/backend/tests/services/test_paper_rag.py
@@ -7,10 +7,16 @@ Covers:
 - Integration with select_candidates() via augment_candidate_scores
 - Anti-hallucination: scores don't introduce phantom candidates
 - Graceful fallback when semantic retrieval fails
+
+Every test in this module runs on the TF-IDF branch: the ``pin_tfidf_path``
+autouse fixture below forces it, so the branch is the same here as it is in
+CI. See that fixture for why that was not previously true.
 """
 
 from __future__ import annotations
 
+import archimedes.services.paper_rag as rag_module
+import pytest
 from archimedes.services.paper_rag import (
     PaperRAGHealth,
     _compute_idf,
@@ -62,6 +68,61 @@ PAPERS = [
         "We apply gradient boosted trees to corporate credit default prediction.",
     ),
 ]
+
+
+@pytest.fixture(autouse=True)
+def pin_tfidf_path(monkeypatch):
+    """Pin every test in this module to the TF-IDF branch, and record the
+    branch that actually ran.
+
+    Why (suite audit P1-3, 2026-09-01): the tests here are NAMED for the
+    TF-IDF path but nothing made them take it. ``semantic_rerank`` picks its
+    branch from ``_get_embedding_model()``
+    (``archimedes/services/paper_rag.py:408-412``), so the branch was decided
+    by what happened to be installed:
+
+    - CI installs ``backend/requirements-base.txt``
+      (``.github/workflows/quality-gate.yml:146``), which deliberately carries
+      no ``torch`` and no ``sentence-transformers`` — CI took the TF-IDF branch.
+    - A dev box with those installed took the EMBEDDING branch, and paid a
+      ~15.4s ``all-MiniLM-L6-v2`` load — including a live HuggingFace Hub
+      request — for the privilege.
+
+    Same test names, two different code paths, and the branch the names claim
+    was the one nobody ran locally. Forcing the loader to ``None`` makes the
+    branch identical everywhere, drops this file from 17.8s to 1.9s, and makes
+    it hermetic (no network, no weights on disk required).
+
+    Nothing is lost by pinning: the embedding branch keeps deterministic,
+    model-free coverage in the hermetic sibling ``backend/tests/test_paper_rag.py``
+    (issue #874) — ``TestSemanticRerank::test_uses_embedding_model_when_available``
+    stubs the encoder instead of loading one.
+
+    Returns the branch recorder (a list) so a test can assert WHICH branch ran.
+
+    MUTATION: delete the ``_get_embedding_model`` monkeypatch below and run
+    this file on a box that has sentence-transformers installed. The recorder
+    fills with ``"embeddings"``, the ``assert pin_tfidf_path == ["tfidf"]``
+    assertions fail, and the file goes back to ~18s.
+    """
+    branch: list[str] = []
+
+    monkeypatch.setattr(rag_module, "_get_embedding_model", lambda: None)
+
+    real_tfidf = rag_module._rerank_tfidf
+    real_embeddings = rag_module._rerank_with_embeddings
+
+    def _record_tfidf(*args, **kwargs):
+        branch.append("tfidf")
+        return real_tfidf(*args, **kwargs)
+
+    def _record_embeddings(*args, **kwargs):
+        branch.append("embeddings")
+        return real_embeddings(*args, **kwargs)
+
+    monkeypatch.setattr(rag_module, "_rerank_tfidf", _record_tfidf)
+    monkeypatch.setattr(rag_module, "_rerank_with_embeddings", _record_embeddings)
+    return branch
 
 
 # ── Tokenizer + TF-IDF tests ────────────────────────────────────
@@ -163,22 +224,25 @@ class TestSemanticRerank:
     def test_empty_input(self):
         assert semantic_rerank("momentum", []) == []
 
-    def test_tfidf_rerank_orders_by_relevance(self):
+    def test_tfidf_rerank_orders_by_relevance(self, pin_tfidf_path):
         """Papers with 'momentum' in their text should rank higher for a
-        'momentum' query."""
+        'momentum' query — on the TF-IDF branch this test is named for."""
         papers = [
             {"arxiv_id": "a1", "title": "Credit Risk", "abstract": "default prediction"},
             {"arxiv_id": "a2", "title": "Momentum Strategies", "abstract": "cross-sectional momentum"},
         ]
         results = semantic_rerank("momentum strategies equity", papers)
+        # The branch the test name claims is the branch that ran (audit P1-3).
+        assert pin_tfidf_path == ["tfidf"]
         # Momentum paper should score higher than credit risk paper
         a1_score = next(s for p, s in results if p["arxiv_id"] == "a1")
         a2_score = next(s for p, s in results if p["arxiv_id"] == "a2")
         assert a2_score > a1_score
 
-    def test_tfidf_rerank_returns_all_papers(self):
+    def test_tfidf_rerank_returns_all_papers(self, pin_tfidf_path):
         papers = [{"arxiv_id": f"p{i}", "title": f"Paper {i}", "abstract": f"Abstract {i}"} for i in range(5)]
         results = semantic_rerank("test query", papers)
+        assert pin_tfidf_path == ["tfidf"]
         assert len(results) == 5
 
     def test_scores_bounded(self):

--- a/backend/tests/test_paper_rag.py
+++ b/backend/tests/test_paper_rag.py
@@ -67,6 +67,45 @@ def _fake_model(embeddings: dict[str, list[float]] | None = None):
     return model
 
 
+@contextlib.contextmanager
+def _stub_sentence_transformers(constructor):
+    """Stub ``sentence_transformers`` — and ``torch`` — for the duration.
+
+    Stubbing only ``sentence_transformers`` is not enough. Once that import
+    succeeds, ``_get_embedding_model`` runs straight on into its CPU-guardrail
+    ``import torch`` (``archimedes/services/paper_rag.py:277-285``). On a box
+    that HAS torch installed, that is a real, first-time C-extension import
+    performed *inside* a ``patch.dict("sys.modules")`` block — and on exit
+    ``patch.dict`` rips the freshly created ``torch.*`` entries back out of
+    ``sys.modules``, leaving dangling extension state that segfaults CPython
+    (``Fatal Python error: Segmentation fault``, exit 139) either immediately
+    or in some later, innocent-looking test.
+
+    This file only survived on main because ``tests/services/test_paper_rag.py``
+    sorts first, loaded the real MiniLM model, and left torch in ``sys.modules``
+    — so the import was a harmless cache hit. The crash is therefore already
+    reachable on main today, by running this file on its own on a torch box::
+
+        pytest backend/tests/test_paper_rag.py   # → Segmentation fault (139)
+
+    Pinning that sibling to its TF-IDF path (suite audit P1-3) removes the
+    accidental pre-import, which also brings the latent crash into the normal
+    full-suite ordering. Stubbing torch alongside sentence_transformers keeps
+    every ordering hermetic: no real model, no real torch, no dangling C
+    extensions.
+
+    The torch stub carries a working ``set_num_threads`` so the 2026-07-04 CPU
+    guardrail still runs its intended branch instead of being diverted into the
+    ``except Exception`` arm.
+    """
+    st_mod = types.ModuleType("sentence_transformers")
+    st_mod.SentenceTransformer = constructor
+    torch_stub = types.ModuleType("torch")
+    torch_stub.set_num_threads = MagicMock()
+    with patch.dict("sys.modules", {"sentence_transformers": st_mod, "torch": torch_stub}):
+        yield st_mod
+
+
 def _mk_paper(arxiv_id: str, title: str, abstract: str = "") -> dict:
     return {"arxiv_id": arxiv_id, "title": title, "abstract": abstract}
 
@@ -125,12 +164,8 @@ class TestPaperRAGHealth:
         monkeypatch.setenv("FUSION_SEMANTIC_RETRIEVAL", "true")
         _reset_model_cache()
 
-        # Patch SentenceTransformer to raise an exception
-        with patch.dict("sys.modules", {"sentence_transformers": types.ModuleType("sentence_transformers")}):
-            import sys
-
-            st_mod = sys.modules["sentence_transformers"]
-            st_mod.SentenceTransformer = MagicMock(side_effect=OSError("corrupted model files"))
+        # Constructor raises the way a corrupted on-disk model cache would.
+        with _stub_sentence_transformers(MagicMock(side_effect=OSError("corrupted model files"))):
             h = paper_rag_health(probe=True)
         # Reset after test
         _reset_model_cache()
@@ -223,11 +258,27 @@ class TestGetEmbeddingModelCaching:
         _reset_model_cache()
 
     def test_returns_none_on_import_error(self, monkeypatch):
-        """If sentence_transformers is not importable, returns None."""
+        """If sentence_transformers is not importable, returns None.
+
+        ``sys.modules[name] = None`` makes the *import statement itself* raise
+        ImportError, which is the condition this test is named for and the one
+        CI actually runs under (``requirements-base.txt`` ships no
+        sentence-transformers). The previous version installed a fake module
+        whose ``SentenceTransformer`` raised only when CALLED, so the import
+        succeeded and ``_get_embedding_model`` ran on into its CPU-guardrail
+        ``import torch`` — a real, first-time torch import performed *inside*
+        a ``patch.dict("sys.modules")`` block, which segfaults CPython when
+        the patch tears the freshly-created C extension modules back out.
+
+        That never fired on main only because ``tests/services/test_paper_rag.py``
+        happened to load the real MiniLM model first and left torch in
+        ``sys.modules``, making this import a cheap cache hit. Pinning that file
+        to its TF-IDF path (audit P1-3) removed the accidental pre-import and
+        exposed the order dependency. Failing at the import keeps the test on
+        the branch it claims and never touches torch at all.
+        """
         _reset_model_cache()
-        fake_mod = types.ModuleType("sentence_transformers")
-        fake_mod.SentenceTransformer = MagicMock(side_effect=ImportError("no module"))
-        with patch.dict("sys.modules", {"sentence_transformers": fake_mod}):
+        with patch.dict("sys.modules", {"sentence_transformers": None}):
             result = rag_module._get_embedding_model()
         _reset_model_cache()
         assert result is None
@@ -238,10 +289,6 @@ class TestGetEmbeddingModelCaching:
         stub = _fake_model()
         call_count = [0]
 
-        import types as _types
-
-        fake_st = _types.ModuleType("sentence_transformers")
-
         # Use a plain function on a ModuleType (not a class attribute) so it is
         # never treated as a bound method and receives exactly the one positional
         # arg that _get_embedding_model passes.
@@ -249,8 +296,7 @@ class TestGetEmbeddingModelCaching:
             call_count[0] += 1
             return stub
 
-        fake_st.SentenceTransformer = _fake_constructor
-        with patch.dict("sys.modules", {"sentence_transformers": fake_st}):
+        with _stub_sentence_transformers(_fake_constructor):
             r1 = rag_module._get_embedding_model()  # triggers real load path
             r2 = rag_module._get_embedding_model()  # must hit the cache
         # Both calls must return the same cached stub.


### PR DESCRIPTION
## Audit citation

Suite/dead-code audit decision package, **Phase 1 → P1-3**
(`session-artifacts-2026-09-01/suite-deadcode-audit-decision-package.md`, §B):

> **P1-3** — Pin `test_tfidf_rerank_orders_by_relevance` to the TF-IDF path it names by patching the model loader to `None` (`services/paper_rag.py:271,383`) — **−13s local + kills a CI/local divergence** (CI has no torch — `requirements-base.txt` via `quality-gate.yml:137` — so CI and local currently test different paths). Risk: *none to signal*.

(Line numbers have drifted since the audit: the loader is now `paper_rag.py:255`, the branch point `paper_rag.py:408-412`, and the CI install `quality-gate.yml:146`.)

## The problem

`semantic_rerank()` picks its branch from `_get_embedding_model()`:

```python
# backend/archimedes/services/paper_rag.py:408-412
model = _get_embedding_model()

if model is not None:
    return _rerank_with_embeddings(query, papers, model)
return _rerank_tfidf(query, papers)
```

Nothing in `backend/tests/services/test_paper_rag.py` constrained that choice, so the branch was decided by what happened to be installed:

| | torch / sentence-transformers | branch actually exercised | cost |
|---|---|---|---|
| **CI** | absent by design — `backend/requirements-base.txt` (installed at `quality-gate.yml:146`) explicitly refuses both | TF-IDF | ~0s |
| **Dev box** | present (here: torch 2.13.0, sentence-transformers 5.6.1) | **embeddings** | 15.4s model load **+ a live HuggingFace Hub request** |

Two different code paths under one set of test names — and the branch the names claim was the one nobody ran locally. The file was also not hermetic: the un-pinned path reaches out to the HF Hub (`Warning: You are sending unauthenticated requests to the HF Hub`) and allocates the ~521 MB RSS that `paper_rag_health`'s own docstring warns about.

## What changed

**Tests only. No production code is touched.**

**1. `backend/tests/services/test_paper_rag.py` — pin and prove the branch**

An autouse `pin_tfidf_path` fixture forces `_get_embedding_model` to `None` and wraps both branch functions with a recorder. The two `test_tfidf_*` tests now assert `pin_tfidf_path == ["tfidf"]`, so the divergence cannot silently return.

No coverage is lost. The embedding branch keeps deterministic, model-free coverage in the hermetic sibling `backend/tests/test_paper_rag.py` (issue #874), whose `TestSemanticRerank::test_uses_embedding_model_when_available` stubs the encoder rather than loading one.

**2. `backend/tests/test_paper_rag.py` — a latent segfault the pin exposes**

Three tests there stubbed `sentence_transformers` in `sys.modules` but let `_get_embedding_model` run on into its CPU-guardrail `import torch` (`paper_rag.py:277-285`). On a torch box that is a real, first-time C-extension import performed **inside** a `patch.dict("sys.modules")` block; on exit `patch.dict` rips the fresh `torch.*` entries back out and CPython segfaults.

**This is already a bug on `main`** — that file cannot be run on its own today:

```
$ git checkout main && pytest backend/tests/test_paper_rag.py -q
backend/tests/test_paper_rag.py ............Fatal Python error: Segmentation fault
  File ".../backend/archimedes/services/paper_rag.py", line 279 in _get_embedding_model
  File ".../backend/tests/test_paper_rag.py", line 231 in test_returns_none_on_import_error
EXIT=139
```

It stayed hidden in full runs only because `tests/services/` sorts first and left torch in `sys.modules` as a side effect of its real model load. Removing that accidental pre-import brings the crash into the normal full-suite ordering, so it is fixed here rather than left for the next person:

- a shared `_stub_sentence_transformers()` helper stubs `torch` alongside `sentence_transformers` (with a working `set_num_threads`, so the 2026-07-04 CPU guardrail still runs its intended branch instead of being diverted into the `except Exception` arm);
- `test_returns_none_on_import_error` now fails at the *import statement* via `sys.modules["sentence_transformers"] = None` — which is the condition its name and docstring claim, and the one CI actually runs under.

```
Note on attribution: either hunk alone breaks the crash chain in this file (verified:
dropping the torch stub → 37 passed; reverting only the import-error test → 37 passed).
Both are kept because together they leave ZERO real torch imports inside a
patch.dict("sys.modules") block — that is what removes the hazard class for full-suite
ordering, not just for this file. The fault itself lands on the NEXT real torch import,
not at patch.dict teardown; teardown is the cause, the later import is the crash site.
```

## Adversarial demo — the guard shown red on the input it rejects

Delete the one pinning line from the fixture (`monkeypatch.setattr(rag_module, "_get_embedding_model", lambda: None)`) and run on a box with sentence-transformers installed:

```
$ pytest "backend/tests/services/test_paper_rag.py::TestSemanticRerank" -q --durations=2

=================================== FAILURES ===================================
___________ TestSemanticRerank.test_tfidf_rerank_orders_by_relevance ___________
backend/tests/services/test_paper_rag.py:234: in test_tfidf_rerank_orders_by_relevance
    assert pin_tfidf_path == ["tfidf"]
E   AssertionError: assert ['embeddings'] == ['tfidf']
E     At index 0 diff: 'embeddings' != 'tfidf'
----------------------------- Captured stderr call -----------------------------
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN ...
Loading weights: 100%|##########| 103/103 [00:00<00:00, 24494.72it/s]
___________ TestSemanticRerank.test_tfidf_rerank_returns_all_papers ____________
backend/tests/services/test_paper_rag.py:243: in test_tfidf_rerank_returns_all_papers
    assert pin_tfidf_path == ["tfidf"]
E   AssertionError: assert ['embeddings'] == ['tfidf']
E     At index 0 diff: 'embeddings' != 'tfidf'
============================= slowest 2 durations ==============================
15.30s call     ...::test_tfidf_rerank_orders_by_relevance
=========================== short test summary info ============================
FAILED ...::test_tfidf_rerank_orders_by_relevance - AssertionError: assert ['embeddings'] == ['tfidf']
FAILED ...::test_tfidf_rerank_returns_all_papers  - AssertionError: assert ['embeddings'] == ['tfidf']
=================== 2 failed, 2 passed, 1 warning in 16.82s ====================
```

The guard fails on exactly the condition it exists to reject, and names the branch that actually ran. The second change is demonstrated by the `main` segfault repro above: revert `_stub_sentence_transformers` and `pytest backend/tests/test_paper_rag.py` returns to exit 139.

## Verification

All on `/opt/homebrew/Caskroom/mambaforge/base/envs/archimedes/bin/pytest`, `-p no:cacheprovider`.

| Check | Before (`origin/main`) | After | Exit |
|---|---|---|---|
| `backend/tests/services/test_paper_rag.py` | 31 passed, **17.82s** (15.37s in the one test) | 31 passed, **1.85s** | 0 |
| Both paper_rag files together | 68 passed, **27.82s** | 68 passed, **2.35s** | 0 |
| `backend/tests/test_paper_rag.py` **alone** | **Segmentation fault, exit 139** | 37 passed, 4.74s | 0 |
| 9 paper_rag/corpus/fusion/health files | 224 passed, 64.97s | 224 passed, 60.9–70.5s (noise-dominated — see caveat) | 0 |
| Full unit suite `-m "not integration"` | — | **5644 passed, 4 skipped, 2 deselected** in 989.94s | 0 |
| `ruff format --check` + `ruff check` (both files) | — | `2 files already formatted` / `All checks passed!` | 0 |

Full-suite log: `/tmp/p1-3-paper-rag-tfidf-suite.log`.

Docs check (deleting-PR blind spot): grepped `docs/` for every touched or removed name — `test_tfidf_rerank_orders_by_relevance`, `test_tfidf_rerank_returns_all_papers`, `test_returns_none_on_import_error`, `test_model_load_exception_leads_to_degraded`, `test_caches_successful_load`, `pin_tfidf_path`, `_stub_sentence_transformers` — **no references**, nothing to update.

## Caveat on the audit's −13s, stated honestly

**The audit's projected suite-wide −13s does not land, and this PR does not claim it.** The saving is real for the named file (−15.9s) and for the two paper_rag files together (−25.5s), but in a *full* run the MiniLM load simply relocates: `backend/tests/test_strategy_fusion.py::test_asset_class_filter_excludes_unrelated` triggers the same real model load independently. That file is untouched by this PR and pays it on `main` too:

```
$ pytest backend/tests/test_strategy_fusion.py -q --durations=3   # unmodified, == main
24.65s call  backend/tests/test_strategy_fusion.py::test_asset_class_filter_excludes_unrelated
48 passed in 32.00s
```

So the suite-wide win needs the same treatment applied there — worth a follow-up, and outside the one-logical-change boundary of this PR. What this PR does deliver is what the audit called the actual defect: **CI and local now execute the same branch, and the test proves which branch that is** — plus a hermetic file (no network, no 521 MB allocation, no weights required) and a segfault fix.

## Follow-ups (not done here)

1. Apply the same pin to `backend/tests/test_strategy_fusion.py` to actually collect the suite-wide −13s.
2. The `torch.set_num_threads(1)` CPU guardrail (`paper_rag.py:277-285`), pinned to the 2026-07-04 starvation incident, has **no test asserting it is applied**. `_stub_sentence_transformers` now provides the seam for one cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.

