### PR TITLE
[guard] Org-rename guard covers SSH and bare-coordinate forms and openwiki/ (#1756)

### DIFF
--- a/backend/tests/test_canonical_repo_links.py
+++ b/backend/tests/test_canonical_repo_links.py
@@ -24,9 +24,33 @@ The second polices the *organisation* rename (#1758). Adding a bare `a-apin` to
 by the docs-site guards (`test_docs_site.py`, `ui/test/docs-link.test.js`'s
 `FORBIDDEN_HOSTS`, `docs-site/infra/main.tf`) to record the Pages host #1634
 moved off, and the OIDC and deploy notes quote "a-apin -> aprin-labs" to explain
-what the rename broke. So the second scan forbids the **repository pointer**
-`github.com/a-apin/` on live surfaces and leaves the *host* and the *rename
-narrative* alone.
+what the rename broke. So the second scan forbids the **repository pointer** and
+leaves the *host* and the *rename narrative* alone.
+
+#1756 widened *what counts as a pointer*. The first cut matched the literal
+substring `github.com/a-apin/`, which is one of three shapes the same dead
+coordinate takes:
+
+* the browser URL — `https://github.com/a-apin/archimedes/issues/1756`
+* the **SSH remote** — `git@github.com:a-apin/archimedes.git`, which a
+  `git clone` line in a runbook carries and which the substring missed entirely
+  because the separator is a colon
+* the **bare coordinate** — `gh issue list --repo a-apin/archimedes`,
+  `repo:a-apin/archimedes:*` in an OIDC trust policy, `a-apin/<any repo>` in
+  prose. No `github.com` in front of it at all.
+
+All three break the same way the redirect does, so the rule is now one regex
+(`_PRE_RENAME_COORDINATE`) over `<old org>/<repo>` with a word boundary in
+front. The boundary is what preserves the allow-list: in `a-apin.github.io` the
+org name is followed by a dot, not a slash, so the *host* — including
+`https://a-apin.github.io/archimedes/` — never matches, and "a-apin ->
+aprin-labs" has no slash at all. `FORBIDDEN_POINTER_SHAPES` and
+`ALLOWED_MENTION_SHAPES` run those claims through the real matcher, so the
+prose above cannot drift away from the rule.
+
+#1756 also put `openwiki/` — the published wiki tree — under both scans. It was
+outside every root, and was carrying four live `github.com/a-apin/archimedes`
+links at the time (`INSTRUCTIONS.md`, `rigor/documented-conflicts.md`).
 
 `CANONICAL_REPO` and `CANONICAL_ORG` are **documentation**. They are the names
 the failure messages point offenders at; no live surface is checked *against*
@@ -61,8 +85,18 @@ CANONICAL_REPO = "aprin-labs/archimedes"
 # Assembled at runtime so this file does not match its own scan.
 PRE_RENAME_NAMES = ("archimedes-" + "arcadia",)
 
-#: Trees whose contents describe the project as it is now.
-LIVE_ROOTS = ("ui/src", "ui/public", "infra", "backend", "contracts", "docs/runbooks", "scripts")
+#: Trees whose contents describe the project as it is now. ``openwiki`` is the
+#: published wiki tree and was outside every root until #1756.
+LIVE_ROOTS = (
+    "ui/src",
+    "ui/public",
+    "infra",
+    "backend",
+    "contracts",
+    "docs/runbooks",
+    "scripts",
+    "openwiki",
+)
 
 #: Point-in-time records, and other people's repositories.
 EXEMPT_PARTS = ("archive", "handovers", "audits", "submodules", "node_modules", "dist", ".git")
@@ -109,6 +143,8 @@ def test_the_scan_reaches_the_files_it_is_policing() -> None:
         "infra/README.md",
         "docs/runbooks/github-security-toggles.md",
         "CLAUDE.md",
+        # The published wiki tree, brought under the scan by #1756.
+        "openwiki/INSTRUCTIONS.md",
     ):
         assert expected in scanned, f"{expected} not scanned — the guard is blind"
 
@@ -147,18 +183,61 @@ CANONICAL_ORG = "aprin-labs"
 #: that flags its own docstring is a guard nobody keeps.
 PRE_RENAME_ORG = "a-" + "apin"
 
-#: What is forbidden is the **repository pointer**, not the organisation name.
-#: ``<old org>.github.io`` is a *host* — the GitHub Pages origin #1634 moved off
-#: — and "old org -> new org" is a *rename narrative*; both are quoted on
-#: purpose and stay green. ``github.com/<old org>/<anything>`` is a link that
-#: only resolves while GitHub keeps redirecting, which is the thing that breaks.
-PRE_RENAME_REPO_POINTER = f"github.com/{PRE_RENAME_ORG}/"
+#: What is forbidden is the **repository coordinate**, not the organisation
+#: name. ``<old org>.github.io`` is a *host* — the GitHub Pages origin #1634
+#: moved off — and "old org -> new org" is a *rename narrative*; both are quoted
+#: on purpose and stay green. ``<old org>/<repo>`` is a pointer that only
+#: resolves while GitHub keeps redirecting, which is the thing that breaks.
+#:
+#: The slash is the whole distinction, and it is why one regex covers all three
+#: shapes #1756 asked for: the HTTPS URL (``github.com/<old org>/…``), the SSH
+#: remote (``github.com:<old org>/…`` — a *colon*, which the old substring check
+#: could not see), and the bare coordinate with nothing in front of it at all
+#: (``gh --repo <old org>/<repo>``, ``repo:<old org>/<repo>:*``). The lookbehind
+#: keeps the match to a whole token, so a longer name ending in the old org's
+#: spelling is not swept in; the required ``/`` right after the org name is what
+#: lets ``<old org>.github.io`` — dot, not slash — through untouched.
+_PRE_RENAME_COORDINATE = re.compile(rf"(?<![0-9A-Za-z._-]){re.escape(PRE_RENAME_ORG)}/[0-9A-Za-z._-]+")
+
+#: The shapes that must be caught, and the mentions that must survive. These are
+#: *inputs to the real matcher* (``test_the_matcher_catches_every_forbidden_shape``
+#: and ``test_the_matcher_lets_every_deliberate_mention_through``), not prose:
+#: #1758's whole lesson is that a constant no assertion reads is a comment with a
+#: colon in it. Assembled from ``PRE_RENAME_ORG`` so this file does not match its
+#: own scan by hand-spelling the stale org.
+FORBIDDEN_POINTER_SHAPES = (
+    f"see https://github.com/{PRE_RENAME_ORG}/archimedes/issues/1756 for context",
+    f"git clone git@github.com:{PRE_RENAME_ORG}/archimedes.git",
+    f"gh issue list --repo {PRE_RENAME_ORG}/archimedes",
+    f"the wiki lives at {PRE_RENAME_ORG}/openwiki these days",
+    f'"token.actions.githubusercontent.com:sub": "repo:{PRE_RENAME_ORG}/archimedes:*"',
+)
+
+#: Deliberate, correct mentions. The Pages host #1634 moved off, that host with a
+#: path on it, the rename narrative in both spellings the repo uses, and the
+#: canonical coordinate itself.
+ALLOWED_MENTION_SHAPES = (
+    f"FORBIDDEN_HOSTS = [{PRE_RENAME_ORG}.github.io]",
+    f"docs was never a CNAME to https://{PRE_RENAME_ORG}.github.io/archimedes/",
+    f"after the org rename {PRE_RENAME_ORG} -> {CANONICAL_ORG}, every deploy broke",
+    f"On 2026-09-01 the `{PRE_RENAME_ORG}` → `{CANONICAL_ORG}` rename landed",
+    f"https://github.com/{CANONICAL_REPO}/issues/1756",
+)
 
 #: Files handed to a reader, or to a package manager, as current truth.
 ORG_LIVE_FILES = ("README.md", "SETUP.md", "CLAUDE.md", "AGENTS.md")
 
-#: Trees that ship: the app, the two published packages, the docs tree.
-ORG_LIVE_ROOTS = ("ui/src", "ui/public", "backend/archimedes", "cli", "mcp-server", "docs")
+#: Trees that ship: the app, the two published packages, the docs tree, and the
+#: published wiki (``openwiki``, added by #1756 — it was outside every root).
+ORG_LIVE_ROOTS = (
+    "ui/src",
+    "ui/public",
+    "backend/archimedes",
+    "cli",
+    "mcp-server",
+    "docs",
+    "openwiki",
+)
 
 ORG_EXEMPT_PARTS = ("archive", "handovers", "audits", "submodules", "node_modules", "dist", "build", ".git")
 
@@ -212,6 +291,11 @@ def _org_live_files() -> list[Path]:
     return _org_walk(apply_exemptions=True)
 
 
+def _points_at_pre_rename_repo(line: str) -> bool:
+    """The rule, in one place, so every test below is proving the same thing."""
+    return bool(_PRE_RENAME_COORDINATE.search(line))
+
+
 def _repo_pointer_offenders(paths: list[Path]) -> list[str]:
     """Report ``path:line`` for every line pointing at the pre-rename org's repo."""
     offenders: list[str] = []
@@ -223,7 +307,7 @@ def _repo_pointer_offenders(paths: list[Path]) -> list[str]:
         except (UnicodeDecodeError, OSError):
             continue
         for lineno, line in enumerate(text.splitlines(), 1):
-            if PRE_RENAME_REPO_POINTER in line:
+            if _points_at_pre_rename_repo(line):
                 offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
     return offenders
 
@@ -247,6 +331,10 @@ def test_the_org_scan_reaches_the_live_surfaces() -> None:
         "backend/archimedes/main.py",
         # A live doc that quotes the rename narrative and must stay green.
         "docs/runbooks/docs-site-setup.md",
+        # The published wiki: outside every root until #1756, and it was
+        # carrying four live pre-rename links when that was noticed.
+        "openwiki/INSTRUCTIONS.md",
+        "openwiki/rigor/documented-conflicts.md",
     ):
         assert expected in scanned, f"{expected} not scanned — the guard is blind"
 
