### PR TITLE
[ux] rejected strategy cards state their own rigor-gate reason

### DIFF
--- a/backend/archimedes/api/strategies_routes.py
+++ b/backend/archimedes/api/strategies_routes.py
@@ -831,9 +831,17 @@ async def list_generated_strategies(
                 [p.get("arxiv_id") for d in page for p in (d.get("source_papers") or []) if isinstance(p, dict)],
                 session,
             )
+            # Each row's OWN rejection reasons, derived from the rigor_verdict
+            # blob `to_dict()` already decoded above — a pure function, zero
+            # extra queries, so the page cost is unchanged (the Library's
+            # "Rejected — did not pass the rigor gate" cards used to share one
+            # paragraph of guessed prose because this field did not exist).
+            from archimedes.services.rigor_reasons import rigor_reasons_for_verdict
+
             rows = []
             for d in page:
                 d["source_papers"] = _resolve_source_papers(d.get("source_papers"), corpus_meta)
+                d["rigor_reasons"] = rigor_reasons_for_verdict(d.get("rigor_verdict"))
                 rows.append(_redact_owner_wallet(d, caller))
     except Exception as exc:
         # Full exception detail is logged server-side only — never echoed to

--- a/backend/archimedes/services/rigor_reasons.py
+++ b/backend/archimedes/services/rigor_reasons.py
@@ -9,9 +9,15 @@ for a DIFFERENT reason the surface stated something false about that strategy.
 
 This module turns a strategy's OWN stored ``rigor_verdict`` into a per-check
 report the card can render. That blob is the JSON in
-``StrategyRecord.rigor_verdict``, written by
-``generation_pipeline._rigor_verdict_for`` on the buy-and-hold/agent path and by
-``debate_engine._rigor_verdict_dict`` on the fusion/debate path.
+``StrategyRecord.rigor_verdict``. On today's live write paths it comes from
+``debate_engine._rigor_verdict_dict`` (the graded fusion/debate verdict, the only
+writer of the four-state ``look_ahead_status``), from
+``debate_engine._abstain_result`` and ``generation_pipeline``'s fixture branch
+(both non-graded, both carrying a verbatim ``reason``), and is then patched by
+``generation_pipeline._patch_pbo`` / ``_patch_dsr_with_pool_correlation``.
+``generation_pipeline._rigor_verdict_for`` — the writer of the too-short-series
+branch — currently has NO production callers (repo-wide, only its own ``def``
+and tests), so the shapes it produces are reachable only on STORED rows.
 
 It is a PURE function over a dict the caller already holds — no DB read, no gate
 re-run — so a list route calls it once per row and adds ZERO queries to the page
@@ -34,13 +40,20 @@ Honesty rules this module keeps
 * ``recorded_reason`` is the verdict's own ``reason`` string, verbatim. The
   pipeline writes it exactly for the branches where the gate did NOT grade the
   candidate at all — return series too short, fixture mode, debate abstain. When
-  it is present it IS this strategy's reason and no derived sentence replaces it.
+  it is present it IS this strategy's reason and no derived sentence replaces it,
+  AND no numeric leg on that blob is reported as a graded result: the numbers
+  sitting on an ungraded verdict are defaults (``_patch_pbo`` stamps ``pbo=0.0``
+  as "undefined for N<2" on exactly these candidates), and printing a default as
+  a passed check is the same overclaim this module exists to remove.
 * ``unattributed`` is True when a row did not pass yet no recorded check fails
   the bar above. The surface then says exactly that instead of naming a culprit
-  it cannot support. This is reachable, not theoretical: the agent path's own
-  ``passing`` uses a STRICTER DSR bar (0.95, hardcoded in ``_rigor_verdict_for``)
-  than the badge profile's ``dsr_p_min`` (0.90), so a p-value in [0.90, 0.95)
-  lands a rejected row with every badge-bar check clear.
+  it cannot support. The known source of that gap is a DSR-bar divergence: the
+  agent path's ``passing`` uses a STRICTER 0.95 (hardcoded in
+  ``_rigor_verdict_for``) than the badge profile's ``dsr_p_min`` (0.90), so a
+  p-value in [0.90, 0.95) lands a rejected row with every badge-bar check clear.
+  With ``_rigor_verdict_for`` currently uncalled in production that shape reaches
+  the surface via stored rows rather than new writes — the state is still
+  rendered, because a row the surface cannot attribute must say so either way.
 """
 
 from __future__ import annotations
@@ -76,6 +89,11 @@ MIN_RETURNS_FOR_GATE = 10
 # branches. Matching them yields a stable ``reason_code`` the frontend can
 # classify on without string-matching prose in JS. An unrecognised reason gets
 # ``reason_code = None`` and is still surfaced verbatim — never dropped.
+#
+# ``SHORT_SERIES_REASON``'s only writer is ``_rigor_verdict_for``, which has no
+# production callers today, so it matches STORED rows only — the short-series
+# summary sentence on the frontend is a legacy path, not one new rows enter.
+# ``FIXTURE_REASON`` is written inline by the fixture branch and is live.
 SHORT_SERIES_REASON = "return series too short for rigor evaluation"
 FIXTURE_REASON = "fixture mode — no LLM call, rigor gate not run"
 
@@ -173,18 +191,22 @@ def _oos_cliff_check(verdict: dict[str, Any], profile) -> dict[str, Any]:
     """The in-/out-of-sample cliff leg.
 
     The gate only applies this ratio when there is a POSITIVE in-sample Sharpe to
