### PR TITLE
perf(tests): make the arXiv polite PDF delay injectable (audit P1-2)

### DIFF
--- a/backend/archimedes/services/arxiv_corpus.py
+++ b/backend/archimedes/services/arxiv_corpus.py
@@ -86,7 +86,10 @@ _TEXT_REL = "data/corpus/text"
 
 # Polite to the arXiv API: their guidance is a single request every ~3s.
 _API_DELAY_SECONDS = 3.0
-_PDF_DOWNLOAD_DELAY = 3.0  # same polite delay between PDF downloads
+# Same polite delay between PDF downloads. This is the *production default*
+# for ``build_corpus(delay_seconds=...)`` — the seam exists so offline callers
+# (tests) can pay 0 without ever changing what a real harvest sends to arXiv.
+_PDF_DOWNLOAD_DELAY = 3.0
 _API_PAGE_SIZE = 100
 _PDF_TIMEOUT_SECONDS = 30
 _PDF_MAX_RETRIES = 3
@@ -376,6 +379,7 @@ def build_corpus(
     search: Callable[[Iterable[str], int], Iterable[CorpusPaper]] | None = None,
     pdf_downloader: Callable[[str], bytes] | None = None,
     fetch_pdfs: bool = True,
+    delay_seconds: float = _PDF_DOWNLOAD_DELAY,
 ) -> list[dict]:
     """Build the manifest and (best-effort) the PDF + text caches.
 
@@ -383,6 +387,10 @@ def build_corpus(
     even rows whose PDF/text failed (``pdf_sha256`` then ``null``). ``search``
     and ``pdf_downloader`` are injectable so the parse → schema → cache →
     dedupe → recency path is fully testable offline.
+
+    ``delay_seconds`` is the polite pause between cached PDFs and defaults to
+    arXiv's guidance (``_PDF_DOWNLOAD_DELAY`` = 3.0s) — a live harvest is
+    unchanged. Offline callers pass 0 to skip the sleep entirely.
     """
     search = search or _default_search
     pdf_downloader = pdf_downloader or _default_pdf_downloader
@@ -414,10 +422,13 @@ def build_corpus(
                 pdf_ok += 1
                 if _extract_text(paper, pdf_dir, text_dir):
                     text_ok += 1
-                # Polite delay between PDF downloads — respect arXiv rate limits
-                import time
+                # Polite delay between PDF downloads — respect arXiv rate
+                # limits. Injected (default 3.0s), so offline callers can
+                # pass 0 and skip the sleep entirely.
+                if delay_seconds > 0:
+                    import time
 
-                time.sleep(_PDF_DOWNLOAD_DELAY)
+                    time.sleep(delay_seconds)
         rows.append(paper.manifest_row(pdf_sha256=sha, fetched_at=fetched_at))
         if idx % 25 == 0:
             logger.info("processed %d/%d papers", idx, len(papers))

--- a/backend/tests/test_arxiv_corpus.py
+++ b/backend/tests/test_arxiv_corpus.py
@@ -10,11 +10,14 @@ defensive behaviour when a PDF download fails (row still emitted, sha null).
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
+import time
 from datetime import UTC, datetime
 
 import pytest
 from archimedes.services.arxiv_corpus import (
+    _PDF_DOWNLOAD_DELAY,
     CorpusPaper,
     _bare_id,
     _dedupe_and_trim,
@@ -165,6 +168,7 @@ def test_manifest_schema_is_frozen(tmp_path) -> None:
         text_dir=tmp_path / "text",
         search=_search_factory(papers),
         pdf_downloader=_fake_downloader,
+        delay_seconds=0,
     )
     assert len(rows) == 2
     for row in rows:
@@ -185,6 +189,7 @@ def test_pdf_sha256_is_content_addressed(tmp_path) -> None:
         text_dir=tmp_path / "text",
         search=_search_factory(papers),
         pdf_downloader=_fake_downloader,
+        delay_seconds=0,
     )
     expected_sha = hashlib.sha256(_FAKE_PDF).hexdigest()
     assert rows[0]["pdf_sha256"] == expected_sha
@@ -211,6 +216,7 @@ def test_cache_is_idempotent_on_rerun(tmp_path) -> None:
         "text_dir": tmp_path / "text",
         "search": _search_factory(papers),
         "pdf_downloader": _counting_downloader,
+        "delay_seconds": 0,
     }
     build_corpus(**kwargs)
     build_corpus(**kwargs)
@@ -227,6 +233,7 @@ def test_failed_pdf_still_emits_metadata_row(tmp_path) -> None:
         text_dir=tmp_path / "text",
         search=_search_factory(papers),
         pdf_downloader=_failing_downloader,
