### PR TITLE
[infra][waf] /api/rigor/verify may carry a year of returns: scoped SizeRestrictions_BODY override + explicit row cap (#1749)

### DIFF
--- a/backend/archimedes/api/rigor_verify_routes.py
+++ b/backend/archimedes/api/rigor_verify_routes.py
@@ -72,7 +72,7 @@ import math
 from typing import Literal
 
 from fastapi import APIRouter, Depends, Request, Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from archimedes.api.account_auth import CurrentUser, require_current_user
 from archimedes.api.limiter import limiter
@@ -121,9 +121,52 @@ class ReturnPoint(BaseModel):
     daily_return: float
 
 
+# #1749: the ceiling on a verify payload belongs to the APPLICATION, at a number
+# we chose, not to whatever byte count the edge happens to enforce.
+#
+# Until this cap existed, `returns` had `min_length=1` and no upper bound, so the
+# only ceiling anywhere in the path was AWS WAF's `SizeRestrictions_BODY` —
+# 8,192 bytes on a REGIONAL web ACL fronting an ALB. Measured (dogfood
+# 2026-09-01, agent-cli): 160 rows = 8,076 B -> 200; 165 rows = 8,326 B -> 403.
+# That is 50.5 bytes per serialised row including the envelope, so the limit is
+# crossed at ~163 rows and one trading year (252 bars, ~12.7 KB extrapolated)
+# 403'd at the edge with an `awselb/2.0` HTML body the CLI could only report as
+# a generic http_error. See infra/waf.tf for the scoped edge fix.
+#
+# 2,600 rows is a decade of daily bars (10 x 252 = 2,520, plus headroom for
+# leap-year/exchange-calendar variation). A full-cap payload measures ~122 KB of
+# JSON with 6-decimal returns and extrapolates to ~131 KB at the 50.5 B/row seen
+# in production — comfortably inside FastAPI/uvicorn's defaults, and small
+# enough that the DSR/OOS math stays sub-second. A decade is the honest outer
+# edge of what a daily-bar rigor verdict can claim anyway; beyond it the caller
+# wants a different endpoint, not a bigger POST.
+#
+# Fail-closed: over the cap is a 422 with a message that names the limit, the
+# count received and the reason — never a truncation, never a silent accept.
+_MAX_RETURN_ROWS = 2600
+
+
 class RigorVerifyRequest(BaseModel):
-    returns: list[ReturnPoint] = Field(min_length=1)
+    # `max_length` is the declarative contract (it lands in the OpenAPI schema
+    # and is the backstop if the validator below is ever removed); the
+    # mode="before" validator runs first and is what produces the explicit
+    # message, because pydantic's own max_length error ("List should have at
+    # most 2600 items after validation") does not tell the caller what to do.
+    returns: list[ReturnPoint] = Field(min_length=1, max_length=_MAX_RETURN_ROWS)
     trials: int = Field(default=1, ge=1, description="Self-attested trial count for the DSR deflation.")
+
+    @field_validator("returns", mode="before")
+    @classmethod
+    def _cap_returns(cls, value: object) -> object:
+        """Reject over-long series with a message that names the limit (#1749)."""
+        if isinstance(value, list) and len(value) > _MAX_RETURN_ROWS:
+            raise ValueError(
+                f"returns has {len(value)} rows; the maximum is {_MAX_RETURN_ROWS} "
+                f"(~10 years of daily bars). Split the series or aggregate to a "
+                f"coarser frequency — a rigor verdict over a longer daily window "
+                f"is not something this endpoint can honestly compute."
+            )
+        return value
 
 
 class RigorCheck(BaseModel):

--- a/backend/archimedes/api/rigor_verify_routes.py
+++ b/backend/archimedes/api/rigor_verify_routes.py
@@ -121,8 +121,9 @@ class ReturnPoint(BaseModel):
     daily_return: float
 
 
-# #1749: the ceiling on a verify payload belongs to the APPLICATION, at a number
-# we chose, not to whatever byte count the edge happens to enforce.
+# #1749: the size ceiling on a verify payload belongs to the APPLICATION, at a
+# row count we chose, instead of being set implicitly by whatever byte count the
+# edge happens to enforce.
 #
 # Until this cap existed, `returns` had `min_length=1` and no upper bound, so the
 # only ceiling anywhere in the path was AWS WAF's `SizeRestrictions_BODY` —
@@ -136,10 +137,13 @@ class ReturnPoint(BaseModel):
 # 2,600 rows is a decade of daily bars (10 x 252 = 2,520, plus headroom for
 # leap-year/exchange-calendar variation). A full-cap payload measures ~122 KB of
 # JSON with 6-decimal returns and extrapolates to ~131 KB at the 50.5 B/row seen
-# in production — comfortably inside FastAPI/uvicorn's defaults, and small
-# enough that the DSR/OOS math stays sub-second. A decade is the honest outer
-# edge of what a daily-bar rigor verdict can claim anyway; beyond it the caller
-# wants a different endpoint, not a bigger POST.
+# in production — well under nginx's implicit 1 MB `client_max_body_size`
+# default (nginx/nginx.conf sets none; nginx is the ALB target, infra/ecs.tf),
+# which with the WAF exception in place is now the only BYTE ceiling on this
+# path. Note this is a ROW cap: FastAPI buffers and json-parses the entire body
+# before dependencies or field validation run, so an over-cap — or
+# unauthenticated — request is still parsed in full first. It is also small
+# enough that the DSR/OOS math stays sub-second.
 #
 # Fail-closed: over the cap is a 422 with a message that names the limit, the
 # count received and the reason — never a truncation, never a silent accept.
@@ -162,9 +166,8 @@ class RigorVerifyRequest(BaseModel):
         if isinstance(value, list) and len(value) > _MAX_RETURN_ROWS:
             raise ValueError(
                 f"returns has {len(value)} rows; the maximum is {_MAX_RETURN_ROWS} "
-                f"(~10 years of daily bars). Split the series or aggregate to a "
-                f"coarser frequency — a rigor verdict over a longer daily window "
-                f"is not something this endpoint can honestly compute."
+                f"(~10 years of daily bars). This is a payload cap, not a statistical "
+                f"one: split the series or aggregate to a coarser frequency."
             )
         return value
 

--- a/backend/tests/test_waf_verify_body.py
+++ b/backend/tests/test_waf_verify_body.py
@@ -28,13 +28,20 @@ The fix is deliberately SCOPED, and these tests exist to keep it scoped:
     "EXACTLY"` matters: widening it to a `/api/*` prefix would hand every API
     route an unlimited body, which is the DoS/parser-abuse control the managed
     rule was there to provide;
+  * the rule's statement NESTING is asserted as a parsed tree, not as substrings.
+    `not_statement { and_statement { size, byte_match } }` — the negation wrapped
+    AROUND the pair rather than ANDed beside the size test — is valid HCL, passes
+    `terraform validate`, and contains every string a substring guard looks for,
+    while meaning "block everything EXCEPT an oversize POST to /api/rigor/verify":
+    a site-wide outage the moment it is applied;
   * the application, not the edge, owns the real ceiling — `RigorVerifyRequest`
     caps `returns` at 2,600 rows (a decade of daily bars) and fails closed with
     a 422 that names the limit.
 
 `terraform validate` cannot catch any of this. A deleted override, an override
-on the wrong rule name, a prefix-widened exception and a custom rule ordered
-ahead of the managed group are all syntactically valid HCL.
+on the wrong rule name, a prefix-widened exception, an inverted NOT/AND nesting
+and a custom rule ordered ahead of the managed group are all syntactically valid
+HCL.
 
 Hermetic: reads one file from the repo and exercises the pydantic model plus the
 router over an in-process ASGI transport. No AWS, no terraform binary, no
@@ -126,6 +133,177 @@ def _collapse(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+# ── Structural reader: the statement TREE, not the strings in it ─────────
+#
+# Substring assertions cannot see nesting. `not_statement { statement {
+# and_statement { size, byte_match } } }` contains every token that
+# `and_statement`/`not_statement`/`EXACTLY` string checks look for, is valid
+# HCL, passes `terraform validate` — and means "block everything EXCEPT an
+# oversize POST to /api/rigor/verify", i.e. a site-wide outage on apply. So the
+# rule's statement tree is parsed and asserted node by node instead.
+
+_TRAILING_IDENT = re.compile(r"([A-Za-z_][A-Za-z0-9_-]*)\s*\Z")
+
+
+def _skip_string(text: str, i: int) -> int:
+    """Index just past the double-quoted string starting at `i`."""
+    i += 1
+    while i < len(text) and text[i] != '"':
+        i += 2 if text[i] == "\\" else 1
+    return i + 1
+
+
+def _child_blocks(body: str) -> list[tuple[str, str]]:
+    """Direct child `label { ... }` blocks of an HCL block body, in source order.
+
+    Quoted strings are skipped, so `"${var.project_name}-oversize-body"` does not
+    open a block. Attribute lines (`size = 8192`) are not blocks and are ignored.
+    """
+    blocks: list[tuple[str, str]] = []
+    depth, label, opened_at, i = 0, None, 0, 0
+    while i < len(body):
+        char = body[i]
+        if char == '"':
+            i = _skip_string(body, i)
+            continue
+        if char == "{":
+            if depth == 0:
+                found = _TRAILING_IDENT.search(body, 0, i)
+                label, opened_at = (found.group(1) if found else None), i
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            assert depth >= 0, "unbalanced braces in infra/waf.tf"
+            if depth == 0 and label is not None:
+                blocks.append((label, body[opened_at + 1 : i]))
+                label = None
+        i += 1
+    assert depth == 0, "unterminated block in infra/waf.tf"
+    return blocks
+
+
+def _own_attrs(body: str) -> str:
+    """`body` with every child block's contents blanked — attributes of THIS block only."""
+    kept, depth, i = [], 0, 0
+    while i < len(body):
+        char = body[i]
+        if char == '"':
+            end = _skip_string(body, i)
+            kept.append(body[i:end] if depth == 0 else " " * (end - i))
+            i = end
+            continue
+        if char == "{":
+            depth += 1
+            kept.append("{" if depth == 1 else " ")
+        elif char == "}":
+            kept.append("}" if depth == 1 else " ")
+            depth -= 1
+        else:
+            kept.append(char if depth == 0 else ("\n" if char == "\n" else " "))
+        i += 1
+    return "".join(kept)
+
+
+def _attr(body: str, key: str) -> str | None:
+    """Value of `key = ...` declared directly on this block (never on a child)."""
+    found = re.search(rf"^\s*{re.escape(key)}\s*=\s*(\S.*?)\s*$", _own_attrs(body), re.MULTILINE)
+    return found.group(1) if found else None
+
+
+def _sole_child(body: str, label: str, *, where: str) -> str:
+    """The body of the ONLY child block, which must be named `label`.
+
+    Strict on purpose: this is what makes an inverted nesting fail. A
+    `not_statement` wrapped around the `and_statement` shows up here as the sole
+    child being `not_statement` instead of `and_statement`.
+    """
+    labels = [name for name, _ in _child_blocks(body)]
+    assert labels == [label], f"{where} must contain exactly one block, `{label} {{...}}`; got {labels}"
+    return _child_blocks(body)[0][1]
+
+
+def _named_child(body: str, label: str, *, where: str) -> str:
+    """The body of the one child block named `label` (siblings of other kinds allowed)."""
+    matches = [child for name, child in _child_blocks(body) if name == label]
+    assert len(matches) == 1, f"{where} must have exactly one `{label}` block; found {len(matches)}"
+    return matches[0]
+
+
+def _descendant_labels(body: str) -> list[str]:
+    labels: list[str] = []
+    for name, child in _child_blocks(body):
+        labels.append(name)
+        labels.extend(_descendant_labels(child))
+    return labels
+
+
+def _verify_rule_statement_tree() -> tuple[str, str]:
+    """Assert the custom rule's EXACT statement nesting; return (size body, byte_match body).
+
+        rule
+          statement
+            and_statement
+              statement -> size_constraint_statement      (the 8 KB ceiling)
+              statement -> not_statement
+                            statement -> byte_match_statement   (the one exempt path)
+
+    The two branches are SIBLINGS. If the `not_statement` were an ancestor of the
+    size constraint instead, the rule would read "block everything except an
+    oversize POST to /api/rigor/verify" — every other request on the site, of any
+    size, blocked at the edge.
+    """
+    rule = _rule_block(CUSTOM_RULE_NAME)
+    top = _named_child(rule, "statement", where=f"rule {CUSTOM_RULE_NAME!r}")
+
+    # The top-level statement must BE the and_statement. Anything wrapped around
+    # it — a not_statement above all, an or_statement — changes what the rule
+    # means while leaving every substring intact.
+    and_body = _sole_child(top, "and_statement", where="rule.statement")
+
+    branches = _child_blocks(and_body)
+    assert [name for name, _ in branches] == ["statement", "statement"], (
+        "rule.statement.and_statement must hold exactly two `statement` branches — "
+        f"the size test and the negated path test; got {[name for name, _ in branches]}"
+    )
+    kinds = {
+        _child_blocks(branch)[0][0]: _sole_child(branch, _child_blocks(branch)[0][0], where="an and_statement branch")
+        for _, branch in branches
+    }
+    assert set(kinds) == {"size_constraint_statement", "not_statement"}, (
+        "the and_statement's two branches must be a size_constraint_statement and a "
+        f"not_statement, as SIBLINGS; got {sorted(kinds)}"
+    )
+
+    size = kinds["size_constraint_statement"]
+    negated = kinds["not_statement"]
+
+    # The negation must not contain the size test: nesting it there is the
+    # inversion this function exists to catch.
+    assert "size_constraint_statement" not in _descendant_labels(negated), (
+        "the not_statement must NOT wrap the size constraint — that inverts the rule "
+        "into a site-wide block of everything except an oversize verify POST"
+    )
+
+    inner = _sole_child(negated, "statement", where="rule.statement.and_statement.*.not_statement")
+    byte_match = _sole_child(inner, "byte_match_statement", where="the not_statement's inner statement")
+
+    # Exactly one of each in the whole rule: no second size test, no smuggled
+    # extra path exception, no or_statement anywhere.
+    labels = _descendant_labels(rule)
+    for label, expected in (
+        ("and_statement", 1),
+        ("not_statement", 1),
+        ("size_constraint_statement", 1),
+        ("byte_match_statement", 1),
+        ("or_statement", 0),
+    ):
+        assert labels.count(label) == expected, (
+            f"rule {CUSTOM_RULE_NAME!r} must contain exactly {expected} `{label}`; found {labels.count(label)}"
+        )
+
+    return size, byte_match
+
+
 # ── 1. The override exists, on the right rule, in the right group ────────
 
 
@@ -167,33 +345,66 @@ def test_custom_rule_blocks_oversize_bodies():
     rule = _rule_block(CUSTOM_RULE_NAME)
     assert "block {}" in _collapse(_brace_block(rule, "action")), "the replacement rule must BLOCK"
 
-    size = _brace_block(rule, "size_constraint_statement")
-    collapsed = _collapse(size)
-    assert 'comparison_operator = "GT"' in collapsed
-    assert f"size = {REGIONAL_BODY_INSPECTION_LIMIT}" in collapsed, (
-        f"the replacement must keep the managed rule's own {REGIONAL_BODY_INSPECTION_LIMIT}-byte ceiling"
+    size, _ = _verify_rule_statement_tree()
+    assert _attr(size, "comparison_operator") == '"GT"'
+    assert _attr(size, "size") == str(REGIONAL_BODY_INSPECTION_LIMIT), (
+        f"the replacement must keep the managed rule's own {REGIONAL_BODY_INSPECTION_LIMIT}-byte "
+        f"ceiling; got size = {_attr(size, 'size')}"
     )
-    body = _collapse(_brace_block(size, "body"))
-    assert 'oversize_handling = "MATCH"' in body, (
+    field = _named_child(size, "field_to_match", where="the size_constraint_statement")
+    measured = _sole_child(field, "body", where="the size_constraint_statement's field_to_match")
+    assert _attr(measured, "oversize_handling") == '"MATCH"', (
         "on an ALB only the first 8 KB reaches WAF, so the GT comparison alone can "
-        'never fire; oversize_handling = "MATCH" is what blocks a >8 KB body'
+        'never fire; oversize_handling = "MATCH" on `body` is what blocks a >8 KB body; '
+        f"got field_to_match -> body {{ oversize_handling = {_attr(measured, 'oversize_handling')} }}"
     )
+    transform = _named_child(size, "text_transformation", where="the size_constraint_statement")
+    assert _attr(transform, "type") == '"NONE"', "the body must be measured as sent, untransformed"
 
 
 def test_the_exception_is_exactly_the_verify_path_and_is_negated():
-    rule = _rule_block(CUSTOM_RULE_NAME)
-    negated = _brace_block(rule, "not_statement")
-    byte_match = _collapse(_brace_block(negated, "byte_match_statement"))
-    assert f'search_string = "{VERIFY_PATH}"' in byte_match, (
-        f"the exception must be the literal path {VERIFY_PATH}; got: {byte_match}"
+    _, byte_match = _verify_rule_statement_tree()
+    assert _attr(byte_match, "search_string") == f'"{VERIFY_PATH}"', (
+        f"the exception must be the literal path {VERIFY_PATH}; got: {_collapse(_own_attrs(byte_match))}"
     )
-    assert 'positional_constraint = "EXACTLY"' in byte_match, (
+    assert _attr(byte_match, "positional_constraint") == '"EXACTLY"', (
         "EXACTLY, never a prefix — a /api/* widening would lift the body ceiling off every API route"
     )
-    assert "uri_path {}" in byte_match, "the exception must match on uri_path"
-    # The negation has to be ANDed with the size test, not left dangling: an
-    # or_statement here would block every request to every other path.
-    assert "and_statement" in _collapse(rule)
+    field = _named_child(byte_match, "field_to_match", where="the byte_match_statement")
+    assert [name for name, _ in _child_blocks(field)] == ["uri_path"], (
+        "the exception must match on uri_path, not on headers, the query string or the body; "
+        f"got field_to_match {{ {_collapse(field)} }}"
+    )
+    transform = _named_child(byte_match, "text_transformation", where="the byte_match_statement")
+    assert _attr(transform, "type") == '"NONE"', (
+        "NONE: the path is compared as sent, so every encoded/case variant of the "
+        "verify path falls through to blocked rather than exempt"
+    )
+
+
+def test_the_negation_is_a_sibling_of_the_size_test_not_a_wrapper():
+    """Adversarial: the inversion that every substring guard passes.
+
+    `not_statement { statement { and_statement { size, byte_match } } }` is valid
+    HCL, passes `terraform validate`, and contains `and_statement`,
+    `not_statement`, `EXACTLY` and the verify path — everything the old string
+    assertions looked for. It means the OPPOSITE of the intended rule: block
+    every request site-wide except an oversize POST to /api/rigor/verify. On
+    apply that is a total outage, so the nesting is asserted structurally.
+    """
+    _verify_rule_statement_tree()
+
+    rule = _rule_block(CUSTOM_RULE_NAME)
+    top = _named_child(rule, "statement", where=f"rule {CUSTOM_RULE_NAME!r}")
+    assert _child_blocks(top)[0][0] == "and_statement", (
+        "the rule's top-level statement must BE the and_statement; wrapping it in a "
+        f"not_statement inverts the rule into a site-wide block. got: {_collapse(top)[:120]}"
+    )
+    # …and the path negation lives strictly beneath it, on one of its branches.
+    and_body = _sole_child(top, "and_statement", where="rule.statement")
+    assert "not_statement" in _descendant_labels(and_body), (
+        "the size test and the negated path test must be SIBLING statements inside the and_statement"
+    )
 
 
 def test_no_wildcard_or_prefix_exception_anywhere_in_the_custom_rule():
@@ -242,8 +453,8 @@ def test_a_decade_of_daily_bars_fits_under_the_cap():
     assert _MAX_RETURN_ROWS == 2600
     assert _MAX_RETURN_ROWS >= 10 * 252, "the cap must admit ten years of daily bars"
     payload = len(json.dumps({"returns": _rows(_MAX_RETURN_ROWS), "trials": 1}, separators=(",", ":")).encode())
-    assert 100_000 < payload < 200_000, (
-        f"a full-cap payload is {payload} B; the ~135 KB claim in the code comment is wrong"
+    assert 118_000 < payload < 126_000, (
+        f"a full-cap payload is {payload} B; the ~122 KB measured claim in the code comment and the PR body is wrong"
     )
 
 

--- a/backend/tests/test_waf_verify_body.py
+++ b/backend/tests/test_waf_verify_body.py
@@ -1,0 +1,305 @@
+"""The 8 KB ceiling on POST /api/rigor/verify — at the edge and in the app (#1749).
+
+`infra/waf.tf` attached `AWSManagedRulesCommonRuleSet` to the ALB in full BLOCK
+mode with no `rule_action_override` and no `scope_down_statement`. Its
+`SizeRestrictions_BODY` rule blocks any body over the WAF body-inspection limit
+for a REGIONAL web ACL — 8,192 bytes. `POST /api/rigor/verify` serialises one
+JSON object per bar and had no `max_length`, so a real returns series crossed
+8 KB at ~163 rows. Dogfood 2026-09-01 (agent-cli), deterministic:
+
+    160 rows / 8,076 B -> 200     MEASURED
+    165 rows / 8,326 B -> 403     MEASURED (HTML from awselb/2.0, not FastAPI)
+    252 rows           -> 403     MEASURED, every time  <- ONE TRADING YEAR
+
+(50.5 B/row including the envelope, from those two measured points; the 8,192
+limit is crossed at ~163 rows.)
+
+The endpoint that exists to give a DSR/OOS verdict statistical power rejected
+exactly the sample size that gives it power.
+
+The fix is deliberately SCOPED, and these tests exist to keep it scoped:
+
+  * `SizeRestrictions_BODY` is overridden to `count` on the CRS group — and
+    NOTHING ELSE is. A blanket `override_action { count {} }` on the group, or a
+    second `rule_action_override`, would silently disable real controls;
+  * a custom rule at priority 11 (immediately after the CRS group, before
+    known-bad-inputs at 20) re-imposes the 8,192-byte ceiling for every path
+    EXCEPT the one literal path `/api/rigor/verify`. `positional_constraint =
+    "EXACTLY"` matters: widening it to a `/api/*` prefix would hand every API
+    route an unlimited body, which is the DoS/parser-abuse control the managed
+    rule was there to provide;
+  * the application, not the edge, owns the real ceiling — `RigorVerifyRequest`
+    caps `returns` at 2,600 rows (a decade of daily bars) and fails closed with
+    a 422 that names the limit.
+
+`terraform validate` cannot catch any of this. A deleted override, an override
+on the wrong rule name, a prefix-widened exception and a custom rule ordered
+ahead of the managed group are all syntactically valid HCL.
+
+Hermetic: reads one file from the repo and exercises the pydantic model plus the
+router over an in-process ASGI transport. No AWS, no terraform binary, no
+network, no DB.
+
+Run:
+    /path/to/env/bin/pytest backend/tests/test_waf_verify_body.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import httpx
+import pytest
+from archimedes.api import account_auth, rigor_verify_routes
+from archimedes.api.rigor_verify_routes import _MAX_RETURN_ROWS, RigorVerifyRequest
+from fastapi import FastAPI
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WAF_TF = REPO_ROOT / "infra" / "waf.tf"
+
+# The AWS body-inspection limit for a REGIONAL web ACL. The managed rule and the
+# custom replacement must agree on it; spelled out so a drifting constant fails.
+REGIONAL_BODY_INSPECTION_LIMIT = 8192
+
+# The one managed rule this change is permitted to soften, and the one literal
+# path it is permitted to soften it for.
+OVERRIDDEN_RULE = "SizeRestrictions_BODY"
+VERIFY_PATH = "/api/rigor/verify"
+
+CUSTOM_RULE_NAME = "oversize-body-except-rigor-verify"
+CRS_RULE_NAME = "aws-core-rules"
+CRS_GROUP = "AWSManagedRulesCommonRuleSet"
+
+# The managed groups that must keep blocking, untouched, at their existing
+# priorities. The custom rule has to sit between the CRS group and these.
+DOWNSTREAM_MANAGED_PRIORITIES = {"aws-known-bad-inputs": 20, "aws-ip-reputation": 30, "aws-sqli": 40}
+
+
+# ── Minimal HCL reader ───────────────────────────────────────────────────
+#
+# Brace-matching over comment-stripped text. Enough to isolate a `rule { ... }`
+# body and assert on its contents; deliberately not a full HCL parser.
+
+
+def _strip_comments(text: str) -> str:
+    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+
+
+def _brace_block(text: str, marker: str, *, start: int = 0) -> str:
+    """Body of the first `{...}` block at/after `marker`, braces matched."""
+    i = text.find(marker, start)
+    assert i != -1, f"no {marker!r} block found — the scoped WAF fix for #1749 is gone"
+    j = text.index("{", i)
+    depth = 0
+    for k in range(j, len(text)):
+        if text[k] == "{":
+            depth += 1
+        elif text[k] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[j + 1 : k]
+    raise AssertionError(f"unterminated block after {marker!r}")
+
+
+def _rule_block(name: str) -> str:
+    """The `rule { ... }` body whose `name = "<name>"` line it contains."""
+    text = _strip_comments(WAF_TF.read_text())
+    for match in re.finditer(r"\brule\s*\{", text):
+        body = _brace_block(text, "rule", start=match.start())
+        if re.search(rf'^\s*name\s*=\s*"{re.escape(name)}"\s*$', body, re.MULTILINE):
+            return body
+    raise AssertionError(f"no rule named {name!r} in infra/waf.tf")
+
+
+def _priority(rule_body: str) -> int:
+    match = re.search(r"^\s*priority\s*=\s*(\d+)\s*$", rule_body, re.MULTILINE)
+    assert match, "rule has no priority"
+    return int(match.group(1))
+
+
+def _collapse(text: str) -> str:
+    """Whitespace-insensitive form, so HCL formatting is not part of the assert."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+# ── 1. The override exists, on the right rule, in the right group ────────
+
+
+def test_size_restrictions_body_is_overridden_to_count_on_the_crs_group():
+    crs = _rule_block(CRS_RULE_NAME)
+    group = _brace_block(crs, "managed_rule_group_statement")
+    assert f'name = "{CRS_GROUP}"' in _collapse(group).replace('name= "', 'name = "')
+
+    override = _brace_block(group, "rule_action_override")
+    collapsed = _collapse(override)
+    assert f'name = "{OVERRIDDEN_RULE}"' in collapsed, f"the CRS override must name {OVERRIDDEN_RULE}; got: {collapsed}"
+    assert "count {}" in _collapse(_brace_block(override, "action_to_use")), (
+        "the override must set the action to count {} (keeps the metric/label while "
+        "the custom rule at priority 11 carries the block)"
+    )
+
+
+def test_the_crs_group_itself_is_still_in_block_mode():
+    """`override_action { none {} }` — softening the GROUP would disable CRS wholesale."""
+    crs = _rule_block(CRS_RULE_NAME)
+    assert "none {}" in _collapse(_brace_block(crs, "override_action"))
+
+
+def test_no_other_managed_rule_is_overridden_anywhere_in_the_web_acl():
+    """Exactly one rule_action_override in the file, and it is SizeRestrictions_BODY."""
+    text = _strip_comments(WAF_TF.read_text())
+    names: list[str] = []
+    for match in re.finditer(r"\brule_action_override\s*\{", text):
+        body = _brace_block(text, "rule_action_override", start=match.start())
+        found = re.search(r'name\s*=\s*"([^"]+)"', body)
+        names.append(found.group(1) if found else "<unnamed>")
+    assert names == [OVERRIDDEN_RULE], f"exactly one managed rule may be overridden ({OVERRIDDEN_RULE}); found {names}"
+
+
+# ── 2. The custom rule re-imposes the ceiling, with an EXACT-path exception ──
+
+
+def test_custom_rule_blocks_oversize_bodies():
+    rule = _rule_block(CUSTOM_RULE_NAME)
+    assert "block {}" in _collapse(_brace_block(rule, "action")), "the replacement rule must BLOCK"
+
+    size = _brace_block(rule, "size_constraint_statement")
+    collapsed = _collapse(size)
+    assert 'comparison_operator = "GT"' in collapsed
+    assert f"size = {REGIONAL_BODY_INSPECTION_LIMIT}" in collapsed, (
+        f"the replacement must keep the managed rule's own {REGIONAL_BODY_INSPECTION_LIMIT}-byte ceiling"
+    )
+    body = _collapse(_brace_block(size, "body"))
+    assert 'oversize_handling = "MATCH"' in body, (
+        "on an ALB only the first 8 KB reaches WAF, so the GT comparison alone can "
+        'never fire; oversize_handling = "MATCH" is what blocks a >8 KB body'
+    )
+
+
+def test_the_exception_is_exactly_the_verify_path_and_is_negated():
+    rule = _rule_block(CUSTOM_RULE_NAME)
+    negated = _brace_block(rule, "not_statement")
+    byte_match = _collapse(_brace_block(negated, "byte_match_statement"))
+    assert f'search_string = "{VERIFY_PATH}"' in byte_match, (
+        f"the exception must be the literal path {VERIFY_PATH}; got: {byte_match}"
+    )
+    assert 'positional_constraint = "EXACTLY"' in byte_match, (
+        "EXACTLY, never a prefix — a /api/* widening would lift the body ceiling off every API route"
+    )
+    assert "uri_path {}" in byte_match, "the exception must match on uri_path"
+    # The negation has to be ANDed with the size test, not left dangling: an
+    # or_statement here would block every request to every other path.
+    assert "and_statement" in _collapse(rule)
+
+
+def test_no_wildcard_or_prefix_exception_anywhere_in_the_custom_rule():
+    """Adversarial: the literal shapes a widening would take."""
+    collapsed = _collapse(_rule_block(CUSTOM_RULE_NAME))
+    for widened in ('"/api/*"', '"/api/"', '"/api"', '"/api/rigor/"', "STARTS_WITH", "CONTAINS"):
+        assert widened not in collapsed, f"exception widened to {widened} — every other route loses the 8 KB ceiling"
+
+
+# ── 3. Ordering ──────────────────────────────────────────────────────────
+
+
+def test_custom_rule_is_evaluated_after_the_managed_group_and_before_the_rest():
+    crs_priority = _priority(_rule_block(CRS_RULE_NAME))
+    custom_priority = _priority(_rule_block(CUSTOM_RULE_NAME))
+    assert custom_priority > crs_priority, (
+        "WAF evaluates by ascending priority; the replacement must run AFTER the group whose rule it replaces"
+    )
+    for name, expected in DOWNSTREAM_MANAGED_PRIORITIES.items():
+        downstream = _priority(_rule_block(name))
+        assert downstream == expected, f"{name} priority moved ({downstream} != {expected})"
+        assert custom_priority < downstream, f"the replacement must run before {name}, not be buried behind it"
+
+
+# ── 4. The application owns the real ceiling ─────────────────────────────
+
+
+def _rows(n: int) -> list[dict]:
+    base = datetime(2024, 1, 1)
+    return [
+        {"date": (base + timedelta(days=i)).date().isoformat(), "daily_return": round(-0.0031 + i * 1e-6, 6)}
+        for i in range(n)
+    ]
+
+
+def test_boundary_measurement_from_the_issue_still_holds():
+    """One trading year really does exceed the 8 KB edge limit — the whole premise."""
+    year = len(json.dumps({"returns": _rows(252), "trials": 1}, separators=(",", ":")).encode())
+    assert year > REGIONAL_BODY_INSPECTION_LIMIT, (
+        f"252 rows serialise to {year} B; the issue's premise is that this exceeds {REGIONAL_BODY_INSPECTION_LIMIT}"
+    )
+    assert 8_192 < year < 20_000, f"252 rows = {year} B, outside the measured band"
+
+
+def test_a_decade_of_daily_bars_fits_under_the_cap():
+    assert _MAX_RETURN_ROWS == 2600
+    assert _MAX_RETURN_ROWS >= 10 * 252, "the cap must admit ten years of daily bars"
+    payload = len(json.dumps({"returns": _rows(_MAX_RETURN_ROWS), "trials": 1}, separators=(",", ":")).encode())
+    assert 100_000 < payload < 200_000, (
+        f"a full-cap payload is {payload} B; the ~135 KB claim in the code comment is wrong"
+    )
+
+
+def test_schema_accepts_one_trading_year():
+    model = RigorVerifyRequest(returns=_rows(252), trials=1)
+    assert len(model.returns) == 252
+
+
+def test_schema_accepts_exactly_the_cap():
+    assert len(RigorVerifyRequest(returns=_rows(_MAX_RETURN_ROWS)).returns) == _MAX_RETURN_ROWS
+
+
+def test_schema_rejects_one_row_over_the_cap_with_a_message_that_names_the_limit():
+    with pytest.raises(ValidationError) as excinfo:
+        RigorVerifyRequest(returns=_rows(_MAX_RETURN_ROWS + 1))
+    message = str(excinfo.value)
+    assert str(_MAX_RETURN_ROWS) in message
+    assert str(_MAX_RETURN_ROWS + 1) in message, "the error must say how many rows were sent"
+
+
+def test_max_length_is_declared_on_the_field_as_the_backstop():
+    """The validator produces the message; max_length is the contract in the OpenAPI schema."""
+    schema = RigorVerifyRequest.model_json_schema()
+    assert schema["properties"]["returns"]["maxItems"] == _MAX_RETURN_ROWS
+    assert schema["properties"]["returns"]["minItems"] == 1
+
+
+# ── 5. …and returns a 422 over HTTP, not a truncation or a silent accept ──
+
+
+@pytest.fixture()
+def app():
+    application = FastAPI()
+    application.middleware("http")(account_auth.better_auth_session_middleware)
+    application.include_router(rigor_verify_routes.rigor_verify_router)
+    return application
+
+
+def _sign_in(monkeypatch, user_id: str = "user-1"):
+    async def fetch(_request):
+        return {
+            "user": {"id": user_id, "name": user_id, "email": f"{user_id}@example.com", "emailVerified": True},
+            "session": {"id": f"s-{user_id}", "expiresAt": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+        }
+
+    monkeypatch.setattr(account_auth, "_fetch_session", fetch)
+
+
+@pytest.mark.asyncio
+async def test_over_cap_payload_is_a_422_over_http(app, monkeypatch):
+    _sign_in(monkeypatch)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"cookie": "better-auth.session_token=opaque", "host": "archimedes-arc.com"},
+    ) as client:
+        resp = await client.post("/api/rigor/verify", json={"returns": _rows(_MAX_RETURN_ROWS + 1), "trials": 1})
+    assert resp.status_code == 422
+    assert str(_MAX_RETURN_ROWS) in json.dumps(resp.json())

--- a/infra/waf.tf
+++ b/infra/waf.tf
@@ -55,6 +55,47 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         vendor_name = "AWS"
         name        = "AWSManagedRulesCommonRuleSet"
+
+        # ── #1749: SizeRestrictions_BODY, counted not blocked ──────────
+        #
+        # The managed CRS rule `SizeRestrictions_BODY` blocks any request whose
+        # body exceeds the WAF body-inspection limit for the protected resource
+        # — 8,192 bytes for a REGIONAL web ACL on an Application Load Balancer.
+        # POST /api/rigor/verify carries one JSON object per bar — shape
+        # {"date": "...", "daily_return": ...} — so payload size is linear in the
+        # sample size. Dogfood 2026-09-01 (agent-cli), deterministic:
+        #
+        #     160 rows / 8,076 B -> 200      MEASURED
+        #     165 rows / 8,326 B -> 403      MEASURED (HTML from awselb/2.0,
+        #                                    not a FastAPI error body)
+        #     252 rows            -> 403     MEASURED, every time <- ONE YEAR
+        #
+        # Those two measured points give 50.5 bytes/row including the envelope
+        # ((8,326 - 8,076) / 5 = 50.0; 8,076 / 160 = 50.5), so the 8,192-byte
+        # limit is crossed at ~163 rows and a 252-bar year is ~12.7 KB
+        # (extrapolated, not measured).
+        #
+        # i.e. the endpoint whose whole purpose is DSR/OOS statistical power
+        # rejects exactly the sample size that gives it power.
+        #
+        # Overriding the rule to `count` here does NOT drop the 8 KB ceiling
+        # site-wide: the custom `oversize-body-except-rigor-verify` rule at
+        # priority 11 (immediately below) re-imposes it for every path EXCEPT
+        # /api/rigor/verify. Count (rather than deleting the rule) keeps the
+        # managed rule's CloudWatch metric and `awswaf:managed:aws:core-rule-set:
+        # SizeRestrictions_Body` label, so oversize traffic stays observable.
+        #
+        # Only this ONE rule is overridden. Every other CRS rule — XSS, LFI,
+        # RFI, the other SizeRestrictions_* (URI/QUERYSTRING/COOKIE_HEADER),
+        # NoUserAgent_HEADER, … — still BLOCKS on every path, /api/rigor/verify
+        # included. Guarded by backend/tests/test_waf_verify_body.py.
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 
@@ -62,6 +103,94 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
       cloudwatch_metrics_enabled = true
       metric_name                = "${var.project_name}-core-rules"
+    }
+  }
+
+  # ── #1749: re-impose the 8 KB body ceiling everywhere but the verify path ──
+  #
+  # Priority 11: evaluated immediately after the CRS group above, before
+  # known-bad-inputs (20), ip-reputation (30) and sqli (40). Blocks any request
+  # whose body exceeds the same 8,192 bytes the managed rule enforced, UNLESS
+  # the URI path is exactly /api/rigor/verify.
+  #
+  # Mechanism (AWS WAF "Oversize handling for request components"): on a
+  # REGIONAL web ACL protecting an ALB, only the first 8,192 bytes of a body are
+  # forwarded to WAF, so the GT-8192 comparison can never be satisfied by the
+  # INSPECTED portion alone. `oversize_handling = "MATCH"` is what actually
+  # fires: a body larger than the inspection limit is treated as matching the
+  # statement. The GT comparison is kept as a belt-and-braces backstop in case
+  # the inspection limit is ever raised (see the association_config note at the
+  # bottom of this file). Either way the effective condition is "body > 8 KB".
+  #
+  # The exception is EXACTLY one literal path, not a prefix: `positional_
+  # constraint = "EXACTLY"` on uri_path. /api/rigor/verifyX, /api/rigor/verify/2
+  # and every other /api/* route keep the 8 KB ceiling. The narrowing is
+  # defensible because the route is auth-gated (require_current_user,
+  # rigor_verify_routes.py) and its schema is closed — a list of
+  # {date: str, daily_return: float} with an explicit 2,600-row cap
+  # (rigor_verify_routes._MAX_RETURN_ROWS), so the application, not the edge,
+  # owns the real ceiling and fails closed at a number we chose.
+  #
+  # KNOWN CONSEQUENCE (documented, NOT fixed here): the ALB body-inspection
+  # limit stays at 8,192 bytes, so on /api/rigor/verify the CRS / SQLi /
+  # known-bad-inputs signatures still see only the FIRST 8 KB of the body. Bytes
+  # past 8,192 on that one path reach the application un-inspected. It cannot be
+  # raised for this resource — see the association_config note at the bottom of
+  # this file for the verification.
+  rule {
+    name     = "oversize-body-except-rigor-verify"
+    priority = 11
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            comparison_operator = "GT"
+            size                = 8192
+
+            field_to_match {
+              body {
+                oversize_handling = "MATCH"
+              }
+            }
+
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                search_string         = "/api/rigor/verify"
+                positional_constraint = "EXACTLY"
+
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project_name}-oversize-body"
     }
   }
 
@@ -194,6 +323,42 @@ resource "aws_wafv2_web_acl" "main" {
 }
 
 # ── Associate WAF with ALB ───────────────────────────────────
+#
+# #1749 — why there is NO `association_config { request_body { ... } }` on
+# aws_wafv2_web_acl.main:
+#
+# The scope IS "REGIONAL", which is one of the two preconditions for raising the
+# body-inspection limit above 8 KB. The other is that the ASSOCIATED RESOURCE
+# TYPE supports it, and an Application Load Balancer does not.
+#
+# Verified locally against the provider schema this stack resolves to
+# (`terraform init -backend=false` under `~> 5.0` from infra/main.tf picks
+# hashicorp/aws v5.100.0), by adding each candidate block and running
+# `terraform validate`:
+#
+#     api_gateway               Success! The configuration is valid.
+#     app_runner_service        Success! The configuration is valid.
+#     cloudfront                Success! The configuration is valid.
+#     cognito_user_pool         Success! The configuration is valid.
+#     verified_access_instance  Success! The configuration is valid.
+#     application_load_balancer Blocks of type "application_load_balancer" are
+#                               not expected here.
+#     alb / load_balancer       (same error)
+#
+# There is no ALB form of the setting to write, which matches the AWS docs:
+# `default_size_inspection_limit` (KB_16/KB_32/KB_48/KB_64) is offered for
+# CloudFront, API Gateway, Cognito user pools, App Runner and Verified Access —
+# not for Application Load Balancers, whose regional body-inspection limit is
+# fixed at 8,192 bytes.
+#
+# CONSEQUENCE, stated plainly: a 13 KB verify payload now REACHES the
+# application (that is the fix), but WAF's signature rules will have inspected
+# only its first 8 KB. On /api/rigor/verify — an authenticated route
+# (require_current_user) with a closed schema (list of {date, daily_return}) and
+# a 2,600-row application-side cap — that residual is bounded and accepted.
+# Full-body inspection there would require moving the enforcement point off the
+# ALB entirely (e.g. onto CloudFront, cloudfront.tf), which is a different
+# change with its own WCU cost.
 
 resource "aws_wafv2_web_acl_association" "main" {
   resource_arn = aws_lb.main.arn


### PR DESCRIPTION
Closes #1749 (WAF half + the application cap; the CLI error-mapping half is left open — see "Not in this PR").

## The boundary, measured

`AWSManagedRulesCommonRuleSet` is attached to the ALB in full BLOCK mode with **no `rule_action_override` and no `scope_down_statement`** (`infra/waf.tf:46-66` before this change). Its `SizeRestrictions_BODY` rule blocks any body over the WAF body-inspection limit for a REGIONAL web ACL — 8,192 bytes. `POST /api/rigor/verify` serialises one `{date, daily_return}` object per bar and had **no `max_length`** (`rigor_verify_routes.py:120-126`).

Dogfood 2026-09-01 (agent-cli), deterministic:

| rows | bytes | result | |
|---|---|---|---|
| 160 | 8,076 | `200` | measured |
| 165 | 8,326 | `403` | measured — HTML from `awselb/2.0`, not a FastAPI error body |
| 252 | — | `403` **every time** | measured — **one trading year** |

Those two measured points give **50.5 B/row** including the envelope (`8,076 / 160 = 50.5`; `(8,326 − 8,076) / 5 = 50.0`), so 8,192 is crossed at **~163 rows** and a 252-bar year is ~12.7 KB (extrapolated, not measured). `8,076 < 8,192 < 8,326`.

The endpoint whose entire purpose is DSR/OOS statistical power rejected exactly the sample size that gives it power.

## Design choice: scoped, not a blanket override

A bare `rule_action_override → count` on `SizeRestrictions_BODY` fixes the 403 and **drops the 8 KB body ceiling for the whole site** — a real DoS/parser-abuse control. So the override is paired with a replacement:

1. **`rule_action_override { name = "SizeRestrictions_BODY"; action_to_use { count {} } }`** on the CRS group (priority 10). `count` rather than deletion keeps the managed rule's CloudWatch metric and `awswaf:managed:aws:core-rule-set:SizeRestrictions_Body` label, so oversize traffic stays observable. **Only this one rule** is softened — XSS, LFI, RFI, the other `SizeRestrictions_*`, `NoUserAgent_HEADER` etc. still block on every path including `/api/rigor/verify`, and `override_action { none {} }` on the group itself is untouched.
2. **New custom rule `oversize-body-except-rigor-verify`, priority 11** — immediately after the group it replaces, before `aws-known-bad-inputs` (20) / `aws-ip-reputation` (30) / `aws-sqli` (40). `and_statement` of a `size_constraint_statement` on `body` (`GT 8192`, `oversize_handling = "MATCH"`) AND a `not_statement` around a `byte_match_statement` on `uri_path`, `search_string = "/api/rigor/verify"`, `positional_constraint = "EXACTLY"`. Every other route keeps the 8 KB ceiling.

   Mechanism, per AWS's "Oversize handling for request components": on a REGIONAL ACL protecting an ALB only the first 8,192 bytes reach WAF, so the `GT 8192` comparison can never be satisfied by the *inspected* portion alone — `oversize_handling = "MATCH"` is what actually fires on a >8 KB body. The `GT` comparison is kept as a backstop in case the limit is ever raised. **Not verified without an apply:** which of the two conditions fires in the live ACL. Either way the effective condition is "body > 8 KB".

   `EXACTLY`, not a prefix, is load-bearing: `/api/rigor/verifyX` and `/api/rigor/verify/2` keep the ceiling. The narrowing is defensible because the route is auth-gated (`require_current_user`) and its schema is closed.

3. **Application-side cap** (`rigor_verify_routes.py`): `returns` is capped at `_MAX_RETURN_ROWS = 2600` — ten years of daily bars (10 × 252 = 2,520 plus calendar headroom), **~122 KB measured** at 6-decimal returns, ~131 KB extrapolated at the production 50.5 B/row. `max_length` carries the declarative contract into the OpenAPI schema; a `mode="before"` field validator runs first and produces the actual message, because pydantic's own `"List should have at most 2600 items after validation"` tells the caller nothing:

   > `returns has 2601 rows; the maximum is 2600 (~10 years of daily bars). This is a payload cap, not a statistical one: split the series or aggregate to a coarser frequency.`

   **What that cap is and is not** (corrected in review — the first draft of this PR claimed a decade was "the honest outer edge of what a daily-bar rigor verdict can claim" and that ~122 KB sits "comfortably inside FastAPI/uvicorn's defaults"; both were wrong):

   - It is a **row** cap, not a byte ceiling, and it is applied **post-parse**. FastAPI's request handler does `await request.body()` / `await request.json()` *before* `solve_dependencies`, so the whole body is buffered and `json.loads`'d before `require_current_user` and before this validator runs. An over-cap — or unauthenticated — request is still parsed in full first.
   - FastAPI and uvicorn have **no** request-body size default; there was nothing to be "inside". With the WAF exception in place the only **byte** ceiling left on this path is nginx's implicit 1 MB `client_max_body_size` (`nginx/nginx.conf` sets none; nginx is the ALB target, `infra/ecs.tf:949-952`). That residual — ~1 MB against nginx's own `limit_req api_read 60r/m burst=20`, under the 1000/5min WAF rate rule — is bounded and accepted here; an explicit `client_max_body_size` is the right hardening but is a second logical change (see "Not in this PR").
   - The cap is not statistical: `compute_dsr_hac_and_iid` / `compute_oos_sharpe` are fine over 3,000 bars and nothing in the module derives a 10-year validity horizon. 2,600 is a size choice, and the 422 now says so.

### `association_config` — verified, then deliberately omitted

The scope IS `REGIONAL`, but the associated resource type must also support raising the limit. **Verified locally** against the provider this stack resolves to (`terraform init -backend=false` under `~> 5.0` from `infra/main.tf` → `hashicorp/aws v5.100.0`), by writing each candidate block into `aws_wafv2_web_acl.association_config.request_body` and running `terraform validate`:

```
api_gateway                 Success! The configuration is valid.
app_runner_service          Success! The configuration is valid.
cloudfront                  Success! The configuration is valid.
cognito_user_pool           Success! The configuration is valid.
verified_access_instance    Success! The configuration is valid.

application_load_balancer   Error: Unsupported block type
                            Blocks of type "application_load_balancer" are not expected here.
alb / load_balancer         (same error)
```

There is no ALB form of `default_size_inspection_limit` to write, matching the AWS docs. **Independently reproduced in review** on a scratch copy against the same 5.100.0 — `application_load_balancer` / `alb` / `load_balancer` all `Unsupported block type`, the other five valid — so this is settled, not an inference. **Consequence, stated plainly:** the ALB body-inspection limit stays at 8,192 bytes. A 13 KB verify payload now *reaches* the application (that is the fix), but WAF's signature rules will have inspected only its first 8 KB — bytes past 8,192 on that one path arrive un-inspected. On an authenticated route with a closed schema and a 2,600-row cap that residual is bounded and accepted. Full-body inspection there would mean moving enforcement onto CloudFront, a different change with its own WCU cost.

## Guards, shown red on the input they reject

`backend/tests/test_waf_verify_body.py` — 15 tests, hermetic (parses `infra/waf.tf` as HCL and exercises the model + router over in-process ASGI; no AWS, no terraform binary, no network, no DB). `terraform validate` catches none of this: a deleted override, an override on the wrong rule name, a prefix-widened exception, an **inverted NOT/AND nesting** and a rule ordered ahead of the group are all valid HCL.

The rule's statement **tree is parsed and asserted node by node**, not substring-matched. Review caught the first version of these guards passing the one mutation that is a site-wide outage (V1 below): the only nesting assertion was `"and_statement" in _collapse(rule)`, and that string survives inversion. The guard now asserts `rule.statement` **is** the `and_statement`; that its two branches are a `size_constraint_statement` and a `not_statement` **as siblings**; that no `size_constraint_statement` appears anywhere beneath the `not_statement`; and that the whole rule holds exactly one and/not/size/byte_match and zero `or_statement`. Attribute reads (`GT`, `8192`, `oversize_handling`, `EXACTLY`, `uri_path`, `text_transformation NONE`) bind to the block that owns them.

**V1 — invert the nesting: `not_statement` WRAPS the `and_statement`** (the outage case; `terraform validate` **Success**, `terraform fmt -check` clean, and it passed all 14 of the previous guards)

```
E   AssertionError: rule.statement must contain exactly one block, `and_statement {...}`; got ['not_statement']
FAILED test_custom_rule_blocks_oversize_bodies
FAILED test_the_exception_is_exactly_the_verify_path_and_is_negated
FAILED test_the_negation_is_a_sibling_of_the_size_test_not_a_wrapper
3 failed, 12 passed          (pytest exit 1)
```

What it would have meant applied: `NOT(body > 8 KB AND path != /api/rigor/verify)` — block every request site-wide **except** an oversize POST to `/api/rigor/verify`.

**V1b — negate the SIZE test instead of the path** (`terraform validate` Success)

```
E   AssertionError: the and_statement's two branches must be a size_constraint_statement and a not_statement, as SIBLINGS; got ['byte_match_statement', 'not_statement']
FAILED test_custom_rule_blocks_oversize_bodies
FAILED test_the_exception_is_exactly_the_verify_path_and_is_negated
FAILED test_the_negation_is_a_sibling_of_the_size_test_not_a_wrapper
3 failed, 12 passed          (pytest exit 1)
```

**M1 — delete the `rule_action_override`**
```
E   AssertionError: no 'rule_action_override' block found — the scoped WAF fix for #1749 is gone
E   AssertionError: exactly one managed rule may be overridden (SizeRestrictions_BODY); found []
E   assert [] == ['SizeRestrictions_BODY']
FAILED test_size_restrictions_body_is_overridden_to_count_on_the_crs_group
FAILED test_no_other_managed_rule_is_overridden_anywhere_in_the_web_acl
2 failed, 13 passed          (pytest exit 1)
```

**M2 — widen the exception to `/api/` `STARTS_WITH`**
```
E   AssertionError: the exception must be the literal path /api/rigor/verify; got: search_string = "/api/" positional_constraint = "STARTS_WITH" field_to_match { } text_transformation { }
E   AssertionError: exception widened to "/api/" — every other route loses the 8 KB ceiling
FAILED test_the_exception_is_exactly_the_verify_path_and_is_negated
FAILED test_no_wildcard_or_prefix_exception_anywhere_in_the_custom_rule
2 failed, 13 passed          (pytest exit 1)
```

**M3 — order the custom rule ahead of the group (priority 5)**
```
E   AssertionError: WAF evaluates by ascending priority; the replacement must run AFTER the group whose rule it replaces
E   assert 5 > 10
FAILED test_custom_rule_is_evaluated_after_the_managed_group_and_before_the_rest
1 failed, 14 passed          (pytest exit 1)
```

**M4 — sneak a second managed-rule override in (`NoUserAgent_HEADER`)**
```
E   AssertionError: the CRS override must name SizeRestrictions_BODY; got: name = "NoUserAgent_HEADER" action_to_use { count {} }
E   AssertionError: exactly one managed rule may be overridden (SizeRestrictions_BODY); found ['NoUserAgent_HEADER', 'SizeRestrictions_BODY']
FAILED test_size_restrictions_body_is_overridden_to_count_on_the_crs_group
FAILED test_no_other_managed_rule_is_overridden_anywhere_in_the_web_acl
2 failed, 13 passed          (pytest exit 1)
```

**M5 — drop the application row cap (`max_length` + validator)**
```
E   Failed: DID NOT RAISE <class 'pydantic_core._pydantic_core.ValidationError'>
E   KeyError: 'maxItems'
E   assert 200 == 422
FAILED test_schema_rejects_one_row_over_the_cap_with_a_message_that_names_the_limit
FAILED test_max_length_is_declared_on_the_field_as_the_backstop
FAILED test_over_cap_payload_is_a_422_over_http
3 failed, 12 passed          (pytest exit 1)
```

M2's `got:` line now prints the byte_match block's own attributes rather than a flattened blob, because the read is scoped to that block. All seven mutations reverted; tree is the committed state.

## Runs (green)

```
pytest backend/tests/test_waf_verify_body.py backend/tests/test_rigor_verify_routes.py
    30 passed          (exit 0)

ruff check   backend/tests/test_waf_verify_body.py backend/archimedes/api/rigor_verify_routes.py   All checks passed!
ruff format --check (same two files)                                                               2 files already formatted
ruff check backend/                          37 errors — byte-identical to origin/main, none in these files

terraform fmt -check -recursive infra/       (clean)
terraform validate                           Success! The configuration is valid.
```

## Owner apply step

The terraform half is **not live until applied**:

```
infra/apply.sh              # plan first
infra/apply.sh --apply
```

Expected plan: **one resource change only** — `aws_wafv2_web_acl.main` updated in place (the `rule_action_override` added to the `aws-core-rules` group, plus the new `oversize-body-except-rigor-verify` rule at priority 11). No ALB, ECS, Aurora or association changes. `terraform init` is needed first if the working copy has not been initialised since the `archive` provider was added (`infra/main.tf`). Anything else in the plan means drift unrelated to this PR — stop and read it.

**Post-apply confirmation the guard cannot give** (nobody has seen the fixed path go green at the edge yet — no apply was run from this branch): re-run the 252-row verify against prod and confirm `200`, then confirm a 9 KB body to any *other* `/api/*` route still `403`s. Worth also reading the ACL's sampled requests for `terminatingRuleId`.

**The "firing rule was inferred, not read from logs" caveat is now retired.** The earlier draft called the override name a guess. Reviewed by elimination instead: `infra/cloudfront.tf:75-114` shows the CLOUDFRONT-scope ACL holds **only** a rate-based rule, and the distribution has no `origin_path` — so a byte-deterministic 403 served by `awselb/2.0` can only come from the regional ALB ACL, where `SizeRestrictions_BODY` is the **only** rule keyed on a byte threshold (the rate-based, KnownBadInputs, IpReputation and SQLi rules have none). The override names the right rule. The sampled-requests check is still worth doing; it is no longer a coin flip.

## Not in this PR

- **CLI error mapping.** #1749 also asks that an `awselb/2.0` 403 surface as a distinct payload-too-large error instead of a generic `exit 2 http_error`. Separate file, separate logical change; the issue stays open for it.
- **The inspection limit** — see above; there is nothing to write for an ALB.
- **An explicit `client_max_body_size` in `nginx/nginx.conf`.** The 1 MB implicit default is the only byte ceiling left on this path; pinning it is the right hardening, but it is a second logical change.
- **`PBORequest.returns_matrix`** (`selection_bias_routes.py:257-260`) carries a *trial matrix* — structurally many times larger than one series, with no cap on rows, columns or `s_partitions` — and is **not** in this WAF exception, so it is almost certainly 403ing at the same 8,192-byte boundary today. That is the endpoint this route's own PBO `not_evaluable` reason points callers at. Needs its own issue.

### Considered and rejected: keying the exception on the CRS label

`label_match_statement` on `awswaf:managed:aws:core-rule-set:SizeRestrictions_Body` would be tidier, but it fails **open**: if the label name is wrong the rule never fires and the 8 KB ceiling is silently gone site-wide. The self-contained `size_constraint_statement` here fails **closed** — if anything about it is wrong, verify keeps 403ing and nothing widens. Owner ruling: keep the self-contained shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.