@@ -276,11 +364,39 @@ def test_no_live_surface_points_at_the_pre_rename_org() -> None:
     """
     offenders = _repo_pointer_offenders(_org_live_files())
     assert not offenders, (
-        f"{sorted(offenders)} point at '{PRE_RENAME_REPO_POINTER}'. The canonical repository is "
-        f"'{CANONICAL_REPO}' under the '{CANONICAL_ORG}' organisation. GitHub's redirect makes the "
-        "stale link work today, so nothing else catches this — and the redirect dies the moment "
-        f"'{PRE_RENAME_ORG}' is re-claimed by anyone."
+        f"{sorted(offenders)} name a repository under '{PRE_RENAME_ORG}/' — as an https:// link, an "
+        f"SSH remote (github.com:{PRE_RENAME_ORG}/…), or a bare coordinate. The canonical repository "
+        f"is '{CANONICAL_REPO}' under the '{CANONICAL_ORG}' organisation. GitHub's redirect makes the "
+        "stale pointer work today, so nothing else catches this — and the redirect dies the moment "
+        f"'{PRE_RENAME_ORG}' is re-claimed by anyone. (The *host* '{PRE_RENAME_ORG}.github.io' and the "
+        f"'{PRE_RENAME_ORG} -> {CANONICAL_ORG}' rename narrative are deliberate and do not trip this.)"
     )
+
+
+@pytest.mark.parametrize("shape", FORBIDDEN_POINTER_SHAPES)
+def test_the_matcher_catches_every_forbidden_shape(shape: str) -> None:
+    """#1756: the same dead coordinate wears three different clothes.
+
+    The first cut of this guard matched the literal substring
+    ``github.com/<old org>/``. An SSH remote uses a colon, and a
+    ``gh --repo``/OIDC-``sub`` coordinate has no host in front of it at all —
+    both walked straight past. This runs each shape through the *live* matcher,
+    so widening the rule is a claim the suite checks rather than one the
+    docstring makes.
+    """
+    assert _points_at_pre_rename_repo(shape), f"{shape!r} is a live pointer at the pre-rename org and was not caught"
+
+
+@pytest.mark.parametrize("shape", ALLOWED_MENTION_SHAPES)
+def test_the_matcher_lets_every_deliberate_mention_through(shape: str) -> None:
+    """The widened rule must not swallow the allow-list it was built around.
+
+    ``<old org>.github.io`` is the Pages host #1634 moved off and is quoted on
+    purpose; "old org -> new org" is the rename narrative the OIDC and deploy
+    notes need. A rule that flagged either would be reverted within a day, which
+    is the failure mode a bare-substring widening walks into.
+    """
+    assert not _points_at_pre_rename_repo(shape), f"{shape!r} is a deliberate mention and must stay green"
 
 
 @pytest.mark.parametrize("keep", DELIBERATE_ORG_MENTIONS)

--- a/openwiki/INSTRUCTIONS.md
+++ b/openwiki/INSTRUCTIONS.md
@@ -283,14 +283,14 @@ GitHub Pages.**
 The build already exists and stays: `mkdocs.yml` mounts this tree via
 `.github/scripts/mkdocs_hooks.py`, and `.github/workflows/docs-site.yml` runs
 `mkdocs build --strict` on every docs-path push and PR. That wiring, landed by
-[#1624](https://github.com/a-apin/archimedes/pull/1624), becomes the **build step** and is
+[#1624](https://github.com/aprin-labs/archimedes/pull/1624), becomes the **build step** and is
 not being replaced.
 
 What changes is the **serving**. The GitHub Pages deploy job — gated on
 `vars.DOCS_SITE_ENABLED` behind three manual console steps, and dark since 2026-08-20 —
 is replaced by S3 + CloudFront + Route 53 in our own account, on the pattern already applied
 for `aprin.ai` in `company-site/infra/main.tf`. That is separate infrastructure work,
-tracked as [#1634](https://github.com/a-apin/archimedes/issues/1634), which also adds the
+tracked as [#1634](https://github.com/aprin-labs/archimedes/issues/1634), which also adds the
 docs link to the landing footer (`ui/src/components/Landing.jsx`) and the public header
 (`ui/src/components/PublicLayout.jsx`).
 

--- a/openwiki/rigor/documented-conflicts.md
+++ b/openwiki/rigor/documented-conflicts.md
@@ -31,7 +31,7 @@ generated: { by: "claude-code", at: "2026-08-31T05:55:43.566Z" }
 > ## ⚠ RESOLVED 2026-08-31 — hand-annotated, not regenerated
 >
 > *This block is a human edit to a generated page, added by
-> [#1598](https://github.com/a-apin/archimedes/issues/1598). Everything below it is the
+> [#1598](https://github.com/aprin-labs/archimedes/issues/1598). Everything below it is the
 > generator's output, preserved verbatim as the evidence record of what the 2026-08-31
 > 05:55 run found.*
 >
@@ -64,7 +64,7 @@ generated: { by: "claude-code", at: "2026-08-31T05:55:43.566Z" }
 > documents disagree; it cannot find that both are wrong. See Önder's eighth conflict on
 > #1598 — a stale `N_eff` formula that every doc in the slice reproduced *consistently*,
 > and which only a check against the code could catch (fixed separately in
-> [#1614](https://github.com/a-apin/archimedes/pull/1614)).
+> [#1614](https://github.com/aprin-labs/archimedes/pull/1614)).
 
 This page exists so a reader does not resolve a contradiction by trusting whichever page
 they happened to open first. Everything below is a disagreement **inside this slice**,


### PR DESCRIPTION
Closes #1756.

Owner decision 2026-09-03: widen the guard and close the issue.

## What was wrong

The org guard that landed in #1775 (`backend/tests/test_canonical_repo_links.py`) matched **one literal substring**, `github.com/<old org>/`. That is one of three shapes the same dead coordinate takes, and it was blind to the other two:

| Shape | Example | Old rule |
|---|---|---|
| HTTPS URL | `https://github.com/a-apin/archimedes/issues/1756` | caught |
| **SSH remote** | `git clone git@github.com:a-apin/archimedes.git` | **missed** — the separator is a colon |
| **Bare coordinate** | `gh issue list --repo a-apin/archimedes`, `repo:a-apin/archimedes:*`, `a-apin/<any repo>` | **missed** — no host in front of it at all |

`openwiki/` — the published wiki tree — was outside every scanned root in both scans, and was carrying **four live pre-rename links** at the time.

## What changed

**One regex is now the rule** (`_PRE_RENAME_COORDINATE`): `<old org>/<repo>` with a token boundary in front. All three shapes collapse into it, because neither `/` nor `:` is a token character.

**The deliberate allow-list is preserved by the same slash that does the catching.** In `a-apin.github.io` the org name is followed by a **dot**, so the Pages host #1634 moved off stays green — with or without a path on it (`https://a-apin.github.io/archimedes/`) — and the rename narrative `a-apin -> aprin-labs` has no slash at all, so the OIDC script and `deploy.yml` notes stay green. That rationale is the guard's existing one, read from its docstring and kept intact.

**The claims are executed, not asserted in prose.** `FORBIDDEN_POINTER_SHAPES` and `ALLOWED_MENTION_SHAPES` are run through the *live* matcher by two new parametrised tests. #1758's lesson was that a constant no assertion reads is a comment with a colon in it; these are inputs, not documentation.

**`openwiki/` joins both scans** (`LIVE_ROOTS` and `ORG_LIVE_ROOTS`), and both "guard on the guard" reach-tests now name openwiki files, so silently dropping the root fails loudly.

**The four live pointers under `openwiki/` are swept** — `INSTRUCTIONS.md` ×2 (#1624, #1634), `rigor/documented-conflicts.md` ×2 (#1598, #1614) — all `github.com/a-apin/archimedes/...` → `github.com/aprin-labs/archimedes/...`.

## Adversarial pass — every new form shown RED

Each mutation was planted, run, captured, then reverted **by editing the file back** (never `git checkout --`). Before each run, `grep -c "github.com/a-apin/" <file>` returned **0**, i.e. the pre-#1756 substring rule would not have seen any of them.

### 1. SSH form, planted in `openwiki/INSTRUCTIONS.md` (proves the new form *and* the new root)

Planted: ``Clone it with `git clone git@github.com:a-apin/archimedes.git` first.``

```
E   AssertionError: ['openwiki/INSTRUCTIONS.md:302'] name a repository under 'a-apin/' — as an https:// link, an SSH remote (github.com:a-apin/…), or a bare coordinate. The canonical repository is 'aprin-labs/archimedes' under the 'aprin-labs' organisation. GitHub's redirect makes the stale pointer work today, so nothing else catches this — and the redirect dies the moment 'a-apin' is re-claimed by anyone. (The *host* 'a-apin.github.io' and the 'a-apin -> aprin-labs' rename narrative are deliberate and do not trip this.)
E   assert not ['openwiki/INSTRUCTIONS.md:302']
FAILED backend/tests/test_canonical_repo_links.py::test_no_live_surface_points_at_the_pre_rename_org
```

**Is the `openwiki` root load-bearing?** With that mutation still planted, `"openwiki"` was removed from `ORG_LIVE_ROOTS`: the offender scan went **green** (blind), and the guard-on-the-guard caught the blindness:

```
E   AssertionError: openwiki/INSTRUCTIONS.md not scanned — the guard is blind
FAILED backend/tests/test_canonical_repo_links.py::test_the_org_scan_reaches_the_live_surfaces
```

### 2. Bare coordinate `a-apin/archimedes`, planted in `README.md`

Planted: ``File issues with `gh issue list --repo a-apin/archimedes`.``

```
E   AssertionError: ['README.md:253'] name a repository under 'a-apin/' — as an https:// link, an SSH remote (github.com:a-apin/…), or a bare coordinate. The canonical repository is 'aprin-labs/archimedes' under the 'aprin-labs' organisation. GitHub's redirect makes the stale pointer work today, so nothing else catches this — and the redirect dies the moment 'a-apin' is re-claimed by anyone. (The *host* 'a-apin.github.io' and the 'a-apin -> aprin-labs' rename narrative are deliberate and do not trip this.)
E   assert not ['README.md:253']
FAILED backend/tests/test_canonical_repo_links.py::test_no_live_surface_points_at_the_pre_rename_org
```

### 3. Bare coordinate for *any* repo, planted in `docs/runbooks/docs-site-setup.md`

Planted: `The wiki mirror is published from a-apin/openwiki nightly.`

```
E   AssertionError: ['docs/runbooks/docs-site-setup.md:255'] name a repository under 'a-apin/' — as an https:// link, an SSH remote (github.com:a-apin/…), or a bare coordinate. The canonical repository is 'aprin-labs/archimedes' under the 'aprin-labs' organisation. GitHub's redirect makes the stale pointer work today, so nothing else catches this — and the redirect dies the moment 'a-apin' is re-claimed by anyone. (The *host* 'a-apin.github.io' and the 'a-apin -> aprin-labs' rename narrative are deliberate and do not trip this.)
E   assert not ['docs/runbooks/docs-site-setup.md:255']
FAILED backend/tests/test_canonical_repo_links.py::test_no_live_surface_points_at_the_pre_rename_org
FAILED backend/tests/test_canonical_repo_links.py::test_deliberate_pre_rename_org_mentions_stay_green[docs/runbooks/docs-site-setup.md] - AssertionError: docs/runbooks/docs-site-setup.md is a repo pointer, not a h...
```

That second failure is the allow-list behaving correctly: being on `DELIBERATE_ORG_MENTIONS` buys the *host and the narrative* a pass, not the file — plant a coordinate in a KEEP file and it still fails.

## The allow-list shown GREEN

**Counter-mutation.** All the allowed shapes were planted on a live surface that is *not* on `DELIBERATE_ORG_MENTIONS` at all (`openwiki/INSTRUCTIONS.md`), so the pass is earned by the rule rather than by a filename exemption:

```
The old Pages host was a-apin.github.io, and https://a-apin.github.io/archimedes/ is where it served from.
The a-apin -> aprin-labs rename landed 2026-09-01; the `a-apin` → `aprin-labs` move is why the OIDC trust policy changed.
```

```
23 passed, 1 warning in 4.96s
```

Reverted afterwards.

**Is the widening itself load-bearing?** With the tree clean, `_points_at_pre_rename_repo` was reverted to the pre-#1756 body (`return f"github.com/{PRE_RENAME_ORG}/" in line`). Four of the five forbidden shapes went red — the https one correctly still passing:

```
FAILED backend/tests/test_canonical_repo_links.py::test_the_matcher_catches_every_forbidden_shape[the wiki lives at a-apin/openwiki these days] - AssertionError: 'the wiki lives at a-apin/openwiki these days' is a live po...
FAILED backend/tests/test_canonical_repo_links.py::test_the_matcher_catches_every_forbidden_shape["token.actions.githubusercontent.com:sub": "repo:a-apin/archimedes:*"] - AssertionError: '"token.actions.githubusercontent.com:sub": "repo:a-apin/ar...
4 failed, 6 passed, 13 deselected, 1 warning in 1.60s
```

Restored; tree is clean, `git status` shows only the three intended files.

## Tests

- `backend/tests/test_canonical_repo_links.py` — 23 passed (was 13; +10 from the two new parametrised shape tests).
- Full backend suite (`python -m pytest backend/tests -q`, archimedes conda env) — **5801 passed, 6 skipped, 334 warnings in 962.73s**, exit 0.
- CI on this head: all checks pass (Backend — unit tests, Frontend + Better Auth, Analytics engine, `mkdocs build --strict`, Ruff, CodeQL, import-guard, migrations chain-fork guard, complexity, supply chain).
- `ruff check` + `ruff format --check` clean on the guard.

Do not merge — owner vets first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx
