### PR TITLE
[deploy][config] Pin FREE_GENERATIONS_PER_ACCOUNT=3 on both task-definition paths (deck Q3)

### DIFF
--- a/.github/scripts/ecs_rewrite_task_def.py
+++ b/.github/scripts/ecs_rewrite_task_def.py
@@ -19,7 +19,11 @@ This script is the path that actually ships. It:
 2. Pins ``PAPER_ADVANCE_ENABLED`` to :data:`PAPER_ADVANCE_VALUE` on the
    backend container, whether the cloned definition had the name unset,
    ``"true"``, or ``"false"``.
-3. Drops the describe-only fields ``register-task-definition`` rejects.
+3. Pins ``FREE_GENERATIONS_PER_ACCOUNT`` to :data:`FREE_GENERATIONS_VALUE`
+   on the backend container, for the same reason (#1643 finding A5): prod was
+   giving away three generations per account by accident of a code default,
+   which is the only knob on the flip-list that hands out paid product.
+4. Drops the describe-only fields ``register-task-definition`` rejects.
 
 The pinned value is ``"true"`` as of 2026-09-01 (#1778, the #1632 lift): the
 paper-advance tick is ARMED. It never runs in the web interpreter —
@@ -47,6 +51,13 @@ from typing import Any
 
 PAPER_ADVANCE_NAME = "PAPER_ADVANCE_ENABLED"
 PAPER_ADVANCE_VALUE = "true"
+
+#: Free generations per account, lifetime (#1643). Kept equal to
+#: ``free_generations.DEFAULT_ALLOWANCE`` so this pin is plumbing, not a policy
+#: change — the twin line in ``infra/ecs.tf`` must say the same number.
+FREE_GENERATIONS_NAME = "FREE_GENERATIONS_PER_ACCOUNT"
+FREE_GENERATIONS_VALUE = "3"
+
 BACKEND_CONTAINER = "backend"
 
 # Same drop-list the previous inline jq used. These fields come back from
@@ -80,6 +91,53 @@ def pin_backend_paper_advance(environment: list[dict[str, Any]] | None) -> list[
     return pinned
 
 
+def pin_backend_free_generations(environment: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Return a copy of ``environment`` with the free allowance pinned explicitly.
+
+    Idempotent and order-preserving, exactly like
+    :func:`pin_backend_paper_advance`: an entry already carrying
+    :data:`FREE_GENERATIONS_VALUE` is left where it is, a different value is
+    overwritten in place, and an absent name is appended — so the result holds
+    the name exactly once whatever the clone carried.
+
+    The overwrite is the part that earns a ``::notice``. Every other outcome is
+    the steady state and says nothing; a clone whose value *disagreed* with
+    this file means the registered revision was serving a different allowance
+    than the repo declares, and an operator reading the deploy log should see
+    the number change rather than infer it from a diff of two task-def
+    revisions after the fact. Written to stderr because stdout is the JSON
+    ``register-task-definition`` consumes.
+    """
+    entries = list(environment or [])
+    pinned: list[dict[str, Any]] = []
+    seen = False
+    for entry in entries:
+        if entry.get("name") != FREE_GENERATIONS_NAME:
+            pinned.append(entry)
+            continue
+        if seen:
+            # A duplicated name: ECS takes the last, so a second entry is a
+            # silent override. Drop it — the one kept above is the pin.
+            continue
+        seen = True
+        previous = entry.get("value")
+        if previous != FREE_GENERATIONS_VALUE:
+            print(
+                f"::notice::{FREE_GENERATIONS_NAME} pinned to {FREE_GENERATIONS_VALUE} "
+                f"(cloned revision carried {previous!r})",
+                file=sys.stderr,
+            )
+        pinned.append({"name": FREE_GENERATIONS_NAME, "value": FREE_GENERATIONS_VALUE})
+    if not seen:
+        print(
+            f"::notice::{FREE_GENERATIONS_NAME} pinned to {FREE_GENERATIONS_VALUE} "
+            "(cloned revision did not carry the name)",
+            file=sys.stderr,
+        )
+        pinned.append({"name": FREE_GENERATIONS_NAME, "value": FREE_GENERATIONS_VALUE})
+    return pinned
+
+
 def rewrite_registered_task_definition(
     task_def: dict[str, Any],
     *,
@@ -87,7 +145,7 @@ def rewrite_registered_task_definition(
     nginx_image: str,
     auth_image: str,
 ) -> dict[str, Any]:
-    """Clone ``task_def``, retag application images, pin the tick flag.
+    """Clone ``task_def``, retag application images, pin the tick + allowance flags.
 
     Raises :class:`RewriteError` if there is no backend container — a silent
     skip would register a revision whose ``PAPER_ADVANCE_ENABLED`` is whatever
@@ -105,7 +163,9 @@ def rewrite_registered_task_definition(
         if name == BACKEND_CONTAINER:
             saw_backend = True
             next_container["image"] = backend_image
-            next_container["environment"] = pin_backend_paper_advance(container.get("environment"))
+            next_container["environment"] = pin_backend_free_generations(
+                pin_backend_paper_advance(container.get("environment"))
+            )
         elif name == "nginx":
             next_container["image"] = nginx_image
         elif name == "auth":

--- a/backend/tests/test_ecs_backend_secrets.py
+++ b/backend/tests/test_ecs_backend_secrets.py
@@ -331,6 +331,42 @@ class TestTheCommentsTellTheTruth:
         )
 
 
+class TestTheFreeAllowanceIsPinnedNotInherited:
+    """`FREE_GENERATIONS_PER_ACCOUNT` must be a decision, not a code default.
+
+    Flip-list finding A5: prod served three free generations per account
+    because `free_generations.allowance()` falls back to `DEFAULT_ALLOWANCE`,
+    not because anybody put the number in a task definition. That is the same
+    config-drift shape `GENERATION_DAILY_CAP_*` and `GENERATION_TIMEOUT_SECONDS`
+    are plumbed here to avoid, and this is the one knob on that page that gives
+    away paid product.
+
+    Fails against `main` before this change: the name was nowhere in ecs.tf.
+    """
+
+    FREE_GENERATIONS_NAME = "FREE_GENERATIONS_PER_ACCOUNT"
+    FREE_GENERATIONS_VALUE = "3"
+
+    def test_the_allowance_is_declared_on_the_backend_container(self, backend_environment: dict[str, str]) -> None:
+        assert self.FREE_GENERATIONS_NAME in backend_environment, (
+            f"{self.FREE_GENERATIONS_NAME} is missing from the backend container's "
+            "`environment` block, so prod's free allowance is whatever "
+            "services/free_generations.py's code default happens to be (A5)."
+        )
+
+    def test_the_declared_value_is_the_owners_number(self, backend_environment: dict[str, str]) -> None:
+        assert backend_environment[self.FREE_GENERATIONS_NAME] == self.FREE_GENERATIONS_VALUE, (
+            f"{self.FREE_GENERATIONS_NAME} is "
+            f"{backend_environment[self.FREE_GENERATIONS_NAME]!r} in infra/ecs.tf; the "
+            f"owner's 2026-09-02 call is {self.FREE_GENERATIONS_VALUE!r}. Changing the "
+            "number someone gets for free is a policy change and wants its own review."
+        )
+
+    def test_it_is_environment_not_a_secret(self, backend_secrets: dict[str, str]) -> None:
+        """An allowance is not a credential; SSM would hide it from this guard."""
+        assert self.FREE_GENERATIONS_NAME not in backend_secrets
+
+
 class TestAntiGoals:
     """#1463 seeds credentials. It must not also arm what spends with them."""
 

--- a/backend/tests/test_ecs_free_generations_pin.py
+++ b/backend/tests/test_ecs_free_generations_pin.py
@@ -1,0 +1,276 @@
+"""``FREE_GENERATIONS_PER_ACCOUNT=3`` must ship on BOTH task-definition paths.
+
+Flip-list finding A5: prod grants three free generations per account because
+``services/free_generations.allowance()`` falls back to ``DEFAULT_ALLOWANCE``,
+not because anyone put the number in a task definition. The owner's 2026-09-02
+call was to pin it explicitly — "pipeline or terraform, whichever aligns with
+what we already do" — and what this repo already does is *both*, because
+neither alone is sufficient:
+
+- ``infra/ecs.tf`` is the declared baseline, but it is drifted (#1799) and
+  ``deploy.yml`` never applies terraform, so a pin that lives only there is not
+  live until somebody runs an apply.
+- ``.github/scripts/ecs_rewrite_task_def.py`` is the path that actually ships —
+  it clones the currently registered revision — but it is not a declaration
+  anyone reads when reasoning about infrastructure.
+
+That is the same two-path split ``PAPER_ADVANCE_ENABLED`` already has, and the
+:211 incident is what happens when only one side is covered. So the invariant
+here is the pair: the name and the value on both paths, and the two agreeing.
+
+Hermetic: the only inputs are two files in the repo. No AWS, no terraform, no
+network, no env.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REWRITE_PY = REPO_ROOT / ".github" / "scripts" / "ecs_rewrite_task_def.py"
+ECS_TF = REPO_ROOT / "infra" / "ecs.tf"
+ALLOWANCE_PY = REPO_ROOT / "backend" / "archimedes" / "services" / "free_generations.py"
+
+NAME = "FREE_GENERATIONS_PER_ACCOUNT"
+VALUE = "3"
+
+BACKEND_IMAGE = "037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-backend:deadbeef"
+NGINX_IMAGE = "037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-nginx:deadbeef"
+AUTH_IMAGE = "037613907429.dkr.ecr.us-east-1.amazonaws.com/archimedes-auth:deadbeef"
+
+
+def _load_rewrite():
+    spec = importlib.util.spec_from_file_location("ecs_rewrite_task_def", REWRITE_PY)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _task_def(*, free_generations: str | None = None) -> dict:
+    """A cloned live revision. ``None`` is today's shape: the name is absent."""
+    env = [
+        {"name": "APP_ENV", "value": "production"},
+        {"name": "GENERATION_PAYMENT_REQUIRED", "value": "true"},
+    ]
+    if free_generations is not None:
+        env.append({"name": NAME, "value": free_generations})
+    env.append({"name": "GENERATION_PRICE_USD", "value": "2.00"})
+    return {
+        "family": "archimedes-backend",
+        "taskDefinitionArn": "arn:aws:ecs:us-east-1:037613907429:task-definition/archimedes-backend:212",
+        "revision": 212,
+        "status": "ACTIVE",
+        "containerDefinitions": [
+            {"name": "backend", "image": "old-backend:cafe", "environment": env},
+            {"name": "nginx", "image": "old-nginx:cafe", "environment": [{"name": "FOO", "value": "1"}]},
+            {"name": "auth", "image": "old-auth:cafe"},
+        ],
+    }
+
+
+def _rewrite(task_def: dict) -> dict:
+    return _load_rewrite().rewrite_registered_task_definition(
+        task_def,
+        backend_image=BACKEND_IMAGE,
+        nginx_image=NGINX_IMAGE,
+        auth_image=AUTH_IMAGE,
+    )
+
+
+def _backend(task_def: dict) -> dict:
+    return next(c for c in task_def["containerDefinitions"] if c["name"] == "backend")
+
+
+def _backend_env(task_def: dict) -> dict[str, str]:
+    return {e["name"]: e["value"] for e in _backend(task_def).get("environment") or []}
+
+
+def _backend_env_names(task_def: dict) -> list[str]:
+    return [e["name"] for e in _backend(task_def).get("environment") or []]
+
+
+class TestThePipelinePathPinsIt:
+    """The path that actually registers a revision. Mutation: delete the
+    ``pin_backend_free_generations`` call from
+    ``rewrite_registered_task_definition`` and every case here goes red."""
+
+    def test_a_clone_without_the_name_ships_the_pin(self) -> None:
+        """Today's production input: :212 has never carried the name."""
+        env = _backend_env(_rewrite(_task_def(free_generations=None)))
+        assert env[NAME] == VALUE
+        # ...without eating the neighbours.
+        assert env["APP_ENV"] == "production"
+        assert env["GENERATION_PAYMENT_REQUIRED"] == "true"
+        assert env["GENERATION_PRICE_USD"] == "2.00"
+
+    @pytest.mark.parametrize("carried", ["0", "10", "", "three"])
+    def test_a_different_value_is_overwritten_not_appended(self, carried: str) -> None:
+        """ECS takes the LAST entry, so appending would look like it worked."""
+        out = _rewrite(_task_def(free_generations=carried))
+        assert _backend_env(out)[NAME] == VALUE
+        assert _backend_env_names(out).count(NAME) == 1
+
+    def test_the_matching_value_is_idempotent_and_keeps_its_position(self) -> None:
+        """Every deploy after the first. Order matters only in that a stable
+        rewrite produces a stable diff between task-def revisions."""
+        out = _rewrite(_task_def(free_generations=VALUE))
+        names = _backend_env_names(out)
+        assert names.count(NAME) == 1
+        assert _backend_env(out)[NAME] == VALUE
+        # The pin does not migrate to the end of the list, which would make
+        # every deploy's task-def diff churn even when nothing changed. Checked
+        # on the helper alone so the paper-advance pin's own append (which
+        # legitimately lands last) does not muddy the claim.
+        mod = _load_rewrite()
+        assert mod.pin_backend_free_generations(
+            [
+                {"name": "APP_ENV", "value": "production"},
+                {"name": NAME, "value": VALUE},
+                {"name": "GENERATION_PRICE_USD", "value": "2.00"},
+            ]
+        ) == [
+            {"name": "APP_ENV", "value": "production"},
+            {"name": NAME, "value": VALUE},
+            {"name": "GENERATION_PRICE_USD", "value": "2.00"},
+        ]
+
+    def test_a_duplicated_name_collapses_to_the_pin(self) -> None:
+        """Two entries is a silent override; one of them must not survive."""
+        task_def = _task_def(free_generations="0")
+        _backend(task_def)["environment"].append({"name": NAME, "value": "99"})
+        out = _rewrite(task_def)
+        assert _backend_env_names(out).count(NAME) == 1
+        assert _backend_env(out)[NAME] == VALUE
+
+    def test_the_paper_advance_pin_still_ships_alongside(self) -> None:
+        """The two pins compose; adding one must not drop the other."""
+        mod = _load_rewrite()
+        env = _backend_env(_rewrite(_task_def()))
+        assert env[mod.PAPER_ADVANCE_NAME] == mod.PAPER_ADVANCE_VALUE
+
+    def test_other_containers_do_not_get_the_allowance(self) -> None:
+        out = _rewrite(_task_def())
+        nginx = next(c for c in out["containerDefinitions"] if c["name"] == "nginx")
+        assert nginx["environment"] == [{"name": "FOO", "value": "1"}]
+        auth = next(c for c in out["containerDefinitions"] if c["name"] == "auth")
+        assert NAME not in {e.get("name") for e in auth.get("environment") or []}
+
+    def test_the_helper_is_pure(self) -> None:
+        """It must not mutate the caller's list — the clone is read again."""
+        mod = _load_rewrite()
+        original = [{"name": NAME, "value": "0"}]
+        mod.pin_backend_free_generations(original)
+        assert original == [{"name": NAME, "value": "0"}]
+
+    def test_none_is_accepted_as_an_absent_environment(self) -> None:
+        mod = _load_rewrite()
+        assert mod.pin_backend_free_generations(None) == [{"name": NAME, "value": VALUE}]
+
+    def test_the_value_is_hard_coded_not_a_cli_flag(self) -> None:
+        """Same reasoning as PAPER_ADVANCE_VALUE: a flag with a default makes
+        the deployed number a property of whoever wrote the workflow line."""
+        source = REWRITE_PY.read_text(encoding="utf-8")
+        assert f'FREE_GENERATIONS_VALUE = "{VALUE}"' in source
+        assert 'add_argument("--free' not in source
+        assert "FREE_GENERATIONS_VALUE" not in source.split("def main(", 1)[1]
+
+    def test_the_cli_emits_the_pin_and_a_notice(self, tmp_path: Path) -> None:
+        """The production invocation shape: JSON on stdout, ``::notice`` on
+        stderr so the deploy log records the change rather than leaving an
+        operator to diff two task-def revisions after the fact."""
+        src = tmp_path / "current-task-def.json"
+        src.write_text(json.dumps(_task_def(free_generations="0")), encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REWRITE_PY),
+                "--backend-image",
+                BACKEND_IMAGE,
+                "--nginx-image",
+                NGINX_IMAGE,
+                "--auth-image",
+                AUTH_IMAGE,
+                str(src),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert _backend_env(json.loads(result.stdout))[NAME] == VALUE
+        assert f"::notice::{NAME} pinned to {VALUE}" in result.stderr
+        assert "'0'" in result.stderr, "the notice must say what the clone carried"
+
+    def test_no_notice_when_the_clone_already_agrees(self, capsys) -> None:
+        """A ``::notice`` on every deploy is noise an operator learns to skip."""
+        mod = _load_rewrite()
+        capsys.readouterr()
+        mod.pin_backend_free_generations([{"name": NAME, "value": VALUE}])
+        assert capsys.readouterr().err == ""
+
+
+class TestTheTerraformPathPinsIt:
+    """The declared baseline. Mutation: delete the line from ``infra/ecs.tf``
+    and this goes red (as does test_ecs_backend_secrets.py)."""
+
+    def test_ecs_tf_declares_the_name_and_value(self) -> None:
+        src = ECS_TF.read_text(encoding="utf-8")
+        matches = re.findall(rf'{{\s*name\s*=\s*"{NAME}"\s*,\s*value\s*=\s*"([^"]*)"\s*}}', src)
+        assert matches, f"{NAME} is not declared in infra/ecs.tf"
+        assert matches == [VALUE], f"infra/ecs.tf declares {NAME} as {matches}, expected ['{VALUE}']"
+
+
+class TestTheTwoPathsAndTheCodeAgree:
+    """Three declarations of one number is two chances to drift.
+
+    A pipeline pin of 3 against a terraform pin of 10 is not a pin — the number
+    prod serves would then depend on whether anybody has run an apply since the
+    last deploy, which is exactly the "decided by nobody" state A5 names.
+    """
+
+    def test_the_pipeline_and_terraform_pins_are_the_same_number(self) -> None:
+        mod = _load_rewrite()
+        tf = re.findall(
+            rf'{{\s*name\s*=\s*"{NAME}"\s*,\s*value\s*=\s*"([^"]*)"\s*}}',
+            ECS_TF.read_text(encoding="utf-8"),
+        )
+        assert tf == [mod.FREE_GENERATIONS_VALUE], (
+            f"infra/ecs.tf says {tf} and ecs_rewrite_task_def.py says "
+            f"{mod.FREE_GENERATIONS_VALUE!r}. The pipeline pin wins on every deploy, "
+            "so terraform would silently be the lie."
+        )
+
+    def test_the_pin_matches_the_code_default_so_the_change_is_plumbing(self) -> None:
+        """This PR pins what prod already serves. If someone changes the pinned
+        number without changing DEFAULT_ALLOWANCE (or vice versa), that is a
+        policy change wearing plumbing's clothes — it should be argued, not
+        slipped in, and this is where it gets caught."""
+        mod = _load_rewrite()
+        default = re.search(r"^DEFAULT_ALLOWANCE = (\d+)$", ALLOWANCE_PY.read_text(encoding="utf-8"), re.M)
+        assert default, "DEFAULT_ALLOWANCE moved in services/free_generations.py"
+        assert default.group(1) == mod.FREE_GENERATIONS_VALUE == VALUE
+
+
+class TestTheReaderStillReadsItAtRequestTime:
+    """A pin on an env var that is snapshotted at import would be a pin on
+    nothing an operator can move without a deploy — and the module's own
+    docstring promises the opposite ("read per call, not cached")."""
+
+    def test_allowance_reads_the_environment_on_every_call(self, monkeypatch) -> None:
+        sys.path.insert(0, str(REPO_ROOT / "backend"))
+        from archimedes.services import free_generations
+
+        monkeypatch.setenv(NAME, "7")
+        assert free_generations.allowance() == 7
+        monkeypatch.setenv(NAME, "1")
+        assert free_generations.allowance() == 1, "the allowance was cached at import"
+        monkeypatch.delenv(NAME)
+        assert free_generations.allowance() == int(VALUE), "the code default is no longer 3"

--- a/docs/operations/feature-flag-fliplist.md
+++ b/docs/operations/feature-flag-fliplist.md
@@ -128,7 +128,7 @@ the part an operator reaches for under pressure.
 | `GENERATION_TIMEOUT_SECONDS` | `_generation_timeout_seconds()` — [`api/generate_routes.py`](../../backend/archimedes/api/generate_routes.py) | `"300"` literal in `infra/ecs.tf` (#1692); code default 600 | **Fail-soft, so mistypes are silent:** `"300s"`, `"5m"`, `"0"` and `"-1"` all fall back to 600 without complaint. `inf` is the one intended escape hatch. Keep it a bare positive number; pinned by [`test_ecs_generation_timeout.py`](../../backend/tests/test_ecs_generation_timeout.py). |
 | `GENERATION_DAILY_CAP_PER_USER` / `_PER_IP` | `user_daily_cap()` / `ip_daily_cap()` — [`services/generation_quota.py`](../../backend/archimedes/services/generation_quota.py) | `"100"` / `"200"` in `infra/ecs.tf` | `<= 0` disables that layer. Both layers must pass. |
 | `PUBLIC_TRACE_VAULTS` | `trace_visibility.py`'s `_PUBLIC_VAULTS_ENV`, falling back to `AGENT_VAULT_ADDRESSES` — [`services/trace_visibility.py`](../../backend/archimedes/services/trace_visibility.py) | `var.public_trace_vaults` in `infra/ecs.tf`; empty default → **unarmed** | Unarmed is the *wider* setting: every unowned trace is house-public. Arming it narrows visibility to the listed vaults. Counter-intuitive direction — check it before assuming an empty value is the safe one. |
-| `FREE_GENERATIONS_PER_ACCOUNT` | `allowance()` — [`services/free_generations.py`](../../backend/archimedes/services/free_generations.py) | **not in `infra/ecs.tf`** → code default `3`; `.env.example` also says `3`. See finding A5. | `<= 0` disables the free path entirely, and does so *without dangling a carrot* — `locked_reason()` returns `None` rather than a lock reason. Sits above `GENERATION_PAYMENT_REQUIRED`: the allowance is spendable only on a **verified** account (`LOCK_EMAIL_UNVERIFIED`). #1643/#1658. |
+| `FREE_GENERATIONS_PER_ACCOUNT` | `allowance()` — [`services/free_generations.py`](../../backend/archimedes/services/free_generations.py) | `"3"` pinned on **both** task-definition paths (owner, 2026-09-02, deck Q3): the literal in `infra/ecs.tf` and `FREE_GENERATIONS_VALUE` in [`.github/scripts/ecs_rewrite_task_def.py`](../../.github/scripts/ecs_rewrite_task_def.py), which is the one that actually ships (`deploy.yml` clones the live task-def and never applies terraform). Equal to the code default, so the pin was plumbing-only. Change **both** or the next CI deploy overwrites you. Guards: [`test_ecs_free_generations_pin.py`](../../backend/tests/test_ecs_free_generations_pin.py), [`test_ecs_backend_secrets.py`](../../backend/tests/test_ecs_backend_secrets.py). Closes A5. | `<= 0` disables the free path entirely, and does so *without dangling a carrot* — `locked_reason()` returns `None` rather than a lock reason. Sits above `GENERATION_PAYMENT_REQUIRED`: the allowance is spendable only on a **verified** account (`LOCK_EMAIL_UNVERIFIED`). #1643/#1658. |
 | `DEBATE_BACKTEST_WORKERS` | `_backtest_max_workers()` — [`agents/debate_engine.py`](../../backend/archimedes/agents/debate_engine.py) | not deployed → code default `2` | Clamped `[1, 2]`. **The clamp is the point:** the knob can make the dedicated backtest pool narrower, never wider, so an operator typo cannot reintroduce the GIL-contention fan-out #1689 removed. |
 | `SERVER_THREAD_POOL_WORKERS` | `_default_executor_workers()` — [`main.py`](../../backend/archimedes/main.py) | not deployed → `0` = auto | `0`/unset picks `min(32, max(16, cpu_count*4))`; a positive value overrides, capped at 64. Floor of 16 exists because one generation parks up to `DEBATE_POOL_MAX` IO-bound proposer threads on this pool (#1689). |
 | `TIINGO_MIN_REQUEST_INTERVAL_S` | `_tiingo_min_request_interval_s()` — [`services/market_data_provider.py`](../../backend/archimedes/services/market_data_provider.py) | commented out in `.env.example` → code default `1.1` s | `0` disables client-side pacing entirely, leaving only Tiingo's own HTTP 429. Negative or unparseable values log a warning and fall back to 1.1 (#1627). |
@@ -236,6 +236,17 @@ in the same PR as this revision. The remaining zero-reader `.env.example`
 entries are contract addresses and credentials, not flags — out of scope for
 #834, and each is a legitimate template line rather than dead config.
 
+**A5 — RESOLVED (2026-09-02): `FREE_GENERATIONS_PER_ACCOUNT` is now pinned on
+both task-definition paths.** The finding as written stands below; the fix
+landed as the literal `{ name = "FREE_GENERATIONS_PER_ACCOUNT", value = "3" }`
+in `infra/ecs.tf` **and** `FREE_GENERATIONS_VALUE = "3"` in
+`.github/scripts/ecs_rewrite_task_def.py`. Both, not either: ecs.tf is the
+declared baseline but is drifted and is not applied by `deploy.yml`, while the
+rewrite script is the path that registers every revision. That is the same
+two-path treatment `PAPER_ADVANCE_ENABLED` already has, for the same reason
+(task-def :211). The value equals the code default, so nothing about what prod
+serves changed — only whether it was decided. Original finding:
+
 **A5 — `FREE_GENERATIONS_PER_ACCOUNT` is not in the task definition.**
 It is read by `free_generations.allowance()` with a code default of 3 and is set
 in `.env.example` — but **nowhere in `infra/ecs.tf`**, so prod grants three free
@@ -247,6 +258,7 @@ one knob on this page that gives away paid product. Fix: add
 `{ name = "FREE_GENERATIONS_PER_ACCOUNT", value = "3" }` to ecs.tf, matching the
 code default so the apply is plumbing-only. **Not done here** — this page is not
 the place to edit terraform, and a value change wants its own review.
+*(Done separately, 2026-09-02 — see the resolution note above.)*
 
 **A6 — five rows' reader citations had drifted in one night.**
 `ARCHIMEDES_FUSION_ENABLED`, `GENERATION_PAYMENT_REQUIRED`,

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -661,6 +661,27 @@ resource "aws_ecs_task_definition" "backend" {
         # below): supplied at apply time once the platform DCW exists, so the
         # flip needs no code change.
         { name = "GENERATION_PAYMENT_REQUIRED", value = "true" },
+        # Free allowance ABOVE the paywall (#1643): the first N generations on
+        # a VERIFIED account never reach GENERATION_PAYMENT_REQUIRED. Pinned
+        # here at the code default (free_generations.DEFAULT_ALLOWANCE = 3) so
+        # the number prod gives away is a decision someone applied rather than
+        # an accident of a code default — finding A5 on the flip-list, and the
+        # same drift GENERATION_DAILY_CAP_* and GENERATION_TIMEOUT_SECONDS
+        # above were plumbed to remove. This is the one knob on that page that
+        # gives away paid product, so it does not get to be implicit.
+        #
+        # TWIN, and the one that actually ships: FREE_GENERATIONS_VALUE in
+        # .github/scripts/ecs_rewrite_task_def.py. deploy.yml clones the live
+        # task definition and does not apply terraform, so this line alone is
+        # not live. Change BOTH or the next CI deploy overwrites you.
+        #
+        # `<= 0` disables the free path entirely and restores the pre-#1643
+        # wallet-gate-on-first-call behaviour; a non-integer falls back to 3
+        # with a warning, so keep it a bare integer.
+        # Reader: allowance() in services/free_generations.py. Guards:
+        # backend/tests/test_ecs_backend_secrets.py (this line) and
+        # backend/tests/test_ecs_free_generations_pin.py (both paths).
+        { name = "FREE_GENERATIONS_PER_ACCOUNT", value = "3" },
         # $2.00/generation (Dan, 2026-08-20): the testnet faucet drips $20
         # per 2h cooldown, so one drip = a clean 10 generations — and $2 sits
         # inside the 10x-margin-over-measured-cost pricing direction (private


### PR DESCRIPTION
Owner decision Q3 (2026-09-02): prod serves `FREE_GENERATIONS_PER_ACCOUNT=3` from a code default — pin it explicitly, *"pipeline or terraform, whichever aligns with what we already do."*

What we already do is **both**, because neither alone ships the value:

| Path | What it is | Why it is not enough alone |
|---|---|---|
| `infra/ecs.tf` | the declared baseline | drifted (#1799), and `deploy.yml` never applies terraform — the pin is not live until someone runs an apply |
| `.github/scripts/ecs_rewrite_task_def.py` | the path that actually registers a revision (clones the live task-def) | not the file anyone reads when reasoning about infrastructure |

That is the same two-path split `PAPER_ADVANCE_ENABLED` already has, and task-def `:211` is what one-sided coverage cost last time.

This is flip-list **finding A5** — and the one knob on that page that gives away paid product. The pinned value equals `free_generations.DEFAULT_ALLOWANCE`, so **nothing prod serves changes**; only whether it was decided.

## What landed

- `infra/ecs.tf` — `{ name = "FREE_GENERATIONS_PER_ACCOUNT", value = "3" }` on the backend container, with the twin-line warning next to it.
- `.github/scripts/ecs_rewrite_task_def.py` — `FREE_GENERATIONS_NAME` / `FREE_GENERATIONS_VALUE` constants and `pin_backend_free_generations()`. Idempotent and order-preserving: an entry already carrying `"3"` stays where it is (a stable rewrite keeps the task-def diff quiet), a different value is **overwritten in place** rather than appended (ECS takes the LAST entry, so appending would look like it worked), a duplicated name collapses to one, an absent name is appended. Emits a `::notice` on stderr **only when the clone disagreed** — an every-deploy notice is noise an operator learns to skip.
- `docs/operations/feature-flag-fliplist.md` — the row now names both paths and the guards; A5 carries a resolution note above the original finding.

## Reader, confirmed

`allowance()` in `backend/archimedes/services/free_generations.py` calls `os.getenv` **per invocation**, not at import (`DEFAULT_ALLOWANCE = 3`). So the pin is live per request and an operator can still move it without a deploy — pinned by a test.

## Guards, each shown red against its mutation

| Mutation | Result |
|---|---|
| drop the line from `infra/ecs.tf` | **4 red** — 2 in `test_ecs_free_generations_pin.py`, 2 in `test_ecs_backend_secrets.py` |
| drop the `pin_backend_free_generations` call from the rewrite | **7 red** |
| pipeline pin drifts to `"10"` while terraform still says `"3"` | **10 red** |
| terraform value drifts to `"10"` | **3 red**, incl. the two-paths-agree check |
| `DEFAULT_ALLOWANCE` drifts to `5` | **2 red** — the plumbing-only claim and the request-time read |

```
FAILED tests/test_ecs_free_generations_pin.py::TestTheTerraformPathPinsIt::test_ecs_tf_declares_the_name_and_value - AssertionError: FREE_GENERATIONS_PER_ACCOUNT is not declared in infra/ecs.tf
FAILED tests/test_ecs_free_generations_pin.py::TestTheTwoPathsAndTheCodeAgree::test_the_pipeline_and_terraform_pins_are_the_same_number - AssertionError: infra/ecs.tf says [] and ecs_rewrite_task_def.py says '3'. ...
FAILED tests/test_ecs_backend_secrets.py::TestTheFreeAllowanceIsPinnedNotInherited::test_the_allowance_is_declared_on_the_backend_container - AssertionError: FREE_GENERATIONS_PER_ACCOUNT is missing from the backend co...
FAILED tests/test_ecs_backend_secrets.py::TestTheFreeAllowanceIsPinnedNotInherited::test_the_declared_value_is_the_owners_number - KeyError: 'FREE_GENERATIONS_PER_ACCOUNT'
=================== 4 failed, 38 passed, 1 warning in 3.67s ====================
```

```
FAILED tests/test_ecs_free_generations_pin.py::TestThePipelinePathPinsIt::test_a_clone_without_the_name_ships_the_pin - KeyError: 'FREE_GENERATIONS_PER_ACCOUNT'
FAILED tests/test_ecs_free_generations_pin.py::TestThePipelinePathPinsIt::test_a_different_value_is_overwritten_not_appended[0] - AssertionError: assert '0' == '3'
FAILED tests/test_ecs_free_generations_pin.py::TestThePipelinePathPinsIt::test_a_different_value_is_overwritten_not_appended[10] - AssertionError: assert '10' == '3'
FAILED tests/test_ecs_free_generations_pin.py::TestThePipelinePathPinsIt::test_a_different_value_is_overwritten_not_appended[] - AssertionError: assert '' == '3'
FAILED tests/test_ecs_free_generations_pin.py::TestThePipelinePathPinsIt::test_a_different_value_is_overwritten_not_appended[three] - AssertionError: assert 'three' == '3'
FAILED tests/test_ecs_free_generations_pin.py::TestThePipelinePathPinsIt::test_a_duplicated_name_collapses_to_the_pin - AssertionError: assert 2 == 1
FAILED tests/test_ecs_free_generations_pin.py::TestThePipelinePathPinsIt::test_the_cli_emits_the_pin_and_a_notice - AssertionError: assert '0' == '3'
=================== 7 failed, 11 passed, 1 warning in 3.02s ====================
```

```
FAILED tests/test_ecs_free_generations_pin.py::TestTheTerraformPathPinsIt::test_ecs_tf_declares_the_name_and_value - AssertionError: infra/ecs.tf declares FREE_GENERATIONS_PER_ACCOUNT as ['10'...
FAILED tests/test_ecs_free_generations_pin.py::TestTheTwoPathsAndTheCodeAgree::test_the_pipeline_and_terraform_pins_are_the_same_number - AssertionError: infra/ecs.tf says ['10'] and ecs_rewrite_task_def.py says '...
FAILED tests/test_ecs_backend_secrets.py::TestTheFreeAllowanceIsPinnedNotInherited::test_the_declared_value_is_the_owners_number - AssertionError: FREE_GENERATIONS_PER_ACCOUNT is '10' in infra/ecs.tf; the o...
=================== 3 failed, 39 passed, 1 warning in 1.50s ====================
```

```
FAILED tests/test_ecs_free_generations_pin.py::TestTheTwoPathsAndTheCodeAgree::test_the_pin_matches_the_code_default_so_the_change_is_plumbing - AssertionError: assert '5' == '3'
FAILED tests/test_ecs_free_generations_pin.py::TestTheReaderStillReadsItAtRequestTime::test_allowance_reads_the_environment_on_every_call - AssertionError: the code default is no longer 3
=================== 2 failed, 16 passed, 1 warning in 2.54s ====================
```

## Green

```
pytest tests/test_ecs_free_generations_pin.py tests/test_ecs_backend_secrets.py \
       tests/test_ecs_paper_advance_deploy_pin.py tests/test_ecs_generation_timeout.py \
       tests/test_feature_flag_fliplist_drift.py tests/test_free_generation_gate.py \
       tests/test_generation_credits.py
====================== 131 passed, 37 warnings in 56.83s =======================
```

`ruff check` + `ruff format --check` clean. `terraform fmt -check` clean; `terraform init -backend=false` + `terraform validate` → **Success! The configuration is valid.** No plan, no apply.

## Shared file

`.github/scripts/ecs_rewrite_task_def.py` is touched concurrently by **#1797** (strips retired env) and the **Tiingo secret PR**. This change is purely additive there: two new constants, one new function, and one call site wrapping the existing `pin_backend_paper_advance` call. Expect at most a trivial conflict; no existing behaviour moved.

## Concerns for the vet

- **The pin only reaches prod on the next CI deploy.** Merging this changes nothing running today — task-def `:212` still carries no `FREE_GENERATIONS_PER_ACCOUNT` and the container still falls through to the code default. Same value either way, so there is no window of wrong behaviour, but the "decided, not inherited" property only becomes true after a deploy.
- **`terraform apply` is still owed** for the ecs.tf side and for the rest of the #1799 drift. The pipeline pin is what makes that non-urgent here.
- **A value change is a policy change.** `test_the_pin_matches_the_code_default_so_the_change_is_plumbing` deliberately couples the pin to `DEFAULT_ALLOWANCE`, so moving the free allowance means editing three places and this test together. That is intended friction, not an oversight — but it does mean a future "just bump it to 5" PR is louder than a one-line diff.
- **The `::notice` is stderr-only** (stdout is the JSON `register-task-definition` consumes). If a future workflow line redirects stderr, the notice disappears silently; nothing guards the workflow's redirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

Do not merge — owner vets first.