-    divide by (``_rigor_verdict_for`` / ``fusion_evaluator``'s
-    ``in_sample_sharpe > 0`` guard). With no such reference the check did not run
-    — reported as not-computed, not as a pass it never earned.
+    divide by (the ``in_sample_sharpe > 0`` guard in ``_rigor_verdict_for`` and in
+    the fusion evaluator's cliff leg). With no such reference — or with no
+    out-of-sample Sharpe to divide — the check did not run, and is reported as
+    not-computed naming the side that is missing, never as a pass it never earned.
     """
     label = "Out-of-sample / in-sample ratio"
     bar = profile.oos_is_ratio_min
     oos = _finite(verdict.get("oos_sharpe"))
     in_sample = _finite(verdict.get("in_sample_sharpe"))
     if oos is None or in_sample is None or in_sample <= 0:
-        return _check(
-            "oos_is_ratio", label, NOT_COMPUTED, "no positive in-sample Sharpe to compare against", threshold=bar
+        # Name the side that is actually missing. "No positive in-sample Sharpe"
+        # is false on a row that HAS one (say 1.20) and is missing the OOS leg.
+        detail = (
+            "no out-of-sample Sharpe to compare" if oos is None else "no positive in-sample Sharpe to compare against"
         )
+        return _check("oos_is_ratio", label, NOT_COMPUTED, detail, threshold=bar)
     ratio = oos / in_sample
     if ratio >= bar:
         return _check("oos_is_ratio", label, PASS, f"{ratio:.2f} ≥ {bar:.2f} required", value=ratio, threshold=bar)
@@ -201,23 +223,45 @@ def _oos_cliff_check(verdict: dict[str, Any], profile) -> dict[str, Any]:
 def _look_ahead_check(verdict: dict[str, Any], *, has_recorded_reason: bool) -> dict[str, Any]:
     """The look-ahead leg, four-state where the writer supplied four states.
 
-    ``look_ahead_status`` (fusion/debate path) is the honest four-state verdict;
-    ``lookahead_audit_passed`` is the fail-closed boolean every path writes. A
-    bare ``False`` is a real audit finding ONLY when the gate actually graded
-    this candidate — on a row whose verdict carries its own ``reason`` the gate
-    never ran, and reporting "the audit found a leak" there would invent a
-    finding out of a default.
+    ``look_ahead_status`` (fusion/debate path) is the honest four-state verdict
+    and is the ONLY field a rendered claim may key off. ``lookahead_audit_passed``
+    is the fail-closed boolean every path writes, and neither of its values is an
+    audit result on its own:
+
+    * a bare ``False`` is a real audit finding ONLY when the gate actually graded
+      this candidate — on a row whose verdict carries its own ``reason`` the gate
+      never ran, and reporting "the audit found a leak" there would invent a
+      finding out of a default;
+    * a bare ``True`` is never a finding at all — it is what the agent path
+      writes when nothing auditable was found to audit.
     """
     label = "Look-ahead audit"
     status = verdict.get("look_ahead_status")
     reason = verdict.get("look_ahead_reason")
-    if status == PASS or bool(verdict.get("lookahead_audit_passed")):
+    if status == PASS:
         return _check("look_ahead", label, PASS, "no forward-looking data access found")
     if status in _LA_INCONCLUSIVE:
         detail = reason.strip() if isinstance(reason, str) and reason.strip() else "the audit reached no verdict"
         return _check("look_ahead", label, NOT_COMPUTED, f"{detail} — blocks admission (fail-closed)")
     if has_recorded_reason:
         return _check("look_ahead", label, NOT_COMPUTED, "not run — see the reason on record")
+    if verdict.get("lookahead_audit_passed") is True:
+        # A bare ``True`` with no four-state status is a DEFAULT, not an audit
+        # result. ``_lookahead_for_candidate`` is documented as "vacuously True
+        # when none expose auditable source" (generation_pipeline.py:622), and
+        # the repo has explicitly retired this rendering:
+        # ``dsl_lookahead_audit.verdict_from_persisted_row`` refuses to honour a
+        # stored True because "the alternative is a live surface showing
+        # 'look_ahead: PASS' on the strength of a sentence an LLM wrote about
+        # itself". Any look-ahead CLAIM keys off ``look_ahead_status``
+        # (debate_engine.py:770-773) — which the fusion writer always sets, so no
+        # conclusive row reaches this branch.
+        return _check(
+            "look_ahead",
+            label,
+            NOT_COMPUTED,
+            "no four-state audit verdict on record — the stored boolean is not an audit result",
+        )
     if verdict.get("lookahead_audit_passed") is False:
         return _check("look_ahead", label, FAIL, "the audit found a forward-looking pattern")
     return _check("look_ahead", label, NOT_COMPUTED, "no look-ahead audit result on record")
@@ -266,6 +310,24 @@ def rigor_reasons_for_verdict(verdict: Any) -> dict[str, Any] | None:
         _oos_cliff_check(verdict, profile),
         _look_ahead_check(verdict, has_recorded_reason=bool(recorded_reason)),
     ]
+    # A verdict that carries its own ``reason`` was NEVER GRADED — the pipeline
+    # writes that string exactly for the branches where the gate did not run
+    # (too-short series, fixture mode, debate abstain). Numbers left on such a
+    # blob are defaults, not measurements: ``_patch_pbo``
+    # (agents/generation_pipeline.py:660) stamps ``pbo = 0.0  # PBO undefined
+    # for N<2`` onto every one of those candidates (they are all
+    # ``has_real_rigor=False``, so they are all in its ``agent_cands``), and
+    # patches ``0.0`` in for any agent candidate missing from the CSCV map even
+    # when N≥2. Reporting that sentinel as "PBO 0.00 < 0.50 required — passed"
+    # claims an overfitting evaluation that never happened, which is the exact
+    # class of overclaim this module exists to remove. The look-ahead leg is
+    # excluded because ``_look_ahead_check`` already handles the recorded-reason
+    # case with its own wording.
+    if recorded_reason:
+        for c in checks:
+            if c["key"] != "look_ahead" and c["status"] != NOT_COMPUTED:
+                c.update(status=NOT_COMPUTED, detail="not scored — see the reason on record", value=None)
+
     passing = bool(verdict.get("passing"))
     any_failed = any(c["status"] == FAIL for c in checks)
 

--- a/backend/archimedes/services/rigor_reasons.py
+++ b/backend/archimedes/services/rigor_reasons.py
@@ -1,0 +1,281 @@
+"""Per-strategy rigor-gate reasons — which checks failed, which passed, against what bar.
+
+The Library's "Rejected (N) — did not pass the rigor gate" section used to
+explain every rejected candidate with ONE shared paragraph of prose ("Most
+rejections at this stage are 'return series too short' … A longer backtest
+window typically unlocks them"). That sentence was written from a guess about
+the population, not read from any strategy's record, so for a candidate rejected
+for a DIFFERENT reason the surface stated something false about that strategy.
+
+This module turns a strategy's OWN stored ``rigor_verdict`` into a per-check
+report the card can render. That blob is the JSON in
+``StrategyRecord.rigor_verdict``, written by
+``generation_pipeline._rigor_verdict_for`` on the buy-and-hold/agent path and by
+``debate_engine._rigor_verdict_dict`` on the fusion/debate path.
+
+It is a PURE function over a dict the caller already holds — no DB read, no gate
+re-run — so a list route calls it once per row and adds ZERO queries to the page
+(see ``strategies_routes.list_generated_strategies``).
+
+Which bar
+---------
+Thresholds are read from ``rigor_profiles.get_profile(STRICTEST_LEVEL)`` — the
+Archimedes Verified bar the badge is defined against — plus the always-on
+``OOS_ABS_FLOOR``. They are never re-declared here, so the number a card prints
+is the number the gate uses.
+
+Honesty rules this module keeps
+-------------------------------
+* ``fail`` is reserved for a check that ran, produced a finite number (or a real
+  audit finding), and did not clear its bar. A check with nothing on record is
+  ``not_computed`` — never folded into ``fail`` (that would claim an evaluation
+  happened), and never counted as ``pass`` (fail-closed: it still blocks
+  admission, and the report says so).
+* ``recorded_reason`` is the verdict's own ``reason`` string, verbatim. The
+  pipeline writes it exactly for the branches where the gate did NOT grade the
+  candidate at all — return series too short, fixture mode, debate abstain. When
+  it is present it IS this strategy's reason and no derived sentence replaces it.
+* ``unattributed`` is True when a row did not pass yet no recorded check fails
+  the bar above. The surface then says exactly that instead of naming a culprit
+  it cannot support. This is reachable, not theoretical: the agent path's own
+  ``passing`` uses a STRICTER DSR bar (0.95, hardcoded in ``_rigor_verdict_for``)
+  than the badge profile's ``dsr_p_min`` (0.90), so a p-value in [0.90, 0.95)
+  lands a rejected row with every badge-bar check clear.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from archimedes.services.rigor_profiles import (
+    OOS_ABS_FLOOR,
+    STRICTEST_LEVEL,
+    get_profile,
+)
+
+# Per-check status vocabulary. Only PASS clears; NOT_COMPUTED is fail-closed
+# (it blocks admission exactly as hard as FAIL) but must never be RENDERED as a
+# failure — same distinction ``RigorGateResult.gate_details`` already draws
+# between "FAIL" and "NOT_RUN".
+PASS = "pass"
+FAIL = "fail"
+NOT_COMPUTED = "not_computed"
+
+# The badge this report grades against, named for the surface.
+BAR_NAME = "Archimedes Verified"
+
+# The gate needs at least this many persisted daily returns before it can score
+# anything. Pinned to the pipeline's own behaviour by
+# ``test_rejected_reason_payload.test_pipeline_still_writes_the_short_series_reason``
+# rather than shared as a constant, so the string and the threshold below can
+# never silently drift away from what the pipeline actually writes.
+MIN_RETURNS_FOR_GATE = 10
+
+# The verbatim ``reason`` strings the pipeline writes for its two non-graded
+# branches. Matching them yields a stable ``reason_code`` the frontend can
+# classify on without string-matching prose in JS. An unrecognised reason gets
+# ``reason_code = None`` and is still surfaced verbatim — never dropped.
+SHORT_SERIES_REASON = "return series too short for rigor evaluation"
+FIXTURE_REASON = "fixture mode — no LLM call, rigor gate not run"
+
+_REASON_CODES = {
+    SHORT_SERIES_REASON: "short_return_series",
+    FIXTURE_REASON: "fixture_mode",
+}
+
+# ``look_ahead_status`` values that are NOT verdicts (see
+# services/dsl_lookahead_audit.py). They block admission and are reported as
+# not-computed, never as a failed audit.
+_LA_INCONCLUSIVE = ("pending", "degenerate")
+
+
+def _finite(value: Any) -> float | None:
+    """Coerce to a finite float, or ``None``.
+
+    ``None``/NaN/inf/non-numeric all become ``None`` — a claim may not rest on a
+    number that isn't one. ``bool`` is rejected explicitly because ``float(True)``
+    is ``1.0``, and a boolean leg (``lookahead_audit_passed``) landing in a
+    numeric slot must not be printed as a measurement.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if math.isfinite(out) else None
+
+
+def _check(
+    key: str,
+    label: str,
+    status: str,
+    detail: str,
+    *,
+    value: float | None = None,
+    threshold: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "status": status,
+        "detail": detail,
+        "value": value,
+        "threshold": threshold,
+    }
+
+
+def _dsr_check(verdict: dict[str, Any], profile) -> dict[str, Any]:
+    label = "DSR confidence"
+    bar = profile.dsr_p_min
+    p = _finite(verdict.get("dsr_p_value"))
+    if p is None:
+        return _check("dsr", label, NOT_COMPUTED, "no deflated-Sharpe p-value on record", threshold=bar)
+    if p >= bar:
+        return _check("dsr", label, PASS, f"{p:.2f} ≥ {bar:.2f} required", value=p, threshold=bar)
+    return _check("dsr", label, FAIL, f"{p:.2f} < {bar:.2f} required", value=p, threshold=bar)
+
+
+def _pbo_check(verdict: dict[str, Any], profile) -> dict[str, Any]:
+    label = "PBO (overfitting probability)"
+    bar = profile.pbo_max
+    pbo = _finite(verdict.get("pbo"))
+    if pbo is None:
+        return _check("pbo", label, NOT_COMPUTED, "no PBO on record", threshold=bar)
+    if pbo < bar:
+        return _check("pbo", label, PASS, f"{pbo:.2f} < {bar:.2f} required", value=pbo, threshold=bar)
+    return _check(
+        "pbo", label, FAIL, f"{pbo:.2f} ≥ {bar:.2f} — at or above the overfitting ceiling", value=pbo, threshold=bar
+    )
+
+
+def _oos_floor_check(verdict: dict[str, Any]) -> dict[str, Any]:
+    label = "Out-of-sample Sharpe"
+    oos = _finite(verdict.get("oos_sharpe"))
+    if oos is None:
+        return _check("oos_sharpe", label, NOT_COMPUTED, "no out-of-sample Sharpe on record", threshold=OOS_ABS_FLOOR)
+    if oos > OOS_ABS_FLOOR:
+        return _check(
+            "oos_sharpe", label, PASS, f"{oos:.2f} > {OOS_ABS_FLOOR:.2f} required", value=oos, threshold=OOS_ABS_FLOOR
+        )
+    return _check(
+        "oos_sharpe",
+        label,
+        FAIL,
+        f"{oos:.2f} ≤ {OOS_ABS_FLOOR:.2f} — no out-of-sample edge",
+        value=oos,
+        threshold=OOS_ABS_FLOOR,
+    )
+
+
+def _oos_cliff_check(verdict: dict[str, Any], profile) -> dict[str, Any]:
+    """The in-/out-of-sample cliff leg.
+
+    The gate only applies this ratio when there is a POSITIVE in-sample Sharpe to
+    divide by (``_rigor_verdict_for`` / ``fusion_evaluator``'s
+    ``in_sample_sharpe > 0`` guard). With no such reference the check did not run
+    — reported as not-computed, not as a pass it never earned.
+    """
+    label = "Out-of-sample / in-sample ratio"
+    bar = profile.oos_is_ratio_min
+    oos = _finite(verdict.get("oos_sharpe"))
+    in_sample = _finite(verdict.get("in_sample_sharpe"))
+    if oos is None or in_sample is None or in_sample <= 0:
+        return _check(
+            "oos_is_ratio", label, NOT_COMPUTED, "no positive in-sample Sharpe to compare against", threshold=bar
+        )
+    ratio = oos / in_sample
+    if ratio >= bar:
+        return _check("oos_is_ratio", label, PASS, f"{ratio:.2f} ≥ {bar:.2f} required", value=ratio, threshold=bar)
+    return _check(
+        "oos_is_ratio",
+        label,
+        FAIL,
+        f"{ratio:.2f} < {bar:.2f} required — the edge collapses out of sample",
+        value=ratio,
+        threshold=bar,
+    )
+
+
+def _look_ahead_check(verdict: dict[str, Any], *, has_recorded_reason: bool) -> dict[str, Any]:
+    """The look-ahead leg, four-state where the writer supplied four states.
+
+    ``look_ahead_status`` (fusion/debate path) is the honest four-state verdict;
+    ``lookahead_audit_passed`` is the fail-closed boolean every path writes. A
+    bare ``False`` is a real audit finding ONLY when the gate actually graded
+    this candidate — on a row whose verdict carries its own ``reason`` the gate
+    never ran, and reporting "the audit found a leak" there would invent a
+    finding out of a default.
+    """
+    label = "Look-ahead audit"
+    status = verdict.get("look_ahead_status")
+    reason = verdict.get("look_ahead_reason")
+    if status == PASS or bool(verdict.get("lookahead_audit_passed")):
+        return _check("look_ahead", label, PASS, "no forward-looking data access found")
+    if status in _LA_INCONCLUSIVE:
+        detail = reason.strip() if isinstance(reason, str) and reason.strip() else "the audit reached no verdict"
+        return _check("look_ahead", label, NOT_COMPUTED, f"{detail} — blocks admission (fail-closed)")
+    if has_recorded_reason:
+        return _check("look_ahead", label, NOT_COMPUTED, "not run — see the reason on record")
+    if verdict.get("lookahead_audit_passed") is False:
+        return _check("look_ahead", label, FAIL, "the audit found a forward-looking pattern")
+    return _check("look_ahead", label, NOT_COMPUTED, "no look-ahead audit result on record")
+
+
+def rigor_reasons_for_verdict(verdict: Any) -> dict[str, Any] | None:
+    """Per-check report for ONE strategy's stored ``rigor_verdict``.
+
+    ``None`` in (no verdict persisted) → ``None`` out: a row with nothing on
+    record gets no reasons block at all, which the card renders as an honest
+    absence rather than as a set of checks that never ran.
+
+    The returned dict is JSON-safe and additive — nothing existing changes shape:
+
+    ``bar`` / ``bar_level``
+        The badge and its strictness level, so the card can name the bar it is
+        quoting instead of printing bare thresholds.
+    ``passing``
+        The verdict's own stored boolean, echoed for callers that hold the
+        report without the verdict.
+    ``recorded_reason`` / ``reason_code``
+        The strategy's own reason string verbatim, plus a stable code
+        (``short_return_series`` / ``fixture_mode`` / ``None``) so a frontend can
+        classify without matching prose.
+    ``min_returns_for_gate``
+        The observation count the gate needs before it can score anything — the
+        number behind ``short_return_series``, carried so no surface invents one.
+    ``checks``
+        Every leg, in gate order, each ``pass`` / ``fail`` / ``not_computed``
+        with the number and the threshold that decided it.
+    ``unattributed``
+        True when the row did not pass, carries no recorded reason, and no check
+        fails the bar — the surface must then say so, not guess.
+    """
+    if not isinstance(verdict, dict):
+        return None
+
+    profile = get_profile(STRICTEST_LEVEL)
+    raw_reason = verdict.get("reason")
+    recorded_reason = raw_reason.strip() if isinstance(raw_reason, str) else ""
+
+    checks = [
+        _dsr_check(verdict, profile),
+        _pbo_check(verdict, profile),
+        _oos_floor_check(verdict),
+        _oos_cliff_check(verdict, profile),
+        _look_ahead_check(verdict, has_recorded_reason=bool(recorded_reason)),
+    ]
+    passing = bool(verdict.get("passing"))
+    any_failed = any(c["status"] == FAIL for c in checks)
+
+    return {
+        "bar": BAR_NAME,
+        "bar_level": profile.level,
+        "passing": passing,
+        "recorded_reason": recorded_reason or None,
+        "reason_code": _REASON_CODES.get(recorded_reason),
+        "min_returns_for_gate": MIN_RETURNS_FOR_GATE,
+        "checks": checks,
+        "unattributed": bool(not passing and not recorded_reason and not any_failed),
+    }

--- a/backend/tests/test_rejected_reason_payload.py
+++ b/backend/tests/test_rejected_reason_payload.py
@@ -9,9 +9,11 @@ could be read — so for a candidate rejected for a DIFFERENT reason the page
 stated something false about it.
 
 ``services/rigor_reasons.rigor_reasons_for_verdict`` derives the per-check
-report from the strategy's own stored ``rigor_verdict`` — the same blob
-``generation_pipeline._rigor_verdict_for`` and ``debate_engine._rigor_verdict_dict``
-write — and ``GET /api/strategies/generated`` serves it as the additive
+report from the strategy's own stored ``rigor_verdict`` — the blob
+``debate_engine._rigor_verdict_dict`` writes on the graded fusion/debate path,
+``debate_engine._abstain_result`` and ``generation_pipeline``'s fixture branch
+write on the non-graded ones, and ``generation_pipeline._patch_pbo`` then patches
+— and ``GET /api/strategies/generated`` serves it as the additive
 ``rigor_reasons`` field.
 
 Hermetic (tmp-sqlite, no .env / network / Redis); the DB fixture copies the
@@ -39,7 +41,12 @@ from httpx import ASGITransport, AsyncClient
 _W_OWNER = "0xAbC0000000000000000000000000000000000009"
 _BADGE = get_profile(STRICTEST_LEVEL)
 
-# A candidate the gate actually GRADED and rejected on the numbers.
+# A candidate the gate actually GRADED and rejected on the numbers. Shape copied
+# from debate_engine._rigor_verdict_dict, which is the only writer of a graded
+# verdict — note it always emits the four-state ``look_ahead_status`` alongside
+# the fail-closed boolean, and derives the boolean FROM it. A graded row without
+# a status does not exist on any live path, and this module will not read one as
+# an audit pass (see test_a_bare_lookahead_true_is_not_a_passed_audit).
 _GRADED_FAIL = {
     "dsr": 0.31,
     "dsr_p_value": 0.08,
@@ -47,6 +54,7 @@ _GRADED_FAIL = {
     "oos_sharpe": -0.14,
     "in_sample_sharpe": 1.4,
     "lookahead_audit_passed": True,
+    "look_ahead_status": "pass",
     "passing": False,
     "num_trials": 6,
 }
@@ -229,6 +237,81 @@ def test_a_real_look_ahead_finding_is_a_failure():
     assert _by_key(report)["look_ahead"]["status"] == FAIL
 
 
+def test_a_default_number_on_an_ungraded_verdict_is_not_a_passed_check():
+    """THE GUARD for the sentinel-as-measurement bug.
+
+    ``_patch_pbo`` stamps ``pbo = 0.0  # PBO undefined for N<2`` onto every
+    candidate that carries a recorded reason (they are all ``has_real_rigor
+    =False``, so they are all in its ``agent_cands``). 0.0 is below the 0.50
+    ceiling, so a naive read renders "PBO — 0.00 < 0.50 required" under
+    **Passed** on a candidate the gate never scored. The fixture here is not
+    hand-written: it is the real blob ``debate_engine._abstain_result`` produces
+    after the real ``_patch_pbo`` runs, so it cannot drift from the pipeline."""
+    from archimedes.agents.debate_engine import _abstain_result
+    from archimedes.agents.generation_pipeline import _patch_pbo
+
+    cand = _abstain_result("c-abstain", regime="neutral", reason="society could not agree on a candidate")
+    _patch_pbo([cand])
+    assert cand.rigor_verdict["pbo"] == 0.0, "pipeline no longer stamps the N<2 sentinel — re-check this guard"
+
+    report = rigor_reasons_for_verdict(cand.rigor_verdict)
+    assert _by_key(report)["pbo"]["status"] == NOT_COMPUTED
+    assert _by_key(report)["pbo"]["value"] is None
+    # Nothing on an ungraded verdict may be reported as a check that cleared.
+    assert not [c for c in report["checks"] if c["status"] == PASS]
+    assert report["recorded_reason"] == "society could not agree on a candidate"
+
+
+def test_a_bare_lookahead_true_is_not_a_passed_audit():
+    """``_lookahead_for_candidate`` is "vacuously True when none expose auditable
+    source", and ``dsl_lookahead_audit.verdict_from_persisted_row`` retired
+    exactly this rendering. With no four-state ``look_ahead_status`` there is no
+    audit result to report — a stored ``True`` is a default, not a finding."""
+    report = rigor_reasons_for_verdict(
+        {"dsr_p_value": 0.97, "pbo": 0.2, "oos_sharpe": 0.8, "lookahead_audit_passed": True, "passing": False}
+    )
+    look_ahead = _by_key(report)["look_ahead"]
+    assert look_ahead["status"] == NOT_COMPUTED
+    assert "not an audit result" in look_ahead["detail"]
+
+
+def test_an_inconclusive_status_beats_a_stored_lookahead_true():
+    """The four-state status is the ONLY field a look-ahead claim keys off. A
+    verdict that explicitly says the audit reached no verdict must not be
+    rendered as a pass because a fail-closed boolean happens to read True."""
+    report = rigor_reasons_for_verdict(
+        {
+            "lookahead_audit_passed": True,
+            "look_ahead_status": "pending",
+            "look_ahead_reason": "spec had no auditable source",
+            "passing": False,
+        }
+    )
+    look_ahead = _by_key(report)["look_ahead"]
+    assert look_ahead["status"] == NOT_COMPUTED
+    assert "spec had no auditable source" in look_ahead["detail"]
+
+
+def test_a_conclusive_look_ahead_pass_still_passes():
+    """The fusion writer derives the boolean from ``look_ahead_status == "pass"``
+    (fusion_evaluator.RigorVerdict), so a genuinely audited row is unaffected."""
+    report = rigor_reasons_for_verdict(
+        {"look_ahead_status": "pass", "lookahead_audit_passed": True, "pbo": 0.2, "passing": False}
+    )
+    assert _by_key(report)["look_ahead"]["status"] == PASS
+
+
+def test_the_ratio_check_names_the_side_that_is_actually_missing():
+    """ "No positive in-sample Sharpe to compare against" is false on a row that
+    HAS one and is missing the out-of-sample leg."""
+    with_is = _by_key(rigor_reasons_for_verdict({"in_sample_sharpe": 1.2, "oos_sharpe": None, "passing": False}))
+    assert with_is["oos_is_ratio"]["status"] == NOT_COMPUTED
+    assert with_is["oos_is_ratio"]["detail"] == "no out-of-sample Sharpe to compare"
+
+    without_is = _by_key(rigor_reasons_for_verdict({"in_sample_sharpe": -0.3, "oos_sharpe": 0.4, "passing": False}))
+    assert without_is["oos_is_ratio"]["detail"] == "no positive in-sample Sharpe to compare against"
+
+
 def test_nan_is_not_a_measurement():
     """A NaN metric must not be printed as a number, nor skip its fail branch."""
     checks = _by_key(
@@ -256,10 +339,18 @@ def test_a_passing_verdict_reports_no_failures():
             "oos_sharpe": 0.9,
             "in_sample_sharpe": 1.2,
             "lookahead_audit_passed": True,
+            "look_ahead_status": "pass",
             "passing": True,
         }
     )
     assert not [c for c in report["checks"] if c["status"] == FAIL]
+    assert [c["key"] for c in report["checks"] if c["status"] == PASS] == [
+        "dsr",
+        "pbo",
+        "oos_sharpe",
+        "oos_is_ratio",
+        "look_ahead",
+    ]
     assert report["unattributed"] is False
 
 
@@ -274,6 +365,7 @@ def test_unattributed_when_nothing_on_record_falls_below_the_bar():
             "oos_sharpe": 0.9,
             "in_sample_sharpe": 1.2,
             "lookahead_audit_passed": True,
+            "look_ahead_status": "pass",
             "passing": False,
         }
     )

--- a/backend/tests/test_rejected_reason_payload.py
+++ b/backend/tests/test_rejected_reason_payload.py
@@ -1,0 +1,385 @@
+"""A rejected strategy's card must state ITS OWN reason, not a shared paragraph.
+
+The owner's screenshot: the Library's "Rejected (1) — did not pass the rigor
+gate" card showed "—" for Sharpe / CAGR / Max DD, a "Gen tokens" count, and one
+paragraph of prose asserting that "most rejections at this stage are 'return
+series too short' … A longer backtest window typically unlocks them". Nothing
+had measured that, and the card carried no field from which the real reason
+could be read — so for a candidate rejected for a DIFFERENT reason the page
+stated something false about it.
+
+``services/rigor_reasons.rigor_reasons_for_verdict`` derives the per-check
+report from the strategy's own stored ``rigor_verdict`` — the same blob
+``generation_pipeline._rigor_verdict_for`` and ``debate_engine._rigor_verdict_dict``
+write — and ``GET /api/strategies/generated`` serves it as the additive
+``rigor_reasons`` field.
+
+Hermetic (tmp-sqlite, no .env / network / Redis); the DB fixture copies the
+``_use_tmp_db`` pattern from ``test_generated_citation_truth.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import archimedes.db as db
+import pytest
+from archimedes.api.auth_siwe import _COOKIE_NAME, _sign_session
+from archimedes.services.rigor_profiles import OOS_ABS_FLOOR, STRICTEST_LEVEL, get_profile
+from archimedes.services.rigor_reasons import (
+    FAIL,
+    NOT_COMPUTED,
+    PASS,
+    SHORT_SERIES_REASON,
+    rigor_reasons_for_verdict,
+)
+from httpx import ASGITransport, AsyncClient
+
+_W_OWNER = "0xAbC0000000000000000000000000000000000009"
+_BADGE = get_profile(STRICTEST_LEVEL)
+
+# A candidate the gate actually GRADED and rejected on the numbers.
+_GRADED_FAIL = {
+    "dsr": 0.31,
+    "dsr_p_value": 0.08,
+    "pbo": 0.62,
+    "oos_sharpe": -0.14,
+    "in_sample_sharpe": 1.4,
+    "lookahead_audit_passed": True,
+    "passing": False,
+    "num_trials": 6,
+}
+
+# A candidate the gate never graded — the branch the deleted paragraph claimed
+# was "most" of them. Shape copied from generation_pipeline._rigor_verdict_for's
+# too-short return.
+_TOO_SHORT = {
+    "dsr": None,
+    "pbo": None,
+    "oos_sharpe": None,
+    "in_sample_sharpe": None,
+    "lookahead_audit_passed": True,
+    "passing": False,
+    "reason": SHORT_SERIES_REASON,
+}
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_db(tmp_path, monkeypatch):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    url = f"sqlite:///{tmp_path / 'rejected_reasons.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    eng = create_engine(url, connect_args={"check_same_thread": False})
+    monkeypatch.setattr(db, "engine", eng)
+    monkeypatch.setattr(db, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False))
+    db.init_db()
+    yield
+
+
+def _siwe_cookies(wallet: str) -> dict[str, str]:
+    return {_COOKIE_NAME: _sign_session(wallet, time.time())}
+
+
+def _mk_strategy(sid: str, verdict: dict | None, *, name: str = "Rejected candidate"):
+    from archimedes.models.strategy_store import StrategyRecord
+
+    with db.get_session() as session:
+        session.add(
+            StrategyRecord(
+                id=sid,
+                content_hash=("0x" + sid).ljust(66, "0"),
+                generation_method="fusion",
+                source_papers="[]",
+                strategy_name=name,
+                thesis="test thesis",
+                asset_universe="[]",
+                risk_profile="moderate",
+                status="rejected",
+                rigor_verdict=json.dumps(verdict) if verdict is not None else None,
+                is_example=False,
+                owner_wallet=_W_OWNER.lower(),
+                is_published=False,
+            )
+        )
+        session.commit()
+
+
+def _by_key(report: dict) -> dict[str, dict]:
+    return {c["key"]: c for c in report["checks"]}
+
+
+# ── The report names the checks, with the gate's own thresholds ─────────────
+
+
+def test_graded_rejection_names_every_failing_check_with_its_threshold():
+    """The screenshot's missing half: which checks said no, and against what."""
+    report = rigor_reasons_for_verdict(_GRADED_FAIL)
+    checks = _by_key(report)
+
+    assert checks["dsr"]["status"] == FAIL
+    assert checks["dsr"]["value"] == pytest.approx(0.08)
+    assert checks["dsr"]["threshold"] == pytest.approx(_BADGE.dsr_p_min)
+    assert "0.08" in checks["dsr"]["detail"] and f"{_BADGE.dsr_p_min:.2f}" in checks["dsr"]["detail"]
+
+    assert checks["pbo"]["status"] == FAIL
+    assert checks["pbo"]["threshold"] == pytest.approx(_BADGE.pbo_max)
+
+    assert checks["oos_sharpe"]["status"] == FAIL
+    assert checks["oos_sharpe"]["threshold"] == pytest.approx(OOS_ABS_FLOOR)
+
+    # Passed checks are shown as passed — the report is not a list of grievances.
+    assert checks["look_ahead"]["status"] == PASS
+
+    assert report["recorded_reason"] is None
+    assert report["reason_code"] is None
+    assert report["unattributed"] is False
+
+
+def test_thresholds_are_the_gates_own_numbers_not_a_second_copy():
+    """Every threshold printed must come from rigor_profiles, so the card can
+    never quote a bar the gate does not enforce."""
+    checks = _by_key(rigor_reasons_for_verdict(_GRADED_FAIL))
+    assert checks["dsr"]["threshold"] == _BADGE.dsr_p_min
+    assert checks["pbo"]["threshold"] == _BADGE.pbo_max
+    assert checks["oos_is_ratio"]["threshold"] == _BADGE.oos_is_ratio_min
+    assert checks["oos_sharpe"]["threshold"] == OOS_ABS_FLOOR
+
+
+def test_short_series_rejection_reads_its_own_recorded_reason():
+    report = rigor_reasons_for_verdict(_TOO_SHORT)
+    assert report["recorded_reason"] == SHORT_SERIES_REASON
+    assert report["reason_code"] == "short_return_series"
+    assert report["min_returns_for_gate"] == 10
+
+
+def test_two_strategies_rejected_for_different_reasons_get_different_reports():
+    """THE defect, at the data layer. One paragraph cannot be true of both of
+    these rows — a graded DSR/PBO/OOS failure and a candidate the gate never
+    scored — so the payload has to distinguish them."""
+    graded = rigor_reasons_for_verdict(_GRADED_FAIL)
+    short = rigor_reasons_for_verdict(_TOO_SHORT)
+
+    assert graded["reason_code"] != short["reason_code"]
+    assert [c["status"] for c in graded["checks"]] != [c["status"] for c in short["checks"]]
+    # The short-series row must NOT be described with the graded row's numbers.
+    assert all("0.08" not in c["detail"] for c in short["checks"])
+
+
+# ── Fail-closed: nothing on record is never rendered as a finding ───────────
+
+
+def test_ungraded_checks_are_not_computed_never_failed():
+    """A check that never ran must not be printed as a check that ran and
+    failed — the same FAIL-vs-NOT_RUN distinction gate_details already keeps.
+    It still does not count as a pass."""
+    checks = _by_key(rigor_reasons_for_verdict(_TOO_SHORT))
+    for key in ("dsr", "pbo", "oos_sharpe", "oos_is_ratio"):
+        assert checks[key]["status"] == NOT_COMPUTED, key
+        assert checks[key]["value"] is None, key
+    assert not any(c["status"] == FAIL for c in rigor_reasons_for_verdict(_TOO_SHORT)["checks"])
+
+
+def test_fixture_mode_does_not_claim_a_look_ahead_failure():
+    """generation_pipeline's fixture verdict carries lookahead_audit_passed=False
+    as a fail-closed DEFAULT, not an audit finding — the gate never ran. Calling
+    that a failed audit would invent a finding out of a default."""
+    from archimedes.services.rigor_reasons import FIXTURE_REASON
+
+    report = rigor_reasons_for_verdict(
+        {
+            "dsr": None,
+            "pbo": None,
+            "oos_sharpe": None,
+            "in_sample_sharpe": None,
+            "lookahead_audit_passed": False,
+            "passing": False,
+            "reason": FIXTURE_REASON,
+        }
+    )
+    assert _by_key(report)["look_ahead"]["status"] == NOT_COMPUTED
+    assert report["reason_code"] == "fixture_mode"
+
+
+def test_an_inconclusive_look_ahead_audit_is_not_a_failed_audit():
+    report = rigor_reasons_for_verdict(
+        {
+            "dsr_p_value": 0.97,
+            "pbo": 0.2,
+            "oos_sharpe": 0.8,
+            "in_sample_sharpe": 1.0,
+            "lookahead_audit_passed": False,
+            "look_ahead_status": "pending",
+            "look_ahead_reason": "no inspectable source for the audit",
+            "passing": False,
+        }
+    )
+    look_ahead = _by_key(report)["look_ahead"]
+    assert look_ahead["status"] == NOT_COMPUTED
+    assert "no inspectable source for the audit" in look_ahead["detail"]
+    assert "fail-closed" in look_ahead["detail"]
+
+
+def test_a_real_look_ahead_finding_is_a_failure():
+    report = rigor_reasons_for_verdict(
+        {"dsr_p_value": 0.97, "pbo": 0.2, "oos_sharpe": 0.8, "lookahead_audit_passed": False, "passing": False}
+    )
+    assert _by_key(report)["look_ahead"]["status"] == FAIL
+
+
+def test_nan_is_not_a_measurement():
+    """A NaN metric must not be printed as a number, nor skip its fail branch."""
+    checks = _by_key(
+        rigor_reasons_for_verdict(
+            {"dsr_p_value": float("nan"), "pbo": float("inf"), "oos_sharpe": None, "passing": False}
+        )
+    )
+    assert checks["dsr"]["status"] == NOT_COMPUTED
+    assert checks["pbo"]["status"] == NOT_COMPUTED
+
+
+def test_no_verdict_yields_no_report():
+    """A row with nothing on record gets no block at all — an honest absence,
+    not a set of checks that never ran."""
+    assert rigor_reasons_for_verdict(None) is None
+    assert rigor_reasons_for_verdict("not-a-dict") is None
+
+
+def test_a_passing_verdict_reports_no_failures():
+    """The block must not cry wolf on a strategy that cleared the bar."""
+    report = rigor_reasons_for_verdict(
+        {
+            "dsr_p_value": 0.97,
+            "pbo": 0.2,
+            "oos_sharpe": 0.9,
+            "in_sample_sharpe": 1.2,
+            "lookahead_audit_passed": True,
+            "passing": True,
+        }
+    )
+    assert not [c for c in report["checks"] if c["status"] == FAIL]
+    assert report["unattributed"] is False
+
+
+def test_unattributed_when_nothing_on_record_falls_below_the_bar():
+    """The agent path grades DSR at 0.95 while the badge bar is 0.90, so a
+    p-value in between lands a rejected row with every badge-bar check clear.
+    The surface must say it cannot attribute the rejection, not name a culprit."""
+    report = rigor_reasons_for_verdict(
+        {
+            "dsr_p_value": 0.92,
+            "pbo": 0.2,
+            "oos_sharpe": 0.9,
+            "in_sample_sharpe": 1.2,
+            "lookahead_audit_passed": True,
+            "passing": False,
+        }
+    )
+    assert report["unattributed"] is True
+    assert not [c for c in report["checks"] if c["status"] == FAIL]
+
+
+# ── The pipeline still writes what this module classifies on ───────────────
+
+
+def test_pipeline_still_writes_the_short_series_reason():
+    """Pins SHORT_SERIES_REASON and the 10-observation minimum to the
+    pipeline's ACTUAL behaviour, so the classification (and the count the
+    frontend prints) can never drift away from what gets stored."""
+    from archimedes.agents.generation_pipeline import _rigor_verdict_for
+    from archimedes.services.rigor_reasons import MIN_RETURNS_FOR_GATE
+
+    series = [0.001 * (i % 3 - 1) for i in range(MIN_RETURNS_FOR_GATE - 1)]
+    verdict = _rigor_verdict_for(series, 1)
+    assert verdict["reason"] == SHORT_SERIES_REASON
+    assert rigor_reasons_for_verdict(verdict)["reason_code"] == "short_return_series"
+
+    # One more observation and the gate grades it — no recorded reason at all.
+    graded = _rigor_verdict_for([*series, 0.002], 1)
+    assert "reason" not in graded
+
+
+# ── The route serves it, per row, with no extra query ──────────────────────
+
+
+async def test_generated_route_carries_each_rows_own_reasons():
+    """THE GUARD: the rejected row's payload carries ITS OWN reasons — the field
+    the card reads. Drop `d["rigor_reasons"] = ...` from
+    strategies_routes.list_generated_strategies and this goes red."""
+    _mk_strategy("rej00000000000001", _GRADED_FAIL, name="Graded rejection")
+    _mk_strategy("rej00000000000002", _TOO_SHORT, name="Too short")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    by_id = {s["id"]: s for s in resp.json()["strategies"]}
+    assert set(by_id) == {"rej00000000000001", "rej00000000000002"}
+
+    graded = by_id["rej00000000000001"]["rigor_reasons"]
+    short = by_id["rej00000000000002"]["rigor_reasons"]
+    assert graded is not None and short is not None
+
+    graded_checks = {c["key"]: c for c in graded["checks"]}
+    assert graded_checks["dsr"]["status"] == FAIL
+    assert f"{_BADGE.dsr_p_min:.2f}" in graded_checks["dsr"]["detail"]
+    assert graded["recorded_reason"] is None
+
+    # Each row carries its OWN reason — not the other's, and not a shared one.
+    assert short["recorded_reason"] == SHORT_SERIES_REASON
+    assert short["reason_code"] == "short_return_series"
+    assert graded["reason_code"] != short["reason_code"]
+
+
+async def test_generated_route_reasons_add_no_queries():
+    """Additive and batched: the reasons are derived from the rigor_verdict the
+    row already carries, so a page of rows costs the same number of SELECTs as
+    a single row did."""
+    from sqlalchemy import event
+
+    for i in range(6):
+        _mk_strategy(f"rejq0000000000{i:02d}", _GRADED_FAIL, name=f"Rejected {i}")
+
+    statements: list[str] = []
+
+    def _record(_conn, _cursor, statement, *_rest):
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    from archimedes.main import app
+
+    event.listen(db.engine, "before_cursor_execute", _record)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+    finally:
+        event.remove(db.engine, "before_cursor_execute", _record)
+
+    assert resp.status_code == 200
+    rows = resp.json()["strategies"]
+    assert len(rows) == 6
+    assert all(r["rigor_reasons"] is not None for r in rows)
+    # Six rows must not cost six lookups. The route's own per-page reads
+    # (strategies, costs, publish rights, corpus meta) are a small constant;
+    # anything scaling with row count would blow past it.
+    assert len(statements) <= 8, f"expected a constant number of SELECTs, got {len(statements)}: {statements}"
+
+
+async def test_a_row_with_no_verdict_carries_a_null_reasons_field():
+    """Honest absence, on the wire: the field is present and null, so the card
+    renders no block rather than an empty one."""
+    _mk_strategy("rejnull000000001", None, name="No verdict on record")
+
+    from archimedes.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/strategies/generated", cookies=_siwe_cookies(_W_OWNER))
+
+    assert resp.status_code == 200
+    row = resp.json()["strategies"][0]
+    assert "rigor_reasons" in row
+    assert row["rigor_reasons"] is None

--- a/ui/src/components/Strategies.jsx
+++ b/ui/src/components/Strategies.jsx
@@ -22,6 +22,17 @@ import {
 } from '../rigorGateStatus.js'
 import { signClass } from '../signClass.js'
 import { strategies as ROADMAP_COPY } from '../roadmapCopyApp.js'
+import {
+  barName,
+  checkLine,
+  failedChecks,
+  isUnattributed,
+  notComputedChecks,
+  passedChecks,
+  recordedReason,
+  rejectedSectionSummary,
+  showsRejectionReasons,
+} from '../rejectionReasons.js'
 
 // A compact "deployable at your level" chip for a library row, driven by the
 // strategy's min_passing_level (from the live gate) and the user's strictness.
@@ -381,11 +392,85 @@ function StrategyRow({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, d
   )
 }
 
+// Why THIS strategy was rejected — read off the row, never guessed.
+//
+// The rejected card showed "—" for Sharpe / CAGR / Max DD (a pre-backtest
+// hypothesis has none) and "Gen tokens", and nothing else: the one fact a
+// reader wanted — which rigor check said no — was the one fact absent, while
+// the section above it asserted a population-wide reason nobody had measured.
+//
+// Everything below comes from `s.rigor_reasons`, the additive per-row field
+// GET /api/strategies/generated serves, built from that strategy's OWN stored
+// rigor_verdict against the gate's own thresholds (see
+// backend/archimedes/services/rigor_reasons.py). Failed and not-computed are
+// kept in SEPARATE lines on purpose: a check that ran and found a problem and a
+// check that never ran are different claims, and only one of them may be
+// printed as a failure. With no field on the row — an old payload, a degraded
+// read, a curated row that never had one — the whole block renders nothing: no
+// heading, no bar name, no prose. Scoped to rows the gate turned down
+// (showsRejectionReasons), so a row still awaiting a verdict is never handed
+// one it has not received.
+function RejectionReasons({ s }) {
+  if (!showsRejectionReasons(s)) return null
+  const reason = recordedReason(s)
+  const failed = failedChecks(s)
+  const notComputed = notComputedChecks(s)
+  const passed = passedChecks(s)
+  const bar = barName(s)
+  return (
+    <div className="caption" style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 3, fontSize: '0.78rem' }}>
+      {reason && (
+        <div style={{ color: 'var(--text-3)' }}>
+          <span style={{ color: 'var(--text-4)' }}>Reason on record:</span>{' '}
+          <strong>{reason}</strong>
+        </div>
+      )}
+      {failed.length > 0 && (
+        <div style={{ color: 'var(--text-3)' }}>
+          {/* Colour on a className, not an inline `color:` — the literal
+              var(--positive)/var(--negative) here encodes a boolean check
+              verdict, not the sign of a number, exactly like the rigor-gate
+              check icon in StrategyRow. ui/test/sign-class.test.js polices the
+              inline form so a signed cell can never quietly hard-code green. */}
+          <span className="text-[var(--negative)]" style={{ fontWeight: 700 }}>Failed:</span>{' '}
+          {failed.map(checkLine).join(' · ')}
+        </div>
+      )}
+      {notComputed.length > 0 && (
+        <div style={{ color: 'var(--text-4)' }}>
+          <span style={{ fontWeight: 700 }}>Not computed:</span>{' '}
+          {notComputed.map(checkLine).join(' · ')} — a check with nothing on record does not count as passed.
+        </div>
+      )}
+      {passed.length > 0 && (
+        <div style={{ color: 'var(--text-3)' }}>
+          <span className="text-[var(--positive)]" style={{ fontWeight: 700 }}>Passed:</span>{' '}
+          {passed.map(checkLine).join(' · ')}
+        </div>
+      )}
+      {isUnattributed(s) && (
+        <div style={{ color: 'var(--text-4)' }}>
+          This strategy did not pass, but no check on record falls below the bar
+          quoted here — the stored verdict does not attribute the rejection.
+          Open the passport for the full record.
+        </div>
+      )}
+      {bar && (failed.length > 0 || passed.length > 0) && (
+        <div style={{ color: 'var(--text-4)' }}>Thresholds are the {bar} bar.</div>
+      )}
+    </div>
+  )
+}
+
 // Shared "expanded" detail content — methodology / source paper(s) / rigor
 // metrics / export actions. Used by both the desktop table row's expanded
 // <tr> and the mobile card list's expanded panel, so the two layouts never
 // drift out of sync with each other.