+        delay_seconds=0,
     )
     # metadata-complete for the full N even though every PDF failed
     assert len(rows) == 2
@@ -249,6 +256,7 @@ def test_no_pdfs_mode_skips_download(tmp_path) -> None:
         text_dir=tmp_path / "text",
         search=_search_factory(papers),
         pdf_downloader=_failing_downloader,
+        delay_seconds=0,
         fetch_pdfs=False,
     )
     assert rows[0]["pdf_sha256"] is None
@@ -269,6 +277,65 @@ def test_build_corpus_dedupes_and_trims_end_to_end(tmp_path) -> None:
         text_dir=tmp_path / "text",
         search=_search_factory(papers),
         pdf_downloader=_fake_downloader,
+        delay_seconds=0,
     )
     assert len(rows) == 2
     assert [r["arxiv_id"] for r in rows] == ["2501.00001", "2401.00001"]
+
+
+# ── Polite-delay seam (P1-2) ────────────────────────────────────
+
+
+def test_polite_pdf_delay_default_is_three_seconds() -> None:
+    """A live harvest still waits arXiv's guided 3.0s between PDFs.
+
+    The delay is injectable only so offline tests can pass 0; the *production*
+    default must not drift. Both halves are pinned: the module constant and the
+    ``build_corpus`` signature default that is bound to it.
+
+    MUTATION: set ``_PDF_DOWNLOAD_DELAY = 0.0``, or change the
+    ``delay_seconds`` default in ``build_corpus`` to anything but the
+    constant, and this fails — that is a real harvest hammering arXiv.
+    """
+    assert _PDF_DOWNLOAD_DELAY == 3.0
+    default = inspect.signature(build_corpus).parameters["delay_seconds"].default
+    assert default == _PDF_DOWNLOAD_DELAY
+    assert default == 3.0
+
+
+def test_build_corpus_honours_the_injected_delay(tmp_path, monkeypatch) -> None:
+    """The polite sleep uses the injected delay, and 0 sleeps not at all.
+
+    ``build_corpus`` imports ``time`` inside the loop, so patching
+    ``time.sleep`` on the module object is what the call actually resolves to.
+
+    MUTATION: revert the seam (``time.sleep(_PDF_DOWNLOAD_DELAY)`` instead of
+    ``time.sleep(delay_seconds)``) and the recorded sleeps become
+    ``[3.0, 3.0]`` in the injected case and ``[3.0, 3.0]`` in the zero case —
+    i.e. this file pays ~21s of wall clock again.
+    """
+    slept: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda seconds: slept.append(seconds))
+
+    papers = [_mk_paper("2401.00001"), _mk_paper("2401.00002")]
+    kwargs = {
+        "max_papers": 10,
+        "out_path": tmp_path / "m.jsonl",
+        "pdf_dir": tmp_path / "pdfs",
+        "text_dir": tmp_path / "text",
+        "search": _search_factory(papers),
+        "pdf_downloader": _fake_downloader,
+    }
+
+    rows = build_corpus(**kwargs, delay_seconds=0.25)
+    # one polite pause per successfully cached PDF, at the injected value
+    assert len(rows) == 2
+    assert slept == [0.25, 0.25]
+
+    # 0 short-circuits the sleep entirely (cache is warm, sha still non-null,
+    # so the delay branch is still reached — it just must not fire)
+    slept.clear()
+    rows = build_corpus(**kwargs, delay_seconds=0)
+    assert len(rows) == 2
+    assert all(r["pdf_sha256"] for r in rows)
+    assert slept == []


### PR DESCRIPTION
## Audit citation

Suite / dead-code decision package (2026-09-01), **Phase 1 → P1-2**:

> Make the arXiv polite delay injectable (`services/arxiv_corpus.py:89`, fired at `:420`); tests pass 0 (`backend/tests/test_arxiv_corpus.py:158,182,199`) — **−18s**, risk: *small prod-code seam, default stays 3.0*.

## What changed

`build_corpus()` slept a hard-coded `time.sleep(_PDF_DOWNLOAD_DELAY)` (3.0s) after **every** successfully cached PDF. The tests in `backend/tests/test_arxiv_corpus.py` inject a fake downloader and never touch the network, so they were paying ~21s of real wall clock in politeness owed to nobody. (The audit named three tests; a fourth, `test_build_corpus_dedupes_and_trims_end_to_end`, pays it too — 21.2s of sleep, not 18s.)

**Prod code** — `backend/archimedes/services/arxiv_corpus.py`:

- new keyword-only parameter `delay_seconds: float = _PDF_DOWNLOAD_DELAY` on `build_corpus`;
- the loop sleeps `delay_seconds` instead of the constant, and skips the sleep entirely when it is `0`;
- `_PDF_DOWNLOAD_DELAY` stays `3.0` and is now commented as the production default.

**The production default is unchanged.** The only prod caller is the CLI `main()` (`arxiv_corpus.py:503`), which passes no override, so a live harvest still waits arXiv's guided 3.0s between PDF downloads. `grep -rn "build_corpus"` across the repo returns no other caller and no doc reference to `_PDF_DOWNLOAD_DELAY`.

**Tests** — `backend/tests/test_arxiv_corpus.py`: every `build_corpus` call site now passes `delay_seconds=0`, plus two new guards on the seam itself.

## Adversarial demo (the guards shown red on the input they reject)

**Mutation 1 — revert the injection** (`time.sleep(_PDF_DOWNLOAD_DELAY)` back in place of `time.sleep(delay_seconds)`, branch forced open):

```
FAILED backend/tests/test_arxiv_corpus.py::test_build_corpus_honours_the_injected_delay
backend/tests/test_arxiv_corpus.py:333: in test_build_corpus_honours_the_injected_delay
    assert slept == [0.25, 0.25]
E   assert [3.0, 3.0] == [0.25, 0.25]
E     At index 0 diff: 3.0 != 0.25

============================= slowest 5 durations ==============================
6.15s call     backend/tests/test_arxiv_corpus.py::test_manifest_schema_is_frozen
6.04s call     backend/tests/test_arxiv_corpus.py::test_build_corpus_dedupes_and_trims_end_to_end
6.02s call     backend/tests/test_arxiv_corpus.py::test_cache_is_idempotent_on_rerun
3.01s call     backend/tests/test_arxiv_corpus.py::test_pdf_sha256_is_content_addressed
=================== 1 failed, 18 passed, 1 warning in 24.03s ===================
```

Red guard **and** the three audit-cited tests are back over 9s (they alone are 15.2s; 21.2s counting the fourth).

**Mutation 2 — drop the production default to 0** (`_PDF_DOWNLOAD_DELAY = 0.0`, i.e. a real harvest hammering arXiv):

```
FAILED backend/tests/test_arxiv_corpus.py::test_polite_pdf_delay_default_is_three_seconds
backend/tests/test_arxiv_corpus.py:300: in test_polite_pdf_delay_default_is_three_seconds
    assert _PDF_DOWNLOAD_DELAY == 3.0
E   assert 0.0 == 3.0
================= 1 failed, 18 deselected, 1 warning in 1.25s ==================
```

Both mutations reverted before commit; the committed tree is the green one below.

## Verification

Timings, `--durations=5`, same box, same env pytest:

| | tests | wall | `test_manifest_schema_is_frozen` | `..._dedupes_and_trims_end_to_end` | `test_cache_is_idempotent_on_rerun` | `test_pdf_sha256_is_content_addressed` |
|---|---|---|---|---|---|---|
| **before** | 17 passed | **22.65s** | 6.16s | 6.04s | 6.02s | 3.01s |
| **after** | 19 passed | **1.58s** | 0.14s | <0.005s | <0.005s | <0.005s |

**−21.1s** on this file (audit projected −18s), and two guards added.

```
$ pytest backend/tests/test_arxiv_corpus.py -q -p no:cacheprovider --durations=5
17 passed, 1 warning in 22.65s          # before   EXIT=0
19 passed, 1 warning in 1.58s           # after    EXIT=0

$ ruff format backend/archimedes/services/arxiv_corpus.py backend/tests/test_arxiv_corpus.py
2 files left unchanged
$ ruff check  backend/archimedes/services/arxiv_corpus.py backend/tests/test_arxiv_corpus.py
All checks passed!                                              RUFF_EXIT=0

$ pytest -m "not integration" -q -p no:cacheprovider   # full unit suite (prod code touched)
5646 passed, 4 skipped, 2 deselected, 328 warnings in 619.72s (0:10:19)
EXIT=0
```

## Notes / risk

- Seam is one keyword argument with a bound default; no behaviour change for any production path.
- `delay_seconds > 0` guards the sleep, so `0` short-circuits it rather than calling `time.sleep(0)` — the second half of the injection guard asserts exactly that, with a warm cache so the branch is still reached.
- The injection guard patches `time.sleep` on the `time` module (`build_corpus` does a function-local `import time`, which resolves to the same module object); `monkeypatch` restores it.
- No deletions, so no `docs/` reference sweep needed — but `grep -rn "_PDF_DOWNLOAD_DELAY\|build_corpus" docs/` was run anyway and is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
