### PR TITLE
[ux] A generation that delivers nothing gives the free slot back

### DIFF
--- a/backend/archimedes/api/generate_routes.py
+++ b/backend/archimedes/api/generate_routes.py
@@ -539,6 +539,11 @@ async def start_generation(
     # gate can raise 402 and the enqueue can error, and either would leave the
     # allowance spent on a generation that never ran. Same shape, and the same
     # reason, as _paywall_with_credit's `except BaseException: void; raise`.
+    # This covers only what THIS request can see fail. Everything that goes
+    # wrong after the enqueue — the corpus yielding too few papers to fuse, a
+    # pipeline crash, a cancel — is released by
+    # `_release_free_slot_if_undelivered` in the run's own `finally`, keyed on
+    # the job id stamped below.
     try:
         # Paid-tier gating (T1.8): a premium (Anthropic) model requires a
         # wallet-connected entitlement. Enforced BEFORE the job is enqueued so a
@@ -584,7 +589,9 @@ async def start_generation(
 
     # The free slot is bound to its generation only now, once the job is queued
     # — the same "spend only what was delivered" point at which a paid credit is
-    # consumed below.
+    # consumed below. The stamp is also what the terminal-failure release finds
+    # the row by, so an unstamped slot cannot be handed back later (see
+    # `free_generations.stamp_job`, which says so where it fails).
     if free_grant_id is not None:
         free_generations.stamp_job(free_grant_id, job_id=job_id)
 
@@ -713,6 +720,136 @@ async def _release_credit_if_undelivered(job_id: str, store) -> None:
         logger.exception("could not evaluate credit release for job %s", sanitize_log_value(job_id))
 
 
+async def _job_persisted_a_strategy(job_id: str, store) -> bool | None:
+    """Did this run put a strategy in the caller's library? ``None`` = cannot tell.
+
+    ``status == "done"`` is NOT the same question. A run can persist the
+    winning strategy (``generation_pipeline`` § "K=1 persistence") and only
+    then die — the backtest fan-out crashing, the user cancelling at the
+    ``backtest_persist`` stage boundary, the process rolling — which leaves a
+    terminal status of ``error``/``cancelled`` beside a strategy that is
+    genuinely in the library. Handing a free generation back for that run would
+    give the account the strategy AND the slot.
+
+    The oracle is the ``persisted`` event the pipeline pushes immediately after
+    ``_persist_candidate`` returns a real ``strategy_id``. Read-only: this is a
+    consumer of the event log, and nothing here writes to it.
+
+    Three-valued on purpose. The event log has a shorter TTL than the job
+    record, the read can fail, and a store double may not expose the surface at
+    all (the same "a store that predates this surface is skipped" allowance
+    ``_abort_if_cancel_requested`` makes). Collapsing any of those onto
+    ``False`` would report "nothing was delivered" on no evidence, and the
+    caller would hand back a slot that may have bought a library row.
+    ``None`` says only what is true — we could not look — and the caller keeps
+    the slot spent, which is recoverable: the ledger row is on disk with its
+    job id.
+    """
+    lister = getattr(store, "list_events", None)
+    if lister is None:
+        logger.debug("free-slot release: store exposes no event log for job %s", sanitize_log_value(job_id))
+        return None
+    try:
+        events = await lister(job_id)
+    except Exception:
+        logger.warning(
+            "free-slot release: could not read the event log for job %s",
+            sanitize_log_value(job_id),
+            exc_info=True,
+        )
+        return None
+    for ev in events:
+        if ev.get("event") != "persisted":
+            continue
+        data = ev.get("data")
+        if isinstance(data, dict) and data.get("strategy_id"):
+            return True
+    return False
+
+
+async def _release_free_slot_if_undelivered(job_id: str, store) -> None:
+    """Give a free generation back unless the job actually delivered (#1643).
+
+    The free-tier sibling of :func:`_release_credit_if_undelivered`, and the
+    fix for what the owner saw on 2026-09-01: a brief whose corpus yielded
+    fewer than two papers failed INSIDE the pipeline with "the society cannot
+    fuse", and the allowance still went 3 → 2. ``/start`` only ever released a
+    slot for failures it could see itself (the entitlement gate, the enqueue —
+    its ``except BaseException: release; raise``); every failure after the
+    enqueue kept the slot spent on a generation that produced nothing.
+
+    Two states keep the slot spent, and only two:
+
+    ``done``
+        The run delivered. Checked first and cheaply.
+    a persisted strategy
+        The run put a strategy in the library and died afterwards. Giving the
+        slot back here would hand out the strategy and the free generation.
+        Deliberately stricter than the paid path, which restores on every
+        non-``done`` status (see :func:`_release_credit_if_undelivered`) —
+        money erring toward the payer is the right direction for an accounting
+        bug on a paywall, but re-granting an allowance that DID buy a library
+        row is just an over-grant.
+
+    …and one more that keeps it spent without deciding anything: a job record
+    or event log this cannot read. Silence is not evidence of non-delivery.
+
+    Idempotent through ``release_grant_for_job``: only a ``used`` row with this
+    ``job_id`` moves, so a retried cleanup cannot mint a second free slot out of
+    one claim. A paid or flag-off run matches no row and this is a no-op.
+
+    Fail-safe: this runs in a background task's ``finally`` with nobody to
+    report to, so it logs and returns. A read failure leaves the slot spent —
+    the honest direction when we cannot tell whether the run delivered, and
+    recoverable, since the ledger row is still on disk with its job id.
+    """
+    try:
+        job = await store.get(job_id)
+        if job is None:
+            # Deliberately NOT the credit path's "reads as undelivered". This
+            # runs in the run's own `finally`, so a job record that is already
+            # gone means the store lost it, not that time passed — and with no
+            # record there is no event log either, so "no strategy persisted"
+            # would be an inference from missing data rather than a reading of
+            # it. The slot stays spent and says so; the ledger row keeps its
+            # job id, so it can still be released by hand.
+            logger.warning(
+                "job %s has no job record at cleanup — the free generation stays spent (undecidable)",
+                sanitize_log_value(job_id),
+            )
+            return
+        status = job.get("status")
+        if status == "done":
+            return
+        persisted = await _job_persisted_a_strategy(job_id, store)
+        if persisted is None:
+            logger.warning(
+                "job %s ended as %s and its event log could not be read — the free generation "
+                "stays spent rather than being handed back on no evidence",
+                sanitize_log_value(job_id),
+                sanitize_log_value(str(status)),
+            )
+            return
+        if persisted:
+            logger.info(
+                "job %s ended as %s but persisted a strategy — the free generation stays spent",
+                sanitize_log_value(job_id),
+                sanitize_log_value(str(status)),
+            )
+            return
+        if free_generations.release_for_job(job_id):
+            logger.warning(
+                "job %s ended as %s with no strategy — free generation returned to the account",
+                sanitize_log_value(job_id),
+                sanitize_log_value(str(status)),
+            )
+    except Exception:
+        logger.exception(
+            "could not evaluate the free-generation release for job %s — the slot stays spent",
+            sanitize_log_value(job_id),
+        )
+
+
 async def _run_with_cleanup(
     job_id: str,
     brief: GenerateBrief,
@@ -811,6 +948,10 @@ async def _run_with_cleanup(
         with contextlib.suppress(asyncio.CancelledError):
             await heartbeat_task
         await _release_credit_if_undelivered(job_id, store)
+        # …and the free-tier equivalent. Both run: a run is funded by a credit
+        # or by a free slot, never both, and each helper is a no-op for the
+        # funding it does not own.
+        await _release_free_slot_if_undelivered(job_id, store)
 
 
 @generate_router.get("/stream/{job_id}")

--- a/backend/archimedes/models/free_generation_grant.py
+++ b/backend/archimedes/models/free_generation_grant.py
@@ -26,10 +26,13 @@ the thing it authorises):
     A free slot was spent on a generation. ``job_id`` is stamped once the job
     reaches the queue.
 ``released``
-    The slot was claimed but the request never reached the queue (the premium
-    -model entitlement gate refused it, the enqueue errored). Nothing was
-    delivered, so the allowance is handed back. Kept as a row rather than
-    deleted so the ledger shows the attempt.
+    Nothing was delivered against the slot, so the allowance is handed back.
+    Two moments produce this, and the second is why ``job_id`` is worth
+    stamping: the request never reached the queue at all (the premium-model
+    entitlement gate refused it, the enqueue errored), or the job DID queue and
+    then died inside the pipeline without producing a strategy — the corpus
+    yielded too few papers to fuse, the run crashed, the user cancelled. Kept
+    as a row rather than deleted so the ledger shows the attempt.
 
 ``seq`` is a per-account monotonically increasing ordinal, and
 ``uq_free_generation_grants_user_seq`` is what makes the claim **atomic**:
@@ -179,6 +182,34 @@ def release_grant(session: Session, grant_id: int) -> FreeGenerationGrantRecord 
     """
     record = session.get(FreeGenerationGrantRecord, grant_id)
     if record is None or record.status != GRANT_USED:
+        return None
+    record.status = GRANT_RELEASED
+    record.released_at = datetime.now(UTC)
+    session.flush()
+    return record
+
+
+def release_grant_for_job(session: Session, job_id: str) -> FreeGenerationGrantRecord | None:
+    """Hand back the slot that funded *job_id* — that run delivered nothing.
+
+    The sibling of ``generation_credit.restore_credit_for_job``, and it exists
+    for the same reason: the claim is taken at ``/start``, but whether anything
+    was DELIVERED is only known when the run ends, in a background task that
+    holds a ``job_id`` and no ``grant_id``. Looking the row up by the job it was
+    stamped with is what lets the terminal-failure path give the slot back
+    without threading state through the task.
+
+    ``job_id`` is left in place: the ledger should show which run burned the
+    slot and handed it back, not silently rewind to a blank row.
+
+    Idempotent, because only a ``used`` row matches: a retried or duplicated
+    cleanup finds a ``released`` row, matches nothing, and returns ``None``
+    rather than minting a second free generation out of one claim.
+    """
+    if not job_id:
+        return None
+    record = session.query(FreeGenerationGrantRecord).filter_by(job_id=job_id, status=GRANT_USED).one_or_none()
+    if record is None:
         return None
     record.status = GRANT_RELEASED
     record.released_at = datetime.now(UTC)

--- a/backend/archimedes/models/free_generation_grant.py
+++ b/backend/archimedes/models/free_generation_grant.py
@@ -80,8 +80,12 @@ class FreeGenerationGrantRecord(Base):
 
     status: Mapped[str] = mapped_column(String(16), nullable=False, default=GRANT_USED)
 
-    #: The generation this slot funded. NULL until the job reaches the queue,
-    #: and NULL forever on a ``released`` row — there was no job.
+    #: The generation this slot funded. NULL until the job reaches the queue.
+    #: A ``released`` row is NULL only on the ``release_grant`` path — the
+    #: request never queued, so there was no job. One released by
+    #: ``release_grant_for_job`` KEEPS its job id: that is how the ledger shows
+    #: which run burned the slot and handed it back, and it is the key the
+    #: terminal-failure release finds the row by.
     job_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/archimedes/services/free_generations.py
+++ b/backend/archimedes/services/free_generations.py
@@ -58,6 +58,7 @@ import os
 from archimedes.models.free_generation_grant import (
     claim_free_grant,
     release_grant,
+    release_grant_for_job,
     stamp_grant_job,
     used_count,
 )
@@ -154,15 +155,22 @@ def claim(user_id: str, *, email_verified: bool) -> int | None:
 
 
 def stamp_job(grant_id: int, *, job_id: str) -> None:
-    """Record which job the slot funded. Quiet: the generation is already queued."""
+    """Record which job the slot funded. Quiet: the generation is already queued.
+
+    Not only provenance: :func:`release_for_job` looks the row up BY this stamp,
+    so an unstamped slot is one the terminal-failure path can no longer hand
+    back. The failure log below says exactly that rather than the reassurance it
+    used to carry.
+    """
     try:
         with _session() as session:
             stamp_grant_job(session, grant_id, job_id=job_id)
             session.commit()
     except Exception:
         logger.error(
-            "free-generation grant %s could not be stamped with job %s — the slot is still "
-            "correctly counted as used, only its provenance is missing.",
+            "free-generation grant %s could not be stamped with job %s — the slot stays counted "
+            "as used and, with no job id on the row, cannot be returned automatically if that "
+            "run fails. Manual release needed if it does.",
             grant_id,
             job_id,
             exc_info=True,
@@ -187,6 +195,41 @@ def release(grant_id: int) -> None:
             grant_id,
             exc_info=True,
         )
+
+
+def release_for_job(job_id: str) -> bool:
+    """Hand back the free slot *job_id* spent, because that run delivered nothing.
+
+    The counterpart of :func:`release` for the OTHER half of the failure
+    surface. ``release`` covers the failures ``/api/generate/start`` can see
+    itself (the entitlement gate refusing, the enqueue erroring) and takes the
+    ``grant_id`` it is still holding. This one covers everything that goes
+    wrong AFTER the job is queued — the corpus yielding too few papers to fuse,
+    a pipeline crash, a cancel — where the only handle the terminal path has is
+    the job id the slot was stamped with.
+
+    Returns ``True`` only when a slot actually moved back, so the caller can
+    log the fact rather than claim it unconditionally.
+
+    Quiet on failure, but logged at ``error`` for the same reason ``release``
+    is: a slot that fails to come back costs the account one of its free
+    generations for a run that produced nothing. That errs against the user.
+    """
+    if not job_id:
+        return False
+    try:
+        with _session() as session:
+            released = release_grant_for_job(session, job_id)
+            session.commit()
+            return released is not None
+    except Exception:
+        logger.error(
+            "free-generation slot for job %s could not be released — the account was charged "
+            "one free generation for a run that delivered nothing.",
+            job_id,
+            exc_info=True,
+        )
+        return False
 
 
 def remaining(user_id: str) -> int | None:

--- a/backend/tests/test_free_generation_gate.py
+++ b/backend/tests/test_free_generation_gate.py
@@ -49,6 +49,7 @@ from archimedes.models.free_generation_grant import (
     FreeGenerationGrantRecord,
     claim_free_grant,
     release_grant,
+    stamp_grant_job,
     used_count,
 )
 from archimedes.services import free_generations, generation_payment
@@ -680,3 +681,400 @@ def test_the_paywall_module_no_longer_claims_there_is_no_free_allowance():
     doc = inspect.getdoc(generation_payment) or ""
     assert "no free path" not in doc
     assert "#1643" in doc, "the docstring must say what replaced the old policy"
+
+
+# ── 7. A run that dies INSIDE the pipeline hands the slot back ───────────
+
+
+#: The literal reason ``generation_pipeline`` emits when the corpus is too thin
+#: to fuse — the owner's 2026-09-01 screenshot. Pinned against the source in
+#: ``test_the_corpus_failure_message_still_exists_in_the_pipeline`` so the
+#: stand-in below cannot drift away from the branch it stands in for.
+_CORPUS_REASON = "the corpus yielded <2 papers for this steer — the society cannot fuse"
+
+#: The owner's brief, verbatim in shape: a floating-rate carry steer whose
+#: corpus came back with fewer than two usable papers.
+_CARRY_BODY = {
+    "brief": {
+        "intent": "floating-rate carry with BKLN and FLOT",
+        "risk_appetite": "moderate",
+    }
+}
+
+
+class _EventfulStore:
+    """Stateful JobStore stand-in — status written by one call is visible to
+    the next ``get``, and the event log is real enough to be read back.
+
+    The ``_FakeStore`` in ``test_generation_timeout.py`` with ``list_events``
+    added, because that read is exactly what the guard under test performs.
+    """
+
+    def __init__(self) -> None:
+        self.status: str | None = "running"
+        self.error: str = ""
+        self.events: list[dict] = []
+
+    async def get(self, job_id: str) -> dict:
+        return {"id": job_id, "status": self.status, "error": self.error}
+
+    async def update_status(self, job_id: str, status: str, *, result=None, error: str = "") -> None:
+        self.status = status
+        self.error = error
+
+    async def update_terminal_status(self, job_id: str, status: str, *, result=None, error: str = "") -> bool:
+        await self.update_status(job_id, status, result=result, error=error)
+        return True
+
+    async def touch(self, job_id: str) -> bool:
+        return True
+
+    async def push_event(self, job_id: str, payload: dict) -> int:
+        self.events.append(payload)
+        return len(self.events)
+
+    async def list_events(self, job_id: str, *, after_id: int = 0) -> list[dict]:
+        return [{**e, "id": i} for i, e in enumerate(self.events, start=1)][after_id:]
+
+
+def _reset_gate(monkeypatch) -> None:
+    monkeypatch.setattr(generate_routes, "_GENERATION_GATE", None)
+    monkeypatch.setattr(generate_routes, "_GENERATION_GATE_LOOP", None)
+    monkeypatch.setattr(generate_routes, "_WAITING_GENERATIONS", 0)
+    monkeypatch.setenv("GENERATION_MAX_CONCURRENT", "1")
+    monkeypatch.setenv("GENERATION_MAX_QUEUE", "10")
+
+
+def _corpus_failure(reason: str = _CORPUS_REASON):
+    """A ``run_generation`` stand-in that fails the way the owner's run failed.
+
+    Not a bare ``raise``: it performs the two store writes the real branch
+    performs (``generation_pipeline.py`` — emit ``error``/``GENERATION_UNAVAILABLE``,
+    then ``update_status(job_id, "error", ...)``, then RETURN). That shape is
+    load-bearing here — the pipeline swallows this failure rather than raising,
+    so ``_run_with_cleanup`` sees a perfectly normal return and the only trace
+    of the failure is the status it left behind.
+    """
+
+    async def _run(*, job_id: str, **_kwargs) -> None:
+        store = generate_routes.get_job_store()
+        await store.push_event(
+            job_id,
+            {
+                "event": "error",
+                "data": {
+                    "job_id": job_id,
+                    "message": f"Generation is unavailable right now: {reason}.",
+                    "recoverable": True,
+                    "code": "GENERATION_UNAVAILABLE",
+                },
+            },
+        )
+        await store.update_status(job_id, "error", error=f"generation unavailable: {reason}")
+
+    return _run
+
+
+def _delivered_then_crashed(strategy_id: str = "strat-abc"):
+    """A run that persists the winner and only THEN dies.
+
+    Real path, not a contrivance: ``_persist_candidate`` writes the library row
+    and emits ``persisted``, and the cancel poll + backtest fan-out that follow
+    can both end the job non-``done``. The strategy is in the user's library;
+    the free generation was genuinely spent.
+    """
+
+    async def _run(*, job_id: str, **_kwargs) -> None:
+        store = generate_routes.get_job_store()
+        await store.push_event(
+            job_id,
+            {"event": "persisted", "data": {"job_id": job_id, "strategy_id": strategy_id}},
+        )
+        await store.push_event(
+            job_id,
+            {"event": "error", "data": {"job_id": job_id, "message": "boom", "code": "PIPELINE_CRASH"}},
+        )
+        await store.update_status(job_id, "error", error="boom")
+
+    return _run
+
+
+async def _run_job(monkeypatch, job_id: str, runner, store: _EventfulStore | None = None) -> _EventfulStore:
+    """Drive the exact coroutine ``/start`` spawns, with *runner* as the pipeline."""
+    _reset_gate(monkeypatch)
+    store = store or _EventfulStore()
+    with (
+        patch.object(generate_routes, "run_generation", runner),
+        patch.object(generate_routes, "get_job_store", return_value=store),
+    ):
+        await generate_routes._run_with_cleanup(job_id, MagicMock(), 1)
+    return store
+
+
+class TestAPipelineFailureReturnsTheFreeSlot:
+    """The owner's 2026-09-01 report, as an executable statement.
+
+    Sequence from the screenshots: two generations attempted, the second dying
+    inside the pipeline with "the corpus yielded <2 papers for this steer — the
+    society cannot fuse", and the Generate page then reporting **1 of 3 free
+    generations left**. The failed run had consumed a slot. ``/start``'s
+    ``except BaseException: release; raise`` only ever covered failures the
+    REQUEST could see (the entitlement gate, the enqueue); nothing released a
+    slot for a job that queued fine and then produced nothing.
+    """
+
+    async def test_the_owners_sequence_a_corpus_failure_leaves_the_allowance_whole(self, monkeypatch):
+        """Claim → the job fails with insufficient corpus → allowance back to 3.
+
+        Both halves in one test on purpose: the claim is made by the real
+        ``/start`` route (not seeded), and the release by the real background
+        coroutine, so a fix that only works when the two are wired together is
+        what is being measured.
+
+        MUTATION (the pre-fix code): drop
+        ``_release_free_slot_if_undelivered`` from ``_run_with_cleanup``'s
+        ``finally``. Red, reporting the owner's exact state — ``assert 2 == 3``.
+        """
+        _paywall_on(monkeypatch)
+        store = _EventfulStore()
+
+        with _as_account(wallet=None):
+            resp = _start(_CARRY_BODY, store=_mock_store("job-carry"))
+            assert resp.status_code == 202, resp.text
+            # Mid-flight: the slot IS spent. This is the state the owner saw
+            # and never got back.
+            assert [(r.status, r.job_id) for r in _grants()] == [(GRANT_USED, "job-carry")]
+            assert free_generations.remaining(USER) == 2
+
+            await _run_job(monkeypatch, "job-carry", _corpus_failure(), store=store)
+
+        assert store.status == "error"
+        assert _CORPUS_REASON in store.error
+        rows = _grants()
+        assert [r.status for r in rows] == [GRANT_RELEASED]
+        assert rows[0].job_id == "job-carry", "the ledger still shows which run burned the slot"
+        assert rows[0].released_at is not None
+        assert free_generations.remaining(USER) == 3, "the owner's counter must read 3 of 3 again"
+
+    async def test_two_attempts_that_both_fail_leave_all_three_slots(self, monkeypatch):
+        """The owner made two attempts. Neither delivered; neither may cost."""
+        _paywall_on(monkeypatch)
+
+        with _as_account(wallet=None):
+            for job_id in ("job-carry-1", "job-carry-2"):
+                assert _start(_CARRY_BODY, store=_mock_store(job_id)).status_code == 202
+                await _run_job(monkeypatch, job_id, _corpus_failure())
+
+        assert [r.status for r in _grants()] == [GRANT_RELEASED, GRANT_RELEASED]
+        assert free_generations.remaining(USER) == 3
+
+    def test_the_corpus_failure_message_still_exists_in_the_pipeline(self):
+        """The stand-in above is only faithful while the real branch says this.
+
+        Guards the test, not the product: if ``generation_pipeline`` reworded
+        or removed the insufficient-corpus branch, ``_corpus_failure`` would be
+        reproducing a failure that no longer happens and the reproduction above
+        would quietly stop meaning anything.
+        """
+        import inspect
+
+        from archimedes.agents import generation_pipeline
+
+        source = inspect.getsource(generation_pipeline)
+        assert _CORPUS_REASON in source
+        assert 'code="GENERATION_UNAVAILABLE"' in source
+
+
+class TestTheReleaseGuardRejects:
+    """CLAUDE.md's "a guard must be shown to REJECT something".
+
+    Four inputs the release must refuse, each one a slot that a naive
+    "non-``done`` ⇒ hand it back" would wrongly re-grant.
+    """
+
+    async def test_a_delivered_run_keeps_the_slot_spent(self, monkeypatch):
+        """The contrast pair for the reproduction: only the outcome differs."""
+        _paywall_on(monkeypatch)
+
+        async def _succeeds(*, job_id: str, **_kwargs) -> None:
+            store = generate_routes.get_job_store()
+            await store.push_event(job_id, {"event": "persisted", "data": {"strategy_id": "s1"}})
+            await store.push_event(job_id, {"event": "done", "data": {"job_id": job_id}})
+            await store.update_status(job_id, "done")
+
+        with _as_account(wallet=None):
+            assert _start(store=_mock_store("job-ok")).status_code == 202
+            await _run_job(monkeypatch, "job-ok", _succeeds)
+
+        assert [r.status for r in _grants()] == [GRANT_USED]
+        assert free_generations.remaining(USER) == 2
+
+    async def test_a_crash_AFTER_the_strategy_persisted_keeps_the_slot_spent(self, monkeypatch):
+        """The over-grant this guard exists to make impossible.
+
+        Terminal status ``error`` — the same status as the owner's corpus
+        failure — but the run already wrote a library row. Release it and the
+        account holds the strategy AND the free generation. Deleting the
+        ``persisted``-event check turns this input green in the wrong
+        direction, which is the whole point of testing it.
+
+        MUTATION: hard-code ``persisted = False`` in
+        ``_release_free_slot_if_undelivered`` (i.e. "non-``done`` ⇒ hand it
+        back", the paid path's rule). Red: ``assert ['released'] == ['used']``.
+        """
+        _paywall_on(monkeypatch)
+
+        with _as_account(wallet=None):
+            assert _start(store=_mock_store("job-late-crash")).status_code == 202
+            store = await _run_job(monkeypatch, "job-late-crash", _delivered_then_crashed())
+
+        assert store.status == "error"  # not "done" — the naive check would release here
+        assert [r.status for r in _grants()] == [GRANT_USED]
+        assert free_generations.remaining(USER) == 2
+
+    async def test_a_cancel_AFTER_the_strategy_persisted_keeps_the_slot_spent(self, monkeypatch):
+        """Same shape via the Cancel button.
+
+        ``_abort_if_cancel_requested`` runs at the ``backtest_persist`` stage
+        boundary, i.e. AFTER ``_persist_candidate`` — so a cancel really can
+        land on a run that already delivered a library row.
+        """
+        _paywall_on(monkeypatch)
+
+        async def _cancelled_after_persist(*, job_id: str, **_kwargs) -> None:
+            store = generate_routes.get_job_store()
+            await store.push_event(job_id, {"event": "persisted", "data": {"strategy_id": "s9"}})
+            await store.update_status(job_id, "cancelled", error="cancelled by client")
+
+        with _as_account(wallet=None):
+            assert _start(store=_mock_store("job-cancel-late")).status_code == 202
+            await _run_job(monkeypatch, "job-cancel-late", _cancelled_after_persist)
+
+        assert [r.status for r in _grants()] == [GRANT_USED]
+
+    async def test_an_unreadable_event_log_keeps_the_slot_spent_rather_than_guessing(self, monkeypatch):
+        """Silence is not evidence of non-delivery.
+
+        With the log unreadable there is no way to tell the owner's failure
+        apart from a delivered-then-crashed run, so the slot stays spent — the
+        recoverable direction, since the ledger row keeps its job id.
+
+        MUTATION: collapse ``_job_persisted_a_strategy``'s ``None`` onto
+        ``False``. Red: ``assert ['released'] == ['used']``.
+        """
+        _paywall_on(monkeypatch)
+        store = _EventfulStore()
+        store.list_events = AsyncMock(side_effect=RuntimeError("event log unreachable"))
+
+        with _as_account(wallet=None):
+            assert _start(store=_mock_store("job-blind")).status_code == 202
+            await _run_job(monkeypatch, "job-blind", _corpus_failure(), store=store)
+
+        assert [r.status for r in _grants()] == [GRANT_USED]
+
+    async def test_a_vanished_job_record_keeps_the_slot_spent_rather_than_guessing(self, monkeypatch):
+        """No record ⇒ no event log either ⇒ nothing to read a verdict out of.
+
+        MUTATION: replace the ``if job is None`` branch with the credit path's
+        ``status = (job or {}).get("status")`` — "a missing record reads as
+        undelivered". Red: ``assert ['released'] == ['used']``.
+        """
+        _paywall_on(monkeypatch)
+        store = _EventfulStore()
+        store.get = AsyncMock(return_value=None)
+
+        with _as_account(wallet=None):
+            assert _start(store=_mock_store("job-gone")).status_code == 202
+            await _run_job(monkeypatch, "job-gone", _corpus_failure(), store=store)
+
+        assert [r.status for r in _grants()] == [GRANT_USED]
+
+
+class TestTheReleaseIsIdempotentAndScoped:
+    async def test_releasing_the_same_job_twice_returns_exactly_one_slot(self, monkeypatch):
+        """A retried or duplicated cleanup must not mint a second free run.
+
+        MUTATION: drop ``status=GRANT_USED`` from ``release_grant_for_job``'s
+        filter. Red: ``assert True is False`` — the second call claims to have
+        released a slot it had already released.
+        """
+        _paywall_on(monkeypatch)
+
+        with _as_account(wallet=None):
+            assert _start(store=_mock_store("job-twice")).status_code == 202
+            await _run_job(monkeypatch, "job-twice", _corpus_failure())
+            assert free_generations.remaining(USER) == 3
+            # …and again, exactly as a re-delivered terminal callback would.
+            assert free_generations.release_for_job("job-twice") is False
+
+        assert [r.status for r in _grants()] == [GRANT_RELEASED]
+        assert free_generations.remaining(USER) == 3, "not 4 — one claim, one slot"
+
+    def test_a_job_that_never_spent_a_free_slot_is_a_no_op(self):
+        """A paid run, a flag-off run, an unknown job: no row matches, nothing moves."""
+        _seed_used(USER, 1)
+        assert free_generations.release_for_job("some-paid-job") is False
+        assert free_generations.release_for_job("") is False
+        assert [r.status for r in _grants()] == [GRANT_USED]
+
+    def test_one_users_failure_never_releases_anothers_slot(self):
+        """The lookup is by job id, and a job funds exactly one account's slot."""
+        with get_session() as session:
+            mine = claim_free_grant(session, user_id=USER, allowance=3)
+            theirs = claim_free_grant(session, user_id="user-free-2", allowance=3)
+            stamp_grant_job(session, mine.id, job_id="job-mine")
+            stamp_grant_job(session, theirs.id, job_id="job-theirs")
+            session.commit()
+
+        assert free_generations.release_for_job("job-mine") is True
+
+        assert [r.status for r in _grants(USER)] == [GRANT_RELEASED]
+        assert [r.status for r in _grants("user-free-2")] == [GRANT_USED]
+
+    def test_an_unstamped_slot_is_reported_as_not_released_rather_than_swept(self, monkeypatch):
+        """The boundary ``stamp_job``'s failure log now names.
+
+        If the job-id stamp never landed, the terminal path cannot find the row
+        — and it must say so (``False``) rather than release whichever row it
+        can reach.
+        """
+        with get_session() as session:
+            grant = claim_free_grant(session, user_id=USER, allowance=3)
+            assert grant.job_id is None
+            session.commit()
+
+        assert free_generations.release_for_job("job-unstamped") is False
+        assert [r.status for r in _grants()] == [GRANT_USED]
+
+    def test_a_ledger_failure_is_reported_false_never_claimed_as_released(self, monkeypatch):
+        """Quiet, but not dishonest: an unwritable ledger returns ``False``."""
+        monkeypatch.setattr(
+            free_generations,
+            "_session",
+            MagicMock(side_effect=RuntimeError("ledger unreachable")),
+        )
+        assert free_generations.release_for_job("job-any") is False
+
+
+class TestThePaidPathAlsoCostsNothingForAFailedRun:
+    """The $2 half of the owner's question, pinned rather than altered.
+
+    ``_release_credit_if_undelivered`` already restores a consumed credit on
+    every terminal state except ``done`` (#1441), so the paid path already
+    survives a pipeline-time corpus failure. This asserts that end to end for
+    the owner's exact failure, so the free-tier change cannot regress it and so
+    the claim in the PR body is measured rather than assumed.
+    """
+
+    async def test_a_corpus_failure_restores_the_paid_credit(self, monkeypatch):
+        with patch.object(generate_routes.generation_credits, "restore_for_job", return_value=True) as restore:
+            await _run_job(monkeypatch, "job-paid-carry", _corpus_failure())
+        restore.assert_called_once_with("job-paid-carry")
+
+    async def test_a_delivered_paid_run_keeps_the_credit_spent(self, monkeypatch):
+        async def _succeeds(*, job_id: str, **_kwargs) -> None:
+            await generate_routes.get_job_store().update_status(job_id, "done")
+
+        with patch.object(generate_routes.generation_credits, "restore_for_job", return_value=True) as restore:
+            await _run_job(monkeypatch, "job-paid-ok", _succeeds)
+        restore.assert_not_called()

--- a/backend/tests/test_free_generation_gate.py
+++ b/backend/tests/test_free_generation_gate.py
@@ -817,7 +817,7 @@ class TestAPipelineFailureReturnsTheFreeSlot:
     Sequence from the screenshots: two generations attempted, the second dying
     inside the pipeline with "the corpus yielded <2 papers for this steer — the
     society cannot fuse", and the Generate page then reporting **1 of 3 free
-    generations left**. The failed run had consumed a slot. ``/start``'s
+    generation left**. The failed run had consumed a slot. ``/start``'s
     ``except BaseException: release; raise`` only ever covered failures the
     REQUEST could see (the entitlement gate, the enqueue); nothing released a
     slot for a job that queued fine and then produced nothing.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -170,6 +170,13 @@ host you asked*:
 > honest case for many agents — the wallet path is the whole answer, and the free tier is
 > not something to wait for.
 >
+> **A run that delivers nothing does not cost a free generation.** The slot is claimed at
+> step 6 and handed back if the job then fails without persisting a strategy — the corpus
+> being too thin to fuse, a crash, a cancel. So a failed generation is not a spent one, and
+> step 5 is where you find out: re-read it after a failure rather than decrementing your own
+> counter. (A run that DID persist a strategy keeps its slot even if it errored afterwards —
+> the strategy is in your library.)
+>
 > This **reverses** the 2026-08-19 directive that earlier revisions of this page
 > documented ("a wallet is required before the first generation"); the verification
 > condition is the owner's 2026-08-31 amendment to it. Read your remaining allowance and


### PR DESCRIPTION
## What the owner saw

Two generations attempted on a verified, wallet-less account. The second was a
brief about **BKLN/FLOT floating-rate carry**, and it died inside the pipeline
with:

> Generation is unavailable right now: the corpus yielded <2 papers for this
> steer — the society cannot fuse.

The Generate page then read **"Your account has 1 of 3 free generation left"**
(`ui/src/freeGenerations.js:129`, singular at `shown === 1` via the `plural`
ternary on :95). Nothing was delivered, and the free allowance had
gone 3 → 1 anyway.

## Root cause

`POST /api/generate/start` claims a free slot **before** the gate it opens, then
releases it if the request itself fails — `except BaseException:
free_generations.release(...); raise` around the entitlement gate and the
enqueue. That window closes at the enqueue.

The corpus failure lives on the other side of it. In
`agents/generation_pipeline.py` the insufficient-corpus branch emits
`error`/`GENERATION_UNAVAILABLE`, writes `update_status(job_id, "error", …)` and
**returns** — it does not raise. So `_run_with_cleanup` sees an ordinary
completion, and the only trace of the failure is the status left in the job
store. `_release_credit_if_undelivered` reads exactly that status for the PAID
path (#1441); the free tier had no equivalent, so every post-enqueue failure —
thin corpus, pipeline crash, cancel, timeout — kept the slot spent on a
generation that produced nothing.

## The change

`_run_with_cleanup`'s `finally` now calls `_release_free_slot_if_undelivered`
beside the credit one. It keeps the slot spent in exactly three cases and hands
it back otherwise:

| Case | Slot | Why |
|---|---|---|
| status `done` | stays spent | the run delivered |
| a `persisted` event carrying a `strategy_id` | stays spent | the run put a library row in the account and died afterwards — the cancel poll (`backtest_persist`) and the backtest fan-out both run AFTER `_persist_candidate`. Releasing would hand out the strategy **and** the free generation. |
| the job record or event log cannot be read | stays spent | silence is not evidence of non-delivery; the ledger row keeps its `job_id`, so it is still releasable by hand |
| anything else terminal, no strategy | **released** | the owner's case |

Deliberately **stricter than the paid path**, which restores on every non-`done`
status: money erring toward the payer is the right direction for an accounting
bug on a paywall, but re-granting an allowance that DID buy a library row is
just an over-grant.

Idempotent by construction — `release_grant_for_job` only moves a `used` row
stamped with that `job_id`, so a retried cleanup cannot mint a second free
generation, and a paid or flag-off run matches no row at all. No schema change:
`free_generation_grants` already carries `job_id`, `status` and `released_at`.

**Paid path: verified, not changed.** `_release_credit_if_undelivered` already
restores a consumed credit on every terminal state except `done`, so a $2 credit
already survived this exact failure. Two new tests pin that end to end through
`_run_with_cleanup` (`restore_for_job` called once for the corpus failure, never
for a delivered run) so the free-tier change cannot regress it. Left alone
otherwise — one logical change per PR.

Three comments that this change falsifies, and one log line that made a claim
that is no longer complete, were corrected alongside it: two in `/start` that
were true only up to the enqueue; `free_generation_grant.py`'s `job_id` column
comment, which said a `released` row is "NULL forever" when a row released by
`release_grant_for_job` deliberately KEEPS its job id; and `stamp_job`'s "only
its provenance is missing" — the stamp is now what the release finds the row
by.

## Adversarial pass — every new guard shown red

`pytest backend/tests/test_free_generation_gate.py` (43 tests, green on the
branch) run against six mutations of the shipped code:

**1. The pre-fix code** — drop `_release_free_slot_if_undelivered` from
`_run_with_cleanup`'s `finally`:

```
E   AssertionError: assert ['used'] == ['released']
E   AssertionError: assert ['used', 'used'] == ['released', 'released']
E   AssertionError: assert 2 == 3
FAILED TestAPipelineFailureReturnsTheFreeSlot::test_the_owners_sequence_a_corpus_failure_leaves_the_allowance_whole - AssertionError: assert ['used'] == ['released']
FAILED TestAPipelineFailureReturnsTheFreeSlot::test_two_attempts_that_both_fail_leave_all_three_slots - AssertionError: assert ['used', 'used'] == ['released', 'released']
FAILED TestTheReleaseIsIdempotentAndScoped::test_releasing_the_same_job_twice_returns_exactly_one_slot - AssertionError: assert 2 == 3
3 failed, 40 passed
```

`assert 2 == 3` is the owner's counter, reproduced.

**2. The over-grant** — hard-code `persisted = False` (i.e. the paid path's
"non-`done` ⇒ hand it back"):

```
FAILED TestTheReleaseGuardRejects::test_a_crash_AFTER_the_strategy_persisted_keeps_the_slot_spent - AssertionError: assert ['released'] == ['used']
FAILED TestTheReleaseGuardRejects::test_a_cancel_AFTER_the_strategy_persisted_keeps_the_slot_spent - AssertionError: assert ['released'] == ['used']
FAILED TestTheReleaseGuardRejects::test_an_unreadable_event_log_keeps_the_slot_spent_rather_than_guessing - AssertionError: assert ['released'] == ['used']
3 failed, 40 passed
```

**3. Guessing from missing data** — replace the `if job is None` branch with the
credit path's `status = (job or {}).get("status")`:

```
FAILED TestTheReleaseGuardRejects::test_a_vanished_job_record_keeps_the_slot_spent_rather_than_guessing - AssertionError: assert ['released'] == ['used']
1 failed, 42 passed
```

**4. Non-idempotent release** — drop `status=GRANT_USED` from
`release_grant_for_job`'s filter:

```
FAILED TestTheReleaseIsIdempotentAndScoped::test_releasing_the_same_job_twice_returns_exactly_one_slot - AssertionError: assert True is False
1 failed, 42 passed
```

**5. Guessing when the log cannot be read** — collapse
`_job_persisted_a_strategy`'s two `return None` exits (no `list_events` surface;
the read raised) onto `False`, i.e. "unreadable ⇒ nothing was delivered":

```
FAILED TestTheReleaseGuardRejects::test_an_unreadable_event_log_keeps_the_slot_spent_rather_than_guessing - AssertionError: assert ['released'] == ['used']
1 failed, 42 passed
```

**6. An unscoped release** — drop `job_id` from `release_grant_for_job`'s filter,
so the cleanup releases *any* `used` row:

```
FAILED TestTheReleaseIsIdempotentAndScoped::test_a_job_that_never_spent_a_free_slot_is_a_no_op - AssertionError: assert True is False
FAILED TestTheReleaseIsIdempotentAndScoped::test_one_users_failure_never_releases_anothers_slot - AssertionError: assert False is True
FAILED TestTheReleaseIsIdempotentAndScoped::test_an_unstamped_slot_is_reported_as_not_released_rather_than_swept - AssertionError: assert True is False
3 failed, 40 passed
```

One user's failed generation cannot hand another user's slot back, and that is
pinned rather than assumed.

(A further attempt — `if False:` in place of the `job is None` branch — did NOT go
red, because it crashes into the outer `except` and the slot stays spent for the
wrong reason. Recorded because a mutation that passes for an accidental reason
proves nothing; it was replaced by mutation 3 above.)

The stand-in for the pipeline is not a bare `raise`: `_corpus_failure` performs
the same two store writes the real branch performs and then RETURNS, which is
the shape that made this bug invisible.
`test_the_corpus_failure_message_still_exists_in_the_pipeline` pins the literal
reason string and `code="GENERATION_UNAVAILABLE"` against
`generation_pipeline`'s source, so the reproduction cannot drift away from the
branch it reproduces.

## Verification

```
pytest backend/tests/test_free_generation_gate.py -q            → 43 passed        (exit 0)
pytest test_free_generation_gate + test_generation_credits
     + test_generation_timeout + test_generation_concurrency
     + test_generate_credits_route -q                           → 89 passed        (exit 0)
ruff check <4 touched python files>                             → All checks passed (exit 0)
ruff format --check <4 touched python files>                    → 4 files already formatted (exit 0)
pytest -m "not integration" -q  (6 chunks, see note)            → 5659 passed, 4 skipped
                                                                  (exit 0 on every chunk)
```

No `ui/` files touched, so no npm run.

**About the full-suite run.** One `pytest -m "not integration"` process on this
machine is killed by the 10-minute tool bound, so it was run as six file-chunks
covering all 336 test files. Chunk 3 died with **exit 139 (SIGSEGV)** — twice,
at two DIFFERENT files (`test_strategy_fusion.py`, then `test_paper_rag.py`),
i.e. not attributable to any one test. Control: the same chunk on a pristine
`origin/main` worktree with none of this branch's changes **also exits 139**, at
`test_strategy_fusion.py`. It is a pre-existing native crash in a long-lived
process in this conda env, not something this PR introduces — nothing here
touches fusion, RAG or any native library. Split in two, the same 825 tests pass
green (615 + 210, exit 0 each). Totals above are the sum across chunks; every
chunk exited 0.

## Concerns for the owner

- **The banner does not refresh itself.** `FreeGenerationBanner.jsx` fetches
  `GET /api/account/usage` once on mount (`useEffect(..., [])`). The number is
  now correct on the server, but a user who watches a generation fail on the
  Generate page still sees the pre-failure count until the component remounts.
  Left out of this PR: it is a UI change on the Generate page, which
  `dbrowneup/reasoning-traces-surfaced` is editing.
- **`scripts/run_generation_job.py` bypasses this cleanup entirely.** It calls
  `run_generation` directly rather than through `_run_with_cleanup`, so on that
  path neither the free slot nor the paid credit is released. Pre-existing
  parity gap — the credit had it too — and nothing in the serving path imports
  that module (it is the #1411 offload spike), but its docstring's "the cost
  meter and the credit ledger all run on their normal code paths" is now wrong
  about one more thing. Worth a line in the ADR.
- **A run whose process dies never runs its `finally`.** A container roll mid-run
  leaves the job `running` until the stalled-heartbeat read reports it, and no
  cleanup executes — so the slot stays spent. The paid credit has the identical
  gap. A sweeper over stalled jobs would close both; not attempted here.
- **A slot whose `stamp_job` write failed cannot be released automatically** —
  the release finds the row by `job_id`. `stamp_job`'s error log now says so
  instead of reassuring.
- **The delivery oracle is the `persisted` event.** It is the honest signal
  available at cleanup time (the job record carries no strategy id on a crash
  path), but the event log has a shorter TTL than the job record. That is why an
  unreadable log keeps the slot spent rather than releasing it. Reading it does
  not touch `generation_pipeline`.

## Collision check

No code overlap with the concurrent branches, and the one shared file is a doc.
`dbrowneup/verdict-of-record-a`
edits `Strategies.jsx`, `StrategyPassport.jsx`, `strategies_routes.py`,
`passport_loader` and `generation_pipeline`'s passport writes;
`dbrowneup/reasoning-traces-surfaced` edits the generation stream components and
the SSE emit code. This PR touches **no** `ui/` file, and **no** file under
`agents/` — `generation_pipeline.py` is only read (by a test asserting its error
string still exists). In `generate_routes.py` the new code sits in the
background-cleanup helpers, ~200 lines below `/start`'s handler body.

Two shared files, both checked rather than assumed:

- `docs/agent-quickstart.md` **is** also edited by `dbrowneup/verdict-of-record-a`
  (~:567 and ~:712). This PR's edit is at ~:170; the hunks are far apart and the
  file merges clean.
- `dbrowneup/ux-too-few-papers` restructures the *exact* insufficient-corpus
  branch that this PR's source-pinning test asserts against — the highest-risk
  neighbour. Union tested in review: `origin/main` + this branch + `ux-too-few-papers`
  merged in a scratch worktree with **no conflicts**, and
  `test_free_generation_gate.py` plus that branch's two new files ran **61
  passed**. Both pinned forms survive there — the reason string ("the corpus
  yielded <2 papers for this steer — the society cannot fuse", `:1332` on this
  branch) and the keyword form `code="GENERATION_UNAVAILABLE",` (`:1338`), which
  the merge relocates but does not alter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.