-function StrategyDetailContent({ s, onOpenRigorExplainer, onOpenPassport, extraActions, years, startStr, endStr }) {
+//
+// `hideRejectionReasons` is set by the mobile card, which already renders the
+// same block un-collapsed above the fold — the desktop table row has nowhere
+// else to put it, so there it stays on.
+function StrategyDetailContent({ s, onOpenRigorExplainer, onOpenPassport, extraActions, years, startStr, endStr, hideRejectionReasons }) {
   return (
     <>
       <div className="text-[0.82rem]" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 18 }}>
@@ -500,6 +585,7 @@ function StrategyDetailContent({ s, onOpenRigorExplainer, onOpenPassport, extraA
           )}
         </div>
       </div>
+      {!hideRejectionReasons && <RejectionReasons s={s} />}
       <div style={{ marginTop: 14, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
         {onOpenPassport && (
           <button
@@ -598,6 +684,10 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
         <div><div className="caption">Max DD</div><div className="mono negative"><MetricValue metric="max_drawdown" value={s.max_drawdown} row={s} surface="Library card" /></div></div>
         <div title={genCost.title}><div className="caption">Gen tokens</div><div className={genCost.measured ? 'mono' : 'caption'}>{genCost.label}</div></div>
       </div>
+      {/* The rejected card's missing half. Four "—" tiles and a token count
+          told the reader nothing about the verdict; this names the checks from
+          this strategy's own record, above the fold, without expanding. */}
+      <RejectionReasons s={s} />
       {open && (
         <div className="lib-card-detail" onClick={(e) => e.stopPropagation()}>
           <StrategyDetailContent
@@ -608,6 +698,7 @@ function StrategyCard({ s, isHighlighted, onOpenRigorExplainer, onOpenPassport, 
             years={years}
             startStr={startStr}
             endStr={endStr}
+            hideRejectionReasons
           />
         </div>
       )}
@@ -793,6 +884,11 @@ function coerceGenerated(row) {
     // Absent for anything generated before the meter — passed through as null so
     // the cost column renders "not measured" rather than a fabricated zero.
     generation_cost: row.generation_cost ?? null,
+    // Per-check rejection reasons for THIS strategy, derived server-side from
+    // its own stored rigor_verdict (backend/archimedes/services/rigor_reasons.py)
+    // and served by /api/strategies/generated. Carried through untouched;
+    // `null` on any payload without the field, which renders as no block at all.
+    rigor_reasons: row.rigor_reasons ?? null,
   }
 }
 
@@ -1129,12 +1225,21 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
                 rejected.length > 0 ? (
                   <div className="card" style={{ padding: 22 }}>
                     <div className="label mb-2">No strategies have passed the rigor gate yet</div>
+                    {/* Same correction as the rejected section's own copy: the
+                        parenthetical here named a single reason for a
+                        population it never counted. The sentence below is
+                        computed from these exact rows and is omitted entirely
+                        when none of them carry that reason. */}
                     <p className="body" style={{ marginBottom: 10 }}>
                       You've generated {rejected.length} {rejected.length === 1 ? 'candidate' : 'candidates'}, but
                       none have cleared the rigor gate yet. Expand the <strong>Rejected</strong> section below
-                      to see the rigor verdicts (most are <code>"return series too short"</code> — a longer
-                      backtest window is needed for DSR / PBO to score them).
+                      to see each candidate's own rigor verdict — the checks it failed, and the ones it passed.
                     </p>
+                    {rejectedSectionSummary(rejected) && (
+                      <p className="body" style={{ marginBottom: 10 }}>
+                        {rejectedSectionSummary(rejected)}
+                      </p>
+                    )}
                     <p className="caption" style={{ color: 'var(--text-3)' }}>
                       This table holds strategies that passed the rigor gate (DSR + PBO +
                       chronological OOS + look-ahead audit) plus candidates still awaiting a
@@ -1176,13 +1281,26 @@ export default function Strategies({ highlightStrategyId, defaultTab, onNavigate
                   Rejected ({rejected.length}) — did not pass the rigor gate. Click to inspect.
                 </summary>
                 <div style={{ marginTop: 12 }}>
+                  {/* The paragraph that used to sit here named one reason (a
+                      too-short return series) for the whole population and
+                      promised a longer backtest window would unlock them.
+                      Nothing had counted that, and it was false for any
+                      candidate rejected on the numbers instead. Each row now
+                      names its own checks (RejectionReasons), and the only
+                      sentence about the group is the one below, computed from
+                      the rows on screen — null when there is nothing true to
+                      say. ui/test/rejected-reason.test.js keeps the old prose
+                      out. */}
                   <p className="caption mb-3" style={{ color: 'var(--text-3)', fontSize: '0.82rem' }}>
-                    These candidates were generated but failed at least one rigor check (DSR, PBO,
-                    chronological OOS, or look-ahead audit). Most rejections at this stage are
-                    "return series too short" — the agent generated a strategy but there isn't
-                    enough backtest history yet to compute DSR / PBO with statistical confidence.
-                    A longer backtest window typically unlocks them.
+                    These candidates were generated and did not pass the rigor gate (DSR, PBO,
+                    chronological OOS, or look-ahead audit). Each row names the checks it failed,
+                    read from that strategy's own recorded verdict.
                   </p>
+                  {rejectedSectionSummary(rejected) && (
+                    <p className="caption mb-3" style={{ color: 'var(--text-3)', fontSize: '0.82rem' }}>
+                      {rejectedSectionSummary(rejected)}
+                    </p>
+                  )}
                   <StrategyTable
                     strategies={rejected}
                     highlightStrategyId={highlightStrategyId}

--- a/ui/src/rejectionReasons.js
+++ b/ui/src/rejectionReasons.js
@@ -1,0 +1,137 @@
+// Rejection reasons for the Library's "Rejected (N) — did not pass the rigor
+// gate" section.
+//
+// The section used to explain every rejected candidate with ONE shared
+// paragraph ("Most rejections at this stage are 'return series too short' …
+// A longer backtest window typically unlocks them"). Nothing measured that
+// claim, so for a candidate rejected for a different reason the page stated
+// something false about it — while the card itself showed "—" for Sharpe /
+// CAGR / Max DD and nothing at all about why the gate said no.
+//
+// The reasons now come off the row: `rigor_reasons` is the additive field
+// GET /api/strategies/generated serves per strategy, built server-side by
+// backend/archimedes/services/rigor_reasons.py from that strategy's OWN stored
+// rigor_verdict, against the thresholds the gate actually uses
+// (services/rigor_profiles.py). Nothing here re-declares a threshold or
+// re-derives a verdict — every number and every bar in the rendered text was
+// computed by the gate's own module and shipped in the payload.
+//
+// Fail-closed by construction: a row with no `rigor_reasons` (an old payload, a
+// degraded read, a curated row that never had one) yields empty lists and a
+// null summary, so the card renders nothing rather than a claim it cannot
+// support.
+
+// Per-check status vocabulary, mirroring services/rigor_reasons.py. Only PASS
+// clears. NOT_COMPUTED blocks admission exactly as hard as FAIL but must never
+// be rendered as a failure — "the check found a problem" and "the check never
+// ran" are different facts about a strategy.
+export const CHECK_PASS = 'pass'
+export const CHECK_FAIL = 'fail'
+export const CHECK_NOT_COMPUTED = 'not_computed'
+
+// Stable reason classifications from the backend. Prose is never matched here.
+export const REASON_SHORT_SERIES = 'short_return_series'
+
+/** The row's reasons report, or null when the row carries none. */
+export function reasonReport(row) {
+  const report = row?.rigor_reasons
+  if (!report || typeof report !== 'object') return null
+  return Array.isArray(report.checks) ? report : null
+}
+
+function checksWithStatus(row, status) {
+  const report = reasonReport(row)
+  if (!report) return []
+  return report.checks.filter((c) => c && c.status === status && c.label && c.detail)
+}
+
+export const failedChecks = (row) => checksWithStatus(row, CHECK_FAIL)
+export const notComputedChecks = (row) => checksWithStatus(row, CHECK_NOT_COMPUTED)
+export const passedChecks = (row) => checksWithStatus(row, CHECK_PASS)
+
+/** The strategy's own recorded reason string, verbatim, or null. */
+export function recordedReason(row) {
+  const reason = reasonReport(row)?.recorded_reason
+  return typeof reason === 'string' && reason.trim() ? reason.trim() : null
+}
+
+export function reasonCode(row) {
+  const code = reasonReport(row)?.reason_code
+  return typeof code === 'string' && code ? code : null
+}
+
+/**
+ * True when the row did not pass, carries no recorded reason, and no check
+ * failed the bar — the one case where the surface must say it cannot attribute
+ * the rejection instead of naming a culprit.
+ */
+export function isUnattributed(row) {
+  return reasonReport(row)?.unattributed === true
+}
+
+/** The bar the thresholds in `detail` are quoted against, e.g. "Archimedes Verified". */
+export function barName(row) {
+  const bar = reasonReport(row)?.bar
+  return typeof bar === 'string' && bar.trim() ? bar.trim() : null
+}
+
+/** One check as a sentence fragment: "DSR confidence — 0.08 < 0.90 required". */
+export function checkLine(check) {
+  return `${check.label} — ${check.detail}`
+}
+
+/**
+ * Is there anything true to render for this row? Gates the whole block, so a
+ * payload without the field renders no heading, no bar name, and no prose.
+ */
+export function hasRejectionDetail(row) {
+  if (!reasonReport(row)) return false
+  return (
+    recordedReason(row) != null ||
+    isUnattributed(row) ||
+    failedChecks(row).length > 0 ||
+    notComputedChecks(row).length > 0 ||
+    passedChecks(row).length > 0
+  )
+}
+
+/**
+ * Should the card render the block at all?
+ *
+ * Scoped to rows the gate actually turned down (`passes_rigor_gate === false`).
+ * A row still awaiting a verdict is `null` here and gets nothing — listing the
+ * checks it has not been graded against yet would read as a verdict it has not
+ * received. A passing row's checks belong on its passport, not under a heading
+ * about rejection.
+ */
+export function showsRejectionReasons(row) {
+  return row?.passes_rigor_gate === false && hasRejectionDetail(row)
+}
+
+/**
+ * A summary sentence for the rejected SECTION — returned only when it is true
+ * of the rows actually on screen, and null otherwise.
+ *
+ * This is what replaces the old "Most rejections at this stage are 'return
+ * series too short'" paragraph: the short-series sentence appears only when
+ * some row on this page really carries that reason code, and it counts them
+ * rather than asserting a majority nobody measured. The minimum-observation
+ * number comes from the payload (`min_returns_for_gate`), never from a literal
+ * typed here.
+ */
+export function rejectedSectionSummary(rows) {
+  const list = Array.isArray(rows) ? rows : []
+  const total = list.length
+  if (!total) return null
+  const short = list.filter((r) => reasonCode(r) === REASON_SHORT_SERIES)
+  if (!short.length) return null
+  const minReturns = reasonReport(short[0])?.min_returns_for_gate
+  if (typeof minReturns !== 'number' || !Number.isFinite(minReturns)) return null
+  const need = `the gate needs at least ${minReturns} daily returns to score one`
+  if (short.length === total) {
+    return total === 1
+      ? `The candidate below was rejected because its persisted return series was too short — ${need}. A longer backtest window unlocks it.`
+      : `All ${total} candidates below were rejected because their persisted return series was too short — ${need}. A longer backtest window unlocks them.`
+  }
+  return `${short.length} of these ${total} candidates were rejected because their persisted return series was too short — ${need}. The rest failed other checks, named on each row.`
+}

--- a/ui/test/rejected-reason.test.js
+++ b/ui/test/rejected-reason.test.js
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+	barName,
+	checkLine,
+	failedChecks,
+	hasRejectionDetail,
+	isUnattributed,
+	notComputedChecks,
+	passedChecks,
+	recordedReason,
+	rejectedSectionSummary,
+	showsRejectionReasons,
+} from "../src/rejectionReasons.js";
+
+// The owner's screenshot: the Library's "Rejected (1) — did not pass the rigor
+// gate" card showed "—" for Sharpe / CAGR / Max DD, a "Gen tokens" count, and
+// one shared paragraph asserting that "most rejections at this stage are
+// 'return series too short' … A longer backtest window typically unlocks them."
+// Nothing measured that sentence, and the card carried no per-strategy reason at
+// all — so for a candidate rejected for a different reason the page stated
+// something false about it.
+//
+// Behaviour lives in ../src/rejectionReasons.js (a plain module, importable
+// here — .jsx is not), so these are real assertions on the rendered strings,
+// not only regex pins on source. The source pins at the bottom cover the two
+// wiring facts a pure module cannot: that the component is mounted on the card,
+// and that the deleted paragraph did not come back.
+
+const src = (p) => readFileSync(new URL(`../src/${p}`, import.meta.url), "utf8");
+const strategies = src("components/Strategies.jsx");
+
+// A row rejected on the numbers — the gate graded it.
+const graded = {
+	id: "graded",
+	passes_rigor_gate: false,
+	rigor_reasons: {
+		bar: "Archimedes Verified",
+		bar_level: 1,
+		passing: false,
+		recorded_reason: null,
+		reason_code: null,
+		min_returns_for_gate: 10,
+		unattributed: false,
+		checks: [
+			{ key: "dsr", label: "DSR confidence", status: "fail", detail: "0.08 < 0.90 required", value: 0.08, threshold: 0.9 },
+			{ key: "pbo", label: "PBO (overfitting probability)", status: "fail", detail: "0.62 ≥ 0.50 — at or above the overfitting ceiling", value: 0.62, threshold: 0.5 },
+			{ key: "oos_sharpe", label: "Out-of-sample Sharpe", status: "pass", detail: "0.41 > 0.00 required", value: 0.41, threshold: 0 },
+			{ key: "look_ahead", label: "Look-ahead audit", status: "pass", detail: "no forward-looking data access found", value: null, threshold: null },
+		],
+	},
+};
+
+// A row the gate never graded — the branch the deleted paragraph claimed was
+// "most" of them.
+const tooShort = {
+	id: "short",
+	passes_rigor_gate: false,
+	rigor_reasons: {
+		bar: "Archimedes Verified",
+		bar_level: 1,
+		passing: false,
+		recorded_reason: "return series too short for rigor evaluation",
+		reason_code: "short_return_series",
+		min_returns_for_gate: 10,
+		unattributed: false,
+		checks: [
+			{ key: "dsr", label: "DSR confidence", status: "not_computed", detail: "no deflated-Sharpe p-value on record", value: null, threshold: 0.9 },
+			{ key: "look_ahead", label: "Look-ahead audit", status: "not_computed", detail: "not run — see the reason on record", value: null, threshold: null },
+		],
+	},
+};
+
+// ── The card states THIS strategy's reason ───────────────────────────────
+
+test("a graded rejection renders the checks that failed, with the gate's thresholds", () => {
+	const failed = failedChecks(graded).map(checkLine);
+	assert.equal(failed.length, 2);
+	assert.match(failed[0], /DSR confidence — 0\.08 < 0\.90 required/);
+	assert.match(failed[1], /PBO .* 0\.62 ≥ 0\.50/);
+	// Passed checks are shown as passed — the block is not a list of grievances.
+	assert.deepEqual(
+		passedChecks(graded).map((c) => c.label),
+		["Out-of-sample Sharpe", "Look-ahead audit"],
+	);
+	assert.equal(recordedReason(graded), null);
+	assert.equal(barName(graded), "Archimedes Verified");
+});
+
+test("a row the gate never graded surfaces its own recorded reason, and claims no failures", () => {
+	assert.equal(recordedReason(tooShort), "return series too short for rigor evaluation");
+	// A check that never ran must not be rendered as one that ran and failed.
+	assert.deepEqual(failedChecks(tooShort), []);
+	assert.equal(notComputedChecks(tooShort).length, 2);
+});
+
+test("two rows rejected for different reasons never render the same text", () => {
+	// THE defect: one paragraph cannot be true of both of these rows.
+	const gradedText = [recordedReason(graded), ...failedChecks(graded).map(checkLine)].join(" ");
+	const shortText = [recordedReason(tooShort), ...failedChecks(tooShort).map(checkLine)].join(" ");
+	assert.notEqual(gradedText, shortText);
+	assert.doesNotMatch(gradedText, /return series too short/);
+	assert.doesNotMatch(shortText, /0\.08 < 0\.90/);
+});
+
+// ── Fail-closed: no field, no claim ──────────────────────────────────────
+
+test("a row without the rigor_reasons field renders no block at all", () => {
+	// The drop-the-field mutation. Every list is empty and the block's own gate
+	// is false, so the card shows nothing rather than an empty heading or a
+	// reason it cannot support.
+	for (const base of [{}, null, undefined, { rigor_reasons: null }, { rigor_reasons: { checks: "nope" } }]) {
+		const row = base == null ? base : { ...base, passes_rigor_gate: false };
+		assert.equal(hasRejectionDetail(row), false);
+		assert.equal(showsRejectionReasons(row), false);
+		assert.deepEqual(failedChecks(row), []);
+		assert.deepEqual(notComputedChecks(row), []);
+		assert.deepEqual(passedChecks(row), []);
+		assert.equal(recordedReason(row), null);
+		assert.equal(barName(row), null);
+	}
+	assert.equal(hasRejectionDetail(graded), true);
+	assert.equal(showsRejectionReasons(graded), true);
+});
+
+test("a row still awaiting a verdict is never handed one", () => {
+	// passes_rigor_gate === null is "not scored yet". Listing the checks it has
+	// not been graded against would read as a verdict it has not received.
+	assert.equal(showsRejectionReasons({ ...graded, passes_rigor_gate: null }), false);
+	assert.equal(showsRejectionReasons({ ...graded, passes_rigor_gate: undefined }), false);
+	assert.equal(showsRejectionReasons({ ...graded, passes_rigor_gate: true }), false);
+});
+
+test("a rejection nothing on record explains says so instead of naming a culprit", () => {
+	const unattributed = {
+		rigor_reasons: { bar: "Archimedes Verified", passing: false, recorded_reason: null, reason_code: null, unattributed: true, checks: [{ key: "dsr", label: "DSR confidence", status: "pass", detail: "0.92 ≥ 0.90 required", value: 0.92, threshold: 0.9 }] },
+	};
+	assert.equal(isUnattributed(unattributed), true);
+	assert.deepEqual(failedChecks(unattributed), []);
+	assert.equal(isUnattributed(graded), false);
+});
+
+// ── The section sentence is shown only when it is true ───────────────────
+
+test("the short-series sentence appears only for rows that actually carry that reason", () => {
+	// The mutation the old paragraph WAS: asserting the short-series reason over
+	// a population that does not have it.
+	assert.equal(rejectedSectionSummary([graded]), null);
+	assert.equal(rejectedSectionSummary([graded, graded]), null);
+	assert.equal(rejectedSectionSummary([]), null);
+	assert.equal(rejectedSectionSummary(null), null);
+});
+
+test("the short-series sentence counts the rows it is true of", () => {
+	const all = rejectedSectionSummary([tooShort, tooShort]);
+	assert.match(all, /All 2 candidates below/);
+	assert.match(all, /at least 10 daily returns/); // the number comes from the payload
+
+	const one = rejectedSectionSummary([tooShort]);
+	assert.match(one, /The candidate below/);
+
+	const mixed = rejectedSectionSummary([tooShort, graded, graded]);
+	assert.match(mixed, /1 of these 3 candidates/);
+	assert.match(mixed, /The rest failed other checks/);
+	assert.doesNotMatch(mixed, /All 3/);
+});
+
+test("no minimum-observation count in the payload means no sentence", () => {
+	// The count is quoted from the backend, never typed into the frontend, so a
+	// payload without it must not produce a number.
+	const noCount = { rigor_reasons: { ...tooShort.rigor_reasons, min_returns_for_gate: null } };
+	assert.equal(rejectedSectionSummary([noCount]), null);
+});
+
+// ── Wiring: the block is mounted, and the old paragraph is gone ──────────
+
+test("Strategies.jsx mounts the reasons block on the card and in the expanded row", () => {
+	assert.match(strategies, /function RejectionReasons\(\{ s \}\) \{/);
+	// The mobile card (the surface in the owner's screenshot) renders it
+	// un-collapsed, right below the "—" stat tiles.
+	assert.match(strategies, /<RejectionReasons s=\{s\} \/>\n\s*\{open && \(/);
+	// The shared detail panel renders it for the desktop table row, and the card
+	// suppresses that copy so it is not shown twice.
+	assert.match(strategies, /\{!hideRejectionReasons && <RejectionReasons s=\{s\} \/>\}/);
+	assert.match(strategies, /hideRejectionReasons\n/);
+});
+
+test("coerceGenerated carries the per-row reasons through to the card", () => {
+	assert.match(strategies, /rigor_reasons: row\.rigor_reasons \?\? null,/);
+});
+
+test("the population-wide rejection prose is gone from Strategies.jsx", () => {
+	// The exact sentences from the owner's screenshot. Each asserted something
+	// about every rejected strategy that nothing had measured.
+	assert.doesNotMatch(strategies, /Most rejections at this stage are/);
+	assert.doesNotMatch(strategies, /A longer backtest window typically unlocks them/);
+	assert.doesNotMatch(strategies, /most are <code>"return series too short"<\/code>/);
+	// And the replacement is the measured, conditional one.
+	assert.match(strategies, /\{rejectedSectionSummary\(rejected\) && \(/);
+});


### PR DESCRIPTION
## The owner's observation

Screenshot of Library → Generated → **"Rejected (1) — did not pass the rigor gate"**:

- the rejected card shows `—` for Sharpe, CAGR and Max DD, and one measured number, `Gen tokens 65,826`;
- the only text about *why* is a paragraph shared by every rejected candidate:

  > These candidates were generated but failed at least one rigor check (DSR, PBO, chronological OOS, or look-ahead audit). **Most rejections at this stage are "return series too short"** — the agent generated a strategy but there isn't enough backtest history yet to compute DSR / PBO with statistical confidence. **A longer backtest window typically unlocks them.**

Nothing had measured "most", and the sentence is simply false for a candidate rejected on the numbers (a DSR below the bar, a PBO above the ceiling, a negative OOS Sharpe). The one fact a reader wants — which check said no — was the one fact absent.

## Root cause

The reason was on the row the whole time, unexposed.

`StrategyRecord.rigor_verdict` (JSON) carries `dsr_p_value` / `pbo` / `oos_sharpe` / `in_sample_sharpe` / `lookahead_audit_passed` (+ `look_ahead_status` on the fusion path), and a verbatim `reason` string for the branches where the gate never graded the candidate at all. On today's live write paths that blob comes from `debate_engine._rigor_verdict_dict` (the graded fusion/debate verdict — the only writer of the four-state `look_ahead_status`), from `debate_engine._abstain_result` and `generation_pipeline`'s fixture branch (both non-graded, both carrying a `reason`), and is then patched by `generation_pipeline._patch_pbo` / `_patch_dsr_with_pool_correlation`. `generation_pipeline._rigor_verdict_for` — the writer of the `"return series too short for rigor evaluation"` branch — has **no production callers** (repo-wide it appears only at its own `def` and in tests), so that shape is reachable only on **stored** rows.

`GET /api/strategies/generated` returned the raw blob via `to_dict()`, but nothing turned it into per-check statements, and `coerceGenerated` mapped only the four numbers onto `deflated_sharpe_ratio` / `pbo_score` / `out_of_sample_sharpe` / `dsr_p_value` — all of which the *rejected card layout* does not render. So the card had numbers it never showed and a paragraph it could not justify.

Deriving the reasons in JS was the wrong fix: it would put the gate's thresholds in a second place, where they can drift from `rigor_profiles`.

## The change

**Backend — `backend/archimedes/services/rigor_reasons.py` (new).** A pure function over the verdict dict:

```python
rigor_reasons_for_verdict(verdict) -> {
  "bar": "Archimedes Verified", "bar_level": 1, "passing": bool,
  "recorded_reason": str | None,          # the strategy's own reason, verbatim
  "reason_code": "short_return_series" | "fixture_mode" | None,
  "min_returns_for_gate": 10,
  "checks": [{key, label, status, detail, value, threshold}, ...],
  "unattributed": bool,
}
```

- Thresholds come from `rigor_profiles.get_profile(STRICTEST_LEVEL)` (`dsr_p_min` 0.90, `pbo_max` 0.50, `oos_is_ratio_min` 0.50) plus `OOS_ABS_FLOOR` — **read, never re-declared**, so the card quotes the bar the gate enforces.
- Three statuses, not two. `fail` is reserved for a check that ran and did not clear its bar; a check with nothing on record is `not_computed` — fail-closed (it still blocks) but never *printed* as a failure. Same FAIL-vs-NOT_RUN distinction `RigorGateResult.gate_details` already keeps.
- **A default is not a measurement.** A verdict carrying its own `reason` was never graded, so no numeric leg on it is reported as a graded result. This is load-bearing, not defensive: `_patch_pbo` (`generation_pipeline.py:660`) stamps `pbo = 0.0  # PBO undefined for N<2` onto exactly those candidates (every one is `has_real_rigor=False`, so every one is in its `agent_cands`), and 0.0 sits below the 0.50 ceiling. Without this rule the card renders **"Passed: PBO (overfitting probability) — 0.00 < 0.50 required"** on a candidate the gate never scored.
- **A look-ahead claim keys off `look_ahead_status` only.** Neither value of the fail-closed `lookahead_audit_passed` boolean is an audit result on its own: `_lookahead_for_candidate` is documented as *"vacuously True when none expose auditable source"*, and `dsl_lookahead_audit.verdict_from_persisted_row` explicitly retired this rendering (*"the alternative is a live surface showing 'look_ahead: PASS' on the strength of a sentence an LLM wrote about itself"*). A bare `True` with no four-state status is therefore `not_computed`, and a `False` on a row carrying a `reason` is `not_computed` rather than an invented leak finding. Conclusive rows are unaffected — the fusion writer derives the boolean *from* `look_ahead_status == "pass"` (`fusion_evaluator.py:143`).
- `unattributed` covers the one honest gap: the agent path's own `passing` uses a stricter DSR bar (0.95, hardcoded in `_rigor_verdict_for`) than the badge's 0.90, so a p-value in [0.90, 0.95) lands a rejected row with every badge-bar check clear. The card then says it cannot attribute the rejection rather than naming a culprit. With `_rigor_verdict_for` currently uncalled in production, that shape reaches the surface via stored rows rather than new writes — the state is still rendered, because a row the surface cannot attribute must say so either way.

**Backend — `strategies_routes.list_generated_strategies`.** One added line inside the existing per-page loop:

```python
d["rigor_reasons"] = rigor_reasons_for_verdict(d.get("rigor_verdict"))
```

Additive, batched by construction: the verdict dict is already decoded by `to_dict()` above, so this is a pure transform and adds **zero queries** (guarded — see verification).

**Frontend — `ui/src/rejectionReasons.js` (new)** holds the reading/selection logic as a plain importable module (the `.jsx` is not importable by `node --test`, so this is what makes the render behaviour testable rather than regex-pinned). Fail-closed: a row without the field yields empty lists and a null summary.

**Frontend — `ui/src/components/Strategies.jsx`.** New `RejectionReasons` component, rendered un-collapsed on the mobile card (right under the four `—` tiles, the surface in the screenshot) and in the shared detail panel for the desktop table row. Scoped to `passes_rigor_gate === false`, so a row still awaiting a verdict is never handed one. Example output for a graded rejection (a fusion row, which carries `look_ahead_status: "pass"`):

> **Failed:** DSR confidence — 0.08 < 0.90 required · PBO (overfitting probability) — 0.62 ≥ 0.50 — at or above the overfitting ceiling
> **Passed:** Out-of-sample Sharpe — 0.41 > 0.00 required · Look-ahead audit — no forward-looking data access found
> Thresholds are the Archimedes Verified bar.

and for one the gate never scored:

> **Reason on record:** society could not agree on a candidate
> **Not computed:** DSR confidence — not scored — see the reason on record · PBO (overfitting probability) — not scored — see the reason on record · … — a check with nothing on record does not count as passed.

The population-wide paragraph is deleted. In its place: one sentence that is unconditionally true ("Each row names the checks it failed, read from that strategy's own recorded verdict"), plus `rejectedSectionSummary(rejected)` — computed from the rows on screen, counting them, quoting `min_returns_for_gate` from the payload, and returning `null` when there is nothing true to say. The same correction is applied to the empty-state card above it, which carried the identical unmeasured parenthetical.

Untouched, as agreed with the concurrent branches: `statusTag` / `statusLabel`, `coerceGenerated`'s verdict lines (the new key is appended after `generation_cost`), `StrategyPassport.jsx`, `passport_loader`, `generation_pipeline`, and the generation-stream/SSE components. The `strategies_routes.py` hunk is a comment block plus a local import (line 839) and one assignment inside `list_generated_strategies`'s existing page loop (line 844), far from the `_passport_to_strategy_response` verdict fields `dbrowneup/verdict-of-record-a` edits.

## Adversarial demo — every guard shown red on the input it rejects

**1. Drop the payload field** (`d["rigor_reasons"] = …` removed from the route):

```
FAILED tests/test_rejected_reason_payload.py::test_generated_route_carries_each_rows_own_reasons - KeyError: 'rigor_reasons'
FAILED tests/test_rejected_reason_payload.py::test_generated_route_reasons_add_no_queries - KeyError: 'rigor_reasons'
FAILED tests/test_rejected_reason_payload.py::test_a_row_with_no_verdict_carries_a_null_reasons_field - AssertionError: assert 'rigor_reasons' in {...}
================== 3 failed, 18 passed, 4 warnings in 15.04s ===================   # exit 1
```

**2. Drop the field on the way to the card** (`rigor_reasons: row.rigor_reasons ?? null` removed from `coerceGenerated`):

```
✖ coerceGenerated carries the per-row reasons through to the card (1.777375ms)
ℹ pass 11
ℹ fail 1
```

**3. Render the generic sentence for strategies whose reason is different** (`rejectedSectionSummary` stops filtering on `reason_code`, so every rejected row is described as a short-series rejection):

```
✖ the short-series sentence appears only for rows that actually carry that reason (2.791459ms)
✖ the short-series sentence counts the rows it is true of (1.950333ms)
ℹ tests 12  ℹ pass 10  ℹ fail 2                                        # exit 1
```

**4. Bring the deleted paragraph back** (the two sentences restored verbatim in the JSX):

```
✖ the population-wide rejection prose is gone from Strategies.jsx (4.297083ms)
ℹ pass 10
ℹ fail 1
```

**5. Report a check that never ran as a failure** (the `has_recorded_reason` branch removed; a missing DSR p-value returned as `FAIL`):

```
FAILED tests/test_rejected_reason_payload.py::test_ungraded_checks_are_not_computed_never_failed - AssertionError: dsr
FAILED tests/test_rejected_reason_payload.py::test_fixture_mode_does_not_claim_a_look_ahead_failure - AssertionError: assert 'fail' == 'not_computed'
FAILED tests/test_rejected_reason_payload.py::test_nan_is_not_a_measurement - AssertionError: assert 'fail' == 'not_computed'
================== 3 failed, 13 passed, 4 warnings in 10.52s ===================
```

**6. Show the block on a row with no verdict yet** (`showsRejectionReasons` stops checking `passes_rigor_gate`):

```
✖ a row still awaiting a verdict is never handed one (0.883875ms)
ℹ pass 11
ℹ fail 1
```

**7. Report a default number on an ungraded verdict as a passed check** (the `if recorded_reason:` downgrade removed, so `_patch_pbo`'s `pbo = 0.0` sentinel renders as "PBO — 0.00 < 0.50 required" under **Passed**):

```
FAILED tests/test_rejected_reason_payload.py::test_a_default_number_on_an_ungraded_verdict_is_not_a_passed_check - AssertionError: assert 'pass' == 'not_computed'
================== 1 failed, 20 passed, 4 warnings in 14.05s ===================   # exit 1
```

The fixture for that guard is not hand-written: it is the blob `debate_engine._abstain_result` actually produces after the real `_patch_pbo` runs on it, so it cannot drift from the pipeline.

**8. Let a bare `lookahead_audit_passed: True` short-circuit the four-state handling** (`if status == PASS or bool(verdict.get("lookahead_audit_passed")):` restored, the `is True` branch removed):

```
FAILED tests/test_rejected_reason_payload.py::test_a_bare_lookahead_true_is_not_a_passed_audit - AssertionError: assert 'pass' == 'not_computed'
FAILED tests/test_rejected_reason_payload.py::test_an_inconclusive_status_beats_a_stored_lookahead_true - AssertionError: assert 'pass' == 'not_computed'
================== 2 failed, 19 passed, 4 warnings in 12.04s ===================   # exit 1
```

The second one is the sharper case: a verdict that *explicitly says the audit reached no verdict* (`look_ahead_status: "pending"`) still rendered as a pass because the boolean happened to read `True`.

**9. Misattribute the not-computed ratio** (the single `"no positive in-sample Sharpe to compare against"` string restored, so a row with `in_sample_sharpe = 1.2` and no OOS Sharpe is told it has no positive in-sample Sharpe):

```
FAILED tests/test_rejected_reason_payload.py::test_the_ratio_check_names_the_side_that_is_actually_missing - AssertionError: assert 'no positive ...mpare against' == 'no out-of-sa...pe...'
=================== 1 failed, 20 passed, 4 warnings in 7.66s ===================   # exit 1
```

## Verification

New guards, green:

```
$ pytest -p no:cacheprovider backend/tests/test_rejected_reason_payload.py -q
21 passed, 4 warnings in 13.98s                                        # exit 0

$ cd ui && node --test test/rejected-reason.test.js
ℹ tests 12  ℹ pass 12  ℹ fail 0                                        # exit 0
```

Neighbouring backend suites on the same route/model (guards included):

```
$ pytest -p no:cacheprovider backend/tests/test_rejected_reason_payload.py \
    backend/tests/test_strategies_routes.py backend/tests/test_strategy_store.py \
    backend/tests/test_generated_citation_truth.py backend/tests/test_unify_curated_generated.py -q
130 passed, 12 warnings in 30.54s                                      # exit 0
```

The write paths the new honesty rules are pinned against (`_patch_pbo`, `_abstain_result`, the passport):

```
$ pytest -p no:cacheprovider backend/tests/test_generation_pipeline.py \
    backend/tests/services/test_generation_pipeline.py backend/tests/test_brief_on_passport.py \
    backend/tests/test_publishable_strategy_ids.py backend/tests/test_strategy_ownership.py -q
108 passed, 33 warnings in 32.64s                                      # exit 0
```

Full UI suite:

```
$ cd ui && node --test
ℹ tests 925  ℹ pass 925  ℹ fail 0                                      # exit 0
```

Lint:

```
$ ruff check backend/archimedes/services/rigor_reasons.py backend/tests/test_rejected_reason_payload.py
All checks passed!                                                     # exit 0
$ ruff format --check <same two files>
2 files already formatted                                              # exit 0
$ npx eslint src/rejectionReasons.js src/components/Strategies.jsx test/rejected-reason.test.js
(no output)                                                            # exit 0
```

`ruff check` on `backend/archimedes/api/strategies_routes.py` reports one `SIM105` at line 1263 (`try/except/pass` around `session.rollback()`). **Pre-existing** — reproduced identically with my changes stashed, and present in `origin/main`'s copy of the file; not in my hunk, not touched.

Backend unit suite, `-m "not integration"`, run on the branch's first commit. The single full-suite invocation cannot complete in this environment — it is killed (`EXIT=143`, SIGTERM) partway through, and one file segfaults the interpreter on shutdown (`EXIT=139`). Both reproduce on unmodified `origin/main`. It was therefore run in chunks covering every collected file; log at `/tmp/rejected-reason-suite.log`:

| chunk | exit | result |
| --- | --- | --- |
| `backend/tests/api` | 0 | 53 passed |
| `backend/tests/chain` | 0 | 336 passed, 2 skipped |
| `backend/tests/marketplace` | 0 | 202 passed |
| `backend/tests/models` | 0 | 16 passed |
| `backend/tests/scripts` | 0 | 62 passed, 1 deselected |
| `backend/tests/services` | 1 | 2 failed, 1374 passed — **pre-existing** |
| `backend/tests/test_*.py` chunks 1–3 | 0 | all passed |
| `backend/tests/test_*.py` chunk 4a | 1 | 5 failed, 102 passed — **pre-existing** |
| `backend/tests/test_*.py` chunk 4b | 0/139 | all tests passed; SIGSEGV at interpreter shutdown — **pre-existing, flaky** |
| `backend/tests/test_*.py` chunk 5 | 0 | 751 passed, 1 skipped |

Every failure baselined against a clean tree (`git stash -u`, same command):

- `services/test_generation_pipeline.py::test_pipeline_{writes,does_not_ledger}_…` — `sqlite3.OperationalError: no such table`, a cross-file DB-isolation problem. Clean main: **identical** `2 failed, 1374 passed`.
- `test_metrics_routes.py` × 5 — same `no such table` shape. Clean main: **identical** `5 failed, 102 passed`.
- `test_paper_rag.py` — segfault (139) at interpreter shutdown after all 37 tests pass. Ran 3× on each tree: this branch 139/0/0, clean main 139/139/0. Flaky and **pre-existing**.

That chunked run predates the second commit. The second commit touches only `rigor_reasons.py` (a new file nothing else imports except the route line) and its own test file, so the suites re-run above are the ones that can reach it; the chunked table has not been repeated.

## What the second commit fixed

The first commit's `rigor_reasons.py` stated the right honesty rules in its docstring and then broke two of them on inputs today's write paths actually produce. Review caught both:

1. **`pbo = 0.0` rendered as a passed overfitting check** on every ungraded candidate — mutation 7 above. Fixed by refusing to grade any numeric leg of a verdict that carries its own `reason`.
2. **A bare `lookahead_audit_passed: True` rendered as a passed audit**, short-circuiting the module's own four-state handling — including on a row whose `look_ahead_status` explicitly said `pending`. Mutation 8 above.

Plus two smaller corrections: the not-computed ratio detail now names the side that is actually missing (mutation 9), and the module/test docstrings no longer attribute live writes to `_rigor_verdict_for`, which has no production callers.

## Concerns for the vet

1. **The 0.90-vs-0.95 divergence is real and is only *reported*, not fixed here.** `generation_pipeline._rigor_verdict_for` hardcodes a 0.95 DSR bar; the badge profile is 0.90. This PR grades the report against the badge bar and adds `unattributed` for the gap, rather than silently quoting a threshold that did not produce the stored `passing`. Reconciling the two bars is a separate change (and Önder's call).
2. **`_rigor_verdict_for` has no production callers at all.** Two knock-ons: `SHORT_SERIES_REASON` / `MIN_RETURNS_FOR_GATE = 10` match **legacy stored rows only**, so `rejectedSectionSummary`'s short-series sentence is a legacy-only path (kept, with its pinning test, because those rows are still in the library); and the `unattributed` state is likewise reached via stored rows. Whether that function is dead code worth deleting is a separate question this PR does not answer.
3. **The report grades the STORED verdict, not a live gate run.** That is deliberate — the rejected card's `passes_rigor_gate` comes from `coerceGenerated(row.rigor_verdict.passing)`, so the reasons and the badge now come from the same blob and cannot disagree. It does mean a stale stored verdict yields stale reasons; the live gate stays the passport's job.
4. **Desktop rows show the block only when expanded.** The mobile card (the screenshot's surface) shows it above the fold; the desktop table has no free row to put it in without a new `<tr>`. Both layouts render "Gen tokens", so the screenshot could be either — worth confirming which surface you were on. A `colSpan` summary row is the fix if it was the table.
5. `_pbo_below_power_floor` (#819's CSCV N floor) is **not** modelled — the stored verdict does not carry `pbo_library_size`, so a PBO that the live gate would treat as non-load-bearing is still reported as a fail here when it is ≥ 0.50. Fixing it needs a new field at write time. (Distinct from the N<2 sentinel fixed above, which is caught because those verdicts carry a `reason`.)
6. **Shared-file contact:** `strategies_routes.py` and `Strategies.jsx` are both touched by concurrent branches. `dbrowneup/reasoning-traces-surfaced` touches neither file. `dbrowneup/verdict-of-record-a` touches `list_generated_strategies` and, in `Strategies.jsx`, `statusTag` / `statusLabel` and `coerceGenerated`'s verdict lines — all of which this branch deliberately leaves alone; a hunk-range diff of both branches against this one came back disjoint. The one spot to eyeball on merge is `strategies_routes.py`'s import block, where the two branches' inserts land a couple of lines apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
