### PR TITLE
[chain] ERC-8004 register path: bounded log window, idempotent-replay 200, STUCK handling (#1527 pre-flight)

### DIFF
--- a/backend/archimedes/chain/circle_signer.py
+++ b/backend/archimedes/chain/circle_signer.py
@@ -52,6 +52,14 @@ _MAX_POLLS = 60  # 2 minutes max
 # expected shape of any retry, not a rarity. Treating 200 as a failure told the operator a
 # transaction that had succeeded had failed, and the tempting next move after that is to
 # force a second one.
+#
+# KNOWN DIVERGENCE, deliberate: oracle_updater.py does NOT come through this method — it
+# POSTs to the same endpoint itself — and it fixed this identical defect first, under #1525
+# ("Circle API error for sBTC (200): {'state': 'COMPLETE'}" every cycle for a push that had
+# landed). Its fix grades on the PAYLOAD (a usable id whose state is not a failure state);
+# this one grades on the STATUS and then requires a usable id below. Same outcome for the
+# shapes Circle actually returns, two implementations, one seam apart. Converging them is
+# its own change; until then, a fix here is not a fix there.
 _SUBMIT_ACCEPTED = frozenset({200, 201})
 
 # Bounded wall-clock ceiling on the wallet-address lookup (#1412). This runs
@@ -272,7 +280,18 @@ class CircleSigner:
                 body = await resp.json()
                 if resp.status not in _SUBMIT_ACCEPTED:
                     raise RuntimeError(f"Circle contract execution failed ({resp.status}): {body}")
-                circle_tx_id = body["data"]["id"]
+                # A 2xx is not automatically a usable answer. ``body["data"]["id"]`` was an
+                # unguarded double subscript: a malformed success — an error envelope, a
+                # proxy's HTML, a 200 with no ``data`` — surfaced as ``KeyError: 'data'``
+                # from inside the signer instead of the RuntimeError every caller here is
+                # written to handle. Newly reachable now that 200 is accepted at all.
+                data = body.get("data") if isinstance(body, dict) else None
+                circle_tx_id = data.get("id") if isinstance(data, dict) else None
+                if not circle_tx_id:
+                    raise RuntimeError(
+                        f"Circle accepted the contract execution ({resp.status}) but the response carries "
+                        f"no transaction id to poll, so nothing can be confirmed: {body}"
+                    )
                 if resp.status == 200:
                     # Not a new transaction — Circle recognised the idempotency key and
                     # handed back the one it already has. Logged as such so a reader of

--- a/backend/archimedes/chain/circle_signer.py
+++ b/backend/archimedes/chain/circle_signer.py
@@ -26,10 +26,33 @@ logger = logging.getLogger(__name__)
 CIRCLE_API_BASE = "https://api.circle.com/v1/w3s"
 CIRCLE_BLOCKCHAIN = "ARC-TESTNET"
 
-# Transaction terminal states
+# Transaction terminal states. Circle's full enum is INITIATED, CLEARED, QUEUED, SENT,
+# STUCK, CONFIRMED, COMPLETE, FAILED, DENIED, CANCELLED (get-transaction API reference).
+# CONFIRMED is deliberately NOT terminal: Circle's blockchain-confirmations doc is explicit
+# that a transaction visible on a block explorer may still not be COMPLETE.
 _TERMINAL = {"COMPLETE", "FAILED", "DENIED", "CANCELLED"}
+
+# STUCK is its own case, and it is not in _TERMINAL because Circle does not call it a
+# failure: "STUCK is a signal for intervention, not a terminal failure" — and, crucially,
+# "if a transaction stays STUCK and you take no action, it can block subsequent
+# transactions from the same wallet" (transaction-limits-and-optimizations). For a caller
+# it is nonetheless the end of the road: nothing this process can do will unstick it, so
+# spinning out the full poll budget and then raising a generic timeout costs two minutes
+# and throws away the one fact the operator needs — WHICH transaction to accelerate or
+# cancel in the Circle Console, before it wedges the oracle's pushes from the same wallet.
+_STUCK = "STUCK"
+
 _POLL_INTERVAL = 2.0  # seconds
 _MAX_POLLS = 60  # 2 minutes max
+
+# Circle answers a contract-execution submit with 201 for a newly created transaction and
+# 200 when it recognises the idempotencyKey and replays the existing one
+# (create-developer-transaction-contract-execution). Our key is deterministic BY DESIGN —
+# uuid5 over wallet+contract+function+args (see execute_contract) — so a replay is the
+# expected shape of any retry, not a rarity. Treating 200 as a failure told the operator a
+# transaction that had succeeded had failed, and the tempting next move after that is to
+# force a second one.
+_SUBMIT_ACCEPTED = frozenset({200, 201})
 
 # Bounded wall-clock ceiling on the wallet-address lookup (#1412). This runs
 # inside the agent tick's reveal-reconciliation pass, so an unbounded read
@@ -192,7 +215,9 @@ class CircleSigner:
             The on-chain transaction hash.
 
         Raises:
-            RuntimeError: If Circle credentials are missing or the tx fails.
+            RuntimeError: If Circle credentials are missing, the submit is rejected
+                (anything outside :data:`_SUBMIT_ACCEPTED`), the transaction reaches a
+                failing terminal state, goes ``STUCK``, or the poll budget runs out.
         """
         if not self.is_configured:
             raise RuntimeError("Circle credentials not configured (CIRCLE_API_KEY / CIRCLE_ENTITY_SECRET / WALLET_ID)")
@@ -245,10 +270,16 @@ class CircleSigner:
                 },
             ) as resp:
                 body = await resp.json()
-                if resp.status != 201:
+                if resp.status not in _SUBMIT_ACCEPTED:
                     raise RuntimeError(f"Circle contract execution failed ({resp.status}): {body}")
                 circle_tx_id = body["data"]["id"]
-                logger.info("Circle tx submitted: %s", circle_tx_id)
+                if resp.status == 200:
+                    # Not a new transaction — Circle recognised the idempotency key and
+                    # handed back the one it already has. Logged as such so a reader of
+                    # the logs can tell one submission from two.
+                    logger.info("Circle tx replayed (idempotent, HTTP 200): %s", circle_tx_id)
+                else:
+                    logger.info("Circle tx submitted: %s", circle_tx_id)
 
             # Poll until terminal state
             return await self._poll_transaction(session, circle_tx_id)
@@ -313,7 +344,13 @@ class CircleSigner:
             return tx_hash
 
     async def _poll_transaction(self, session: aiohttp.ClientSession, circle_tx_id: str) -> str:
-        """Poll Circle transaction until terminal state."""
+        """Poll Circle transaction until terminal state.
+
+        Returns the on-chain hash only for ``COMPLETE``. Every other end — a failing
+        terminal state, ``STUCK``, or exhausting the budget — raises, and the ``STUCK``
+        message names the transaction because that is what an operator has to type into
+        the Circle Console to clear it.
+        """
         for _ in range(_MAX_POLLS):
             # Scope the list to this wallet's transactions via the walletIds
             # filter. An unfiltered GET /transactions returns the newest txs
@@ -331,6 +368,17 @@ class CircleSigner:
                         if tx.get("id") == circle_tx_id:
                             state = tx.get("state", "UNKNOWN")
                             tx_hash = tx.get("txHash", "")
+
+                            if state == _STUCK:
+                                raise RuntimeError(
+                                    f"Circle tx {circle_tx_id} is STUCK "
+                                    f"(txHash {tx_hash or 'not yet assigned'}, wallet {self._wallet_id}): "
+                                    "Circle accepted and broadcast it but it is not being mined, and a "
+                                    "stuck transaction blocks every later transaction from the same "
+                                    "wallet — including the oracle's price pushes. Accelerate or cancel "
+                                    f"transaction {circle_tx_id} in the Circle Console (Transactions), "
+                                    "then re-run. Do NOT submit a replacement first."
+                                )
 
                             if state in _TERMINAL:
                                 if state == "COMPLETE":

--- a/backend/archimedes/chain/erc8004_identity.py
+++ b/backend/archimedes/chain/erc8004_identity.py
@@ -316,8 +316,11 @@ async def find_agent_id(owner: str, client=None, from_block: int | str = 0) -> t
     candidate is then re-checked with ``ownerOf``, because a mint log proves the token was
     once minted to this wallet, not that it is still held.
 
-    ``(None, detail)`` means "no identity found"; a raised exception means "could not
-    look" and the caller must not read it as either.
+    ``(None, detail)`` means "no identity found", and it is returned for exactly ONE fact:
+    ``balanceOf == 0``. A raised exception means "could not look" — the RPC refused the
+    range, or the wallet holds something this window could not name — and the caller must
+    not read it as either. Those two must never share a return value: the caller's next
+    move on "no identity found" is to MINT, and a second identity cannot be un-minted.
     """
     from archimedes.chain.client import chain_client
 
@@ -342,8 +345,14 @@ async def find_agent_id(owner: str, client=None, from_block: int | str = 0) -> t
             return candidate, f"balanceOf == {balance}; mint log + ownerOf({candidate}) both name {owner}"
 
     # balanceOf says it holds something the mint logs cannot name — a transferred-in token,
-    # or a log scan that started after the mint. Refusing beats guessing.
-    return None, (
+    # or, far more likely, a bounded scan that started AFTER the mint. This is not "no
+    # identity"; it is "this window could not see the identity that balanceOf just proved
+    # exists". Returning ``None`` here would hand the register path the one answer that
+    # makes it mint (``_resolve_existing`` → ``_pending`` → fall through to ``register()``),
+    # for a wallet already holding a token — a double mint, from a fail-safe. It is a
+    # raise, so the caller's existing "could not read the registry → refused" arm catches
+    # it. See the returns contract above.
+    raise RuntimeError(
         f"balanceOf({owner}) == {balance} but no mint log in range names a token this wallet still owns "
         f"(scanned from block {from_block}); pass the agentId explicitly"
     )

--- a/backend/tests/chain/test_circle_signer.py
+++ b/backend/tests/chain/test_circle_signer.py
@@ -9,6 +9,11 @@ exercised.
 
 Hermetic: the aiohttp HTTP boundary is mocked; the RSA encrypt helper is mocked
 where a real key would otherwise be needed. No network, no Circle, no Arc RPC.
+
+See also backend/tests/test_circle_signer.py (#1527): the submit-status contract is
+{200, 201}, not 201 alone — 200 is Circle replaying our deterministic idempotency key —
+and ``STUCK`` raises immediately instead of burning the poll budget. Both are proven
+there, against a fake with real RSA rather than a mocked encrypt.
 """
 
 from __future__ import annotations
@@ -278,7 +283,13 @@ class TestExecuteContract:
         ):
             await configured.execute_contract("0xVault", "setAgent(address)", ["0xabc"])
 
-    async def test_non_201_submit_raises(self, configured):
+    async def test_a_rejected_submit_raises(self, configured):
+        """A NON-2xx submit raises. 200 does not — it is Circle replaying our idempotency key.
+
+        Renamed from ``test_non_201_submit_raises``: the old name asserted a rule the code
+        no longer follows. {200, 201} are both accepted (``_SUBMIT_ACCEPTED``); the 200 path
+        is proven in ``backend/tests/test_circle_signer.py``, alongside ``STUCK``.
+        """
         session = _mock_session()
         session.get = MagicMock(return_value=session._cm(_resp(200, {"data": {"publicKey": "PEM"}})))
         session.post = MagicMock(return_value=session._cm(_resp(400, {"error": "bad"})))

--- a/backend/tests/test_circle_signer.py
+++ b/backend/tests/test_circle_signer.py
@@ -1,9 +1,21 @@
 """``CircleSigner.execute_contract`` — the two answers from Circle we used to mishandle.
 
 WHAT IS UNDER TEST
-    ``archimedes.chain.circle_signer`` — the seam every state-changing on-chain call in
-    this repo goes through (the oracle's price pushes, strategy/trace publication, and the
-    ERC-8004 identity mint of #1527).
+    ``CircleSigner.execute_contract`` in ``archimedes.chain.circle_signer``. Its callers,
+    enumerated rather than gestured at, because the blast radius of a change here is the
+    list: ``TracePublisher.publish`` / ``.commit`` / ``.reveal``, ``StrategyPublisher.anchor``,
+    ``ChainExecutor.execute_trades`` / ``.create_vault`` / ``._send_vault_admin_tx`` /
+    ``.set_token_oracles`` / ``.set_target_allocations``, ``scripts/bootstrap_vaults.py``
+    (14 sites), ``scripts/deploy_contracts.py``, ``services/amm_bootstrap.py``,
+    ``api/marketplace_routes.py``, and ``erc8004_identity.register_identity`` (#1527).
+
+    NOT the oracle. ``oracle_updater`` POSTs to Circle's contract-execution endpoint itself
+    (``oracle_updater.py``, in ``push_prices_on_chain``) and polls with its own ``_poll_circle_tx``,
+    so nothing in this file constrains it. It also got there first: the identical
+    200-vs-201 defect was fixed for the oracle under **#1525**, on the payload rather than
+    the status. See the ``_SUBMIT_ACCEPTED`` comment in the module under test — the two
+    implementations are a known divergence, not an accident, and ``_poll_circle_tx`` still
+    has no ``STUCK`` case.
 
 THE TWO DEFECTS, BOTH GROUNDED IN CIRCLE'S OWN DOCS
     1. **HTTP 200 on submit was raised as a failure.** Circle's contract-execution
@@ -94,10 +106,20 @@ class FakeCircleAPI:
     route and 404s its sibling would let a change of endpoint pass unnoticed.
     """
 
-    def __init__(self, public_pem: str, *, submit_status: int = 201, states: tuple[str, ...] = ("COMPLETE",)):
+    def __init__(
+        self,
+        public_pem: str,
+        *,
+        submit_status: int = 201,
+        states: tuple[str, ...] = ("COMPLETE",),
+        submit_body: dict | None = None,
+    ):
         self._pem = public_pem
         self._submit_status = submit_status
         self._states = states
+        # ``submit_body`` overrides the well-formed answer, for the malformed-2xx cases.
+        # ``None`` means "use the real shape"; ``{}`` is itself a case under test.
+        self._submit_body = submit_body
         self.submits: list[dict] = []
         self.polls = 0
         self.unexpected: list[str] = []
@@ -119,6 +141,8 @@ class FakeCircleAPI:
     def post(self, url: str, *_a, json: dict | None = None, **_kw):
         if url.endswith("/developer/transactions/contractExecution"):
             self.submits.append(json or {})
+            if self._submit_body is not None:
+                return _Resp(self._submit_status, self._submit_body)
             body = (
                 {"data": {"id": CIRCLE_TX_ID, "state": "INITIATED"}}
                 if self._submit_status in (200, 201)
@@ -216,6 +240,30 @@ async def test_every_other_status_is_still_a_failure(signer, status):
     with pytest.raises(RuntimeError, match=f"Circle contract execution failed \\({status}\\)"):
         await _register(s)
     assert api.polls == 0, "polled for a transaction the submit never created"
+
+
+@pytest.mark.parametrize("status", [200, 201])
+@pytest.mark.parametrize(
+    "body",
+    [{}, {"data": None}, {"data": {}}, {"data": {"state": "INITIATED"}}, {"code": 156000, "message": "no."}],
+    ids=["empty", "null-data", "data-without-id", "state-but-no-id", "error-envelope-under-2xx"],
+)
+async def test_an_accepted_status_with_no_transaction_id_is_a_clean_error(signer, status, body):
+    """An accepted STATUS is not an accepted ANSWER.
+
+    ``circle_tx_id = body["data"]["id"]`` was an unguarded double subscript. A 2xx without
+    a ``data`` envelope — an error body a proxy stamped 200 on, a shape change — came out
+    as ``KeyError: 'data'`` from inside the signer, which no caller on this seam catches:
+    ``register_identity`` turns a ``RuntimeError`` into ``action: refused`` and would turn
+    a ``KeyError`` into a traceback. Widening to 200 made the case newly reachable, so the
+    guard ships with the widening.
+    """
+    s, api = signer(submit_status=status, submit_body=body)
+
+    with pytest.raises(RuntimeError, match="no transaction id to poll"):
+        await _register(s)
+
+    assert api.polls == 0, "polled for a transaction id that was never returned"
 
 
 # ── STUCK ────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_circle_signer.py
+++ b/backend/tests/test_circle_signer.py
@@ -1,0 +1,320 @@
+"""``CircleSigner.execute_contract`` — the two answers from Circle we used to mishandle.
+
+WHAT IS UNDER TEST
+    ``archimedes.chain.circle_signer`` — the seam every state-changing on-chain call in
+    this repo goes through (the oracle's price pushes, strategy/trace publication, and the
+    ERC-8004 identity mint of #1527).
+
+THE TWO DEFECTS, BOTH GROUNDED IN CIRCLE'S OWN DOCS
+    1. **HTTP 200 on submit was raised as a failure.** Circle's contract-execution
+       reference documents 200 (an idempotent replay of a key it has already seen) as a
+       success alongside 201 (a new transaction). Our idempotency key is deterministic by
+       construction — ``uuid5`` over wallet+contract+function+args — so a replay is what a
+       retry of the SAME logical call looks like, not an exotic case. Reporting it as
+       ``Circle contract execution failed (200)`` tells an operator a landed transaction
+       failed, and the next move after that reading is to force a second one. For the
+       ERC-8004 mint, a second one is an identity that cannot be un-minted.
+    2. **``STUCK`` was not handled.** It is not in ``_TERMINAL``, so the poller spun its
+       full 120-second budget and raised a generic timeout — discarding the one operational
+       fact that matters. Circle: "if a transaction stays STUCK and you take no action, it
+       can block subsequent transactions from the same wallet". The wallet in question also
+       runs the oracle.
+
+HERMETIC
+    ``aiohttp`` is replaced inside the module under test with a fake whose routes are
+    Circle's three real endpoints. Everything above the socket runs for real, including
+    the RSA-OAEP entity-secret encryption — against a throwaway key generated in-process.
+    No network, and **no real credential**: the "entity secret" here is 32 bytes of 0x11.
+"""
+
+from __future__ import annotations
+
+import base64
+import types
+import uuid
+
+import pytest
+from archimedes.chain import circle_signer as cs
+
+WALLET_ID = "11111111-2222-3333-4444-555555555555"
+CIRCLE_TX_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+TX_HASH = "0xfeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface"
+REGISTRY = "0x8004A818BFB912233c491871b3d84c89A494BD9e"
+AGENT_URI = "https://archimedes-arc.com/.well-known/agent-registration.json"
+FAKE_ENTITY_SECRET = "11" * 32  # 32 bytes of filler — never a real secret, in any environment
+
+
+# ── the Circle double ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def public_pem() -> str:
+    """A throwaway RSA public key, so ``_encrypt_entity_secret`` runs for real.
+
+    Generated lazily and once: stubbing the encryption instead would leave the one piece
+    of cryptography in this file untested, and it is the piece Circle rejects if it is
+    wrong (single-use OAEP ciphertext, MGF1-SHA256).
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+
+
+class _Resp:
+    """aiohttp's response: ``.status``, awaitable ``.json()``, async context manager."""
+
+    def __init__(self, status: int, payload: dict):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeCircleAPI:
+    """Circle's three endpoints, with the answers under test made settable.
+
+    The whole surface ``execute_contract`` touches is modelled — public key, submit, and
+    the poll list — not only the endpoint one test cares about. A double that answers one
+    route and 404s its sibling would let a change of endpoint pass unnoticed.
+    """
+
+    def __init__(self, public_pem: str, *, submit_status: int = 201, states: tuple[str, ...] = ("COMPLETE",)):
+        self._pem = public_pem
+        self._submit_status = submit_status
+        self._states = states
+        self.submits: list[dict] = []
+        self.polls = 0
+        self.unexpected: list[str] = []
+
+    def get(self, url: str, *_a, **_kw):
+        if url.endswith("/config/entity/publicKey"):
+            return _Resp(200, {"data": {"publicKey": self._pem}})
+        if "/transactions?" in url:
+            assert f"walletIds={WALLET_ID}" in url, f"poll dropped the walletIds filter (#941): {url}"
+            state = self._states[min(self.polls, len(self._states) - 1)]
+            self.polls += 1
+            return _Resp(
+                200,
+                {"data": {"transactions": [{"id": CIRCLE_TX_ID, "state": state, "txHash": TX_HASH}]}},
+            )
+        self.unexpected.append(f"GET {url}")
+        return _Resp(404, {})
+
+    def post(self, url: str, *_a, json: dict | None = None, **_kw):
+        if url.endswith("/developer/transactions/contractExecution"):
+            self.submits.append(json or {})
+            body = (
+                {"data": {"id": CIRCLE_TX_ID, "state": "INITIATED"}}
+                if self._submit_status in (200, 201)
+                else {"code": 156000, "message": "no."}
+            )
+            return _Resp(self._submit_status, body)
+        self.unexpected.append(f"POST {url}")
+        return _Resp(404, {})
+
+
+class _FakeSession:
+    def __init__(self, api: FakeCircleAPI):
+        self._api = api
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def get(self, *a, **kw):
+        return self._api.get(*a, **kw)
+
+    def post(self, *a, **kw):
+        return self._api.post(*a, **kw)
+
+
+@pytest.fixture
+def signer(monkeypatch, public_pem):
+    """A configured ``CircleSigner`` wired to a fake Circle, with the poll sleep removed."""
+
+    def _make(**api_kwargs) -> tuple[cs.CircleSigner, FakeCircleAPI]:
+        api = FakeCircleAPI(public_pem, **api_kwargs)
+        monkeypatch.setattr(
+            cs,
+            "aiohttp",
+            types.SimpleNamespace(
+                ClientSession=lambda *a, **kw: _FakeSession(api),
+                ClientTimeout=lambda **kw: None,
+                ClientError=Exception,
+            ),
+        )
+        monkeypatch.setattr(cs, "_POLL_INTERVAL", 0.0)
+        monkeypatch.setenv("CIRCLE_API_KEY", "TEST_API_KEY:not-a-real-key")
+        monkeypatch.setenv("CIRCLE_ENTITY_SECRET", FAKE_ENTITY_SECRET)
+        monkeypatch.setenv("WALLET_ID", WALLET_ID)
+        return cs.CircleSigner(), api
+
+    return _make
+
+
+async def _register(signer_obj: cs.CircleSigner) -> str:
+    return await signer_obj.execute_contract(
+        contract_address=REGISTRY,
+        abi_function="register(string)",
+        abi_params=[AGENT_URI],
+    )
+
+
+# ── the submit status ────────────────────────────────────────────────────────
+
+
+async def test_a_new_transaction_201_is_accepted(signer):
+    """The baseline. Its whole job is to be the sibling of the 200 test below."""
+    s, api = signer(submit_status=201)
+
+    assert await _register(s) == TX_HASH
+    assert len(api.submits) == 1
+    assert api.unexpected == []
+
+
+async def test_an_idempotent_replay_200_is_accepted_not_raised(signer):
+    """THE FIX, shown working: Circle's documented 200 is a success, not a failure.
+
+    Byte-identical to the 201 test except for the status Circle answers with. Before this
+    change the call raised ``Circle contract execution failed (200): ...`` and the
+    transaction it was reporting on was live on-chain.
+    """
+    s, api = signer(submit_status=200)
+
+    assert await _register(s) == TX_HASH, "a documented idempotent replay was treated as a failure"
+    assert len(api.submits) == 1, "a replay must not be resubmitted"
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 409, 429, 500, 202, 204])
+async def test_every_other_status_is_still_a_failure(signer, status):
+    """THE GUARD, shown rejecting: widening to {200, 201} must not widen to 'any 2xx'.
+
+    202 and 204 are in here deliberately. They are the statuses a lazy fix — ``status <
+    300``, or ``status in range(200, 300)`` — would swallow, and neither carries a
+    transaction Circle has accepted.
+    """
+    s, api = signer(submit_status=status)
+
+    with pytest.raises(RuntimeError, match=f"Circle contract execution failed \\({status}\\)"):
+        await _register(s)
+    assert api.polls == 0, "polled for a transaction the submit never created"
+
+
+# ── STUCK ────────────────────────────────────────────────────────────────────
+
+
+async def test_stuck_is_an_actionable_error_naming_the_transaction(signer):
+    """THE GUARD, shown rejecting: STUCK ends the poll and says which tx to go and clear.
+
+    The old behaviour raised ``Circle tx <id> timed out after 60 polls`` — two minutes
+    later, and describing the poller rather than the transaction. What an operator needs
+    is the id to type into the Circle Console and the fact that leaving it there wedges
+    every later transaction from the same wallet, the oracle's price pushes included.
+    """
+    s, api = signer(states=("STUCK",))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await _register(s)
+
+    message = str(excinfo.value)
+    assert CIRCLE_TX_ID in message, f"the STUCK error does not name the transaction: {message}"
+    assert "STUCK" in message
+    assert "Circle Console" in message
+    assert "blocks every later transaction from the same wallet" in message
+    assert "timed out" not in message
+    assert api.polls == 1, f"STUCK is the end of the road; it was polled {api.polls} times"
+
+
+async def test_a_transaction_that_settles_after_processing_still_completes(signer):
+    """STUCK ending the loop must not make every non-terminal state end it.
+
+    QUEUED and SENT are ordinary in-flight states — the poller has to keep going through
+    them, or the fix above turns into a false failure on every slightly slow transaction.
+    """
+    s, api = signer(states=("QUEUED", "SENT", "CONFIRMED", "COMPLETE"))
+
+    assert await _register(s) == TX_HASH
+    assert api.polls == 4, "CONFIRMED is not COMPLETE — Circle documents the difference"
+
+
+async def test_a_failed_terminal_state_still_raises(signer):
+    s, _api = signer(states=("FAILED",))
+
+    with pytest.raises(RuntimeError, match="ended in FAILED"):
+        await _register(s)
+
+
+async def test_the_poll_budget_still_ends_in_a_timeout(signer):
+    """The generic timeout survives for what it was always for: a transaction that hangs."""
+    s, api = signer(states=("SENT",))
+
+    with pytest.raises(RuntimeError, match=f"Circle tx {CIRCLE_TX_ID} timed out"):
+        await _register(s)
+    assert api.polls == cs._MAX_POLLS
+
+
+# ── the idempotency key itself ───────────────────────────────────────────────
+
+
+async def test_the_idempotency_key_is_deterministic_and_content_addressed(signer):
+    """Pinned, because accepting 200 is only correct while the key is deterministic.
+
+    If this key ever became a fresh ``uuid4`` per call, a retry would mint a SECOND
+    identity instead of replaying the first — and the 200 branch above, which exists to
+    handle that replay, would quietly never fire again.
+    """
+    s, api = signer()
+    await _register(s)
+    await _register(s)
+
+    keys = [submit["idempotencyKey"] for submit in api.submits]
+    assert keys[0] == keys[1], "the same logical call produced two different idempotency keys"
+    assert uuid.UUID(keys[0]).version == 5
+
+    await s.execute_contract(contract_address=REGISTRY, abi_function="register(string)", abi_params=["other"])
+    assert api.submits[-1]["idempotencyKey"] != keys[0], "different arguments must not share a key"
+
+
+async def test_the_submit_payload_is_the_shape_circle_documents(signer):
+    """The submitted body, checked whole — including that the entity secret is encrypted."""
+    s, api = signer()
+    await _register(s)
+
+    payload = api.submits[0]
+    assert payload["walletId"] == WALLET_ID
+    assert payload["contractAddress"] == REGISTRY
+    assert payload["abiFunctionSignature"] == "register(string)"
+    assert payload["abiParameters"] == [AGENT_URI]
+    assert payload["feeLevel"] == "MEDIUM"
+    assert payload["blockchain"] == "ARC-TESTNET"
+    ciphertext = payload["entitySecretCiphertext"]
+    assert FAKE_ENTITY_SECRET not in ciphertext, "the entity secret was sent in the clear"
+    assert len(base64.b64decode(ciphertext)) == 256, "not a 2048-bit RSA-OAEP ciphertext"
+
+
+async def test_an_unconfigured_signer_sends_nothing(signer, monkeypatch):
+    _s, api = signer()
+    monkeypatch.delenv("CIRCLE_API_KEY", raising=False)
+    unconfigured = cs.CircleSigner()
+
+    with pytest.raises(RuntimeError, match="Circle credentials not configured"):
+        await _register(unconfigured)
+    assert api.submits == []

--- a/backend/tests/test_erc8004_log_window.py
+++ b/backend/tests/test_erc8004_log_window.py
@@ -25,11 +25,14 @@ THE DEFECT
     find, which is exactly when it is needed.
 
 HERMETIC
-    :class:`RangeCappedRPC` is the fake that makes this real: it enforces the SAME 10,000
-    block cap the live RPC does, over both transports the code uses — the script's plain
-    ``httpx`` JSON-RPC and the backend's web3 ``get_logs``. Every "bounded window works"
-    test in here is paired with a sibling proving that the unbounded scan the fix replaced
-    is refused by that same fake. No network, no credentials, no key material.
+    :class:`RangeCappedRPC` serves both transports the code uses — the script's plain
+    ``httpx`` JSON-RPC (``eth_blockNumber``, which is how the window is resolved) and the
+    backend's web3 ``get_logs`` (the scan itself). The 10,000-block cap is enforced on the
+    ``get_logs`` side, which is the only one that scans; the httpx side answers the height
+    and rejects everything else. Every "bounded window works" test in here is paired with a
+    sibling proving the opposite input is refused by that same fake — the unbounded scan
+    the fix replaced, and the too-narrow window the fix introduced. No network, no
+    credentials, no key material.
 """
 
 from __future__ import annotations
@@ -183,10 +186,39 @@ class FakeChainClient:
         return address
 
 
-@pytest.fixture
-def wired(monkeypatch):
+class CountingSigner:
+    """``CircleSigner``'s surface, with the submissions counted. The count IS the assertion.
+
+    ``execute_contract`` is the only method: if the register path ever reaches for
+    ``sign_and_broadcast`` instead, this fake raises ``AttributeError`` rather than letting
+    a permissive double absorb the change. A submit optionally mints into the registry and
+    drops the mint log inside the window, so the confirming scan behaves like a real one.
+    """
+
+    is_configured = True
+
+    def __init__(
+        self,
+        registry: FakeRegistry | None = None,
+        rpc: RangeCappedRPC | None = None,
+        token_id: int = 7,
+    ):
+        self.submits: list[tuple] = []
+        self._registry = registry
+        self._rpc = rpc
+        self._token_id = token_id
+
+    async def execute_contract(self, *, contract_address, abi_function, abi_params, fee_level="MEDIUM"):
+        self.submits.append((contract_address, abi_function, tuple(abi_params)))
+        if self._registry is not None and self._rpc is not None:
+            self._registry.tokens[self._token_id] = (OURS, abi_params[0])
+            self._rpc.token_id = self._token_id
+            self._rpc.mint_block = self._rpc.head - 1
+        return TX_HASH
+
+
+def _install(monkeypatch, rpc: RangeCappedRPC) -> tuple[RangeCappedRPC, FakeRegistry]:
     """Install the capped RPC everywhere the register path can reach a chain, and hand it back."""
-    rpc = RangeCappedRPC()
     registry = FakeRegistry({rpc.token_id: (OURS, AGENT_URI)})
 
     from archimedes.chain.contracts import ContractLoader
@@ -207,6 +239,24 @@ def wired(monkeypatch):
     monkeypatch.setenv("ERC8004_OWNER_ADDRESS", OURS)
     monkeypatch.delenv("ERC8004_AGENT_ID", raising=False)
     return rpc, registry
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """The mint is 120 blocks back — comfortably inside the default window."""
+    return _install(monkeypatch, RangeCappedRPC())
+
+
+@pytest.fixture
+def aged(monkeypatch):
+    """The same wiring, but the mint is 50,000 blocks old — OUTSIDE the default window.
+
+    This is what every wallet looks like ~77 minutes after its mint (Arc's block time
+    measured live at 0.515 s/block on 2026-09-03, so 9,000 blocks is 77 minutes), and it is
+    the state in which the bounded window can lie: the scan succeeds, the cap is never hit,
+    and it names nothing — while ``balanceOf`` says an identity is right there.
+    """
+    return _install(monkeypatch, RangeCappedRPC(mint_block=HEAD - 50_000))
 
 
 def _run(monkeypatch, *argv: str) -> int:
@@ -415,3 +465,130 @@ def test_a_submitted_mint_still_prints_the_recovery_and_the_follow_up(wired, mon
 def test_the_transfer_topic_the_recovery_prints_is_the_one_the_scanner_matches(wired):
     """Two spellings of the same event is how a recovery instruction goes quietly wrong."""
     assert mod.topic(mod.TRANSFER_EVENT_SIG) == erc8004._TRANSFER_TOPIC
+
+
+# ── the window that is too NARROW: "I could not look" must not read as "nothing there" ──
+#
+# The bounded window fixes a scan that was always refused. It also introduces the opposite
+# failure, and that one is silent: a mint older than the window leaves the scan SUCCEEDING
+# and naming nothing. If that were reported as "no identity found", the register path's
+# whole idempotency check would invert — its "refusing to mint blind" fail-safe would
+# become a fail-OPEN double mint, on a token that cannot be un-minted. So the scan raises.
+
+
+async def test_a_balance_the_window_cannot_name_raises_instead_of_answering_no(aged):
+    """THE FIX: ``balanceOf > 0`` + nothing in range is an error, not a verdict."""
+    rpc, _registry = aged
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await erc8004.find_agent_id(OURS, FakeChainClient(rpc), from_block=HEAD - 9_000)
+
+    assert "balanceOf" in str(excinfo.value)
+    assert "pass the agentId explicitly" in str(excinfo.value)
+    # The cap was never hit: this scan was ACCEPTED and simply could not see far enough
+    # back. That is what makes the case reachable in the first place.
+    assert rpc.ranges == [(HEAD - 9_000, HEAD)]
+
+
+async def test_a_zero_balance_is_still_a_plain_no_identity_found(wired):
+    """THE PAIRED PROOF: the raise did not swallow the one fact that legitimately means "no".
+
+    ``balanceOf == 0`` is the chain saying this wallet holds nothing — the only input that
+    may license a mint. Without this test the fix above could be "raise on everything",
+    which would make a first registration impossible.
+    """
+    rpc, registry = wired
+    registry.tokens.clear()
+
+    found, detail = await erc8004.find_agent_id(OURS, FakeChainClient(rpc), from_block=HEAD - 9_000)
+
+    assert found is None
+    assert "== 0" in detail
+    assert rpc.ranges == [], "balanceOf == 0 short-circuits before the scan"
+
+
+async def test_register_refuses_rather_than_minting_a_second_identity_it_cannot_see(aged):
+    """THE FIX, at the only place it costs money: no submit for a wallet that already holds one.
+
+    ``--execute`` on a wallet whose mint has aged out of the window is the exact production
+    sequence — register once, come back 77 minutes later, re-run. The assertion that matters
+    is ``signer.submits == []``.
+    """
+    rpc, registry = aged
+    signer = CountingSigner()
+
+    result = await erc8004.register_identity(
+        agent_uri=AGENT_URI,
+        expected_owner=OURS,
+        signer=signer,
+        client=FakeChainClient(rpc),
+        from_block=HEAD - 9_000,
+    )
+
+    assert signer.submits == [], (
+        f"DOUBLE MINT: register() was submitted for a wallet already holding agentId {rpc.token_id}"
+    )
+    assert result.action == "refused"
+    assert result.agent_id is None
+    assert result.tx_hash is None
+    assert "refusing to mint blind" in result.detail
+    assert "pass the agentId explicitly" in result.detail, "the refusal does not say how to get unstuck"
+    assert registry.tokens == {rpc.token_id: (OURS, AGENT_URI)}, "the registry gained a token"
+
+
+async def test_an_empty_wallet_still_mints_exactly_once(wired):
+    """THE PAIRED PROOF: the refusal above is not "refuse always".
+
+    A wallet the chain says is empty still registers, once, and the confirming scan — same
+    bounded window — names what it minted.
+    """
+    rpc, registry = wired
+    registry.tokens.clear()
+    signer = CountingSigner(registry, rpc, token_id=7)
+
+    result = await erc8004.register_identity(
+        agent_uri=AGENT_URI,
+        expected_owner=OURS,
+        signer=signer,
+        client=FakeChainClient(rpc),
+        from_block=HEAD - 9_000,
+    )
+
+    assert len(signer.submits) == 1, "an empty wallet did not register"
+    assert signer.submits[0][1] == erc8004.REGISTER_SIGNATURE
+    assert result.action == "registered"
+    assert result.agent_id == 7
+    assert result.tx_hash == TX_HASH
+
+
+def test_verify_says_undetermined_not_pending_when_the_window_could_not_look(aged, monkeypatch, capsys):
+    """THE FIX on the read-only surface: exit 1 and a different word, not a cheerful zero.
+
+    ``registration_pending (no identity found for this wallet)`` is what step 2 of the
+    runbook reads as "step 3 is safe". Printing it for a wallet that demonstrably holds an
+    identity is how an operator is talked into the double mint by hand.
+    """
+    _rpc, _registry = aged
+
+    rc = _run(monkeypatch, "--verify")
+    out = capsys.readouterr().out
+
+    assert rc != 0, "an undetermined read exited 0"
+    assert "registration_pending" not in out, "an unlookable wallet was reported as pending"
+    assert "status:     undetermined" in out
+    assert "could not look" in out
+    assert "--verify --agent-id <ID>" in out, "the way out is not printed"
+    assert "Do NOT run --execute off this answer." in out
+
+
+def test_verify_still_reports_pending_for_a_wallet_that_really_holds_nothing(wired, monkeypatch, capsys):
+    """THE PAIRED PROOF: ``undetermined`` did not eat the honest ``pending``."""
+    _rpc, registry = wired
+    registry.tokens.clear()
+
+    rc = _run(monkeypatch, "--verify")
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "status:     registration_pending (no identity found for this wallet)" in out
+    assert "undetermined" not in out

--- a/backend/tests/test_erc8004_log_window.py
+++ b/backend/tests/test_erc8004_log_window.py
@@ -1,0 +1,417 @@
+"""The ERC-8004 register path's pre-flight: the log window, and what happens if it fails.
+
+WHAT IS UNDER TEST
+    ``scripts/register_erc8004_identity.py`` (imported by path, like this suite's other
+    script tests) together with ``archimedes.chain.erc8004_identity.find_agent_id``.
+
+THE DEFECT
+    There is no owner→agentId lookup on the ERC-8004 registry, so discovering our own
+    identity is an ``eth_getLogs`` scan for the mint. Arc's public RPC refuses a range
+    wider than 10,000 blocks — verified live 2026-09-03 against
+    ``https://rpc.testnet.arc.network``:
+
+        {"code":-32614,"message":"eth_getLogs is limited to a 10,000 range"}
+
+    The scan defaulted to block 0. Arc testnet is ~60,294,500 blocks tall. So the
+    confirming read after a successful mint was guaranteed to fail, ``--execute`` would
+    report ``action: submitted``, and — before this change — print nothing further. The
+    identity would exist on-chain, unnamed, with the operator holding a transaction hash
+    and no instructions. The next move a person reaches for in that state is
+    ``--allow-second-identity``, and a second identity cannot be un-minted.
+
+    ``--verify`` had the same bug from the other side: it never forwarded ``--from-block``
+    at all, so it scanned from 0 no matter what was passed. Harmless while ``balanceOf ==
+    0`` short-circuits the scan; a ``-32614`` traceback the moment there is something to
+    find, which is exactly when it is needed.
+
+HERMETIC
+    :class:`RangeCappedRPC` is the fake that makes this real: it enforces the SAME 10,000
+    block cap the live RPC does, over both transports the code uses — the script's plain
+    ``httpx`` JSON-RPC and the backend's web3 ``get_logs``. Every "bounded window works"
+    test in here is paired with a sibling proving that the unbounded scan the fix replaced
+    is refused by that same fake. No network, no credentials, no key material.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import ClassVar
+
+import httpx
+import pytest
+from archimedes.chain import erc8004_identity as erc8004
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "register_erc8004_identity.py"
+
+OURS = "0x9257460000000000000000000000000000000000"
+AGENT_URI = "https://archimedes-arc.com/.well-known/agent-registration.json"
+TX_HASH = "0xfeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface"
+HEAD = 60_294_500  # the real Arc testnet height on 2026-09-03, to scale
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("register_erc8004_identity", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_script()
+
+
+# ── the fake RPC: the 10,000-block cap, enforced ─────────────────────────────
+
+
+class RangeCappedRPC:
+    """An Arc-shaped RPC that refuses an ``eth_getLogs`` range wider than 10,000 blocks.
+
+    Serves both transports on purpose. ``handle`` is an ``httpx.MockTransport`` handler for
+    the script's own JSON-RPC helper (``eth_blockNumber``); ``get_logs`` is the web3 method
+    ``find_agent_id`` reaches through the chain client. A fake that capped only one of them
+    would leave whichever half is not exercised free to regress.
+    """
+
+    LIMIT = 10_000
+    ERROR: ClassVar[dict] = {"code": -32614, "message": "eth_getLogs is limited to a 10,000 range"}
+
+    def __init__(self, head: int = HEAD, mint_block: int = HEAD - 120, token_id: int = 3):
+        self.head = head
+        self.mint_block = mint_block
+        self.token_id = token_id
+        self.ranges: list[tuple[int, int]] = []
+        self.rpc_calls: list[str] = []
+
+    # -- the script's transport ------------------------------------------------
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        body = _json.loads(request.content)
+        self.rpc_calls.append(body["method"])
+        if body["method"] == "eth_blockNumber":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": hex(self.head)})
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "no"}})
+
+    # -- the web3 transport ----------------------------------------------------
+    def _resolve(self, block) -> int:
+        if isinstance(block, str):
+            if block in {"latest", "pending", "safe", "finalized"}:
+                return self.head
+            if block == "earliest":
+                return 0
+            return int(block, 16) if block.startswith("0x") else int(block)
+        return int(block)
+
+    def get_logs(self, params: dict) -> list[dict]:
+        start = self._resolve(params.get("fromBlock", 0))
+        end = self._resolve(params.get("toBlock", "latest"))
+        self.ranges.append((start, end))
+        if end - start > self.LIMIT:
+            # web3 surfaces a JSON-RPC error object as a raised ValueError.
+            raise ValueError(self.ERROR)
+        if not start <= self.mint_block <= end:
+            return []
+        return [
+            {
+                "blockNumber": self.mint_block,
+                "topics": [
+                    erc8004._TRANSFER_TOPIC,
+                    erc8004._address_topic(erc8004.ZERO_ADDRESS),
+                    erc8004._address_topic(OURS),
+                    hex(self.token_id),
+                ],
+            }
+        ]
+
+
+class _Call:
+    def __init__(self, fn):
+        self._fn = fn
+
+    async def call(self):
+        return self._fn()
+
+
+class FakeRegistry:
+    """``balanceOf``/``ownerOf``/``tokenURI`` — the whole surface the scan path touches."""
+
+    def __init__(self, tokens: dict[int, tuple[str, str]]):
+        self.tokens = dict(tokens)
+        self.calls: list[tuple] = []
+        self.functions = self
+
+    def balanceOf(self, owner):
+        self.calls.append(("balanceOf", owner))
+        return _Call(lambda: sum(1 for holder, _ in self.tokens.values() if holder.lower() == owner.lower()))
+
+    def ownerOf(self, token_id):
+        self.calls.append(("ownerOf", token_id))
+
+        def _run():
+            if token_id not in self.tokens:
+                raise ValueError("execution reverted: ERC721NonexistentToken")
+            return self.tokens[token_id][0]
+
+        return _Call(_run)
+
+    def tokenURI(self, token_id):
+        self.calls.append(("tokenURI", token_id))
+        return _Call(lambda: self.tokens[token_id][1])
+
+
+class FakeChainClient:
+    """The ``ChainClient`` surface ``find_agent_id`` uses, backed by the capped RPC."""
+
+    def __init__(self, rpc: RangeCappedRPC):
+        outer = rpc
+        # ContractLoader(client) reads ``client.settings.abi_dir`` on construction; the
+        # registry itself is stubbed at the factory, so the directory is never opened.
+        self.settings = types.SimpleNamespace(abi_dir="/nonexistent")
+
+        class _Eth:
+            async def get_logs(self, params):
+                return outer.get_logs(params)
+
+        self.w3 = types.SimpleNamespace(eth=_Eth())
+
+    @staticmethod
+    def to_checksum(address: str) -> str:
+        return address
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Install the capped RPC everywhere the register path can reach a chain, and hand it back."""
+    rpc = RangeCappedRPC()
+    registry = FakeRegistry({rpc.token_id: (OURS, AGENT_URI)})
+
+    from archimedes.chain.contracts import ContractLoader
+
+    monkeypatch.setattr(ContractLoader, "erc8004_identity_registry", lambda self, address: registry)
+
+    client = FakeChainClient(rpc)
+    import archimedes.chain.client as chain_client_module
+
+    monkeypatch.setattr(chain_client_module, "chain_client", client)
+    monkeypatch.setattr(
+        mod,
+        "httpx",
+        types.SimpleNamespace(
+            Client=lambda **kw: httpx.Client(transport=httpx.MockTransport(rpc.handle), **kw), HTTPError=httpx.HTTPError
+        ),
+    )
+    monkeypatch.setenv("ERC8004_OWNER_ADDRESS", OURS)
+    monkeypatch.delenv("ERC8004_AGENT_ID", raising=False)
+    return rpc, registry
+
+
+def _run(monkeypatch, *argv: str) -> int:
+    monkeypatch.setattr(sys, "argv", ["register_erc8004_identity.py", *argv])
+    return mod.main()
+
+
+# ── the window, resolved ─────────────────────────────────────────────────────
+
+
+def test_the_default_window_is_the_head_minus_nine_thousand(wired):
+    rpc, _registry = wired
+
+    start, note = mod.resolve_from_block(
+        None, "http://rpc.invalid", client=httpx.Client(transport=httpx.MockTransport(rpc.handle))
+    )
+
+    assert start == HEAD - 9_000
+    assert HEAD - start <= RangeCappedRPC.LIMIT, "the default window is wider than the RPC allows"
+    assert "eth_blockNumber" in rpc.rpc_calls
+    assert "10,000" in note and str(HEAD) in note.replace(",", "")
+
+
+def test_a_low_head_clamps_at_zero_instead_of_going_negative(monkeypatch):
+    """A fresh chain is not a negative block number."""
+    rpc = RangeCappedRPC(head=42)
+
+    start, _note = mod.resolve_from_block(
+        None, "http://rpc.invalid", client=httpx.Client(transport=httpx.MockTransport(rpc.handle))
+    )
+
+    assert start == 0
+
+
+def test_an_explicit_from_block_is_used_verbatim(wired):
+    rpc, _registry = wired
+
+    start, note = mod.resolve_from_block("12345", "http://rpc.invalid")
+
+    assert start == 12345
+    assert "explicit" in note
+    assert rpc.rpc_calls == [], "an explicit --from-block still dialled the RPC for a head it does not need"
+
+
+def test_an_unreachable_rpc_falls_back_to_zero_and_says_the_scan_will_probably_fail():
+    """Fail-soft, loudly. The one thing that must not happen is a manufactured height."""
+
+    def _dead(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    start, note = mod.resolve_from_block(
+        None, "http://rpc.invalid", client=httpx.Client(transport=httpx.MockTransport(_dead))
+    )
+
+    assert start == 0
+    assert note.startswith("!")
+    assert "-32614" in note and "--from-block" in note
+
+
+def test_a_junk_from_block_is_refused_not_coerced():
+    with pytest.raises(SystemExit):
+        mod.resolve_from_block("banana", "http://rpc.invalid")
+    with pytest.raises(SystemExit):
+        mod.resolve_from_block("-5", "http://rpc.invalid")
+
+
+# ── the window, against the cap that motivated it ────────────────────────────
+
+
+async def test_the_bounded_window_is_a_scan_the_arc_rpc_accepts(wired):
+    """THE FIX, end to end: head − 9,000 finds the mint the capped RPC will serve."""
+    rpc, _registry = wired
+
+    found, detail = await erc8004.find_agent_id(OURS, FakeChainClient(rpc), from_block=HEAD - 9_000)
+
+    assert found == rpc.token_id, detail
+    assert rpc.ranges == [(HEAD - 9_000, HEAD)]
+
+
+async def test_scanning_from_block_zero_is_what_the_arc_rpc_refuses(wired):
+    """THE PAIRED PROOF: the old default, against the same fake, is rejected.
+
+    Without this test the one above proves only that a number was passed through. With it,
+    the fake is demonstrably enforcing the live RPC's documented limit — so the window is
+    load-bearing, not decorative.
+    """
+    rpc, _registry = wired
+
+    with pytest.raises(ValueError) as excinfo:
+        await erc8004.find_agent_id(OURS, FakeChainClient(rpc), from_block=0)
+
+    assert "-32614" in str(excinfo.value)
+    assert rpc.ranges == [(0, HEAD)]
+
+
+# ── --verify: the forwarding that was missing ────────────────────────────────
+
+
+def test_verify_forwards_the_resolved_window_into_the_discovery_scan(wired, monkeypatch, capsys):
+    """THE FIX: ``--verify`` reaches the chain through the bounded window, and finds the id.
+
+    Recording fake at the seam that was dropping the value: ``find_agent_id``'s
+    ``from_block``. The old line called ``find_agent_id(owner)`` — no window at all — so
+    the recorder would see the module default of 0.
+    """
+    rpc, _registry = wired
+    seen: list[object] = []
+    real = erc8004.find_agent_id
+
+    async def _recording(owner, client=None, from_block=0):
+        seen.append(from_block)
+        return await real(owner, client or FakeChainClient(rpc), from_block)
+
+    monkeypatch.setattr(erc8004, "find_agent_id", _recording)
+
+    rc = _run(monkeypatch, "--verify")
+    out = capsys.readouterr().out
+
+    assert seen == [HEAD - 9_000], f"--verify scanned from {seen} instead of the bounded window"
+    assert f"agentId:    {rpc.token_id}" in out
+    assert rc == 0
+
+
+def test_verify_honours_an_explicit_from_block(wired, monkeypatch):
+    _rpc, _registry = wired
+    seen: list[object] = []
+
+    async def _recording(owner, client=None, from_block=0):
+        seen.append(from_block)
+        return None, "nothing here"
+
+    monkeypatch.setattr(erc8004, "find_agent_id", _recording)
+
+    _run(monkeypatch, "--verify", "--from-block", "51000")
+
+    assert seen == [51000]
+
+
+def test_verify_with_an_explicit_agent_id_never_scans(wired, monkeypatch):
+    """The runbook's post-mint command must not depend on a log scan at all."""
+    rpc, _registry = wired
+
+    async def _must_not_run(*a, **kw):
+        raise AssertionError("--verify --agent-id scanned the logs")
+
+    monkeypatch.setattr(erc8004, "find_agent_id", _must_not_run)
+
+    assert _run(monkeypatch, "--verify", "--agent-id", str(rpc.token_id)) == 0
+
+
+# ── --execute: the same window, and the follow-up that was missing ───────────
+
+
+def test_execute_passes_the_same_bounded_window_to_the_registration_runner(wired, monkeypatch, capsys):
+    rpc, _registry = wired
+    seen: dict = {}
+
+    async def _fake_register(**kwargs):
+        seen.update(kwargs)
+        return erc8004.RegistrationResult("noop", rpc.token_id, AGENT_URI, None, "already registered")
+
+    monkeypatch.setattr(erc8004, "register_identity", _fake_register)
+
+    rc = _run(monkeypatch, "--execute")
+
+    assert seen["from_block"] == HEAD - 9_000
+    assert rc == 0
+    assert "scan:      scanning blocks" in capsys.readouterr().out
+
+
+def test_a_submitted_mint_still_prints_the_recovery_and_the_follow_up(wired, monkeypatch, capsys):
+    """THE FIX: a landed transaction whose scan failed is not left as a dead end.
+
+    This is the exact state the log-range cap produced in production shape — Circle
+    reported the transaction, the confirming scan came back empty — and the old code
+    printed the result lines and stopped. The agentId is in the receipt; the operator has
+    to be told so, in the same breath as the transaction hash, or the next move is a
+    second mint.
+    """
+    _rpc, _registry = wired
+
+    async def _fake_register(**kwargs):
+        return erc8004.RegistrationResult(
+            "submitted", None, None, TX_HASH, "register() was submitted but no identity is readable yet"
+        )
+
+    monkeypatch.setattr(erc8004, "register_identity", _fake_register)
+
+    rc = _run(monkeypatch, "--execute")
+    out = capsys.readouterr().out
+
+    assert rc == 2, "submitted is not success"
+    # The transaction, and the recovery that turns it into an agentId.
+    assert TX_HASH in out
+    assert "cast receipt" in out
+    assert "topics[3] IS THE AGENT ID" in out
+    assert mod.topic(mod.TRANSFER_EVENT_SIG) in out
+    assert "--verify --agent-id <AGENT_ID>" in out
+    assert "allow-second-identity" in out
+    # And the follow-up itself, templated rather than withheld.
+    assert "ERC8004_AGENT_ID=<AGENT_ID>" in out
+    assert '"agentId": <AGENT_ID>' in out, "the template ships agentId as a string, not an integer"
+    assert "agent-registration.json" in out
+
+
+def test_the_transfer_topic_the_recovery_prints_is_the_one_the_scanner_matches(wired):
+    """Two spellings of the same event is how a recovery instruction goes quietly wrong."""
+    assert mod.topic(mod.TRANSFER_EVENT_SIG) == erc8004._TRANSFER_TOPIC

--- a/docs/runbooks/erc8004-identity-registration.md
+++ b/docs/runbooks/erc8004-identity-registration.md
@@ -72,10 +72,19 @@ ERC8004_OWNER_ADDRESS=0x<PLATFORM_WALLET> \
   python scripts/register_erc8004_identity.py --verify
 ```
 
-`registration_pending (no identity found for this wallet)` means step 3 is safe. If it
-reports an agentId, **we are already registered** — skip to step 4. Re-registering mints a
-second identity that cannot be un-minted and permanently splits the reputation surface the
-standard exists to accumulate.
+There are **three** answers here, not two:
+
+| `status:` | what it means | what to do |
+| --- | --- | --- |
+| `registration_pending (no identity found for this wallet)` | `balanceOf == 0` — the chain says this wallet holds nothing | step 3 is safe |
+| an agentId + `registered` | **we are already registered** | skip to step 4 |
+| `undetermined` (exit 1) | the scan could not look: the range was refused, or `balanceOf > 0` and the window named nothing | **stop** — see below |
+
+Re-registering mints a second identity that cannot be un-minted and permanently splits the
+reputation surface the standard exists to accumulate, so `undetermined` is never a licence
+to run step 3. Re-run as `--verify --agent-id <ID>` (reads `ownerOf` directly and scans no
+logs) or widen `--from-block`. `--execute` refuses on its own in that state — `action:
+refused`, nothing sent — but do not lean on it: get a real answer first.
 
 The `scan:` line above the verdict says which blocks were searched. There is no
 owner→agentId lookup on this registry, so discovery is an `eth_getLogs` scan for the mint,
@@ -89,6 +98,14 @@ and Arc's public RPC refuses a range wider than 10,000 blocks:
 used by both `--verify` and `--execute`. If the wallet's mint is older than that window,
 pass `--from-block <block>` explicitly — or, better, `--verify --agent-id <ID>`, which
 reads `ownerOf` directly and scans nothing.
+
+A bounded window can be too **narrow** as well as too wide, and that direction is the
+dangerous one: an identity minted more than 9,000 blocks ago (~77 minutes at Arc's measured
+0.515 s/block) is outside it. The discovery scan therefore refuses to answer at all in that
+state rather than reporting "no identity found" — `balanceOf > 0` with nothing nameable in
+range raises, `--verify` prints `undetermined`, and `--execute` returns `action: refused`.
+"I could not look" and "there is nothing there" must never arrive as the same answer, because
+the second one is what makes the next command mint.
 
 ## 3. Register (owner only)
 

--- a/docs/runbooks/erc8004-identity-registration.md
+++ b/docs/runbooks/erc8004-identity-registration.md
@@ -77,7 +77,28 @@ reports an agentId, **we are already registered** — skip to step 4. Re-registe
 second identity that cannot be un-minted and permanently splits the reputation surface the
 standard exists to accumulate.
 
+The `scan:` line above the verdict says which blocks were searched. There is no
+owner→agentId lookup on this registry, so discovery is an `eth_getLogs` scan for the mint,
+and Arc's public RPC refuses a range wider than 10,000 blocks:
+
+```
+{"code":-32614,"message":"eth_getLogs is limited to a 10,000 range"}
+```
+
+`--from-block` therefore defaults to `eth_blockNumber - 9,000`, resolved once per run and
+used by both `--verify` and `--execute`. If the wallet's mint is older than that window,
+pass `--from-block <block>` explicitly — or, better, `--verify --agent-id <ID>`, which
+reads `ownerOf` directly and scans nothing.
+
 ## 3. Register (owner only)
+
+A note on retries before you start: the idempotency key for this call is deterministic
+(uuid5 over wallet + contract + function + args), so a resubmission of the *same* call is
+recognised by Circle and answered `HTTP 200` with the existing transaction rather than
+`201` with a new one. That is a success, not a failure. If Circle reports the transaction
+`STUCK`, the signer now fails immediately naming the Circle transaction id — accelerate or
+cancel it in the Circle Console before doing anything else, because a stuck transaction
+blocks every later transaction from the same wallet, the oracle's price pushes included.
 
 Credentials are Circle's — the same three the oracle already runs on. They go in the
 environment, never on the command line, and never into this repo.
@@ -97,7 +118,11 @@ transaction), submits `register(string)` through
 and confirm ownership. Only `action: registered` with a non-null `agentId` is a success.
 
 - `action: submitted` means the transaction went out but the confirming read did not
-  complete. Do not publish anything. Re-run step 2 once the block has settled.
+  complete. Do not publish anything, and **do not re-run `--execute`** — the mint may well
+  have landed. The script prints the recovery: pull the receipt for the transaction hash it
+  gives you and read the `Transfer(0x0, <owner>, tokenId)` log, whose `topics[3]` is the
+  agentId. Then `--verify --agent-id <ID>` and `--print-followup <ID>`. `--allow-second-identity`
+  is never the answer here.
 - `action: refused` means nothing was sent; the `detail` line says why.
 
 Independent confirmation with `cast`:

--- a/scripts/register_erc8004_identity.py
+++ b/scripts/register_erc8004_identity.py
@@ -55,6 +55,14 @@ USAGE
     # (CIRCLE_API_KEY / CIRCLE_ENTITY_SECRET / WALLET_ID), the same three the oracle uses:
     ERC8004_OWNER_ADDRESS=0x... python scripts/register_erc8004_identity.py --execute
 
+THE LOG-SCAN WINDOW
+    Discovering an existing agentId is an ``eth_getLogs`` scan for the mint. Arc's public
+    RPC refuses a range wider than 10,000 blocks (``-32614``), and the chain is ~60,000,000
+    blocks tall, so a scan from block 0 — the old default — is that error every time.
+    ``--from-block`` now defaults to ``eth_blockNumber - 9,000``, resolved once and used by
+    BOTH the pre-flight read and the confirming read. Pass ``--from-block`` explicitly to
+    override it; the value is then used verbatim.
+
 AFTER A SUCCESSFUL --execute
     The script prints the minted agentId and the exact follow-up: set ``ERC8004_AGENT_ID``
     and ``ERC8004_OWNER_ADDRESS`` in the deployment environment, and land the
@@ -86,8 +94,22 @@ REGISTRATION_FILE = REPO_ROOT / "ui" / "public" / ".well-known" / "agent-registr
 # well-formed calldata for a function that does not exist.
 REGISTER_STRING_SIG = "register(string)"
 REGISTERED_EVENT_SIG = "Registered(uint256,string,address)"
+# The registry is an ERC-721, so the mint is a Transfer from the zero address and the token
+# id — the agentId — is its fourth topic. That log, in the receipt of the transaction we
+# already have, is the recovery path when the discovery scan cannot name the id.
+TRANSFER_EVENT_SIG = "Transfer(address,address,uint256)"
 
 DEFAULT_RPC = "https://rpc.testnet.arc.network"
+
+# Arc's public RPC refuses an eth_getLogs range wider than 10,000 blocks. Verified live
+# 2026-09-03 against https://rpc.testnet.arc.network:
+#     {"code":-32614,"message":"eth_getLogs is limited to a 10,000 range"}
+# The mint-log scan used to default to block 0, which on a ~60,000,000-block chain is that
+# error every time — so a real mint would report ``action: submitted`` and print nothing,
+# for a transaction that had actually landed. 9,000 rather than 10,000 leaves headroom for
+# the blocks mined between resolving the window and running the scan.
+LOG_RANGE_LIMIT = 10_000
+DEFAULT_LOG_WINDOW = 9_000
 
 # No CIRCLE_API_BASE / GAS_MULTIPLIER here any more: gas and the Circle endpoint are the
 # signer's problem, and the signer is chain/circle_signer.py. A second copy of either
@@ -175,6 +197,59 @@ def owner_address_from_env() -> str | None:
     needs to know which address to estimate gas from and which owner to verify against.
     """
     return os.environ.get("ERC8004_OWNER_ADDRESS", "").strip() or None
+
+
+def head_block(client: httpx.Client, rpc_url: str) -> int:
+    return int(str(rpc(client, rpc_url, "eth_blockNumber", [])), 16)
+
+
+def resolve_from_block(raw: object, rpc_url: str, *, client: httpx.Client | None = None) -> tuple[int | str, str]:
+    """The first block of the mint-log scan, plus the line that explains where it came from.
+
+    ``raw is None`` (no ``--from-block``) means *work it out*: ask the RPC for the head and
+    subtract :data:`DEFAULT_LOG_WINDOW`. Block 0 is NOT a safe default on Arc — the public
+    RPC caps ``eth_getLogs`` at :data:`LOG_RANGE_LIMIT` blocks and refuses anything wider
+    with ``-32614``, so the old default guaranteed that the confirming read after a mint
+    would fail on a chain 60 million blocks tall.
+
+    A value the operator passed is used verbatim, including the string block tags web3
+    accepts (``earliest``/``latest``/…): an explicit instruction is not second-guessed.
+
+    An unreachable RPC falls back to 0 and says so *loudly* rather than inventing a height.
+    A guessed window would silently scan the wrong range and report "no identity found",
+    which is the one answer that must never be manufactured — it is the input that decides
+    whether a second, un-burnable identity gets minted.
+    """
+    if raw is not None:
+        text = str(raw).strip()
+        if text.lower() in {"earliest", "latest", "pending", "safe", "finalized"}:
+            return text.lower(), f"scanning from block tag {text.lower()!r} (--from-block, explicit)"
+        try:
+            value = int(text, 0)
+        except ValueError:
+            raise SystemExit(f"✗ --from-block must be a block number or a block tag, got {raw!r}") from None
+        if value < 0:
+            raise SystemExit(f"✗ --from-block must not be negative, got {value}")
+        return value, f"scanning from block {value} (--from-block, explicit)"
+
+    try:
+        if client is None:
+            with httpx.Client(timeout=30.0) as owned:
+                head = head_block(owned, rpc_url)
+        else:
+            head = head_block(client, rpc_url)
+    except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        return 0, (
+            f"! could not read eth_blockNumber from {rpc_url} ({exc}) — falling back to block 0. "
+            f"The public Arc RPC refuses eth_getLogs ranges wider than {LOG_RANGE_LIMIT:,} blocks "
+            "(-32614), so this scan will probably be REFUSED. Pass --from-block <recent block>."
+        )
+
+    start = max(0, head - DEFAULT_LOG_WINDOW)
+    return start, (
+        f"scanning blocks {start}..latest — a {head - start:,}-block window below head {head:,}, "
+        f"because the public Arc RPC refuses eth_getLogs ranges wider than {LOG_RANGE_LIMIT:,} (-32614)"
+    )
 
 
 def preflight(client: httpx.Client, rpc_url: str, registry: str, want_chain_id: int) -> list[str]:
@@ -298,7 +373,13 @@ def verify(args: argparse.Namespace) -> int:
 
     agent_id = args.agent_id if args.agent_id is not None else erc8004.configured_agent_id()
     if agent_id is None:
-        found, detail = asyncio.run(erc8004.find_agent_id(owner))
+        # The discovery scan is an eth_getLogs range, so it gets the SAME bounded window
+        # --execute uses. Before this, --verify dropped --from-block on the floor and
+        # scanned from block 0 — harmless while balanceOf == 0 short-circuits it, and a
+        # -32614 traceback the moment there is an identity to find.
+        from_block, note = resolve_from_block(args.from_block, args.rpc)
+        print(f"scan:       {note}")
+        found, detail = asyncio.run(erc8004.find_agent_id(owner, from_block=from_block))
         print(f"discovery:  {detail}")
         if found is None:
             print("status:     registration_pending (no identity found for this wallet)")
@@ -331,17 +412,23 @@ def execute(args: argparse.Namespace) -> int:
         print("  registration this project is willing to publish.")
         return 2
 
+    # Both chain reads around the mint — the idempotency check before and the confirming
+    # scan after — run through this one window, so what proved the wallet was empty is the
+    # same range that later finds what it minted.
+    from_block, note = resolve_from_block(args.from_block, args.rpc)
+
     print(f"EXECUTE: {REGISTER_STRING_SIG} \u2192 {erc8004.registry_address()}")
     print(f"  agentURI:  {agent_uri}")
     print(f"  owner:     {owner}")
     print("  signer:    Circle dev-controlled wallet (CIRCLE_API_KEY / CIRCLE_ENTITY_SECRET / WALLET_ID)")
+    print(f"  scan:      {note}")
 
     result = asyncio.run(
         erc8004.register_identity(
             agent_uri=agent_uri,
             expected_owner=owner,
             agent_id=args.agent_id,
-            from_block=args.from_block,
+            from_block=from_block,
             allow_second_identity=args.allow_second_identity,
         )
     )
@@ -354,6 +441,15 @@ def execute(args: argparse.Namespace) -> int:
     if result.action in {"noop", "registered"} and result.agent_id is not None:
         print()
         return print_followup(result.agent_id)
+
+    if result.action == "submitted":
+        # The mint LANDED; only the read that names it did not. Printing nothing here is
+        # how a real registration gets lost: the operator sees "submitted", has no id, and
+        # the tempting next move is --allow-second-identity, which double-mints. The
+        # agentId is already in the receipt of the transaction we just printed.
+        print()
+        print_followup(None, tx_hash=result.tx_hash, owner=owner, rpc_url=args.rpc)
+
     # "submitted" is not success: a transaction with no confirmed agentId behind it must
     # not be treated as a registration by a caller or a CI step.
     return 0 if result.action == "noop" else (0 if result.action == "registered" else 2)
@@ -362,18 +458,68 @@ def execute(args: argparse.Namespace) -> int:
 # ── follow-up ─────────────────────────────────────────────────────────────────────────
 
 
-def print_followup(agent_id: int) -> int:
-    """The exact edits that turn a real receipt into an honest 'registered' claim."""
+def print_recovery(tx_hash: str | None, owner: str | None, rpc_url: str) -> None:
+    """How to read the agentId out of a mint receipt when the discovery scan came up empty.
+
+    This exists because the scan and the mint fail independently. ``register()`` can land
+    on-chain while the ``eth_getLogs`` scan that would name the token is refused (a range
+    cap, a rate limit, an RPC blip) — and in that state the id is not lost, it is sitting in
+    the receipt of a transaction whose hash we are holding. No second transaction is needed,
+    and minting one would be the expensive mistake.
+    """
+    print("THE TRANSACTION WENT OUT — the agentId is in its receipt, not in a second mint.")
+    print()
+    print(f"  tx: {tx_hash}")
+    print(f"  cast receipt {tx_hash} --rpc-url {rpc_url}")
+    print()
+    print(f"  In its logs, find the mint — {TRANSFER_EVENT_SIG} from the registry:")
+    print(f"    topics[0] == {topic(TRANSFER_EVENT_SIG)}   ({TRANSFER_EVENT_SIG})")
+    print("    topics[1] == 0x0…0 (the zero address — that is what makes it a mint)")
+    print(f"    topics[2] == the owner{f' ({owner})' if owner else ''}")
+    print("    topics[3] IS THE AGENT ID  (hex — convert to decimal)")
+    print()
+    print("  Then confirm it against the chain and print the follow-up:")
+    print("    python scripts/register_erc8004_identity.py --verify --agent-id <AGENT_ID>")
+    print("    python scripts/register_erc8004_identity.py --print-followup <AGENT_ID>")
+    print()
+    print("  Do NOT re-run --execute and do NOT pass --allow-second-identity: the identity")
+    print("  exists, and a second one cannot be un-minted.")
+    print()
+
+
+def print_followup(
+    agent_id: int | None,
+    *,
+    tx_hash: str | None = None,
+    owner: str | None = None,
+    rpc_url: str = DEFAULT_RPC,
+) -> int:
+    """The exact edits that turn a real receipt into an honest 'registered' claim.
+
+    ``agent_id=None`` is the post-mint-but-unconfirmed case: the same edits are printed
+    with an ``<AGENT_ID>`` placeholder, behind :func:`print_recovery`'s instructions for
+    getting the real number out of the receipt. The operator is holding a landed
+    transaction either way, and the follow-up they need does not change because our scan
+    missed.
+    """
+    if agent_id is None:
+        print_recovery(tx_hash, owner, rpc_url)
     block = load_identity_block()
-    entry = {"agentId": agent_id, "agentRegistry": f"{block['chain']}:{block['identityRegistry']}"}
+    shown: object = agent_id if agent_id is not None else "<AGENT_ID>"
+    entry = {"agentId": shown, "agentRegistry": f"{block['chain']}:{block['identityRegistry']}"}
+    rendered = json.dumps([entry], indent=2)
+    if agent_id is None:
+        # json.dumps quotes the placeholder; the real field is an integer, and a template
+        # that ships the wrong JSON type is a template that gets pasted in wrong.
+        rendered = rendered.replace('"<AGENT_ID>"', "<AGENT_ID>")
     print("Land these in ONE commit, with the transaction hash in the message:")
     print()
     print("1. ui/public/.well-known/agent-registration.json AND agent-registration.domain.json —")
     print('   replace "registrations": [] with:')
-    print("   " + json.dumps([entry], indent=2).replace("\n", "\n   "))
+    print("   " + rendered.replace("\n", "\n   "))
     print()
     print("2. the DEPLOYMENT environment (SSM / .env — NOT a code constant):")
-    print(f"   ERC8004_AGENT_ID={agent_id}")
+    print(f"   ERC8004_AGENT_ID={shown}")
     print("   ERC8004_OWNER_ADDRESS=<the Circle wallet address that owns it>")
     print("   These only tell the verifier WHICH token to read. The 'registered' claim still")
     print("   comes from a live ownerOf() call on every request — set them wrong and the")
@@ -407,7 +553,13 @@ def main() -> int:
     ap.add_argument("--offline", action="store_true", help="plan only: build calldata, make no RPC calls")
     ap.add_argument("--agent-id", type=int, default=None, help="verify/execute against this agentId specifically")
     ap.add_argument(
-        "--from-block", default=0, help="first block of the mint-log scan used to discover an existing agentId"
+        "--from-block",
+        default=None,
+        help=(
+            "first block of the mint-log scan used to discover an existing agentId "
+            f"(default: head − {DEFAULT_LOG_WINDOW:,}, because the public Arc RPC refuses "
+            f"eth_getLogs ranges wider than {LOG_RANGE_LIMIT:,} blocks)"
+        ),
     )
     ap.add_argument(
         "--allow-second-identity", action="store_true", help="permit --execute when an agentId already exists"

--- a/scripts/register_erc8004_identity.py
+++ b/scripts/register_erc8004_identity.py
@@ -63,6 +63,13 @@ THE LOG-SCAN WINDOW
     BOTH the pre-flight read and the confirming read. Pass ``--from-block`` explicitly to
     override it; the value is then used verbatim.
 
+    A bounded window can be too NARROW as well as too wide: an identity minted before it
+    is invisible to the scan. That is why ``find_agent_id`` RAISES when ``balanceOf`` says
+    the wallet holds something the window cannot name, rather than answering "no identity
+    found" — ``--verify`` prints ``status: undetermined`` and exits non-zero, and
+    ``--execute`` refuses. ``--verify --agent-id <ID>`` reads ``ownerOf`` and scans nothing,
+    so it is immune to the window entirely.
+
 AFTER A SUCCESSFUL --execute
     The script prints the minted agentId and the exact follow-up: set ``ERC8004_AGENT_ID``
     and ``ERC8004_OWNER_ADDRESS`` in the deployment environment, and land the
@@ -379,7 +386,20 @@ def verify(args: argparse.Namespace) -> int:
         # -32614 traceback the moment there is an identity to find.
         from_block, note = resolve_from_block(args.from_block, args.rpc)
         print(f"scan:       {note}")
-        found, detail = asyncio.run(erc8004.find_agent_id(owner, from_block=from_block))
+        try:
+            found, detail = asyncio.run(erc8004.find_agent_id(owner, from_block=from_block))
+        except Exception as exc:
+            # "I could not look" is not "there is nothing there". find_agent_id raises for
+            # a refused range AND for the balanceOf > 0 / nothing-in-this-window case, and
+            # neither may be printed as registration_pending: that line is what step 2 of
+            # the runbook reads as "step 3 (--execute) is safe", and --execute on a wallet
+            # that already holds an identity mints a second one that cannot be un-minted.
+            print(f"discovery:  could not look ({type(exc).__name__}: {exc})")
+            print("status:     undetermined  \u2014 NOT 'no identity found'. Nothing was proved either way.")
+            print("            Re-run as --verify --agent-id <ID> (reads ownerOf directly, scans no logs),")
+            print("            or widen the scan with --from-block <block below the mint>.")
+            print("            Do NOT run --execute off this answer.")
+            return 1
         print(f"discovery:  {detail}")
         if found is None:
             print("status:     registration_pending (no identity found for this wallet)")


### PR DESCRIPTION
Part of #1527.

**Do not merge — owner vets first.**

Pre-flight for the identity mint. This does **not** register anything: no transaction is sent, no AWS or on-chain write happens here. It fixes the three ways the register path turns a transaction that *landed* into an operator who believes it did not, plus the two Circle-API gaps the grounding review found.

Grounding: a local report (`~/.claude/jobs/09189ac8/tmp/erc8004-grounding.md`, not readable from GitHub) — §1 the call graph, §4 items 1–3 and 10 the pre-flight blockers, "What I would fix in code" 1–3. Everything it is cited for below is restated inline here. On-chain and RPC facts in it were read live on 2026-09-03 against `https://rpc.testnet.arc.network`.

## The defects

### 1. The mint-log scan defaulted to block 0 — blocker

There is no owner→agentId lookup on the ERC-8004 registry, so discovery is an `eth_getLogs` scan for the mint. Arc's public RPC refuses a range wider than 10,000 blocks:

```
{"code":-32614,"message":"eth_getLogs is limited to a 10,000 range"}
```

The chain is ~60,294,500 blocks tall. So the confirming read after `--execute` was **guaranteed** to fail: the mint lands, the script reports `action: submitted`, and — before this — prints nothing further.

`--from-block` now defaults to `eth_blockNumber - 9,000`, resolved **once per run** and used by *both* chain reads around the mint (the idempotency check before, the confirming scan after), so what proved the wallet was empty is the same range that later finds what it minted. 9,000 rather than 10,000 leaves headroom for blocks mined between resolving the window and running the scan. An explicit `--from-block` is used verbatim, block tags included. An unreachable RPC falls back to 0 and says loudly that the scan will probably be refused — it never invents a height, because a manufactured "no identity found" is the input that decides whether a second, un-burnable identity gets minted.

### 2. `--verify` never forwarded `--from-block` (`:301`)

It called `find_agent_id(owner)` — no window at all. `balanceOf == 0` short-circuits the scan today, so the bug is invisible right up until there is an identity to find, which is the only moment `--verify` matters. Now forwarded, through the same resolver.

### 3. `action: submitted` was a dead end

The agentId is not lost in that state — it is `topics[3]` of the `Transfer(0x0, owner, tokenId)` log in the receipt of the transaction the script just printed. The follow-up is now printed anyway, behind a recovery block carrying the tx hash, the `cast receipt` command, the topic layout, and an explicit *do not reach for `--allow-second-identity`*. The registrations-entry template ships with an `<AGENT_ID>` placeholder as an integer, not a quoted string.

### 4. `circle_signer.py:248` — 201-only submit check

Circle documents **200** for a replayed `idempotencyKey` and 201 for a new transaction. Ours is deterministic *by design* (`uuid5` over wallet+contract+function+args), which makes a replay the shape of any retry rather than a rarity — so a landed transaction was being reported as `Circle contract execution failed (200)`, and the tempting next move after that reading is to force a second one.

Now `{200, 201}`. **The deterministic uuid5 key is unchanged**, and is now pinned by a test — accepting 200 is only correct while the key stays content-addressed.

### 5. `circle_signer.py:30` — `STUCK` unhandled

The poller spun its full 120-second budget and raised `Circle tx <id> timed out after 60 polls`, describing the poller rather than the transaction. Circle: a stuck transaction *"can block subsequent transactions from the same wallet"* — and that wallet also runs the oracle's price pushes. It now fails immediately, naming the Circle transaction id to accelerate or cancel in the Console. `STUCK` deliberately stays out of `_TERMINAL` (Circle does not call it a failure); the ordinary in-flight states `QUEUED`/`SENT`/`CONFIRMED` still poll through, and the generic timeout survives for what it was always for.

## Tests — hermetic, and each guard shown red first

`backend/tests/test_erc8004_log_window.py` (19 after the review round, 13 before) and `backend/tests/test_circle_signer.py` (27 after, 17 before). Targeted modules — those two plus `chain/test_circle_signer.py`, `test_erc8004_identity.py`, `test_erc8004_registration.py`, `test_agent_manifest.py` — **120 passed**. Full backend suite from the repo root, `eb7a3037`: **5834 passed, 6 skipped** in 27:03; three unrelated modules (`test_security_hardening.py` ×2, `test_generation_credits.py` ×1) flaked on a box running 12 concurrent suites — two `subprocess.TimeoutExpired … after 30 seconds` and one `sqlite3.OperationalError: database is locked` — and all 49 of their tests pass on a serial re-run. CI's **Backend — unit tests** is green on `eb7a3037` (15m48s). No network, no credentials, no key material — the "entity secret" in the signer tests is 32 bytes of `0x11` against a throwaway in-process RSA key, and the RSA-OAEP encryption runs for real.

`RangeCappedRPC` serves both transports the code uses — the script's `httpx` JSON-RPC (`eth_blockNumber`, how the window is resolved) and the backend's web3 `get_logs` (the scan itself). The **real** 10,000-block cap is enforced on the `get_logs` side, which is the only one that scans; the httpx side answers the height and rejects everything else. Every "the window works" test is paired with one proving the opposite input is refused — the unbounded scan the fix replaced, and (after the review round below) the too-narrow window the fix introduced.

Every guard was mutated red before this was pushed (mutation → run → capture → revert by editing):

| Mutation | Red |
|---|---|
| `start = 0` in `resolve_from_block` | `assert 0 == (60294500 - 9000)`, and `--verify` end-to-end: `ValueError: {'code': -32614, 'message': 'eth_getLogs is limited to a 10,000 range'}` |
| `find_agent_id(owner)` (drop the forward) | `assert [0] == [51000]`, plus the same `-32614` |
| delete the `submitted` follow-up | `AssertionError: assert 'cast receipt' in 'EXECUTE: … detail: register() was submitted but no identity is readable yet\n'` |
| `RangeCappedRPC.LIMIT = 100_000_000` | `Failed: DID NOT RAISE <class 'ValueError'>` — the cap is load-bearing, not decorative |
| `if resp.status != 201` | `RuntimeError: Circle contract execution failed (200): {'data': {'id': 'aaaa…', 'state': 'INITIATED'}}` |
| `if not (200 <= resp.status < 300)` (over-wide) | `KeyError: 'data'` on 202 and 204 — the widening must not become "any 2xx" |
| delete the `STUCK` branch | `AssertionError: assert 'STUCK' in 'Circle tx aaaaaaaa-… timed out after 60 polls'` |

## Also

`docs/runbooks/erc8004-identity-registration.md` gains the window explanation, the `submitted` recovery, and the 200/`STUCK` notes at the point in the runbook where each bites.

## Review round (commit `eb7a3037`)

A verification pass found one **blocker in this PR's own headline fix**, and three minors. All four are addressed here.

### Blocker — the bounded window converted a fail-safe into a fail-open double mint

`find_agent_id` returned `(None, detail)` for two different facts:

1. `balanceOf == 0` — definitively no identity.
2. `balanceOf > 0` but the scanned range names nothing.

With `from_block=0`, case 2 was **unreachable**: the Arc RPC answered `-32614`, the read raised, and `register_identity` returned `action: refused` ("refusing to mint blind"). With `--from-block` defaulting to head−9,000, any identity minted more than 9,000 blocks ago makes the scan **succeed** and name nothing — so `_resolve_existing` returned `_pending(...)`, `register_identity` fell through, and `register(string)` was submitted **for a wallet that already holds an identity**. Arc's block time measured live at 0.515 s/block, so the window ages out ~77 minutes after any real mint; from then on every `--execute` re-run double-minted. `_resolve_existing`'s own docstring states the rule that violated: *"'I could not check' and 'there is nothing there' must not share a return value."*

Proven live against `https://rpc.testnet.arc.network` on wallet `0xb7ac…1553` (which holds two identities — `ownerOf(1)` names it): the PR branch printed `status: registration_pending (no identity found for this wallet)` and exited **0**, where `origin/main` failed loudly with `-32614`. This PR traded main's *always refuses after a mint* — safe and annoying — for *usually correct, occasionally mints an identity that cannot be un-minted*.

**Fixed:**

- `find_agent_id` now **raises** on the `balance > 0` / nothing-in-range branch. `(None, detail)` is returned for exactly one fact: `balanceOf == 0`. `register_identity`'s existing "could not read the registry → refused" arm catches it, so nothing is submitted.
- `--verify` no longer prints `registration_pending (no identity found for this wallet)` and exits 0 for that state. It prints `status: undetermined`, names the way out (`--verify --agent-id <ID>`, which reads `ownerOf` and scans nothing; or a wider `--from-block`), and exits **1**. That pending line is what step 2 of the runbook reads as "step 3 is safe".
- The runbook now documents **three** answers at step 2, not two.

There was **no test on this path at all** — applying the one-line raise left all of the previous round's targeted tests green. Six now exist, each with its paired opposite so the fix cannot degenerate into "refuse always":

| Guard | Paired proof |
|---|---|
| `test_a_balance_the_window_cannot_name_raises_instead_of_answering_no` | `test_a_zero_balance_is_still_a_plain_no_identity_found` |
| `test_register_refuses_rather_than_minting_a_second_identity_it_cannot_see` (asserts `signer.submits == []`) | `test_an_empty_wallet_still_mints_exactly_once` |
| `test_verify_says_undetermined_not_pending_when_the_window_could_not_look` | `test_verify_still_reports_pending_for_a_wallet_that_really_holds_nothing` |

### Minors

- **`backend/tests/test_circle_signer.py` header claimed the oracle goes through `circle_signer`.** It does not: `oracle_updater.push_prices_on_chain` POSTs to `/developer/transactions/contractExecution` itself and polls with its own `_poll_circle_tx`. The header now enumerates the **real** callers — `TracePublisher.publish`/`.commit`/`.reveal`, `StrategyPublisher.anchor`, `ChainExecutor.execute_trades`/`.create_vault`/`._send_vault_admin_tx`/`.set_token_oracles`/`.set_target_allocations`, `bootstrap_vaults` (14 sites), `deploy_contracts`, `amm_bootstrap`, `marketplace_routes`, `erc8004_identity.register_identity` — and states that the oracle fixed this *identical* 200-vs-201 defect first, under **#1525**, grading on the payload rather than the status. The `_SUBMIT_ACCEPTED` comment records that as a known divergence rather than an accident. (Converging the two is its own change; `_poll_circle_tx` still has no `STUCK` case.)
- **`chain/test_circle_signer.py::test_non_201_submit_raises` documented the opposite of the shipped behaviour.** Renamed `test_a_rejected_submit_raises` (it uses 400, so it always passed), with a pointer from that canonical file to where `{200, 201}` is proven.
- **`body["data"]["id"]` was unguarded on the newly accepted 200 path.** A malformed 2xx — an error envelope, a proxy's stamp, a shape change — came out as `KeyError: 'data'` from inside the signer, which no caller on this seam catches: `register_identity` turns a `RuntimeError` into `action: refused` and would turn a `KeyError` into a traceback. Now a clean `RuntimeError`, with ten parametrized cases.
- **The `RangeCappedRPC` overclaim** in the tests-section paragraph above and in the test module's own `HERMETIC` note is corrected: the cap is enforced on the web3 side only.

### Review-round mutations (mutate → run → capture → revert by editing)

| Mutation | Red |
|---|---|
| `raise RuntimeError(…)` → `return None, (…)` in `find_agent_id` (i.e. undo the blocker fix) | `Failed: DID NOT RAISE <class 'RuntimeError'>`; `AssertionError: DOUBLE MINT: register() was submitted for a wallet already holding agentId 3`; `AssertionError: an undetermined read exited 0` — 3 failed, 16 passed |
| the lazy over-fix: `balance == 0` raises too | `RuntimeError: balanceOf(0x9257…) == 0 — this wallet holds no ERC-8004 identity`; `AssertionError: an empty wallet did not register — assert 0 == 1`; `assert 1 == 0` — 3 failed, 16 passed |
| restore `circle_tx_id = body["data"]["id"]` | `KeyError: 'data'` / `TypeError: 'NoneType' object is not subscriptable` / `KeyError: 'id'` — 10 failed, 17 passed |
| `--verify` keeps the `undetermined` wording but `return 0` | `AssertionError: an undetermined read exited 0 — assert 0 != 0` |
| `_SUBMIT_ACCEPTED = frozenset({200, 201, 400})` | `test_a_rejected_submit_raises`: `Regex pattern did not match. Expected regex: 'contract execution failed'` — the renamed test still guards what its new name claims |

**Out of scope, deliberately:** `oracle_updater._poll_circle_tx` is a second, independent poller with the same missing `STUCK` case (it returns states rather than raising, so the shape of the fix differs); the by-id `GET /transactions/{id}` poll; `setAgentURI` in the pinned ABI; and `sign_and_broadcast`, which the grounding review found cannot work as written (wrong endpoint, missing `entitySecretCiphertext`) and which nothing on this path calls.

Owner decisions from the grounding review — which wallet owns the identity, and whether `agentWallet` should be moved to the x402 recipient — are untouched here; they are §5 of that report and want an answer *before* signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx

