### PR TITLE
[infra][deploy] Post-rollout probe: retry transport flakes, judge on an observed streak + good final sample (#1791)

### DIFF
--- a/.github/scripts/post_rollout_probe.sh
+++ b/.github/scripts/post_rollout_probe.sh
@@ -22,25 +22,35 @@
 #   Both were edge/TLS transients, not the app. A probe that cries wolf
 #   trains everyone to ignore red deploys, which is the one outcome a probe
 #   exists to prevent. So:
-#     * TRANSPORT-level failures (http=000, or curl exit != 0 — timeout,
-#       reset, TLS handshake) are RETRIED up to TRANSPORT_RETRIES times
+#     * TRANSPORT-level failures — NO HTTP ANSWER CAME BACK AT ALL, which
+#       curl reports as http_code 000 (connect refused, DNS, TLS handshake
+#       reset, client timeout) — are RETRIED up to TRANSPORT_RETRIES times
 #       after RETRY_PAUSE before they count. A real outage still fails,
 #       because the retries fail too.
-#     * A 5xx, any non-200, or a 200 slower than MAX_SECONDS counts
-#       IMMEDIATELY as NOT-OK with no retry — those are the app answering,
-#       and #1714/#1713's rollout-window 503s must not be retried away.
+#     * ANYTHING THE APP ANSWERED counts IMMEDIATELY as NOT-OK with no
+#       retry: a 5xx, any non-200, or a 200 slower than MAX_SECONDS. Those
+#       are the app talking, and #1714/#1713's rollout-window 503s must not
+#       be retried away.
 #     * The verdict is "a run of NEED_STREAK consecutive good samples was
 #       OBSERVED SOMEWHERE in the window, AND the final (post-retry) sample
-#       is good, AND that final sample reports EXPECTED_VERSION".
+#       is good, AND that final sample reports EXPECTED_VERSION, AND no more
+#       than MAX_NOT_OK samples were NOT-OK".
 #       "Observed somewhere" is what stops one mid-window transient from
 #       failing an otherwise healthy deploy; "final sample is good" is what
 #       keeps it fail-closed — a run that is broken AT THE END fails no
 #       matter how healthy its start was, so a cold-start tail (the #1532
-#       failure mode this probe was built for) still goes red.
+#       failure mode this probe was built for) still goes red; and
+#       MAX_NOT_OK is what stops "observed somewhere" from tolerating a
+#       pockmarked window. Without that cap the streak rule alone would pass
+#       a window with SAMPLES - NEED_STREAK - 1 = 4 bad samples out of 10
+#       (owner ruling, #1791 review): a transient is one or two samples, a
+#       third is a degraded deploy and goes red.
 #   Every sample and every retry is printed with http/time/curl_exit: the
 #   timings ARE the evidence (#1532 had to be diagnosed by hand-curling
 #   because the pipeline kept none), and a degradation that this verdict
-#   tolerates must still be visible in the log.
+#   tolerates must still be visible in the log — including a sample that
+#   FAILED AND THEN RECOVERED ON RETRY, which is counted and warned on
+#   separately (it does not appear in the NOT-OK tally, because it recovered).
 #
 # Parameters (all via environment):
 #   HEALTH_URL         required — probed URL (deploy.yml uses /api/health
@@ -49,21 +59,29 @@
 #   EXPECTED_VERSION   required — the commit this run deployed
 #   SAMPLES            default 10
 #   NEED_STREAK        default 5
+#   MAX_NOT_OK         default 2   — most NOT-OK samples (after retries) a
+#                                    passing run may contain. 3+ is a
+#                                    degraded window, not a transient.
 #   MAX_SECONDS        default 5   — client-realistic deadline, deliberately
 #                                    below #1436's recorded p99 of 16.8s
 #   INTERVAL           default 3   — seconds between samples
 #   TRANSPORT_RETRIES  default 2   — retries per sample, transport failures only
 #   RETRY_PAUSE        default 3   — seconds before each retry
 #   CURL_MAX_TIME      default 15  — per-request curl --max-time
-#   MAX_TOTAL_SECONDS  default 300 — wall-clock ceiling for the whole probe.
-#                      Retries widen the worst case (3 attempts x
-#                      CURL_MAX_TIME + pauses per sample), and deploy.yml's
-#                      poll step asserts the deploy-ecs job has headroom for
-#                      "the answer probe and the CloudFront invalidation".
-#                      Blowing through that headroom would turn a clean
-#                      ::error into an opaque job timeout, so the probe stops
-#                      itself first — and stopping early always FAILS, it can
-#                      never pass a deploy it did not finish measuring.
+#   MAX_TOTAL_SECONDS  default 300 — REAL wall-clock ceiling for the whole
+#                      probe, not a between-samples check: no request is
+#                      started with a deadline that reaches past it (curl's
+#                      --max-time is capped to the remaining budget) and no
+#                      sleep runs past it. The only possible overshoot is
+#                      sub-second rounding plus the 1s floor this keeps on
+#                      --max-time (`curl --max-time 0` means NO timeout).
+#                      It matters because deploy.yml's poll step reserves 7
+#                      minutes of the deploy-ecs job timeout for "the answer
+#                      probe and the CloudFront invalidation": a probe that
+#                      overran that reserve would turn a clean ::error into
+#                      an opaque job timeout AND eat the invalidation's
+#                      share of it. Stopping early always FAILS — the probe
+#                      can never pass a deploy it did not finish measuring.
 #
 # Exit 0 = the app answers. Exit 1 = it does not, or it is answering with
 # code this run did not build.
@@ -81,6 +99,7 @@ HEALTH_URL="${HEALTH_URL:-}"
 EXPECTED_VERSION="${EXPECTED_VERSION:-}"
 SAMPLES="${SAMPLES:-10}"
 NEED_STREAK="${NEED_STREAK:-5}"
+MAX_NOT_OK="${MAX_NOT_OK:-2}"
 MAX_SECONDS="${MAX_SECONDS:-5}"
 INTERVAL="${INTERVAL:-3}"
 TRANSPORT_RETRIES="${TRANSPORT_RETRIES:-2}"
@@ -92,6 +111,21 @@ if [ -z "$HEALTH_URL" ] || [ -z "$EXPECTED_VERSION" ]; then
   echo "::error::post-rollout probe: HEALTH_URL and EXPECTED_VERSION are both required (got HEALTH_URL='${HEALTH_URL}', EXPECTED_VERSION='${EXPECTED_VERSION}'). Refusing to report a deploy as verified without probing it."
   exit 1
 fi
+
+# Every parameter used in integer arithmetic or an integer test is validated
+# BEFORE it is used. `set -e` is off by design (see above), so a `[ "$a" -gt
+# "$b" ]` against a non-integer would print a bash error, return 2, and be
+# read as FALSE — i.e. a garbage MAX_NOT_OK would silently DISABLE the cap
+# and pass a window it must fail. Fail-closed on the misconfiguration instead.
+for _int_param in SAMPLES NEED_STREAK MAX_NOT_OK TRANSPORT_RETRIES MAX_TOTAL_SECONDS; do
+  eval "_int_value=\${${_int_param}}"
+  case "$_int_value" in
+    '' | *[!0-9]*)
+      echo "::error::post-rollout probe misconfigured: ${_int_param}='${_int_value}' is not a non-negative integer. Refusing to run with a parameter that would silently disable a check."
+      exit 1
+      ;;
+  esac
+done
 if [ "$NEED_STREAK" -gt "$SAMPLES" ]; then
   echo "::error::post-rollout probe misconfigured: NEED_STREAK=${NEED_STREAK} exceeds SAMPLES=${SAMPLES}, so no run of samples could ever satisfy it and this step could never pass."
   exit 1
@@ -104,16 +138,43 @@ trap 'rm -f "$BODY_FILE" "$ERR_FILE"' EXIT
 sample_code=""
 sample_secs=""
 sample_rc=0
+started_at="$(date +%s)"
+
+# Whole seconds of MAX_TOTAL_SECONDS left, never negative. Every piece of work
+# the probe starts — request or sleep — is bounded by this, which is what makes
+# MAX_TOTAL_SECONDS a ceiling rather than a suggestion.
+remaining_budget() {
+  local left
+  left=$(( MAX_TOTAL_SECONDS - ( $(date +%s) - started_at ) ))
+  [ "$left" -gt 0 ] || left=0
+  printf '%s' "$left"
+}
+
+# Sleep, truncated to the remaining budget (and skipped entirely when there is
+# none). RETRY_PAUSE/INTERVAL may be fractional, hence awk rather than `[ -lt ]`.
+capped_sleep() {
+  local want left
+  want="$1"
+  left="$(remaining_budget)"
+  [ "$left" -gt 0 ] || return 0
+  sleep "$(awk -v w="$want" -v l="$left" 'BEGIN { print (w + 0 < l + 0) ? w + 0 : l + 0 }')"
+}
 
 # Takes one sample. The body of the LAST request made lands in $BODY_FILE, so
 # the version assertion below is made against the very response that closed
 # the window rather than an extra request taken afterwards.
 take_sample() {
-  local out
+  local out max_time
+  # Per-request deadline: CURL_MAX_TIME, but never more wall clock than the
+  # probe has left. Floored at 1 because `curl --max-time 0` means NO timeout —
+  # the exact opposite of a cap (the caller does not start a sample with zero
+  # budget left, so this floor is only ever the sub-second rounding tail).
+  max_time="$(awk -v c="$CURL_MAX_TIME" -v l="$(remaining_budget)" \
+    'BEGIN { m = (c + 0 < l + 0) ? c + 0 : l + 0; if (m < 1) m = 1; print m }')"
   # Declared and assigned separately on purpose: `local out="$(curl ...)"`
   # would make $? the exit status of `local`, not of curl.
   out="$(curl -sS -o "$BODY_FILE" -w '%{http_code} %{time_total}' \
-    --max-time "$CURL_MAX_TIME" "$HEALTH_URL" 2>"$ERR_FILE")"
+    --max-time "$max_time" "$HEALTH_URL" 2>"$ERR_FILE")"
   sample_rc=$?
   # curl writes the -w line even on timeout/connect failure (http_code 000);
   # this only backfills the case where it wrote nothing at all, so an empty
@@ -123,10 +184,20 @@ take_sample() {
   sample_secs="${out##* }"
 }
 
-# Transport level: no HTTP answer came back at all. http=000 covers connect /
-# TLS / timeout failures; a non-zero curl exit covers the rest.
+# Transport level: NO HTTP ANSWER CAME BACK AT ALL. http_code 000 is curl's
+# report for connect / DNS / TLS / client-timeout failures, and it is the only
+# thing retried here.
+#
+# Deliberately NOT `|| [ "$sample_rc" -ne 0 ]` (#1791 review, defect 1): curl
+# also exits non-zero on a TRUNCATED answer that DID carry a real status line —
+# exit 18 "transfer closed with N bytes remaining", exit 56 "recv failure" —
+# and an origin that 503s while dropping the body under load is exactly the
+# #1714/#1713 rollout-window shape. Retrying those retries a 5xx, which is the
+# one thing this probe promises never to do. Both #1791 production shapes
+# (curl 28 client timeout, curl 35 TLS reset) report http=000, so nothing real
+# is lost by keying on the status line alone.
 is_transport_failure() {
-  [ "$sample_code" = "000" ] || [ "$sample_rc" -ne 0 ]
+  [ "$sample_code" = "000" ]
 }
 
 # Good: the app answered 200 inside the client deadline.
@@ -145,12 +216,12 @@ curl_error_text() {
 streak=0
 best_streak=0
 not_ok=0
+retried=0
 taken=0
 final_good=0
 deadline_hit=0
-started_at="$(date +%s)"
 
-echo "Probing $HEALTH_URL — ${SAMPLES} samples every ${INTERVAL}s; need ${NEED_STREAK} consecutive good (200 under ${MAX_SECONDS}s) anywhere in the window AND a good final sample reporting version ${EXPECTED_VERSION}. Transport-level failures are retried ${TRANSPORT_RETRIES}x after ${RETRY_PAUSE}s; 5xx and slow 200s are never retried."
+echo "Probing $HEALTH_URL — ${SAMPLES} samples every ${INTERVAL}s; need ${NEED_STREAK} consecutive good (200 under ${MAX_SECONDS}s) anywhere in the window AND a good final sample reporting version ${EXPECTED_VERSION} AND at most ${MAX_NOT_OK} NOT-OK samples. ONLY transport-level failures (no HTTP answer at all, http=000) are retried, ${TRANSPORT_RETRIES}x after ${RETRY_PAUSE}s; anything the app answered — a 5xx, any non-200, a 200 slower than ${MAX_SECONDS}s — counts immediately and is NEVER retried. Whole-probe wall-clock ceiling ${MAX_TOTAL_SECONDS}s; hitting it fails the run."
 
 for i in $(seq 1 "$SAMPLES"); do
   elapsed=$(( $(date +%s) - started_at ))
@@ -168,10 +239,19 @@ for i in $(seq 1 "$SAMPLES"); do
       prefix="$(printf 'probe %2d/%s retry %d/%s:' "$i" "$SAMPLES" "$attempt" "$TRANSPORT_RETRIES")"
     fi
     if is_transport_failure && [ "$attempt" -lt "$TRANSPORT_RETRIES" ]; then
+      if [ "$(remaining_budget)" -le 0 ]; then
+        # The retry is work, and work stops at the ceiling. The sample counts
+        # as it stands (NOT-OK), and the run fails on the ceiling regardless.
+        printf '%s transport failure (%s) — NOT retried: the probe has used all %ss of its wall-clock ceiling; the sample counts as it stands\n' \
+          "$prefix" "$(curl_error_text)" "$MAX_TOTAL_SECONDS"
+        deadline_hit=1
+        break
+      fi
       printf '%s http=%s time=%ss curl_exit=%s -> transport failure (%s) — retrying in %ss\n' \
         "$prefix" "$sample_code" "$sample_secs" "$sample_rc" "$(curl_error_text)" "$RETRY_PAUSE"
       attempt=$(( attempt + 1 ))
-      sleep "$RETRY_PAUSE"
+      retried=$(( retried + 1 ))
+      capped_sleep "$RETRY_PAUSE"
       continue
     fi
     break
@@ -195,7 +275,7 @@ for i in $(seq 1 "$SAMPLES"); do
     "$prefix" "$sample_code" "$sample_secs" "$sample_rc" "$verdict" "$streak" "$best_streak"
 
   if [ "$i" -lt "$SAMPLES" ]; then
-    sleep "$INTERVAL"
+    capped_sleep "$INTERVAL"
   fi
 done
 
@@ -205,12 +285,17 @@ if [ "$deadline_hit" -eq 1 ]; then
   # Fail-closed by construction: a probe that ran out of wall clock did not
   # finish measuring, so it cannot report a deploy as verified — no matter how
   # good the samples it did take were.
-  echo "::error::post-rollout answer probe: ran out of its ${MAX_TOTAL_SECONDS}s wall-clock budget after $(( i - 1 )) of ${SAMPLES} samples. Samples were taking long enough that the probe would have eaten the deploy-ecs job's remaining timeout; whatever the app is doing, it is not answering at the speed a finished deploy answers at. Timings are printed above."
+  echo "::error::post-rollout answer probe: ran out of its ${MAX_TOTAL_SECONDS}s wall-clock budget after ${taken} of ${SAMPLES} samples. Samples were taking long enough that the probe would have eaten the deploy-ecs job's remaining timeout; whatever the app is doing, it is not answering at the speed a finished deploy answers at. Timings are printed above."
   fail=1
 fi
 
 if [ "$best_streak" -lt "$NEED_STREAK" ]; then
   echo "::error::post-rollout answer probe: the longest run of consecutive good samples anywhere in the window was ${best_streak} (needed ${NEED_STREAK}) out of ${SAMPLES}. ECS reported the rollout COMPLETED, but the app never answered 200 under ${MAX_SECONDS}s ${NEED_STREAK} times in a row — this is the 58e337dc failure mode from #1532, and it is an outage whether or not the badge would have been green. Every sample is printed above."
+  fail=1
+fi
+
+if [ "$not_ok" -gt "$MAX_NOT_OK" ]; then
+  echo "::error::post-rollout answer probe: ${not_ok} of the ${SAMPLES} samples were NOT-OK after retries (MAX_NOT_OK=${MAX_NOT_OK}). A ${NEED_STREAK}-sample good run was allowed to be observed ANYWHERE in the window (#1791) so that one transient cannot fail a healthy deploy — this cap is what keeps that from tolerating a pockmarked one. ${not_ok} bad samples in a window of ${SAMPLES} is a degraded deploy, not a transient: read the sample lines above for what came back."
   fail=1
 fi
 
@@ -238,8 +323,8 @@ fi
 
 [ "$fail" = 0 ] || exit 1
 
-if [ "$not_ok" -gt 0 ]; then
-  echo "::warning::post-rollout probe passed with ${not_ok} of ${SAMPLES} samples NOT-OK. The verdict tolerates a transient inside an otherwise healthy window (#1791), but repeated warnings here are a real finding about post-rollout latency/availability (#1309, #1436, #1714) — read the sample lines above."
+if [ "$not_ok" -gt 0 ] || [ "$retried" -gt 0 ]; then
+  echo "::warning::post-rollout probe passed with ${not_ok} of ${SAMPLES} samples NOT-OK (cap MAX_NOT_OK=${MAX_NOT_OK}) and ${retried} transport retry attempt(s) spent. A sample that failed at transport level and RECOVERED on retry counts as good and never reaches the NOT-OK tally — which is exactly why the retry count is warned on too: a window that needed retries is a window where the origin did not answer the first request (#1791 review, defect 3). Repeated warnings here are a real finding about post-rollout latency/availability (#1309, #1436, #1714) — read the sample lines above."
 fi
 
-echo "post-rollout probe OK: longest good streak ${best_streak}/${SAMPLES} (needed ${NEED_STREAK}), final sample 200 in ${sample_secs}s under ${MAX_SECONDS}s, serving version ${version}."
+echo "post-rollout probe OK: longest good streak ${best_streak}/${SAMPLES} (needed ${NEED_STREAK}), ${not_ok} NOT-OK (cap ${MAX_NOT_OK}), ${retried} transport retry attempt(s), final sample 200 in ${sample_secs}s under ${MAX_SECONDS}s, serving version ${version}."

--- a/.github/scripts/post_rollout_probe.sh
+++ b/.github/scripts/post_rollout_probe.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+#
+# Post-rollout answer probe — "does the deployed app answer a real client,
+# inside a client-realistic deadline, on the commit this run built?"
+#
+# Extracted from the `Assert the deployed app actually answers (post-rollout
+# probe)` step of .github/workflows/deploy.yml (issue #1791) so the hermetic
+# test backend/tests/test_post_rollout_probe.py can run THE EXACT SCRIPT CI
+# RUNS against a fake /api/health, instead of a paraphrase of it that can
+# drift from the workflow.
+#
+# WHY THE VERDICT IS WHAT IT IS (#1791)
+#   The original verdict was "the LAST 5 samples must be consecutive 200s
+#   under MAX_SECONDS". Two of the last four main deploys went red on it
+#   while prod was already serving the new version:
+#     run 33566302291 — samples 1-7 = 200 in ~0.4s, sample 8 http=000
+#                       time=15.0s curl_exit=28 (client timeout), 9-10 = 200
+#                       -> "only 2 consecutive trailing" -> exit 1
+#     run 33573075995 — samples 1-9 = 200 in ~0.4s, sample 10 http=000
+#                       time=0.025s curl_exit=35 (TLS reset at 25 ms)
+#                       -> "only 0 consecutive trailing" -> exit 1
+#   Both were edge/TLS transients, not the app. A probe that cries wolf
+#   trains everyone to ignore red deploys, which is the one outcome a probe
+#   exists to prevent. So:
+#     * TRANSPORT-level failures (http=000, or curl exit != 0 — timeout,
+#       reset, TLS handshake) are RETRIED up to TRANSPORT_RETRIES times
+#       after RETRY_PAUSE before they count. A real outage still fails,
+#       because the retries fail too.
+#     * A 5xx, any non-200, or a 200 slower than MAX_SECONDS counts
+#       IMMEDIATELY as NOT-OK with no retry — those are the app answering,
+#       and #1714/#1713's rollout-window 503s must not be retried away.
+#     * The verdict is "a run of NEED_STREAK consecutive good samples was
+#       OBSERVED SOMEWHERE in the window, AND the final (post-retry) sample
+#       is good, AND that final sample reports EXPECTED_VERSION".
+#       "Observed somewhere" is what stops one mid-window transient from
+#       failing an otherwise healthy deploy; "final sample is good" is what
+#       keeps it fail-closed — a run that is broken AT THE END fails no
+#       matter how healthy its start was, so a cold-start tail (the #1532
+#       failure mode this probe was built for) still goes red.
+#   Every sample and every retry is printed with http/time/curl_exit: the
+#   timings ARE the evidence (#1532 had to be diagnosed by hand-curling
+#   because the pipeline kept none), and a degradation that this verdict
+#   tolerates must still be visible in the log.
+#
+# Parameters (all via environment):
+#   HEALTH_URL         required — probed URL (deploy.yml uses /api/health
+#                      through CloudFront, which is on CachingDisabled, so
+#                      every sample is a real origin round trip)
+#   EXPECTED_VERSION   required — the commit this run deployed
+#   SAMPLES            default 10
+#   NEED_STREAK        default 5
+#   MAX_SECONDS        default 5   — client-realistic deadline, deliberately
+#                                    below #1436's recorded p99 of 16.8s
+#   INTERVAL           default 3   — seconds between samples
+#   TRANSPORT_RETRIES  default 2   — retries per sample, transport failures only
+#   RETRY_PAUSE        default 3   — seconds before each retry
+#   CURL_MAX_TIME      default 15  — per-request curl --max-time
+#   MAX_TOTAL_SECONDS  default 300 — wall-clock ceiling for the whole probe.
+#                      Retries widen the worst case (3 attempts x
+#                      CURL_MAX_TIME + pauses per sample), and deploy.yml's
+#                      poll step asserts the deploy-ecs job has headroom for
+#                      "the answer probe and the CloudFront invalidation".
+#                      Blowing through that headroom would turn a clean
+#                      ::error into an opaque job timeout, so the probe stops
+#                      itself first — and stopping early always FAILS, it can
+#                      never pass a deploy it did not finish measuring.
+#
+# Exit 0 = the app answers. Exit 1 = it does not, or it is answering with
+# code this run did not build.
+
+# `set +e` is load-bearing, exactly as it was in the workflow step (#1762):
+# GitHub runs `run:` under `bash -e`, and `sample="$(curl ...)"` is an
+# assignment whose exit status IS curl's. With -e in force a single timed-out
+# sample (curl exit 28) aborted the whole step before rc was read and before a
+# single `probe N/10` line was printed — run 33553292497 went red that way with
+# the rollout COMPLETED, having never measured whether the app was answering.
+# Every failure below is handled explicitly; nothing here may rely on -e.
+set +e -uo pipefail
+
+HEALTH_URL="${HEALTH_URL:-}"
+EXPECTED_VERSION="${EXPECTED_VERSION:-}"
+SAMPLES="${SAMPLES:-10}"
+NEED_STREAK="${NEED_STREAK:-5}"
+MAX_SECONDS="${MAX_SECONDS:-5}"
+INTERVAL="${INTERVAL:-3}"
+TRANSPORT_RETRIES="${TRANSPORT_RETRIES:-2}"
+RETRY_PAUSE="${RETRY_PAUSE:-3}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-15}"
+MAX_TOTAL_SECONDS="${MAX_TOTAL_SECONDS:-300}"
+
+if [ -z "$HEALTH_URL" ] || [ -z "$EXPECTED_VERSION" ]; then
+  echo "::error::post-rollout probe: HEALTH_URL and EXPECTED_VERSION are both required (got HEALTH_URL='${HEALTH_URL}', EXPECTED_VERSION='${EXPECTED_VERSION}'). Refusing to report a deploy as verified without probing it."
+  exit 1
+fi
+if [ "$NEED_STREAK" -gt "$SAMPLES" ]; then
+  echo "::error::post-rollout probe misconfigured: NEED_STREAK=${NEED_STREAK} exceeds SAMPLES=${SAMPLES}, so no run of samples could ever satisfy it and this step could never pass."
+  exit 1
+fi
+
+BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/post-rollout-probe-body.XXXXXX")"
+ERR_FILE="$(mktemp "${TMPDIR:-/tmp}/post-rollout-probe-err.XXXXXX")"
+trap 'rm -f "$BODY_FILE" "$ERR_FILE"' EXIT
+
+sample_code=""
+sample_secs=""
+sample_rc=0
+
+# Takes one sample. The body of the LAST request made lands in $BODY_FILE, so
+# the version assertion below is made against the very response that closed
+# the window rather than an extra request taken afterwards.
+take_sample() {
+  local out
+  # Declared and assigned separately on purpose: `local out="$(curl ...)"`
+  # would make $? the exit status of `local`, not of curl.
+  out="$(curl -sS -o "$BODY_FILE" -w '%{http_code} %{time_total}' \
+    --max-time "$CURL_MAX_TIME" "$HEALTH_URL" 2>"$ERR_FILE")"
+  sample_rc=$?
+  # curl writes the -w line even on timeout/connect failure (http_code 000);
+  # this only backfills the case where it wrote nothing at all, so an empty
+  # sample can never be mistaken for a fast 200.
+  [ -n "$out" ] || out="000 0"
+  sample_code="${out%% *}"
+  sample_secs="${out##* }"
+}
+
+# Transport level: no HTTP answer came back at all. http=000 covers connect /
+# TLS / timeout failures; a non-zero curl exit covers the rest.
+is_transport_failure() {
+  [ "$sample_code" = "000" ] || [ "$sample_rc" -ne 0 ]
+}
+
+# Good: the app answered 200 inside the client deadline.
+is_good() {
+  [ "$sample_code" = "200" ] &&
+    awk -v t="$sample_secs" -v m="$MAX_SECONDS" 'BEGIN { exit !(t + 0 < m + 0) }'
+}
+
+curl_error_text() {
+  local line
+  line="$(head -1 "$ERR_FILE" 2>/dev/null)"
+  [ -n "$line" ] || line="no curl diagnostic"
+  printf '%s' "$line"
+}
+
+streak=0
+best_streak=0
+not_ok=0
+taken=0
+final_good=0
+deadline_hit=0
+started_at="$(date +%s)"
+
+echo "Probing $HEALTH_URL — ${SAMPLES} samples every ${INTERVAL}s; need ${NEED_STREAK} consecutive good (200 under ${MAX_SECONDS}s) anywhere in the window AND a good final sample reporting version ${EXPECTED_VERSION}. Transport-level failures are retried ${TRANSPORT_RETRIES}x after ${RETRY_PAUSE}s; 5xx and slow 200s are never retried."
+
+for i in $(seq 1 "$SAMPLES"); do
+  elapsed=$(( $(date +%s) - started_at ))
+  if [ "$elapsed" -ge "$MAX_TOTAL_SECONDS" ]; then
+    echo "probe ${i}/${SAMPLES}: not taken — the probe has already run ${elapsed}s of its ${MAX_TOTAL_SECONDS}s wall-clock ceiling."
+    deadline_hit=1
+    break
+  fi
+  attempt=0
+  while : ; do
+    take_sample
+    if [ "$attempt" -eq 0 ]; then
+      prefix="$(printf 'probe %2d/%s:' "$i" "$SAMPLES")"
+    else
+      prefix="$(printf 'probe %2d/%s retry %d/%s:' "$i" "$SAMPLES" "$attempt" "$TRANSPORT_RETRIES")"
+    fi
+    if is_transport_failure && [ "$attempt" -lt "$TRANSPORT_RETRIES" ]; then
+      printf '%s http=%s time=%ss curl_exit=%s -> transport failure (%s) — retrying in %ss\n' \
+        "$prefix" "$sample_code" "$sample_secs" "$sample_rc" "$(curl_error_text)" "$RETRY_PAUSE"
+      attempt=$(( attempt + 1 ))
+      sleep "$RETRY_PAUSE"
+      continue
+    fi
+    break
+  done
+
+  taken=$(( taken + 1 ))
+  if is_good; then
+    streak=$(( streak + 1 ))
+    final_good=1
+    verdict="ok"
+  else
+    streak=0
+    final_good=0
+    not_ok=$(( not_ok + 1 ))
+    verdict="NOT-OK"
+  fi
+  [ "$streak" -le "$best_streak" ] || best_streak="$streak"
+
+  # Every sample is printed, passing or not.
+  printf '%s http=%s time=%ss curl_exit=%s -> %-6s (consecutive good: %d, best so far: %d)\n' \
+    "$prefix" "$sample_code" "$sample_secs" "$sample_rc" "$verdict" "$streak" "$best_streak"
+
+  if [ "$i" -lt "$SAMPLES" ]; then
+    sleep "$INTERVAL"
+  fi
+done
+
+fail=0
+
+if [ "$deadline_hit" -eq 1 ]; then
+  # Fail-closed by construction: a probe that ran out of wall clock did not
+  # finish measuring, so it cannot report a deploy as verified — no matter how
+  # good the samples it did take were.
+  echo "::error::post-rollout answer probe: ran out of its ${MAX_TOTAL_SECONDS}s wall-clock budget after $(( i - 1 )) of ${SAMPLES} samples. Samples were taking long enough that the probe would have eaten the deploy-ecs job's remaining timeout; whatever the app is doing, it is not answering at the speed a finished deploy answers at. Timings are printed above."
+  fail=1
+fi
+
+if [ "$best_streak" -lt "$NEED_STREAK" ]; then
+  echo "::error::post-rollout answer probe: the longest run of consecutive good samples anywhere in the window was ${best_streak} (needed ${NEED_STREAK}) out of ${SAMPLES}. ECS reported the rollout COMPLETED, but the app never answered 200 under ${MAX_SECONDS}s ${NEED_STREAK} times in a row — this is the 58e337dc failure mode from #1532, and it is an outage whether or not the badge would have been green. Every sample is printed above."
+  fail=1
+fi
+
+if [ "$final_good" -ne 1 ]; then
+  if [ "$taken" -eq 0 ]; then
+    echo "::error::post-rollout answer probe: the FINAL sample never happened — no sample completed at all (see the error above). Nothing about this deploy has been verified."
+  else
+    echo "::error::post-rollout answer probe: the FINAL sample taken (${taken}/${SAMPLES}, after up to ${TRANSPORT_RETRIES} transport retries) did not answer 200 under ${MAX_SECONDS}s — http=${sample_code} time=${sample_secs}s curl_exit=${sample_rc}. The window may have looked healthy earlier; it is not healthy now, and now is when the deploy is finishing."
+  fi
+  fail=1
+fi
+
+if [ "$final_good" -eq 1 ]; then
+  version="$(jq -r '.version // empty' < "$BODY_FILE" 2>/dev/null)"
+  if [ -z "$version" ]; then
+    echo "::error::post-rollout version check: could not read .version from ${HEALTH_URL} on the final sample (body was empty or not JSON). Cannot confirm which commit is serving."
+    fail=1
+  elif [ "$version" != "$EXPECTED_VERSION" ]; then
+    echo "::error::post-rollout version check: ${HEALTH_URL} reports version=${version} but this job deployed ${EXPECTED_VERSION}. The rollout completed and the app answers — but it is answering with different code than this run built, so this deploy did not take."
+    fail=1
+  fi
+else
+  echo "post-rollout version check: not attempted — the final sample did not answer (see the error above)."
+fi
+
+[ "$fail" = 0 ] || exit 1
+
+if [ "$not_ok" -gt 0 ]; then
+  echo "::warning::post-rollout probe passed with ${not_ok} of ${SAMPLES} samples NOT-OK. The verdict tolerates a transient inside an otherwise healthy window (#1791), but repeated warnings here are a real finding about post-rollout latency/availability (#1309, #1436, #1714) — read the sample lines above."
+fi
+
+echo "post-rollout probe OK: longest good streak ${best_streak}/${SAMPLES} (needed ${NEED_STREAK}), final sample 200 in ${sample_secs}s under ${MAX_SECONDS}s, serving version ${version}."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -658,10 +658,14 @@ jobs:
     # and the CloudFront invalidation wait — otherwise the job timeout silently
     # becomes the real budget and #1532 returns with a bigger number. 30 min
     # covers the 20-min default budget + the probe + the invalidation wait
-    # with margin. The probe is ~35s when the app is healthy and bounds its
-    # own worst case at MAX_TOTAL_SECONDS (300s, see
-    # .github/scripts/post_rollout_probe.sh) precisely so retrying transport
-    # flakes (#1791) cannot turn a clean ::error into an opaque job timeout.
+    # with margin. The probe is ~35s when the app is healthy and hard-caps its
+    # own wall clock at MAX_TOTAL_SECONDS (300s, see
+    # .github/scripts/post_rollout_probe.sh). That is a REAL ceiling, not a
+    # check between samples: the script starts no request whose deadline
+    # reaches past it (curl's --max-time is capped to the remaining budget)
+    # and no sleep that runs past it, precisely so retrying transport flakes
+    # (#1791) cannot turn a clean ::error into an opaque job timeout — or eat
+    # the CloudFront invalidation's share of the reserve below.
     # The poll step asserts this headroom explicitly (see
     # DEPLOY_JOB_TIMEOUT_MINUTES there) rather than trusting the two numbers to
     # be edited together.
@@ -816,6 +820,10 @@ jobs:
           # timeout would kill the job first, with no verdict — exactly #1532's
           # bug wearing a bigger number. Reserve 7 min for the post-rollout
           # probe + the CloudFront invalidation wait that follow this step.
+          # The probe can consume at most MAX_TOTAL_SECONDS=300s of that 420s
+          # (a hard wall-clock ceiling, see .github/scripts/post_rollout_probe.sh);
+          # the rest is the invalidation wait's, and a test asserts the probe's
+          # ceiling stays strictly smaller than this reserve.
           JOB_TIMEOUT_SECONDS=$(( DEPLOY_JOB_TIMEOUT_MINUTES * 60 ))
           if [ "$BUDGET" -gt $(( JOB_TIMEOUT_SECONDS - 420 )) ]; then
             echo "::error::DEPLOY_ROLLOUT_BUDGET_SECONDS=${BUDGET}s leaves under 7 minutes of the deploy-ecs job's ${DEPLOY_JOB_TIMEOUT_MINUTES}-minute timeout for the answer probe and the CloudFront invalidation. Raise timeout-minutes on the deploy-ecs job (and DEPLOY_JOB_TIMEOUT_MINUTES here) alongside the budget."
@@ -915,16 +923,29 @@ jobs:
         # the culprit in the first place.)
         #
         # The verdict is "NEED_STREAK consecutive good samples were OBSERVED
-        # somewhere in the window AND the final (post-retry) sample is good".
-        # It was "the LAST 5 samples", and #1791 shows what that cost: two of
+        # somewhere in the window AND the final (post-retry) sample is good
+        # AND it reports this commit AND no more than MAX_NOT_OK samples were
+        # NOT-OK". It was "the LAST 5 samples", and #1791 shows what that
+        # cost: two of
         # the last four main deploys went red on a single transport transient
         # (curl exit 28 at 15.0s; curl exit 35 — a TLS reset — at 25 ms) while
         # prod was already serving the expected version. The "final sample must
         # be good" half is what keeps this fail-closed: a cold-start tail —
         # slow-then-fast, the #1532 shape this step exists for — still fails,
         # because a window that is broken AT THE END fails no matter how
-        # healthy its start was. The 5s ceiling is a client-realistic deadline,
-        # not a generous one: it is below #1436's recorded p99 of 16.8s on
+        # healthy its start was. MAX_NOT_OK is the other half of that: the
+        # observed-streak rule ALONE would tolerate 4 bad samples out of 10
+        # (SAMPLES - NEED_STREAK - 1), so the cap is what keeps "one transient
+        # does not fail a healthy deploy" from becoming "a pockmarked window
+        # passes". Two NOT-OK samples pass with a ::warning; three go red.
+        # ONLY transport-level failures (no HTTP answer at all, http=000 —
+        # connect/DNS/TLS/client timeout) are retried. Anything the app
+        # answered is never retried, INCLUDING a 5xx that was truncated
+        # mid-body (curl exits non-zero there while reporting a real 503):
+        # #1714/#1713's rollout-window 503s have to stay visible.
+        #
+        # The 5s ceiling is a client-realistic deadline, not a generous one:
+        # it is below #1436's recorded p99 of 16.8s on
         # purpose. If this step turns out to be the flakiest thing in the
         # pipeline for reasons OTHER than transport flakes, that is a finding
         # about the app's post-rollout latency (#1309, #1436), not a reason to
@@ -956,8 +977,10 @@ jobs:
           # THIS STEP RUNS against a fake /api/health (transport reset, 5xx,
           # slow 200, wrong version) instead of a paraphrase that drifts.
           # SAMPLES / NEED_STREAK / MAX_SECONDS / INTERVAL / TRANSPORT_RETRIES /
-          # RETRY_PAUSE default to 10 / 5 / 5s / 3s / 2 / 3s inside the script;
-          # they are documented and tested there.
+          # RETRY_PAUSE default to 10 / 5 / 5s / 3s / 2 / 3s inside the script,
+          # alongside MAX_NOT_OK=2 (most NOT-OK samples a passing run may
+          # contain), CURL_MAX_TIME=15s and MAX_TOTAL_SECONDS=300s; they are
+          # documented and tested there.
           bash .github/scripts/post_rollout_probe.sh
 
       - name: Invalidate CloudFront (unhashed SPA entry points only)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -657,8 +657,12 @@ jobs:
     # DEPLOY_ROLLOUT_BUDGET_SECONDS (top-level env) plus the post-rollout probe
     # and the CloudFront invalidation wait — otherwise the job timeout silently
     # becomes the real budget and #1532 returns with a bigger number. 30 min
-    # covers the 20-min default budget + ~1 min probe + the invalidation wait
-    # with margin. The poll step asserts this headroom explicitly (see
+    # covers the 20-min default budget + the probe + the invalidation wait
+    # with margin. The probe is ~35s when the app is healthy and bounds its
+    # own worst case at MAX_TOTAL_SECONDS (300s, see
+    # .github/scripts/post_rollout_probe.sh) precisely so retrying transport
+    # flakes (#1791) cannot turn a clean ::error into an opaque job timeout.
+    # The poll step asserts this headroom explicitly (see
     # DEPLOY_JOB_TIMEOUT_MINUTES there) rather than trusting the two numbers to
     # be edited together.
     timeout-minutes: 30
@@ -910,14 +914,21 @@ jobs:
         # window. Static fast + API timing out is what identified the origin as
         # the culprit in the first place.)
         #
-        # Requiring the LAST 5 CONSECUTIVE samples to pass, rather than 5 of 10,
-        # is what makes a cold-start tail fail this step: a service warming up
-        # produces slow-then-fast, and only a trailing run of good samples shows
-        # it actually got there. The 5s ceiling is a client-realistic deadline,
-        # not a generous one — it is below #1436's recorded p99 of 16.8s on
+        # The verdict is "NEED_STREAK consecutive good samples were OBSERVED
+        # somewhere in the window AND the final (post-retry) sample is good".
+        # It was "the LAST 5 samples", and #1791 shows what that cost: two of
+        # the last four main deploys went red on a single transport transient
+        # (curl exit 28 at 15.0s; curl exit 35 — a TLS reset — at 25 ms) while
+        # prod was already serving the expected version. The "final sample must
+        # be good" half is what keeps this fail-closed: a cold-start tail —
+        # slow-then-fast, the #1532 shape this step exists for — still fails,
+        # because a window that is broken AT THE END fails no matter how
+        # healthy its start was. The 5s ceiling is a client-realistic deadline,
+        # not a generous one: it is below #1436's recorded p99 of 16.8s on
         # purpose. If this step turns out to be the flakiest thing in the
-        # pipeline, that is a finding about the app's post-rollout latency
-        # (#1309, #1436), not a reason to loosen the number.
+        # pipeline for reasons OTHER than transport flakes, that is a finding
+        # about the app's post-rollout latency (#1309, #1436), not a reason to
+        # loosen the number.
         env:
           # Through CloudFront and the ALB, exactly as a user reaches it —
           # not the ECS task's own container health check, which is what
@@ -930,69 +941,24 @@ jobs:
           EXPECTED_VERSION: ${{ github.sha }}
         run: |
           # `set +e` is load-bearing: GitHub runs `run:` under `bash -e`, and
-          # `sample="$(curl ...)"` is an assignment whose exit status IS curl's.
-          # With -e in force a single timed-out sample (curl exit 28) aborted
-          # this whole step before `rc=$?` ran and before a single
-          # `probe N/10` line was printed — the 2026-09-01 run 33553292497 went
-          # red that way with the rollout COMPLETED; the step never got to
-          # measure whether the app was answering. Every failure below is
-          # handled explicitly through `fail`; nothing here may rely on -e.
+          # `sample="$(curl ...)"` inside the probe is an assignment whose exit
+          # status IS curl's. With -e in force a single timed-out sample (curl
+          # exit 28) aborted this whole step before `rc=$?` ran and before a
+          # single `probe N/10` line was printed — the 2026-09-01 run
+          # 33553292497 went red that way with the rollout COMPLETED; the step
+          # never got to measure whether the app was answering. The script sets
+          # the same `set +e -uo pipefail` for itself and handles every failure
+          # explicitly; this line keeps the step shell honest too.
           set +e -uo pipefail
 
-          PROBES=10
-          REQUIRED_STREAK=5
-          MAX_SECONDS=5
-          streak=0
-          fail=0
-          body=""
-
-          echo "Probing $HEALTH_URL — ${PROBES} samples, need the last ${REQUIRED_STREAK} consecutive at 200 under ${MAX_SECONDS}s."
-          for i in $(seq 1 "$PROBES"); do
-            sample="$(curl -sS -o /dev/null -w '%{http_code} %{time_total}' --max-time 15 "$HEALTH_URL" 2>/dev/null)"
-            rc=$?
-            # curl writes the -w line even on timeout/connect failure (http_code
-            # 000); this only backfills the case where it wrote nothing at all,
-            # so an empty sample can never be mistaken for a fast 200.
-            [ -n "$sample" ] || sample="000 0"
-            code="${sample%% *}"
-            secs="${sample##* }"
-            if [ "$code" = "200" ] && awk -v t="$secs" -v m="$MAX_SECONDS" 'BEGIN { exit !(t + 0 < m + 0) }'; then
-              streak=$(( streak + 1 ))
-              verdict="ok"
-            else
-              streak=0
-              verdict="NOT-OK"
-            fi
-            # Every sample is printed, passing or not: the timings ARE the
-            # evidence, and #1532 had to be diagnosed by hand-curling because
-            # the pipeline kept none.
-            printf 'probe %2d/%d: http=%s time=%ss curl_exit=%s -> %-6s (consecutive good: %d)\n' \
-              "$i" "$PROBES" "$code" "$secs" "$rc" "$verdict" "$streak"
-            if [ "$i" -eq "$PROBES" ]; then
-              # The last probe also reads the body, so the version assertion is
-              # made against the same request that closed the streak.
-              body="$(curl -sS --max-time 15 "$HEALTH_URL" 2>/dev/null)"
-            else
-              sleep 3
-            fi
-          done
-
-          if [ "$streak" -lt "$REQUIRED_STREAK" ]; then
-            echo "::error::post-rollout answer probe: only ${streak} consecutive trailing samples answered 200 under ${MAX_SECONDS}s (needed ${REQUIRED_STREAK}). ECS reported the rollout COMPLETED, but the app is not answering inside a client-realistic deadline — this is the 58e337dc failure mode from #1532, and it is an outage whether or not the badge would have been green. Timings are printed above."
-            fail=1
-          fi
-
-          version="$(printf '%s' "$body" | jq -r '.version // empty' 2>/dev/null)"
-          if [ -z "$version" ]; then
-            echo "::error::post-rollout version check: could not read .version from ${HEALTH_URL} on the final probe (body was empty or not JSON). Cannot confirm which commit is serving."
-            fail=1
-          elif [ "$version" != "$EXPECTED_VERSION" ]; then
-            echo "::error::post-rollout version check: ${HEALTH_URL} reports version=${version} but this job deployed ${EXPECTED_VERSION}. The rollout completed and the app answers — but it is answering with different code than this run built, so this deploy did not take."
-            fail=1
-          fi
-
-          [ "$fail" = 0 ] || exit 1
-          echo "post-rollout probe OK: ${streak} consecutive samples 200 under ${MAX_SECONDS}s, serving version ${version}."
+          # The probe body lives in a script, not inline here, so
+          # backend/tests/test_post_rollout_probe.py can run THE EXACT SCRIPT
+          # THIS STEP RUNS against a fake /api/health (transport reset, 5xx,
+          # slow 200, wrong version) instead of a paraphrase that drifts.
+          # SAMPLES / NEED_STREAK / MAX_SECONDS / INTERVAL / TRANSPORT_RETRIES /
+          # RETRY_PAUSE default to 10 / 5 / 5s / 3s / 2 / 3s inside the script;
+          # they are documented and tested there.
+          bash .github/scripts/post_rollout_probe.sh
 
       - name: Invalidate CloudFront (unhashed SPA entry points only)
         # Gated on the ROLLOUT VERDICT, not on job success (issue #1532). The

--- a/backend/tests/test_post_rollout_probe.py
+++ b/backend/tests/test_post_rollout_probe.py
@@ -1,0 +1,423 @@
+"""The post-rollout probe, run against a fake ``/api/health`` (#1791).
+
+``.github/scripts/post_rollout_probe.sh`` is the body of deploy.yml's
+"Assert the deployed app actually answers (post-rollout probe)" step. It was
+inline in the workflow, which meant nothing could execute it: the two red
+main deploys in #1791 —
+
+    run 33566302291  samples 1-7 = 200 in ~0.4s, sample 8 http=000
+                     time=15.0s curl_exit=28 (client timeout), 9-10 = 200
+                     -> "only 2 consecutive trailing" -> exit 1
+    run 33573075995  samples 1-9 = 200 in ~0.4s, sample 10 http=000
+                     time=0.025s curl_exit=35 (TLS reset at 25 ms)
+                     -> "only 0 consecutive trailing" -> exit 1
+
+were both green deploys reported red by an unexecutable probe. These tests
+run THE EXACT SCRIPT CI RUNS against a local HTTP server that can be told to
+drop a connection, answer 503, answer slowly, or answer with the wrong
+version — no AWS, no network, no CloudFront.
+
+Fail-closed is the property under test as much as flake-tolerance is: a
+transient inside a healthy window passes, and an outage that reaches the end
+of the window still fails.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import socket
+import subprocess
+import threading
+import time
+from collections import deque
+from collections.abc import Iterator, Sequence
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROBE_SH = REPO_ROOT / ".github" / "scripts" / "post_rollout_probe.sh"
+DEPLOY_YML = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
+PROBE_STEP_NAME = "Assert the deployed app actually answers (post-rollout probe)"
+
+DEPLOYED_SHA = "7a6c5b7300112233445566778899aabbccddeeff"
+OTHER_SHA = "25dc64dcffeeddccbbaa99887766554433221100"
+
+
+class _FakeHealth:
+    """A scripted ``/api/health``.
+
+    ``actions`` is consumed one entry per HTTP REQUEST (a retry consumes its
+    own entry); once exhausted the last entry repeats forever, so
+    ``["ok"] * 5 + ["reset"]`` means "healthy, then broken from sample 6 on".
+
+    Actions:
+      ``ok``            200 ``{"version": DEPLOYED_SHA}``
+      ``ok:<version>``  200 with that version instead
+      ``reset``         close the connection without writing a response —
+                        curl reports http_code 000 with a non-zero exit, the
+                        transport-level flake class from #1791's two red runs
+      ``status:<code>`` that status with a JSON body (the app answering)
+      ``slow:<secs>``   sleep, then 200 — a 200 outside the client deadline
+    """
+
+    def __init__(self, actions: Sequence[str]) -> None:
+        if not actions:
+            raise ValueError("at least one action is required")
+        self._queue = deque(actions)
+        self._last = actions[-1]
+        self._lock = threading.Lock()
+        self.served: list[str] = []
+
+    def next_action(self) -> str:
+        with self._lock:
+            action = self._queue.popleft() if self._queue else self._last
+            self._last = action
+            self.served.append(action)
+            return action
+
+    @property
+    def request_count(self) -> int:
+        with self._lock:
+            return len(self.served)
+
+
+def _handler_for(fake: _FakeHealth) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt: str, *args: object) -> None:  # keep pytest output readable
+            pass
+
+        def do_GET(self) -> None:  # BaseHTTPRequestHandler's own casing
+            action = fake.next_action()
+
+            if action == "reset":
+                # Not a 5xx and not a timeout — no HTTP answer at all. curl
+                # reports http_code 000 with exit 52/56, exactly what an edge
+                # or TLS transient looks like to the probe.
+                self.close_connection = True
+                with contextlib.suppress(OSError):
+                    self.connection.shutdown(socket.SHUT_RDWR)
+                self.connection.close()
+                return
+
+            if action.startswith("slow:"):
+                time.sleep(float(action.split(":", 1)[1]))
+                action = "ok"
+
+            if action.startswith("status:"):
+                self._respond(int(action.split(":", 1)[1]), {"detail": "service unavailable"})
+                return
+
+            version = DEPLOYED_SHA if action == "ok" else action.split(":", 1)[1]
+            self._respond(200, {"status": "ok", "version": version})
+
+        def _respond(self, code: int, payload: dict) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return Handler
+
+
+@contextlib.contextmanager
+def _serving(fake: _FakeHealth) -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _handler_for(fake))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/api/health"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def run_probe(
+    actions: Sequence[str],
+    *,
+    samples: int = 10,
+    need_streak: int = 5,
+    max_seconds: str = "5",
+    transport_retries: int = 2,
+    expected_version: str = DEPLOYED_SHA,
+    max_total_seconds: str = "300",
+    url_override: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], _FakeHealth]:
+    """Run the real script against a scripted fake health endpoint.
+
+    INTERVAL and RETRY_PAUSE are 0.1s here and 3s in CI; every other number is
+    the one deploy.yml ships with.
+    """
+    fake = _FakeHealth(actions)
+    env = {
+        **os.environ,
+        "EXPECTED_VERSION": expected_version,
+        "SAMPLES": str(samples),
+        "NEED_STREAK": str(need_streak),
+        "MAX_SECONDS": max_seconds,
+        "INTERVAL": "0.1",
+        "TRANSPORT_RETRIES": str(transport_retries),
+        "RETRY_PAUSE": "0.1",
+        "CURL_MAX_TIME": "10",
+        "MAX_TOTAL_SECONDS": max_total_seconds,
+    }
+    with _serving(fake) as url:
+        env["HEALTH_URL"] = url_override or url
+        proc = subprocess.run(
+            ["bash", str(PROBE_SH)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+    return proc, fake
+
+
+def _log(proc: subprocess.CompletedProcess[str]) -> str:
+    return f"\n--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+
+
+def _errors(proc: subprocess.CompletedProcess[str]) -> list[str]:
+    return [line for line in proc.stdout.splitlines() if line.startswith("::error::")]
+
+
+class TestHealthyWindow:
+    def test_all_good_samples_pass(self) -> None:
+        proc, fake = run_probe(["ok"])
+        assert proc.returncode == 0, _log(proc)
+        assert "post-rollout probe OK" in proc.stdout
+        assert fake.request_count == 10, "one request per sample, no retries needed"
+        # Every sample printed — the timings ARE the evidence (#1532).
+        assert len(re.findall(r"^probe\s+\d+/10:", proc.stdout, re.M)) == 10, _log(proc)
+
+
+class TestTransportRetry:
+    def test_one_transport_reset_mid_window_is_retried_and_passes(self) -> None:
+        """Run 33566302291's shape: healthy window, one dropped connection."""
+        proc, fake = run_probe(["ok"] * 6 + ["reset", "ok"])
+        assert proc.returncode == 0, _log(proc)
+        assert re.search(r"^probe\s+7/10: http=000 .*transport failure.*retrying", proc.stdout, re.M), _log(proc)
+        assert re.search(r"^probe\s+7/10 retry 1/2: http=200 .*-> ok", proc.stdout, re.M), _log(proc)
+        assert fake.request_count == 11, "the retry is one extra request, not a re-run of the window"
+
+    def test_transport_reset_on_the_final_sample_is_retried_and_passes(self) -> None:
+        """Run 33573075995's shape: the TLS reset landed on sample 10 of 10.
+
+        MUTATION: delete the retry branch from the script and this goes red —
+        the final sample counts NOT-OK and the deploy is reported failed while
+        prod serves the new version.
+        """
+        proc, fake = run_probe(["ok"] * 9 + ["reset", "ok"])
+        assert proc.returncode == 0, _log(proc)
+        assert re.search(r"^probe\s+10/10 retry 1/2: http=200 .*-> ok", proc.stdout, re.M), _log(proc)
+        assert fake.request_count == 11
+
+    def test_mid_window_outage_burst_passes_on_an_observed_streak_and_a_good_final_sample(self) -> None:
+        """Sample 6 fails through both retries; samples 1-5 and 7-10 are good.
+
+        The trailing run is only 4, so the OLD "last 5 consecutive" verdict
+        called this a failed deploy. The observed streak of 5 plus a good
+        final sample is what makes it a pass.
+
+        MUTATION: judge on the trailing streak instead of the observed one and
+        this goes red.
+        """
+        proc, fake = run_probe(["ok"] * 5 + ["reset"] * 3 + ["ok"])
+        assert proc.returncode == 0, _log(proc)
+        assert re.search(r"^probe\s+6/10 retry 2/2: http=000 .*-> NOT-OK", proc.stdout, re.M), _log(proc)
+        assert "best so far: 5" in proc.stdout
+        # Tolerated, but never hidden: the log still carries a warning.
+        assert "::warning::post-rollout probe passed with 1 of 10 samples NOT-OK" in proc.stdout, _log(proc)
+        assert fake.request_count == 12
+
+    def test_transport_failure_that_persists_to_the_end_fails(self) -> None:
+        """Fail-closed: five consecutive broken samples at the end of a window.
+
+        A healthy streak of 5 WAS observed (samples 1-5) — the run still fails,
+        because the final sample is what says whether the deploy landed.
+        """
+        proc, _ = run_probe(["ok"] * 5 + ["reset"])
+        assert proc.returncode == 1, _log(proc)
+        assert any("the FINAL sample" in e for e in _errors(proc)), _log(proc)
+        assert any("version check: not attempted" in line for line in proc.stdout.splitlines())
+
+    def test_total_transport_outage_fails(self) -> None:
+        """Every sample and every retry dropped — the app is down."""
+        proc, fake = run_probe(["reset"])
+        assert proc.returncode == 1, _log(proc)
+        errors = _errors(proc)
+        assert any("longest run of consecutive good samples anywhere in the window was 0" in e for e in errors), _log(
+            proc
+        )
+        assert any("the FINAL sample" in e for e in errors), _log(proc)
+        assert fake.request_count == 30, "10 samples x (1 attempt + 2 retries) — the retries are bounded"
+
+
+class TestAppLevelFailuresAreNotRetried:
+    def test_one_503_inside_the_window_restarts_the_streak_but_a_new_streak_forms(self) -> None:
+        proc, fake = run_probe(["ok", "ok", "status:503", "ok"])
+        assert proc.returncode == 0, _log(proc)
+        assert re.search(r"^probe\s+3/10: http=503 .*-> NOT-OK \(consecutive good: 0", proc.stdout, re.M), _log(proc)
+        assert "retry" not in proc.stdout, "a 5xx is the app answering — retrying it would mask #1714's 503 windows"
+        assert fake.request_count == 10
+
+    def test_503_that_prevents_any_streak_fails(self) -> None:
+        proc, _ = run_probe(["ok", "ok", "status:503", "ok"], samples=6)
+        assert proc.returncode == 1, _log(proc)
+        assert any("was 3 (needed 5)" in e for e in _errors(proc)), _log(proc)
+
+    def test_503_on_the_final_sample_fails(self) -> None:
+        proc, fake = run_probe(["ok"] * 9 + ["status:503"])
+        assert proc.returncode == 1, _log(proc)
+        assert any("the FINAL sample" in e and "http=503" in e for e in _errors(proc)), _log(proc)
+        assert fake.request_count == 10, "no retry burned on a 5xx"
+
+    def test_slow_200_counts_not_ok_and_is_not_retried(self) -> None:
+        proc, fake = run_probe(["ok"] * 9 + ["slow:1.6"], max_seconds="1")
+        assert proc.returncode == 1, _log(proc)
+        assert re.search(r"^probe\s+10/10: http=200 .*-> NOT-OK", proc.stdout, re.M), _log(proc)
+        assert any("the FINAL sample" in e and "http=200" in e for e in _errors(proc)), _log(proc)
+        assert fake.request_count == 10, "a slow 200 is the app answering slowly, not a transport flake"
+
+
+class TestVersionAssertion:
+    def test_wrong_version_fails_and_the_error_names_both_versions(self) -> None:
+        """MUTATION: drop the version comparison and this goes red."""
+        proc, _ = run_probe([f"ok:{OTHER_SHA}"])
+        assert proc.returncode == 1, _log(proc)
+        version_errors = [e for e in _errors(proc) if "version check" in e]
+        assert version_errors, _log(proc)
+        assert OTHER_SHA in version_errors[0] and DEPLOYED_SHA in version_errors[0], _log(proc)
+
+    def test_version_is_read_from_the_final_sample_not_an_extra_request(self) -> None:
+        """The final sample is served by its retry — the version must come from it."""
+        proc, fake = run_probe(["ok"] * 9 + ["reset", f"ok:{OTHER_SHA}"])
+        assert proc.returncode == 1, _log(proc)
+        assert any(OTHER_SHA in e for e in _errors(proc)), _log(proc)
+        assert fake.request_count == 11, "no extra request after the window — the verdict is on what was measured"
+
+    def test_body_that_is_not_json_fails(self) -> None:
+        proc, _ = run_probe(["ok:"])  # 200 with .version == ""
+        assert proc.returncode == 1, _log(proc)
+        assert any("could not read .version" in e for e in _errors(proc)), _log(proc)
+
+
+class TestBudgetsAndMisconfiguration:
+    def test_probe_stops_at_its_wall_clock_ceiling_and_fails(self) -> None:
+        """Fail-closed: an unfinished probe cannot report a deploy as verified.
+
+        The samples it did take were good and satisfied NEED_STREAK, so the
+        wall-clock ceiling is the only thing failing this run.
+        """
+        proc, _ = run_probe(["slow:1.0"], need_streak=2, max_seconds="5", max_total_seconds="3")
+        assert proc.returncode == 1, _log(proc)
+        errors = _errors(proc)
+        assert any("wall-clock budget" in e for e in errors), _log(proc)
+        assert not any("longest run of consecutive good samples" in e for e in errors), _log(proc)
+
+    def test_missing_required_env_fails_without_probing(self) -> None:
+        env = {**os.environ, "HEALTH_URL": "", "EXPECTED_VERSION": ""}
+        proc = subprocess.run(["bash", str(PROBE_SH)], env=env, capture_output=True, text=True, timeout=30, check=False)
+        assert proc.returncode == 1, _log(proc)
+        assert "HEALTH_URL and EXPECTED_VERSION are both required" in proc.stdout, _log(proc)
+
+    def test_a_streak_longer_than_the_window_is_rejected_as_misconfiguration(self) -> None:
+        proc, fake = run_probe(["ok"], samples=3, need_streak=5)
+        assert proc.returncode == 1, _log(proc)
+        assert any("could ever satisfy it" in e for e in _errors(proc)), _log(proc)
+        assert fake.request_count == 0
+
+    def test_script_is_syntactically_valid_bash(self) -> None:
+        proc = subprocess.run(["bash", "-n", str(PROBE_SH)], capture_output=True, text=True, check=False)
+        assert proc.returncode == 0, proc.stderr
+
+
+def _probe_step() -> dict:
+    workflow = yaml.safe_load(DEPLOY_YML.read_text(encoding="utf-8"))
+    steps = [step for job in workflow["jobs"].values() for step in job.get("steps", [])]
+    matches = [step for step in steps if step.get("name") == PROBE_STEP_NAME]
+    assert len(matches) == 1, f"expected exactly one {PROBE_STEP_NAME!r} step, found {len(matches)}"
+    return matches[0]
+
+
+class TestWorkflowWiring:
+    """deploy.yml and the script cannot drift: the step must call the script."""
+
+    def test_the_step_invokes_the_script_under_test(self) -> None:
+        run = _probe_step()["run"]
+        assert ".github/scripts/post_rollout_probe.sh" in run, run
+        assert PROBE_SH.exists()
+        assert os.access(PROBE_SH, os.X_OK), "the script is committed executable"
+
+    def test_the_step_does_not_reimplement_the_probe_inline(self) -> None:
+        """A second inline curl loop would be a copy this suite cannot test."""
+        code = [line for line in _probe_step()["run"].splitlines() if not line.strip().startswith("#")]
+        assert not any("curl" in line for line in code), (
+            "the probe body belongs in the script, not back in the step: " + "\n".join(code)
+        )
+
+    def test_the_step_keeps_set_plus_e_semantics(self) -> None:
+        """#1762: `run:` is `bash -e`; a curl assignment's status is curl's."""
+        run = _probe_step()["run"]
+        assert re.search(r"^\s*set \+e -uo pipefail\s*$", run, re.M), run
+        script = PROBE_SH.read_text(encoding="utf-8")
+        assert re.search(r"^set \+e -uo pipefail$", script, re.M), "the script sets it for itself too"
+        assert not re.search(r"^set -e", script, re.M), "-e would abort on the first timed-out sample"
+
+    def test_the_step_passes_the_url_and_the_expected_commit(self) -> None:
+        env = _probe_step()["env"]
+        assert env["HEALTH_URL"] == "https://archimedes-arc.com/api/health", (
+            "/api/* is on CloudFront's CachingDisabled policy — every sample must be an origin round trip"
+        )
+        assert env["EXPECTED_VERSION"] == "${{ github.sha }}"
+
+    def test_the_step_still_runs_only_on_a_completed_rollout(self) -> None:
+        assert _probe_step()["if"] == "steps.rollout.outputs.rollout == 'completed'"
+
+    def test_script_defaults_are_the_numbers_the_workflow_documents(self) -> None:
+        """The step's comment names these; nothing else sets them in CI."""
+        script = PROBE_SH.read_text(encoding="utf-8")
+        expected = {
+            "SAMPLES": "10",
+            "NEED_STREAK": "5",
+            "MAX_SECONDS": "5",
+            "INTERVAL": "3",
+            "TRANSPORT_RETRIES": "2",
+            "RETRY_PAUSE": "3",
+            "CURL_MAX_TIME": "15",
+            "MAX_TOTAL_SECONDS": "300",
+        }
+        for name, value in expected.items():
+            assert re.search(rf'^{name}="\$\{{{name}:-{value}\}}"$', script, re.M), f"{name} default drifted"
+        run = _probe_step()["run"]
+        assert "10 / 5 / 5s / 3s / 2 / 3s" in run, "the step's comment must quote the script's live defaults"
+
+    def test_the_probe_fits_inside_the_deploy_job_timeout(self) -> None:
+        """MAX_TOTAL_SECONDS + the rollout budget must leave the job room.
+
+        Retrying transport flakes widens the probe's worst case; the job
+        timeout must not silently become the real budget (#1532).
+        """
+        workflow_text = DEPLOY_YML.read_text(encoding="utf-8")
+        rollout_budget_s = int(re.search(r"DEPLOY_ROLLOUT_BUDGET_SECONDS:\s*(\d+)", workflow_text).group(1))
+        job_timeout_s = int(re.search(r"DEPLOY_JOB_TIMEOUT_MINUTES:\s*(\d+)", workflow_text).group(1)) * 60
+        probe_ceiling_s = int(
+            re.search(r'MAX_TOTAL_SECONDS="\$\{MAX_TOTAL_SECONDS:-(\d+)\}"', PROBE_SH.read_text()).group(1)
+        )
+        assert rollout_budget_s + probe_ceiling_s < job_timeout_s, (
+            f"rollout budget {rollout_budget_s}s + probe ceiling {probe_ceiling_s}s does not fit in the "
+            f"deploy-ecs job's {job_timeout_s}s timeout, leaving nothing for the CloudFront invalidation"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/tests/test_post_rollout_probe.py
+++ b/backend/tests/test_post_rollout_probe.py
@@ -14,12 +14,13 @@ main deploys in #1791 —
 
 were both green deploys reported red by an unexecutable probe. These tests
 run THE EXACT SCRIPT CI RUNS against a local HTTP server that can be told to
-drop a connection, answer 503, answer slowly, or answer with the wrong
-version — no AWS, no network, no CloudFront.
+drop a connection, answer 503, answer slowly, answer with the wrong version,
+or answer 503 and then hang up mid-body — no AWS, no network, no CloudFront.
 
 Fail-closed is the property under test as much as flake-tolerance is: a
-transient inside a healthy window passes, and an outage that reaches the end
-of the window still fails.
+transient inside a healthy window passes, an outage that reaches the end of
+the window still fails, and a window that is bad more than MAX_NOT_OK times
+fails even when a good streak was observed.
 """
 
 from __future__ import annotations
@@ -140,45 +141,112 @@ def _serving(fake: _FakeHealth) -> Iterator[str]:
         thread.join(timeout=5)
 
 
-def run_probe(
-    actions: Sequence[str],
+@contextlib.contextmanager
+def _serving_truncated_503() -> Iterator[tuple[str, list[str]]]:
+    """A raw socket that answers ``503`` and then hangs up mid-body.
+
+    This is the shape ``is_transport_failure`` used to get wrong (#1791
+    review, defect 1): the status line DID come back, so it is the app
+    answering — but curl still exits non-zero (18, "transfer closed with N
+    bytes remaining to read") because the promised body never arrived. An
+    origin/ALB that 503s while dropping bodies under load is precisely the
+    #1714/#1713 rollout-window shape that must never be retried away.
+
+    http.server cannot produce this — it always finishes what it starts — so
+    the response is written byte by byte onto a raw socket.
+    """
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(16)
+    requests: list[str] = []
+    stop = threading.Event()
+
+    def serve() -> None:
+        while not stop.is_set():
+            try:
+                conn, _ = listener.accept()
+            except OSError:
+                return
+            try:
+                conn.settimeout(5)
+                with contextlib.suppress(OSError):
+                    requests.append(conn.recv(4096).decode("latin-1", "replace"))
+                with contextlib.suppress(OSError):
+                    conn.sendall(
+                        b"HTTP/1.1 503 Service Unavailable\r\n"
+                        b"Content-Type: application/json\r\n"
+                        b"Content-Length: 100\r\n"
+                        b"\r\n"
+                        b'{"detail":'  # 10 bytes of the 100 promised, then gone
+                    )
+                    conn.shutdown(socket.SHUT_RDWR)
+            finally:
+                conn.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{listener.getsockname()[1]}/api/health", requests
+    finally:
+        stop.set()
+        listener.close()
+        thread.join(timeout=5)
+
+
+def _run_script(
+    url: str,
     *,
     samples: int = 10,
     need_streak: int = 5,
+    max_not_ok: str = "2",
     max_seconds: str = "5",
     transport_retries: int = 2,
     expected_version: str = DEPLOYED_SHA,
     max_total_seconds: str = "300",
-    url_override: str | None = None,
-) -> tuple[subprocess.CompletedProcess[str], _FakeHealth]:
-    """Run the real script against a scripted fake health endpoint.
+    curl_max_time: str = "10",
+    retry_pause: str = "0.1",
+    interval: str = "0.1",
+) -> subprocess.CompletedProcess[str]:
+    """Run the real script against ``url``.
 
-    INTERVAL and RETRY_PAUSE are 0.1s here and 3s in CI; every other number is
-    the one deploy.yml ships with.
+    INTERVAL and RETRY_PAUSE default to 0.1s here and 3s in CI; every other
+    number is the one deploy.yml ships with unless a test says otherwise.
     """
-    fake = _FakeHealth(actions)
     env = {
         **os.environ,
+        "HEALTH_URL": url,
         "EXPECTED_VERSION": expected_version,
         "SAMPLES": str(samples),
         "NEED_STREAK": str(need_streak),
+        "MAX_NOT_OK": max_not_ok,
         "MAX_SECONDS": max_seconds,
-        "INTERVAL": "0.1",
+        "INTERVAL": interval,
         "TRANSPORT_RETRIES": str(transport_retries),
-        "RETRY_PAUSE": "0.1",
-        "CURL_MAX_TIME": "10",
+        "RETRY_PAUSE": retry_pause,
+        "CURL_MAX_TIME": curl_max_time,
         "MAX_TOTAL_SECONDS": max_total_seconds,
     }
+    return subprocess.run(
+        ["bash", str(PROBE_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+
+def run_probe(
+    actions: Sequence[str],
+    *,
+    url_override: str | None = None,
+    **kwargs: object,
+) -> tuple[subprocess.CompletedProcess[str], _FakeHealth]:
+    """Run the real script against a scripted fake health endpoint."""
+    fake = _FakeHealth(actions)
     with _serving(fake) as url:
-        env["HEALTH_URL"] = url_override or url
-        proc = subprocess.run(
-            ["bash", str(PROBE_SH)],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=180,
-            check=False,
-        )
+        proc = _run_script(url_override or url, **kwargs)  # type: ignore[arg-type]
     return proc, fake
 
 
@@ -190,6 +258,11 @@ def _errors(proc: subprocess.CompletedProcess[str]) -> list[str]:
     return [line for line in proc.stdout.splitlines() if line.startswith("::error::")]
 
 
+def _retry_lines(proc: subprocess.CompletedProcess[str]) -> list[str]:
+    """Lines for an actual retried REQUEST — not prose that contains "retry"."""
+    return re.findall(r"^.*retry \d+/\d+:.*$", proc.stdout, re.M)
+
+
 class TestHealthyWindow:
     def test_all_good_samples_pass(self) -> None:
         proc, fake = run_probe(["ok"])
@@ -198,6 +271,8 @@ class TestHealthyWindow:
         assert fake.request_count == 10, "one request per sample, no retries needed"
         # Every sample printed — the timings ARE the evidence (#1532).
         assert len(re.findall(r"^probe\s+\d+/10:", proc.stdout, re.M)) == 10, _log(proc)
+        # A clean window earns no warning at all.
+        assert "::warning::" not in proc.stdout, _log(proc)
 
 
 class TestTransportRetry:
@@ -208,6 +283,23 @@ class TestTransportRetry:
         assert re.search(r"^probe\s+7/10: http=000 .*transport failure.*retrying", proc.stdout, re.M), _log(proc)
         assert re.search(r"^probe\s+7/10 retry 1/2: http=200 .*-> ok", proc.stdout, re.M), _log(proc)
         assert fake.request_count == 11, "the retry is one extra request, not a re-run of the window"
+
+    def test_a_sample_that_recovered_on_retry_is_still_annotated(self) -> None:
+        """#1791 review, defect 3: a recovered retry left NO trace in the verdict.
+
+        The sample counts as good — the origin still failed to answer the
+        first request, which is the modal shape of both #1791 red runs, and a
+        run that reports "10/10, no warnings" would be hiding it.
+
+        MUTATION: gate the warning on ``not_ok`` alone and this goes red.
+        """
+        proc, _ = run_probe(["ok"] * 6 + ["reset", "ok"])
+        assert proc.returncode == 0, _log(proc)
+        warnings = [line for line in proc.stdout.splitlines() if line.startswith("::warning::")]
+        assert warnings, "a retried-and-recovered sample must not pass silently" + _log(proc)
+        assert "0 of 10 samples NOT-OK" in warnings[0], _log(proc)
+        assert "1 transport retry attempt(s) spent" in warnings[0], _log(proc)
+        assert "1 transport retry attempt(s)" in proc.stdout.splitlines()[-1], "the summary line names it too"
 
     def test_transport_reset_on_the_final_sample_is_retried_and_passes(self) -> None:
         """Run 33573075995's shape: the TLS reset landed on sample 10 of 10.
@@ -267,8 +359,28 @@ class TestAppLevelFailuresAreNotRetried:
         proc, fake = run_probe(["ok", "ok", "status:503", "ok"])
         assert proc.returncode == 0, _log(proc)
         assert re.search(r"^probe\s+3/10: http=503 .*-> NOT-OK \(consecutive good: 0", proc.stdout, re.M), _log(proc)
-        assert "retry" not in proc.stdout, "a 5xx is the app answering — retrying it would mask #1714's 503 windows"
+        assert not _retry_lines(proc), "a 5xx is the app answering — retrying it would mask #1714's 503 windows"
         assert fake.request_count == 10
+
+    def test_a_truncated_5xx_is_not_retried(self) -> None:
+        """#1791 review, defect 1: ``|| curl_exit != 0`` retried a REAL 503.
+
+        The origin sends ``503`` with ``Content-Length: 100`` and hangs up
+        after 10 bytes: curl reports ``http_code=503`` AND exits 18. That is
+        the app answering — #1714/#1713's rollout-window 503s must stay
+        visible, so it counts NOT-OK immediately and burns no retry.
+
+        MUTATION: restore ``|| [ "$sample_rc" -ne 0 ]`` in
+        ``is_transport_failure`` and this goes red (3 retry lines appear and
+        the request count triples).
+        """
+        with _serving_truncated_503() as (url, requests):
+            proc = _run_script(url, samples=3, need_streak=2)
+        assert proc.returncode == 1, _log(proc)
+        assert re.search(r"^probe\s+1/3: http=503 .*curl_exit=(18|56) .*-> NOT-OK", proc.stdout, re.M), _log(proc)
+        assert not _retry_lines(proc), "a truncated 5xx is still a 5xx" + _log(proc)
+        assert len(requests) == 3, f"one request per sample, no retry burned — got {len(requests)}" + _log(proc)
+        assert any("the FINAL sample" in e and "http=503" in e for e in _errors(proc)), _log(proc)
 
     def test_503_that_prevents_any_streak_fails(self) -> None:
         proc, _ = run_probe(["ok", "ok", "status:503", "ok"], samples=6)
@@ -287,6 +399,52 @@ class TestAppLevelFailuresAreNotRetried:
         assert re.search(r"^probe\s+10/10: http=200 .*-> NOT-OK", proc.stdout, re.M), _log(proc)
         assert any("the FINAL sample" in e and "http=200" in e for e in _errors(proc)), _log(proc)
         assert fake.request_count == 10, "a slow 200 is the app answering slowly, not a transport flake"
+
+
+class TestNotOkCap:
+    """Owner ruling (#1791 review): a streak alone must not pass a bad window.
+
+    "Observed somewhere in the window" on its own tolerates
+    ``SAMPLES - NEED_STREAK - 1`` = 4 bad samples out of 10. Two is a
+    transient; three is a degraded deploy.
+    """
+
+    def test_two_not_ok_samples_with_a_streak_and_a_good_final_sample_pass_with_a_warning(self) -> None:
+        proc, fake = run_probe(["ok"] * 5 + ["status:503"] * 2 + ["ok"])
+        assert proc.returncode == 0, _log(proc)
+        assert "::warning::post-rollout probe passed with 2 of 10 samples NOT-OK" in proc.stdout, _log(proc)
+        assert not any("were NOT-OK after retries" in e for e in _errors(proc)), _log(proc)
+        assert fake.request_count == 10
+
+    def test_three_not_ok_samples_fail_even_with_a_streak_and_a_good_final_sample(self) -> None:
+        """MUTATION: delete the MAX_NOT_OK check and this exits 0."""
+        proc, fake = run_probe(["ok"] * 5 + ["status:503"] * 3 + ["ok"])
+        assert proc.returncode == 1, _log(proc)
+        cap_errors = [e for e in _errors(proc) if "were NOT-OK after retries" in e]
+        assert cap_errors, "the cap must be the thing that failed this run" + _log(proc)
+        assert "3 of the 10 samples were NOT-OK after retries (MAX_NOT_OK=2)" in cap_errors[0], _log(proc)
+        # The other three conjuncts all held — only the cap failed it.
+        assert not any("longest run of consecutive good samples" in e for e in _errors(proc)), _log(proc)
+        assert not any("the FINAL sample" in e for e in _errors(proc)), _log(proc)
+        assert "best so far: 5" in proc.stdout
+        assert fake.request_count == 10
+
+    def test_the_cap_can_be_tightened_to_zero(self) -> None:
+        proc, _ = run_probe(["ok"] * 5 + ["status:503"] + ["ok"], max_not_ok="0")
+        assert proc.returncode == 1, _log(proc)
+        assert any("1 of the 10 samples were NOT-OK after retries (MAX_NOT_OK=0)" in e for e in _errors(proc)), _log(
+            proc
+        )
+
+    def test_a_non_integer_cap_is_rejected_instead_of_silently_disabling_the_check(self) -> None:
+        """`set -e` is off: `[ 3 -gt "two" ]` returns 2, which reads as FALSE.
+
+        A typo'd cap must not quietly pass a window the cap exists to fail.
+        """
+        proc, fake = run_probe(["ok"] * 5 + ["status:503"] * 3 + ["ok"], max_not_ok="two")
+        assert proc.returncode == 1, _log(proc)
+        assert any("MAX_NOT_OK='two' is not a non-negative integer" in e for e in _errors(proc)), _log(proc)
+        assert fake.request_count == 0, "rejected before a single request"
 
 
 class TestVersionAssertion:
@@ -315,14 +473,43 @@ class TestBudgetsAndMisconfiguration:
     def test_probe_stops_at_its_wall_clock_ceiling_and_fails(self) -> None:
         """Fail-closed: an unfinished probe cannot report a deploy as verified.
 
-        The samples it did take were good and satisfied NEED_STREAK, so the
-        wall-clock ceiling is the only thing failing this run.
+        The samples it did take satisfied NEED_STREAK, so the wall-clock
+        ceiling is the only thing failing this run.
         """
-        proc, _ = run_probe(["slow:1.0"], need_streak=2, max_seconds="5", max_total_seconds="3")
+        proc, _ = run_probe(["slow:1.0"], need_streak=1, max_seconds="5", max_total_seconds="3")
         assert proc.returncode == 1, _log(proc)
         errors = _errors(proc)
         assert any("wall-clock budget" in e for e in errors), _log(proc)
         assert not any("longest run of consecutive good samples" in e for e in errors), _log(proc)
+
+    def test_the_ceiling_bounds_the_whole_probe_not_just_the_gap_between_samples(self) -> None:
+        """#1791 review, defect 2: MAX_TOTAL_SECONDS was checked only BEFORE a
+        sample, so the last one could still start a full retry cycle
+        (``(TRANSPORT_RETRIES + 1) x CURL_MAX_TIME + retries x RETRY_PAUSE +
+        INTERVAL``) past it — 353s of overshoot at shipped defaults, eating
+        the reserve deploy.yml's poll step holds back for the CloudFront
+        invalidation.
+
+        4s ceiling, 4s retry pause, 4s interval: the old between-samples check
+        let this run ~12s.
+
+        MUTATION: drop the budget check on the retry path and the `capped_`
+        halves of the sleeps and this goes red on wall clock alone.
+        """
+        started = time.monotonic()
+        proc, _ = run_probe(["reset"], max_total_seconds="4", retry_pause="4", interval="4")
+        elapsed = time.monotonic() - started
+        assert proc.returncode == 1, _log(proc)
+        assert any("wall-clock budget" in e for e in _errors(proc)), _log(proc)
+        assert elapsed < 8, f"probe ran {elapsed:.1f}s against a 4s ceiling{_log(proc)}"
+
+    def test_a_single_slow_request_cannot_run_past_the_ceiling(self) -> None:
+        """curl's own --max-time is capped to the budget the probe has left."""
+        started = time.monotonic()
+        proc, _ = run_probe(["slow:8"], samples=3, need_streak=1, max_total_seconds="3", curl_max_time="20")
+        elapsed = time.monotonic() - started
+        assert proc.returncode == 1, _log(proc)
+        assert elapsed < 6, f"probe ran {elapsed:.1f}s against a 3s ceiling{_log(proc)}"
 
     def test_missing_required_env_fails_without_probing(self) -> None:
         env = {**os.environ, "HEALTH_URL": "", "EXPECTED_VERSION": ""}
@@ -389,6 +576,7 @@ class TestWorkflowWiring:
         expected = {
             "SAMPLES": "10",
             "NEED_STREAK": "5",
+            "MAX_NOT_OK": "2",
             "MAX_SECONDS": "5",
             "INTERVAL": "3",
             "TRANSPORT_RETRIES": "2",
@@ -400,12 +588,15 @@ class TestWorkflowWiring:
             assert re.search(rf'^{name}="\$\{{{name}:-{value}\}}"$', script, re.M), f"{name} default drifted"
         run = _probe_step()["run"]
         assert "10 / 5 / 5s / 3s / 2 / 3s" in run, "the step's comment must quote the script's live defaults"
+        assert "MAX_NOT_OK=2" in run, "the step's comment must name the NOT-OK cap too"
 
     def test_the_probe_fits_inside_the_deploy_job_timeout(self) -> None:
         """MAX_TOTAL_SECONDS + the rollout budget must leave the job room.
 
         Retrying transport flakes widens the probe's worst case; the job
-        timeout must not silently become the real budget (#1532).
+        timeout must not silently become the real budget (#1532). This holds
+        as stated only because MAX_TOTAL_SECONDS is a REAL ceiling — no
+        request or sleep starts that reaches past it (#1791 review, defect 2).
         """
         workflow_text = DEPLOY_YML.read_text(encoding="utf-8")
         rollout_budget_s = int(re.search(r"DEPLOY_ROLLOUT_BUDGET_SECONDS:\s*(\d+)", workflow_text).group(1))
@@ -416,6 +607,22 @@ class TestWorkflowWiring:
         assert rollout_budget_s + probe_ceiling_s < job_timeout_s, (
             f"rollout budget {rollout_budget_s}s + probe ceiling {probe_ceiling_s}s does not fit in the "
             f"deploy-ecs job's {job_timeout_s}s timeout, leaving nothing for the CloudFront invalidation"
+        )
+
+    def test_the_probe_ceiling_fits_the_reserve_the_poll_step_holds_back(self) -> None:
+        """The poll step refuses a rollout budget that eats the tail reserve.
+
+        That reserve is for the probe AND the CloudFront invalidation wait, so
+        the probe's ceiling has to be strictly smaller than all of it.
+        """
+        workflow_text = DEPLOY_YML.read_text(encoding="utf-8")
+        reserve_s = int(re.search(r"JOB_TIMEOUT_SECONDS - (\d+)", workflow_text).group(1))
+        probe_ceiling_s = int(
+            re.search(r'MAX_TOTAL_SECONDS="\$\{MAX_TOTAL_SECONDS:-(\d+)\}"', PROBE_SH.read_text()).group(1)
+        )
+        assert probe_ceiling_s < reserve_s, (
+            f"the probe's {probe_ceiling_s}s ceiling consumes the whole {reserve_s}s the poll step reserves "
+            "for the probe plus the CloudFront invalidation wait"
         )
 
 


### PR DESCRIPTION
Closes #1791.

## The bug

Two of the last four `deploy.yml` runs on main ended **red** at *Assert the deployed app actually answers (post-rollout probe)* while the rollout had already succeeded and prod was serving the expected version:

**run 33566302291** (22:39Z, #1765, head `25dc64dc`)
```
probe  1/10: http=200 time=0.4s ... -> ok     (consecutive good: 1)
...
probe  7/10: http=200 time=0.4s ... -> ok     (consecutive good: 7)
probe  8/10: http=000 time=15.0s curl_exit=28 -> NOT-OK (consecutive good: 0)   # client timeout
probe  9/10: http=200 ... -> ok     (consecutive good: 1)
probe 10/10: http=200 ... -> ok     (consecutive good: 2)
::error::post-rollout answer probe: only 2 consecutive trailing samples answered 200 under 5s (needed 5)...
```

**run 33573075995** (00:06Z, #1734, head `7a6c5b73`)
```
probe  1/10 .. 9/10: http=200 time=~0.4s -> ok  (consecutive good: 9)
probe 10/10: http=000 time=0.025s curl_exit=35 -> NOT-OK (consecutive good: 0)  # TLS handshake reset, 25 ms
::error::post-rollout answer probe: only 0 consecutive trailing samples answered 200 under 5s (needed 5)...
```

`/api/health` reported the expected version immediately afterwards in both cases (verified 00:45Z: `version=7a6c5b73…`, task-def 225, 2/2 running). The deploys succeeded; the probe reported them failed. That trains everyone to ignore red deploys, which is the one outcome a probe exists to prevent.

Root cause: the verdict was "the **last 5** samples must be consecutive 200s under 5 s", so one transport-level flake (curl exit 28/35/56, `http=000`) at any of the last five positions failed the run.

## The change

**1. The probe body moves into `.github/scripts/post_rollout_probe.sh`**, and the step calls it with the same env. It was inline, which is why nothing could ever execute it — the two runs above were the first real test of a verdict no test could reach. The step keeps `set +e -uo pipefail` (#1762) and the script sets the same for itself; a test asserts the step invokes the script and does not reimplement a `curl` loop inline, so the two cannot drift.

**2. A request that never got an answer is retried. Anything the app answered is not.**

| what came back | treated as | retried? |
|---|---|---|
| `http=000` — no HTTP answer at all (connect / DNS / TLS reset / client timeout) | transport failure | **yes** — `TRANSPORT_RETRIES=2` after `RETRY_PAUSE=3s` |
| 5xx, any non-200 | NOT-OK immediately | no — this is the app answering (#1714/#1713's rollout-window 503s must stay visible) |
| a 5xx **truncated mid-body** (real status line, `curl_exit=18/56`) | NOT-OK immediately | no — it is still the app answering; see defect 1 below |
| 200 slower than `MAX_SECONDS=5` | NOT-OK immediately | no — this is the #1532 latency failure mode |

The predicate is `[ "$sample_code" = "000" ]` and nothing else. It is deliberately **not** `|| [ "$sample_rc" -ne 0 ]`: both #1791 production shapes report `http=000`, so keying on the status line alone loses nothing real and keeps every 5xx unretried.

**3. The verdict is four conjuncts** — all must hold:
- `NEED_STREAK=5` consecutive good samples were **observed somewhere** in the window (was: in the *last* five positions), **and**
- the **final (post-retry) sample is good**, **and**
- that final sample reports `.version == EXPECTED_VERSION`, **and**
- at most `MAX_NOT_OK=2` samples were NOT-OK after their retries.

The "final sample" conjunct is what keeps this fail-closed: a cold-start tail — slow-then-fast, the #1532 shape this step was built for — still fails, because a window that is broken **at the end** fails no matter how healthy its start was.

`MAX_NOT_OK` is the owner ruling from review. "Observed somewhere" **alone** tolerates `SAMPLES - NEED_STREAK - 1` = **4 of 10** samples being 503s, which is far more than the "one transient" this PR was arguing for. Two NOT-OK samples now pass with a `::warning`; **three go red**, naming the count, even when a 5-streak was observed and the final sample is good.

Every sample and every retry is still printed with `http/time/curl_exit`. A passing run warns when it had any NOT-OK sample **or spent any retry** — a sample that failed and recovered on retry never reaches the NOT-OK tally, and both #1791 red runs are exactly that shape, so it would otherwise be the one degradation the log hid. `::error` lines name exactly which conjunct failed.

**4. `MAX_TOTAL_SECONDS=300` is a real wall-clock ceiling**, not a check between samples: curl's `--max-time` is capped to the budget the probe has left (floored at 1s — `--max-time 0` means *no* timeout), a retry is refused once the budget is gone, and both sleeps are truncated to what remains. deploy.yml's poll step reserves 420s of the deploy-ecs timeout for "the answer probe and the CloudFront invalidation"; overrunning it would turn a clean `::error` into an opaque job timeout *and* eat the invalidation's share. Hitting the ceiling always **fails**: a probe that did not finish measuring cannot report a deploy as verified. Tests assert `DEPLOY_ROLLOUT_BUDGET_SECONDS + MAX_TOTAL_SECONDS < DEPLOY_JOB_TIMEOUT_MINUTES`, that the ceiling is smaller than the poll step's 420s reserve, and — twice — the measured wall clock.

**5. Integer parameters are validated before use.** `set -e` is off by design (#1762), so `[ 3 -gt "two" ]` prints a bash error, returns 2, and reads as **false** — a typo'd `MAX_NOT_OK` would have silently disabled the cap. `SAMPLES`, `NEED_STREAK`, `MAX_NOT_OK`, `TRANSPORT_RETRIES` and `MAX_TOTAL_SECONDS` must be non-negative integers or the probe exits 1 before a single request.

**6. Hermetic test** `backend/tests/test_post_rollout_probe.py` (33 tests, ~56 s) starts a scripted `/api/health` on `127.0.0.1` (`http.server` in a thread) that can drop the connection without a response, answer 503, answer slowly, or answer with the wrong commit — plus a **raw socket** that answers a real `503` and hangs up mid-body — and runs **the exact script CI runs** with `INTERVAL`/`RETRY_PAUSE` at 0.1 s. No AWS, no network, no CloudFront.

## Guards shown red on the input they reject

Every block below is real output from this branch, trimmed only where marked `…`. Mutations A-D are the shipped verdict; E-G are one per review defect.

### Mutation A — remove the transport retry (`if is_transport_failure && [ "$attempt" -lt "$TRANSPORT_RETRIES" ]` → `if false`)

Input: run 33573075995's shape — nine good samples, the connection dropped on sample 10 of 10.

Baseline (correct — the flake is retried, the deploy is reported green, and the retry is warned on):
```
probe  9/10: http=200 time=0.000878s curl_exit=0 -> ok     (consecutive good: 9, best so far: 9)
probe 10/10: http=000 time=0.000621s curl_exit=52 -> transport failure (curl: (52) Empty reply from server) — retrying in 0.1s
probe 10/10 retry 1/2: http=200 time=0.000729s curl_exit=0 -> ok     (consecutive good: 10, best so far: 10)
::warning::post-rollout probe passed with 0 of 10 samples NOT-OK (cap MAX_NOT_OK=2) and 1 transport retry attempt(s) spent. …
post-rollout probe OK: longest good streak 10/10 (needed 5), 0 NOT-OK (cap 2), 1 transport retry attempt(s), final sample 200 in 0.000729s under 5s, serving version 7a6c5b73…
$ echo $?
0
```

Mutated (red — this is the bug being fixed):
```
probe  9/10: http=200 time=0.000799s curl_exit=0 -> ok     (consecutive good: 9, best so far: 9)
probe 10/10: http=000 time=0.001097s curl_exit=52 -> NOT-OK (consecutive good: 0, best so far: 9)
::error::post-rollout answer probe: the FINAL sample taken (10/10, after up to 2 transport retries) did not answer 200 under 5s — http=000 time=0.001097s curl_exit=52. …
post-rollout version check: not attempted — the final sample did not answer (see the error above).
$ echo $?
1
```
```
FAILED backend/tests/test_post_rollout_probe.py::TestTransportRetry::test_one_transport_reset_mid_window_is_retried_and_passes
FAILED backend/tests/test_post_rollout_probe.py::TestTransportRetry::test_a_sample_that_recovered_on_retry_is_still_annotated
FAILED backend/tests/test_post_rollout_probe.py::TestTransportRetry::test_transport_reset_on_the_final_sample_is_retried_and_passes
FAILED backend/tests/test_post_rollout_probe.py::TestTransportRetry::test_mid_window_outage_burst_passes_on_an_observed_streak_and_a_good_final_sample
FAILED backend/tests/test_post_rollout_probe.py::TestTransportRetry::test_total_transport_outage_fails
FAILED backend/tests/test_post_rollout_probe.py::TestVersionAssertion::test_version_is_read_from_the_final_sample_not_an_extra_request
6 failed, 27 passed, 1 warning in 51.94s          # pytest exit 1
```

### Mutation B — verdict back to the trailing streak (`[ "$best_streak" -lt "$NEED_STREAK" ]` → `[ "$streak" -lt … ]`)

Input: sample 6 fails through both retries; samples 1-5 and 7-10 are good, so the trailing run is only 4.

Baseline (correct — an observed 5-streak plus a good final sample; the transient is logged loudly and tolerated, 1 NOT-OK is inside the cap):
```
probe  5/10: http=200 time=0.001778s curl_exit=0 -> ok     (consecutive good: 5, best so far: 5)
probe  6/10: http=000 time=0.000642s curl_exit=52 -> transport failure (curl: (52) Empty reply from server) — retrying in 0.1s
probe  6/10 retry 1/2: http=000 time=0.000654s curl_exit=52 -> transport failure (curl: (52) Empty reply from server) — retrying in 0.1s
probe  6/10 retry 2/2: http=000 time=0.000642s curl_exit=52 -> NOT-OK (consecutive good: 0, best so far: 5)
probe  7/10 … 10/10: http=200 -> ok     (consecutive good: 4, best so far: 5)
::warning::post-rollout probe passed with 1 of 10 samples NOT-OK (cap MAX_NOT_OK=2) and 2 transport retry attempt(s) spent. …
post-rollout probe OK: longest good streak 5/10 (needed 5), 1 NOT-OK (cap 2), 2 transport retry attempt(s), final sample 200 in 0.000763s under 5s, serving version 7a6c5b73…
$ echo $?
0
```

Mutated (red):
```
probe 10/10: http=200 time=0.000742s curl_exit=0 -> ok     (consecutive good: 4, best so far: 5)
::error::post-rollout answer probe: the longest run of consecutive good samples anywhere in the window was 5 (needed 5) out of 10. …
$ echo $?
1
```
(The message still interpolates `best_streak`, hence the odd "was 5 (needed 5)" — an artifact of the mutation, not of the shipped script.)
```
FAILED …::TestTransportRetry::test_mid_window_outage_burst_passes_on_an_observed_streak_and_a_good_final_sample
FAILED …::TestNotOkCap::test_two_not_ok_samples_with_a_streak_and_a_good_final_sample_pass_with_a_warning
FAILED …::TestNotOkCap::test_three_not_ok_samples_fail_even_with_a_streak_and_a_good_final_sample
FAILED …::TestBudgetsAndMisconfiguration::test_probe_stops_at_its_wall_clock_ceiling_and_fails
4 failed, 29 passed, 1 warning in 57.06s          # pytest exit 1
```

### Mutation C — drop the version comparison (`elif [ "$version" != "$EXPECTED_VERSION" ]` → `elif false`)

Input: a perfectly healthy window where the app reports a different commit.

Baseline (correct — red):
```
probe 10/10: http=200 time=0.000766s curl_exit=0 -> ok     (consecutive good: 10, best so far: 10)
::error::post-rollout version check: …/api/health reports version=25dc64dc… but this job deployed 7a6c5b73…. The rollout completed and the app answers — but it is answering with different code than this run built, so this deploy did not take.
$ echo $?
1
```

Mutated (a deploy that did not take is reported green — exactly what the guard exists to stop):
```
probe 10/10: http=200 time=0.001842s curl_exit=0 -> ok     (consecutive good: 10, best so far: 10)
post-rollout probe OK: longest good streak 10/10 (needed 5), 0 NOT-OK (cap 2), 0 transport retry attempt(s), final sample 200 in 0.001842s under 5s, serving version 25dc64dc…
$ echo $?
0
```
```
FAILED …::TestVersionAssertion::test_wrong_version_fails_and_the_error_names_both_versions
FAILED …::TestVersionAssertion::test_version_is_read_from_the_final_sample_not_an_extra_request
2 failed, 31 passed, 1 warning in 57.72s          # pytest exit 1
```

### Mutation D — remove the NOT-OK cap (`if [ "$not_ok" -gt "$MAX_NOT_OK" ]` → `if false`)

Input: samples 1-5 good, 6-8 = 503, 9-10 good — a 5-streak *was* observed and the final sample *is* good, so the other three conjuncts all hold.

Baseline (correct — three NOT-OK samples is a degraded window, not a transient):
```
probe  6/10: http=503 time=0.000771s curl_exit=0 -> NOT-OK (consecutive good: 0, best so far: 5)
probe  7/10: http=503 time=0.000790s curl_exit=0 -> NOT-OK (consecutive good: 0, best so far: 5)
probe  8/10: http=503 time=0.000831s curl_exit=0 -> NOT-OK (consecutive good: 0, best so far: 5)
probe  9/10: http=200 time=0.000861s curl_exit=0 -> ok     (consecutive good: 1, best so far: 5)
probe 10/10: http=200 time=0.000798s curl_exit=0 -> ok     (consecutive good: 2, best so far: 5)
::error::post-rollout answer probe: 3 of the 10 samples were NOT-OK after retries (MAX_NOT_OK=2). A 5-sample good run was allowed to be observed ANYWHERE in the window (#1791) so that one transient cannot fail a healthy deploy — this cap is what keeps that from tolerating a pockmarked one. …
$ echo $?
1
```

Mutated (the pockmarked window passes — the tolerance the owner ruled against):
```
probe  8/10: http=503 time=0.001217s curl_exit=0 -> NOT-OK (consecutive good: 0, best so far: 5)
probe 10/10: http=200 time=0.001051s curl_exit=0 -> ok     (consecutive good: 2, best so far: 5)
::warning::post-rollout probe passed with 3 of 10 samples NOT-OK (cap MAX_NOT_OK=2) and 0 transport retry attempt(s) spent. …
post-rollout probe OK: longest good streak 5/10 (needed 5), 3 NOT-OK (cap 2), 0 transport retry attempt(s), final sample 200 in 0.001051s under 5s, serving version 7a6c5b73…
$ echo $?
0
```
```
FAILED …::TestNotOkCap::test_three_not_ok_samples_fail_even_with_a_streak_and_a_good_final_sample
FAILED …::TestNotOkCap::test_the_cap_can_be_tightened_to_zero
2 failed, 31 passed, 1 warning in 60.40s          # pytest exit 1
```

### Mutation E — restore `|| [ "$sample_rc" -ne 0 ]` (review defect 1)

Input: a raw socket that answers `503` with `Content-Length: 100` and hangs up after 10 bytes — curl reports `http=503` **and** exit 18. `SAMPLES=3`.

Baseline (correct — a truncated 5xx is still the app answering; 3 requests for 3 samples, no retry):
```
[requests the origin received: 3]
probe  1/3: http=503 time=0.000732s curl_exit=18 -> NOT-OK (consecutive good: 0, best so far: 0)
probe  2/3: http=503 time=0.000691s curl_exit=18 -> NOT-OK (consecutive good: 0, best so far: 0)
probe  3/3: http=503 time=0.000758s curl_exit=18 -> NOT-OK (consecutive good: 0, best so far: 0)
::error::… the longest run of consecutive good samples anywhere in the window was 0 (needed 2) out of 3. …
::error::… 3 of the 3 samples were NOT-OK after retries (MAX_NOT_OK=2). …
::error::… the FINAL sample taken (3/3, after up to 2 transport retries) did not answer 200 under 5s — http=503 time=0.000758s curl_exit=18. …
$ echo $?
1
```

Mutated (the shipped-in-b78ab9db bug: a 503 is retried three times over — 9 requests for 3 samples):
```
[requests the origin received: 9]
probe  1/3: http=503 time=0.000728s curl_exit=18 -> transport failure (curl: (18) transfer closed with 90 bytes remaining to read) — retrying in 0.1s
probe  1/3 retry 1/2: http=503 time=0.000723s curl_exit=18 -> transport failure (curl: (18) transfer closed with 90 bytes remaining to read) — retrying in 0.1s
probe  1/3 retry 2/2: http=503 time=0.000602s curl_exit=18 -> NOT-OK (consecutive good: 0, best so far: 0)
…
$ echo $?
1
```
```
FAILED …::TestAppLevelFailuresAreNotRetried::test_a_truncated_5xx_is_not_retried
1 failed, 32 passed, 1 warning in 57.41s          # pytest exit 1
```
(The mutated run still exits 1 here because *every* attempt fails. It fails open the moment one retry lands a 200: the 503 then leaves the verdict **and** the NOT-OK tally.)

### Mutation F — ceiling back to a between-samples check (review defect 2)

Input: every connection dropped, `MAX_TOTAL_SECONDS=4`, `RETRY_PAUSE=4`, `INTERVAL=4`.

Baseline (correct — the retry is refused at the ceiling, the sleeps are truncated, wall clock ≈ the ceiling):
```
probe  1/10: http=000 time=0.001510s curl_exit=52 -> transport failure (curl: (52) Empty reply from server) — retrying in 4s
probe  1/10 retry 1/2: transport failure (curl: (52) Empty reply from server) — NOT retried: the probe has used all 4s of its wall-clock ceiling; the sample counts as it stands
probe  1/10 retry 1/2: http=000 time=0.003797s curl_exit=52 -> NOT-OK (consecutive good: 0, best so far: 0)
probe 2/10: not taken — the probe has already run 4s of its 4s wall-clock ceiling.
::error::post-rollout answer probe: ran out of its 4s wall-clock budget after 1 of 10 samples. …
$ echo $?
1
[wall clock 4.7s]
```

Mutated (3.2× the "ceiling" — the arithmetic deploy.yml asserts against becomes fiction):
```
probe  1/10 retry 1/2: http=000 time=0.005582s curl_exit=52 -> transport failure … — retrying in 4s
probe  1/10 retry 2/2: http=000 time=0.002191s curl_exit=52 -> NOT-OK (consecutive good: 0, best so far: 0)
probe 2/10: not taken — the probe has already run 12s of its 4s wall-clock ceiling.
$ echo $?
1
[wall clock 12.7s]
```
```
FAILED …::TestBudgetsAndMisconfiguration::test_the_ceiling_bounds_the_whole_probe_not_just_the_gap_between_samples
FAILED …::TestBudgetsAndMisconfiguration::test_a_single_slow_request_cannot_run_past_the_ceiling
2 failed, 31 passed, 1 warning in 64.67s          # pytest exit 1
```

### Mutation G — warn on `not_ok` alone (review defect 3)

Input: sample 7 drops the connection and recovers on its first retry — the modal shape of both #1791 red runs.

Baseline (correct — the run passes, and the retry is on the record):
```
probe  7/10: http=000 time=0.000673s curl_exit=52 -> transport failure (curl: (52) Empty reply from server) — retrying in 0.1s
probe  7/10 retry 1/2: http=200 time=0.000965s curl_exit=0 -> ok     (consecutive good: 7, best so far: 7)
::warning::post-rollout probe passed with 0 of 10 samples NOT-OK (cap MAX_NOT_OK=2) and 1 transport retry attempt(s) spent. …
post-rollout probe OK: longest good streak 10/10 (needed 5), 0 NOT-OK (cap 2), 1 transport retry attempt(s), final sample 200 in 0.000725s under 5s, serving version 7a6c5b73…
$ echo $?
0
```

Mutated (the origin hung past the client deadline and the summary says `10/10` with no warning at all):
```
probe  7/10 retry 1/2: http=200 time=0.000773s curl_exit=0 -> ok     (consecutive good: 7, best so far: 7)
post-rollout probe OK: longest good streak 10/10 (needed 5), 0 NOT-OK (cap 2), 1 transport retry attempt(s), final sample 200 in 0.000809s under 5s, serving version 7a6c5b73…
$ echo $?
0
```
```
FAILED …::TestTransportRetry::test_a_sample_that_recovered_on_retry_is_still_annotated
1 failed, 32 passed, 1 warning in 56.18s          # pytest exit 1
```

### Fail-closed cases that are green in this PR

| input | result |
|---|---|
| every sample and retry dropped (30 requests) | exit 1 — no streak **and** bad final sample **and** over the cap |
| healthy for 5 samples, then broken from sample 6 to the end | exit 1 — a 5-streak *was* observed; the final sample still decides |
| one 503 mid-window that leaves no 5-streak (6-sample window) | exit 1 — `was 3 (needed 5)` |
| 3 of 10 samples 503 with a 5-streak and a good final sample | exit 1 — `3 of the 10 samples were NOT-OK after retries (MAX_NOT_OK=2)` |
| 2 of 10 samples 503 with a 5-streak and a good final sample | exit 0 + `::warning` — the tolerated case, named in the log |
| 503 on the final sample | exit 1, and **no retry burned** (10 requests) |
| a 503 truncated mid-body on every sample | exit 1, **no retry burned** (3 requests for 3 samples) |
| 200 in 1.6 s against `MAX_SECONDS=1` on the final sample | exit 1, **not retried** (10 requests) |
| wall-clock ceiling hit while samples were good | exit 1 — an unfinished probe verifies nothing |
| `MAX_NOT_OK=two` (or a non-integer `SAMPLES`/`NEED_STREAK`/`TRANSPORT_RETRIES`/`MAX_TOTAL_SECONDS`) | exit 1 before a single request — a garbage cap must not silently disable itself |
| `NEED_STREAK > SAMPLES` | exit 1 before a single request |
| `HEALTH_URL`/`EXPECTED_VERSION` unset | exit 1 before a single request |

## Verification

Run on macOS with `bash 3.2.57` (the script uses no bash-4 construct — no `[[`, arrays, `<<<`, `mapfile` or `date -d`).

```
$ pytest -p no:cacheprovider backend/tests/test_post_rollout_probe.py
33 passed, 1 warning in 55.72s                    # exit 0

$ pytest -p no:cacheprovider backend/tests/test_cloudwatch_alarms.py backend/tests/test_single_openssl.py \
    backend/tests/test_ecs_paper_advance_deploy_pin.py backend/tests/scripts/test_alembic_migrate_preflight.py \
    backend/tests/services/test_paper_advance_kill_switch.py
97 passed, 2 skipped, 1 warning in 2.40s          # exit 0 — every existing test that reads deploy.yml

$ pytest -p no:cacheprovider backend/tests/test_feature_flag_fliplist_drift.py backend/tests/test_docs_site.py \
    backend/tests/test_infra_gate_workflow.py backend/tests/test_local_mode_contract.py
69 passed, 1 warning in 3.74s                     # exit 0 — every other test that reads .github/workflows

$ ruff check backend/tests/test_post_rollout_probe.py            # exit 0
$ ruff format --check backend/tests/test_post_rollout_probe.py   # exit 0
$ bash -n .github/scripts/post_rollout_probe.sh                  # exit 0 (also asserted as a test)
```

**`actionlint` is not available on this machine, so it was not run** — flagging that rather than claiming it, and `shellcheck` is not installed either. Nothing in `.github/workflows/` runs either tool and `main-format-guard` is ruff-only, so this shell script has no linter in CI at all. The workflow is parsed with PyYAML and the probe step is located and asserted through the parsed YAML (name, `if`, `env`, `run`) rather than by text grep.

## Concerns for the reviewer

- **The tolerance is real, and now bounded twice.** Up to two NOT-OK samples — including two dropped connections that failed through both retries — pass if a 5-streak was observed and the final sample is good. That is deliberate (#1791's whole complaint). It is bounded by the final-sample conjunct and by `MAX_NOT_OK`, and every tolerated sample is a `::warning`, not a silent pass. If those warnings become routine, that is a finding about post-rollout availability, not a reason to loosen further.
- **`MAX_NOT_OK` counts what a sample *answered with*, not what version it reported.** `.version` is deliberately read only from the final sample (no extra request after the window), and a mismatch fails the run outright — it can never be "capped away". I did **not** add a per-sample version check: during ALB deregistration draining an old task can still legitimately answer a sample after `rolloutState=COMPLETED`, and counting that NOT-OK would newly red-flag healthy deploys. Say the word if you want the stricter reading.
- **`MAX_TOTAL_SECONDS=300` is new policy**, chosen to fit the 1200s rollout budget + the probe inside the 30-minute deploy-ecs timeout with room for the CloudFront invalidation. Tests pin the arithmetic (including against the poll step's 420s reserve); the number itself is a judgement call.
- **This adds ~56s of mostly-sleep to `quality-gate`'s hard-blocking `backend-tests` job** (no xdist in the plugin set). The sleeps are `INTERVAL`/`RETRY_PAUSE` at 0.1s plus three deliberately slow cases.
- The script depends on `jq`, `awk`, `curl`, `seq`, `date` — all present on `ubuntu-latest` and used by neighbouring steps already. Missing `jq` degrades to "could not read .version" → exit 1 (fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
