### PR TITLE
cli: one session file per lane (ARCHIMEDES_SESSION_FILE + --session-file) with an advisory lock

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -45,10 +45,37 @@ archimedes manifest                   emit this tool's machine-readable contract
 ```
 
 `login` prompts for email and password (or reads `ARCHIMEDES_EMAIL` / `ARCHIMEDES_PASSWORD`
-for CI) and caches the session cookie at `~/.config/archimedes/session.json`, mode 600.
-`meter`, `generate`, and `verify` read that cache; run `login` first. `generate` also
-accepts an `ARCHIMEDES_API_KEY` environment variable, which it sends as an
-`Authorization: Bearer` header for non-interactive use.
+for CI) and caches the session cookie at `~/.config/archimedes/session.json`, mode 600 —
+or wherever `--session-file` / `ARCHIMEDES_SESSION_FILE` points, see below. `meter`,
+`generate`, and `verify` read that cache; run `login` first. `generate` also accepts an
+`ARCHIMEDES_API_KEY` environment variable, which it sends as an `Authorization: Bearer`
+header for non-interactive use.
+
+## One session file per lane
+
+The session cache is a path, not a fixed location. `--session-file PATH` on `login`,
+`meter`, `verify` and `generate` — or `ARCHIMEDES_SESSION_FILE` in the environment, which
+the flag overrides — decides which file that invocation reads and writes:
+
+```bash
+# Two agents, one runner, two identities.
+ARCHIMEDES_SESSION_FILE=~/.archimedes/lane-a.json archimedes login   # as agent A
+ARCHIMEDES_SESSION_FILE=~/.archimedes/lane-b.json archimedes login   # as agent B
+ARCHIMEDES_SESSION_FILE=~/.archimedes/lane-a.json archimedes meter   # still agent A
+
+archimedes meter --session-file ~/.archimedes/lane-b.json            # or per command
+```
+
+Give every concurrent lane its own file. Sharing one file means sharing one identity: the
+second `login` overwrites the first, and the first lane carries on getting clean `200`s as
+somebody else — which is exactly what happened on 2026-09-01, when `$HOME` was the only
+lever there was ([#1752](https://github.com/aprin-labs/archimedes/issues/1752)).
+
+Every file the CLI writes here is mode 600 wherever you point it, and reads and writes take
+an advisory `flock` on it, so a lane that *does* share a file with another still never reads
+a half-written one. The same variable moves the MCP server's credential — it loads this
+cache rather than reimplementing it — so a per-agent `ARCHIMEDES_SESSION_FILE` in an
+`mcpServers` env block isolates that agent too.
 
 ## Generate
 

--- a/cli/src/archimedes_cli/cli.py
+++ b/cli/src/archimedes_cli/cli.py
@@ -33,7 +33,15 @@ import click
 import httpx
 
 from . import __version__, exits
-from .session import load_session, pick_session_cookie, save_session
+from .session import (
+    DEFAULT_SESSION_FILE,
+    SESSION_FILE_ENV,
+    load_session,
+    pick_session_cookie,
+    save_session,
+    session_path,
+    set_session_file,
+)
 
 DEFAULT_API_URL = "https://archimedes-arc.com"
 
@@ -51,6 +59,26 @@ _api_url_option = click.option(
     show_default=True,
     metavar="URL",
     help="Base URL of the Archimedes API.",
+)
+
+
+# Which session file this invocation reads and writes. A CLI process is one lane;
+# without this the only lever was $HOME, so two agents sharing a runner shared one
+# identity and the second one's `login` clobbered the first's (#1752). Not declared with
+# click's `envvar=`, deliberately: `archimedes_cli.session.session_path` reads
+# ARCHIMEDES_SESSION_FILE itself — it has to, because `archimedes_mcp.credentials` calls
+# it with no click context anywhere in the process — and a second reader of the same
+# variable is a second place for the precedence rule to drift.
+_session_file_option = click.option(
+    "--session-file",
+    "session_file",
+    default=None,
+    metavar="PATH",
+    help=(
+        f"Read/write the cached session here instead of {DEFAULT_SESSION_FILE}. "
+        f"Also settable as ${SESSION_FILE_ENV}; the flag wins. One file per lane keeps "
+        f"concurrent agents from clobbering each other's identity."
+    ),
 )
 
 
@@ -234,8 +262,9 @@ def main() -> None:
 
 @main.command()
 @_api_url_option
+@_session_file_option
 @_json_option
-def login(api_url: str, as_json: bool) -> None:
+def login(api_url: str, session_file: str | None, as_json: bool) -> None:
     """Sign in and cache the session.
 
     Archimedes accounts are Better Auth (email + password) — there is no wallet
@@ -244,12 +273,14 @@ def login(api_url: str, as_json: bool) -> None:
     answer an interactive prompt); otherwise prompts for them, with the password hidden.
 
     The password is sent once, over this one request (``POST /api/auth/sign-in/email``),
-    and is never stored. What gets cached at ``~/.config/archimedes/session.json``
-    (mode 600) is the session cookie Better Auth issues back, after confirming it round
+    and is never stored. What gets cached at ``~/.config/archimedes/session.json`` —
+    or at ``--session-file``/``$ARCHIMEDES_SESSION_FILE``, one file per lane — at mode 600
+    is the session cookie Better Auth issues back, after confirming it round
     trips against ``GET /api/auth/get-session``. Linking a crypto wallet is a separate,
     optional, later step (for on-chain vault actions) — it does not authenticate you and
     is not part of this command.
     """
+    set_session_file(session_file)
     email = os.environ.get("ARCHIMEDES_EMAIL", "").strip()
     password = os.environ.get("ARCHIMEDES_PASSWORD", "")
     if not email:
@@ -314,7 +345,21 @@ def login(api_url: str, as_json: bool) -> None:
             message="signed in, but the session cookie did not round-trip on GET /api/auth/get-session",
         )
 
-    path = save_session(api_url=api_url, cookies={cookie_name: token}, email=confirmed_email)
+    # `--session-file` is user input, so the write can fail on a path that is a
+    # directory, is read-only, or has an unwritable parent — and it fails HERE, after a
+    # successful sign-in. An uncaught OSError exits 1, which this CLI's exit-code
+    # contract reserves for "the gate returned a failing verdict"; a CI job branching on
+    # 1 would read a mistyped path as a research finding. It is a usage error (2).
+    try:
+        path = save_session(api_url=api_url, cookies={cookie_name: token}, email=confirmed_email)
+    except OSError as exc:
+        _fail(
+            "login",
+            as_json=as_json,
+            exit_code=exits.USAGE,
+            error="session_file_unwritable",
+            message=f"signed in, but the session could not be written to {session_path()}: {exc}",
+        )
 
     if as_json:
         click.echo(json.dumps({"ok": True, "email": confirmed_email}))
@@ -343,8 +388,9 @@ def _render_usage(usage: dict) -> None:
 
 @main.command()
 @_api_url_session_option
+@_session_file_option
 @_json_option
-def meter(api_url: str | None, as_json: bool) -> None:
+def meter(api_url: str | None, session_file: str | None, as_json: bool) -> None:
     """Show what you have used today and what it costs.
 
     ``GET /api/account/usage`` — today's generation count against both the per-user and
@@ -352,6 +398,7 @@ def meter(api_url: str | None, as_json: bool) -> None:
     call the paywall itself reads, so this number and the invoice can never drift apart).
     Requires a cached session; run ``archimedes login`` first.
     """
+    set_session_file(session_file)
     session = load_session()
     if session is None:
         _fail(
@@ -511,8 +558,16 @@ def _render_verify(body: dict) -> None:
     help="Self-attested trial/variant count the DSR deflation is computed against (>= 1).",
 )
 @_api_url_session_option
+@_session_file_option
 @_json_option
-def verify(returns_csv: str, run_local: bool, trials: int, api_url: str | None, as_json: bool) -> None:
+def verify(
+    returns_csv: str,
+    run_local: bool,
+    trials: int,
+    api_url: str | None,
+    session_file: str | None,
+    as_json: bool,
+) -> None:
     """Run the rigor gate over a returns series.
 
     RETURNS_CSV is a two-column CSV of date and daily return (a header row, if present,
@@ -531,6 +586,7 @@ def verify(returns_csv: str, run_local: bool, trials: int, api_url: str | None, 
     passes and 1 when it fails, which is what makes ``archimedes verify returns.csv``
     usable as a CI check before a deploy.
     """
+    set_session_file(session_file)
     if run_local:
         _unavailable("verify", as_json=as_json)
 
@@ -991,6 +1047,7 @@ def _read_brief_text(brief: str | None, brief_file: str | None) -> str | None:
     help="How long to wait for the job. On expiry the job keeps running server-side and exit is 8.",
 )
 @_api_url_session_option
+@_session_file_option
 @_json_option
 # One parameter per field of the server's brief schema plus the operational flags —
 # the width is the API's, not an accident.
@@ -1004,6 +1061,7 @@ def generate(
     no_stream: bool,
     timeout_seconds: float,
     api_url: str | None,
+    session_file: str | None,
     as_json: bool,
 ) -> None:
     """Generate a rigor-gated strategy from a research brief.
@@ -1032,6 +1090,7 @@ def generate(
     action required (verify email / connect wallet) · 7 the job failed · 8 still running
     when the wait budget ran out.
     """
+    set_session_file(session_file)
     if brief and brief_file:
         _fail(
             "generate",

--- a/cli/src/archimedes_cli/manifest.py
+++ b/cli/src/archimedes_cli/manifest.py
@@ -31,6 +31,19 @@ EXIT_CODES = {
     "8": "STILL_RUNNING — the CLI stopped waiting; the job is NOT cancelled and may still finish",
 }
 
+# Declared once and shared by every command that touches the session cache: the same
+# flag, the same env var, the same meaning on all four. Four copies of this prose would
+# be four places for it to drift (#1752).
+SESSION_FILE_INPUT = {
+    "env": "ARCHIMEDES_SESSION_FILE",
+    "default": "~/.config/archimedes/session.json",
+    "meaning": (
+        "which session cache this invocation reads/writes; the flag wins over the env var. "
+        "Give each concurrent agent its own file — two lanes sharing one file share one "
+        "identity, and the second `login` wins"
+    ),
+}
+
 MANIFEST: dict = {
     "tool": "archimedes",
     "version": __version__,
@@ -45,13 +58,14 @@ MANIFEST: dict = {
             "description": "Authenticate with an Archimedes account and cache the session cookie.",
             "inputs": {
                 "--api-url": {"env": "ARCHIMEDES_API_URL", "default": "https://archimedes-arc.com"},
+                "--session-file": SESSION_FILE_INPUT,
                 "--json": {"flag": True},
                 "email": {"env": "ARCHIMEDES_EMAIL", "prompted_if_absent": True},
                 "password": {"env": "ARCHIMEDES_PASSWORD", "prompted_if_absent": True, "hidden": True},
             },
             "output": {"ok": "bool", "email": "str"},
             "cost_class": "network: 2 HTTP calls (sign-in + session round-trip); no funds, no chain",
-            "side_effects": "writes ~/.config/archimedes/session.json (mode 600)",
+            "side_effects": "writes the session cache (mode 600) — see --session-file for where",
         },
         "meter": {
             "implemented": True,
@@ -61,6 +75,7 @@ MANIFEST: dict = {
                     "env": "ARCHIMEDES_API_URL",
                     "default": "the cached session's URL, else https://archimedes-arc.com",
                 },
+                "--session-file": SESSION_FILE_INPUT,
                 "--json": {"flag": True},
             },
             "output": {
@@ -82,6 +97,7 @@ MANIFEST: dict = {
                     "env": "ARCHIMEDES_API_URL",
                     "default": "the cached session's URL, else https://archimedes-arc.com",
                 },
+                "--session-file": SESSION_FILE_INPUT,
                 "--json": {"flag": True},
             },
             "output": {
@@ -117,6 +133,7 @@ MANIFEST: dict = {
                     "env": "ARCHIMEDES_API_URL",
                     "default": "the cached session's URL, else https://archimedes-arc.com",
                 },
+                "--session-file": SESSION_FILE_INPUT,
                 "--json": {"flag": True},
             },
             "output": {

--- a/cli/src/archimedes_cli/session.py
+++ b/cli/src/archimedes_cli/session.py
@@ -1,10 +1,11 @@
 """Session cache for the Better Auth cookie ``archimedes login`` obtains.
 
-Stored at ``~/.config/archimedes/session.json``, mode ``600`` — this file holds a live
-session credential, so it gets the same treatment any other credential store in this repo
-does (compare ``.env`` staying gitignored, ``~/.arc-canteen/`` team credentials). The value
-cached here is opaque to the CLI: it is whatever cookie(s) ``POST /api/auth/sign-in/email``
-sets, forwarded verbatim on later requests. The CLI never parses or validates the cookie
+Stored at ``~/.config/archimedes/session.json`` by default (overridable — see "One file
+per lane" below), mode ``600`` — this file holds a live session credential, so it gets the
+same treatment any other credential store in this repo does (compare ``.env`` staying
+gitignored, ``~/.arc-canteen/`` team credentials). The value cached here is opaque to the
+CLI: it is whatever cookie(s) ``POST /api/auth/sign-in/email`` sets, forwarded verbatim
+on later requests. The CLI never parses or validates the cookie
 itself — same division of responsibility as the server side, which also never parses it and
 just forwards it to Better Auth's ``/api/auth/get-session``
 (``backend/archimedes/api/account_auth.py``, ``_fetch_session``).
@@ -17,13 +18,37 @@ the ``__Secure-`` prefix cannot legally be set without TLS. This module and
 ``archimedes_mcp.credentials`` both go through :func:`pick_session_cookie` rather than a
 single hardcoded name, so they work against local HTTP and production alike, and store
 back exactly the name+value pair that was actually issued.
+
+**One file per lane.** The path is resolved per process, not baked in:
+``--session-file`` (highest precedence), then :data:`SESSION_FILE_ENV`
+(``ARCHIMEDES_SESSION_FILE``), then the default above. Before that override existed the
+only lever was ``HOME``, so two CLI lanes sharing one runner shared one file and the
+second lane's ``login`` silently clobbered the first lane's identity *between* two
+otherwise clean calls — observed live on 2026-09-01 (issue #1752). Fleet operation is a
+first-class use case here, so isolating a lane is now one flag rather than a fabricated
+``HOME``. ``archimedes_mcp.credentials`` imports :func:`session_path` rather than
+rebuilding it, so the same override moves the MCP server's credential too.
+
+**Reads and writes take an advisory ``flock``** (shared to read, exclusive to write) on
+the session file itself, for the case the override is *not* used and two processes do
+share one path: without it a reader can observe the truncated-but-not-yet-rewritten file
+a concurrent ``login`` leaves behind for a few microseconds, and read "not logged in"
+from a perfectly good session. The lock is advisory — it binds the processes that go
+through this module, which is every reader and writer of this file that we ship.
 """
 
 from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+
+try:  # pragma: no cover - the except branch is unreachable on POSIX, where CI and prod run
+    import fcntl
+except ImportError:  # Windows has no fcntl; see `_locked` for what that costs.
+    fcntl = None  # type: ignore[assignment]
 
 SESSION_COOKIE_NAME = "better-auth.session_token"
 """The bare cookie name Better Auth issues on sign-in over plain HTTP — matching the
@@ -66,28 +91,118 @@ def pick_session_cookie(cookies) -> tuple[str, str] | None:
     return None
 
 
-def session_path() -> Path:
-    """Where the session cache lives.
+SESSION_FILE_ENV = "ARCHIMEDES_SESSION_FILE"
+"""Env var naming the session cache file. Set it per lane (``ARCHIMEDES_SESSION_FILE=
+/run/lane-a.json archimedes meter``) and two concurrent agents on one runner keep their
+own identities. Blank or whitespace-only is treated as unset — an empty env var is how a
+shell says "not configured", the same reading ``archimedes_mcp.credentials`` gives
+``ARCHIMEDES_API_KEY``."""
 
-    Built from ``Path.home()`` rather than hardcoded, so tests can point it at a tmp
-    directory by setting ``HOME`` (``Path.home()`` reads that on POSIX) instead of
-    monkeypatching this function.
+DEFAULT_SESSION_FILE = "~/.config/archimedes/session.json"
+"""The default location, in display form (help text, docs, error messages). The real
+path is built from ``Path.home()`` at call time in :func:`session_path` — never cached at
+import — so a test that redirects ``HOME`` still gets an isolated cache."""
+
+_session_file_override: Path | None = None
+"""Set by ``--session-file`` through :func:`set_session_file`. Process-wide by design: a
+CLI process runs exactly one command, and the alternative — threading a path through
+``load_session``/``save_session`` and every caller — would leave
+``archimedes_mcp.credentials`` (which has no flags to thread) unable to be redirected at
+all."""
+
+
+def set_session_file(path: str | os.PathLike[str] | None) -> Path | None:
+    """Point every later :func:`session_path` in this process at ``path``.
+
+    ``None`` (or an empty string — an unset click option arrives as ``None``, and a
+    ``--session-file ''`` is a user saying nothing rather than naming a file) restores
+    the env-var-or-default resolution, which is what makes calling this unconditionally
+    at the top of a command safe. ``~`` is expanded here so ``--session-file
+    ~/lane-a.json`` works from a shell that did not expand it (a quoted argument, an
+    ``execve`` with no shell in between).
     """
+    global _session_file_override
+    _session_file_override = Path(path).expanduser() if path else None
+    return _session_file_override
+
+
+def session_path() -> Path:
+    """Where the session cache lives, resolved fresh on every call.
+
+    Precedence: ``--session-file`` (via :func:`set_session_file`), then
+    :data:`SESSION_FILE_ENV`, then :data:`DEFAULT_SESSION_FILE` built from
+    ``Path.home()`` — so a test can still isolate the cache by setting ``HOME``
+    (``Path.home()`` reads that on POSIX) instead of monkeypatching this function.
+    """
+    if _session_file_override is not None:
+        return _session_file_override
+    from_env = os.environ.get(SESSION_FILE_ENV, "").strip()
+    if from_env:
+        return Path(from_env).expanduser()
     return Path.home() / ".config" / "archimedes" / "session.json"
+
+
+_LOCK_SHARED = getattr(fcntl, "LOCK_SH", 0)
+_LOCK_EXCLUSIVE = getattr(fcntl, "LOCK_EX", 0)
+
+
+@contextmanager
+def _locked(fd: int, operation: int) -> Iterator[None]:
+    """Hold an advisory ``flock`` of ``operation`` on ``fd`` for the block.
+
+    Blocking on purpose: the lock is held for one small write, so waiting for it is
+    measured in microseconds, and the alternative (``LOCK_NB`` plus a retry loop) would
+    have to invent a timeout policy and a failure mode for a contention window this
+    short. Released explicitly rather than relying on the close that follows, so the
+    window where the fd is open and unlocked is as small as it can be.
+
+    On a platform without ``fcntl`` (Windows) this degrades to no lock at all rather
+    than to an import error that would make the whole CLI unusable there. That is a
+    real, documented gap — not a claim that the file is protected everywhere.
+    """
+    if fcntl is None:  # pragma: no cover - POSIX-only lock; CI, prod and dev are POSIX
+        yield
+        return
+    fcntl.flock(fd, operation)
+    try:
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def _read_all(fd: int) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(fd, 65536)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
 
 
 def load_session() -> dict | None:
     """The cached session, or ``None`` if there isn't a usable one.
 
-    Never raises. A missing file, a permissions error, a corrupt JSON body, or a body
-    missing its cookie jar are all just "not logged in" from the caller's point of view —
-    the CLI can always fall back to telling the user to run ``archimedes login``.
+    Never raises. A missing file, a permissions error, a corrupt JSON body, a body that
+    is not even UTF-8, or a body missing its cookie jar are all just "not logged in" from
+    the caller's point of view — the CLI can always fall back to telling the user to run
+    ``archimedes login``.
+
+    The read happens under a shared ``flock``, so it never observes a concurrent
+    :func:`save_session` half-written (see the module docstring). Shared locks do not
+    exclude each other, so any number of readers still run at once.
     """
     path = session_path()
     try:
-        raw = path.read_text()
+        fd = os.open(path, os.O_RDONLY)
     except OSError:
         return None
+    try:
+        with _locked(fd, _LOCK_SHARED):
+            raw = _read_all(fd).decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    finally:
+        os.close(fd)
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
@@ -106,26 +221,44 @@ def save_session(*, api_url: str, cookies: dict[str, str], email: str) -> Path:
     Uses ``os.open`` with an explicit mode rather than ``Path.write_text`` so the file is
     never briefly world- or group-readable between creation and a follow-up ``chmod`` — and
     still ``chmod``s afterward, in case the path already existed with looser permissions
-    from an older version (``O_TRUNC`` reuses an existing file's mode, it does not reset it).
+    from an older version (a reused file keeps its own mode; ``O_CREAT``'s mode argument
+    only applies when the file is created).
+
+    ``O_TRUNC`` is deliberately NOT in the open flags: the kernel would apply it before
+    this process could take the lock, so a concurrent reader could catch an empty file
+    even with locking in place. The truncation happens inside the exclusive lock instead,
+    which is the whole point of taking one.
     """
     path = session_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps({"api_url": api_url, "cookies": cookies, "email": email}, indent=2) + "\n"
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    data = payload.encode("utf-8")
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT, 0o600)
     try:
-        os.write(fd, payload.encode("utf-8"))
+        with _locked(fd, _LOCK_EXCLUSIVE):
+            os.ftruncate(fd, 0)
+            os.lseek(fd, 0, os.SEEK_SET)
+            written = 0
+            while written < len(data):
+                written += os.write(fd, data[written:])
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            else:  # pragma: no cover - Windows, where fchmod does not exist
+                path.chmod(0o600)
     finally:
         os.close(fd)
-    path.chmod(0o600)
     return path
 
 
 __all__ = [
+    "DEFAULT_SESSION_FILE",
     "SECURE_SESSION_COOKIE_NAME",
     "SESSION_COOKIE_NAME",
     "SESSION_COOKIE_NAMES",
+    "SESSION_FILE_ENV",
     "load_session",
     "pick_session_cookie",
     "save_session",
     "session_path",
+    "set_session_file",
 ]

--- a/cli/tests/test_api_url_resolution.py
+++ b/cli/tests/test_api_url_resolution.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 
 from archimedes_cli import cli as cli_mod
 from archimedes_cli.cli import DEFAULT_API_URL, _resolve_api_url, main
-from archimedes_cli.session import save_session
+from archimedes_cli.session import SESSION_FILE_ENV, save_session
 
 STAGING = "https://staging.archimedes.invalid"
 
@@ -27,6 +27,7 @@ def test_meter_uses_the_session_url_not_the_default(monkeypatch, tmp_path):
     then run plain `meter` — the request must go to the session's host.
     Pre-fix, seen_base_urls captured DEFAULT_API_URL and this test fails."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(SESSION_FILE_ENV, raising=False)  # overrides HOME outright (#1752)
     monkeypatch.delenv("ARCHIMEDES_API_URL", raising=False)
     save_session(api_url=STAGING, cookies={"better-auth.session_token": "t"}, email="a@b.co")
 

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -24,7 +24,13 @@ import pytest
 from archimedes_cli import __version__
 from archimedes_cli.cli import main
 from archimedes_cli.exits import AUTH, GATE_FAILED, INCOMPLETE, NOT_IMPLEMENTED, OK, USAGE
-from archimedes_cli.session import SECURE_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, save_session, session_path
+from archimedes_cli.session import (
+    SECURE_SESSION_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
+    SESSION_FILE_ENV,
+    save_session,
+    session_path,
+)
 from click.testing import CliRunner
 
 # ── Fixtures & test-only helpers ────────────────────────────────────────
@@ -37,6 +43,9 @@ def runner(tmp_path, monkeypatch):
     from the real environment."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    # ARCHIMEDES_SESSION_FILE would override HOME outright (#1752), so an exported one
+    # would point this suite at the developer's own session file.
+    monkeypatch.delenv(SESSION_FILE_ENV, raising=False)
     monkeypatch.delenv("ARCHIMEDES_EMAIL", raising=False)
     monkeypatch.delenv("ARCHIMEDES_PASSWORD", raising=False)
     monkeypatch.delenv("ARCHIMEDES_API_URL", raising=False)

--- a/cli/tests/test_generate.py
+++ b/cli/tests/test_generate.py
@@ -35,7 +35,7 @@ from archimedes_cli.exits import (
     STILL_RUNNING,
     USAGE,
 )
-from archimedes_cli.session import SESSION_COOKIE_NAME, save_session
+from archimedes_cli.session import SESSION_COOKIE_NAME, SESSION_FILE_ENV, save_session
 from click.testing import CliRunner
 
 API = "https://archimedes-arc.com"
@@ -61,6 +61,9 @@ def runner(tmp_path, monkeypatch):
     """CliRunner in a tmp dir with an isolated $HOME and no ambient credentials."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    # ARCHIMEDES_SESSION_FILE overrides HOME outright (#1752) — clear it for the same
+    # reason HOME is redirected at all.
+    monkeypatch.delenv(SESSION_FILE_ENV, raising=False)
     monkeypatch.delenv("ARCHIMEDES_API_URL", raising=False)
     monkeypatch.delenv("ARCHIMEDES_API_KEY", raising=False)
     # Polling must never actually sleep: the fallback tests would otherwise take

--- a/cli/tests/test_session_isolation.py
+++ b/cli/tests/test_session_isolation.py
@@ -1,0 +1,449 @@
+"""One session file per lane, and a lock around it — issue #1752.
+
+The bug this file pins was observed live on 2026-09-01: two agent-CLI lanes on one runner
+shared ``~/.config/archimedes/session.json`` because ``HOME`` was the only lever, so the
+second lane's ``login`` overwrote the first lane's identity *between* two otherwise clean
+``meter`` calls. The first lane kept working, kept returning 200s, and was answering as
+somebody else.
+
+Four claims are made here, and each has an input written to break it:
+
+* **Isolation** — two paths, two identities, verified through the real ``login``/``meter``
+  commands rather than only through the loader. The adversarial partner
+  (``test_adversarial_two_lanes_sharing_one_file_still_clobber``) drives the *same* file
+  twice and asserts the clobber still happens, so the isolation tests cannot pass for the
+  vacuous reason that a second login never overwrites anything.
+* **The lock is really taken** — a *separate process* holds ``flock(LOCK_EX)`` on the
+  session file and the tests assert that a write, and a read, both WAIT. Delete either
+  ``flock`` call in ``session.py`` and these go red, because the operation completes
+  immediately instead. ``test_two_readers_do_not_block_each_other`` is the other side:
+  the read lock must be shared, not exclusive, or every concurrent reader serializes.
+* **0600 survives the override** — including the case that motivates the second ``chmod``:
+  a file that already exists, world-readable, from an older version.
+* **A bad path is exit 2, not exit 1** — the flag takes user input, so it can name a
+  directory or a read-only file, and this CLI's exit-code contract reserves 1 for "the
+  gate returned a failing verdict". Before the guard, that write raised through click and
+  exited 1.
+
+The lock tests are POSIX-only by construction (``flock`` is), which is where CI, prod and
+every developer machine run; they skip rather than lie on a platform without ``fcntl``.
+Only those tests skip — the isolation and permission claims hold with or without it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+import archimedes_cli.cli as cli_module
+import httpx
+import pytest
+from archimedes_cli.cli import main
+from archimedes_cli.exits import OK, USAGE
+from archimedes_cli.session import (
+    SESSION_COOKIE_NAME,
+    SESSION_FILE_ENV,
+    load_session,
+    save_session,
+    session_path,
+    set_session_file,
+)
+from click.testing import CliRunner
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+requires_flock = pytest.mark.skipif(fcntl is None, reason="flock is POSIX-only; CI, prod and dev are POSIX")
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _seed(path: Path, *, email: str, cookie: str) -> Path:
+    """Write a session at ``path`` the way ``login`` would, and leave the override off."""
+    set_session_file(path)
+    try:
+        return save_session(api_url="https://archimedes-arc.com", cookies={SESSION_COOKIE_NAME: cookie}, email=email)
+    finally:
+        set_session_file(None)
+
+
+def _install_transport(monkeypatch, handler):
+    """Mock HTTP at the CLI's one client-construction point — same boundary as
+    ``test_cli.py``, never a command's internals."""
+
+    def factory(api_url, *, cookies=None):
+        return httpx.Client(base_url=api_url, cookies=cookies, transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(cli_module, "_http_client", factory)
+
+
+def _login_handler(*, email: str, cookie: str):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/sign-in/email":
+            return httpx.Response(
+                200,
+                json={"redirect": False},
+                headers=[("set-cookie", f"{SESSION_COOKIE_NAME}={cookie}; Path=/; HttpOnly")],
+            )
+        if request.url.path == "/api/auth/get-session":
+            return httpx.Response(200, json={"user": {"id": "u1", "email": email}, "session": {"id": "s1"}})
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    return handler
+
+
+# A second PROCESS, so the lock under test is a real inter-process lock and not something
+# this process could satisfy from its own bookkeeping. It takes LOCK_EX, announces it on
+# stdout, and holds it until the parent writes a line to its stdin — no sleeps, no polling,
+# so the handshake is deterministic.
+_LOCK_HOLDER = """
+import fcntl, os, sys
+fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT, 0o600)
+fcntl.flock(fd, fcntl.LOCK_EX if sys.argv[2] == "exclusive" else fcntl.LOCK_SH)
+sys.stdout.write("locked\\n")
+sys.stdout.flush()
+sys.stdin.readline()
+os.close(fd)
+"""
+
+
+@contextmanager
+def _held_by_another_process(path: Path, mode: str = "exclusive"):
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _LOCK_HOLDER, str(path), mode],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert proc.stdout.readline().strip() == "locked", "the helper process never took the lock"
+        yield
+    finally:
+        try:
+            proc.stdin.write("\n")
+            proc.stdin.close()
+        except (BrokenPipeError, OSError, ValueError):
+            # The helper already exited (it crashed, or the assertion above fired first).
+            # Swallowed so the real failure is what the test reports, not a broken pipe.
+            pass
+        proc.stdout.close()
+        proc.wait(timeout=30)
+
+
+def _in_a_thread(work):
+    """Run ``work()`` on a daemon thread; return an Event set when it returns."""
+    finished = threading.Event()
+
+    def run():
+        work()
+        finished.set()
+
+    threading.Thread(target=run, daemon=True).start()
+    return finished
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_session_file(monkeypatch):
+    """Clear both levers around every test in this module.
+
+    ``CliRunner`` runs commands **in this process**, so a test that passes
+    ``--session-file`` leaves ``set_session_file``'s process-wide override installed for
+    whatever runs next; and a developer with ``ARCHIMEDES_SESSION_FILE`` exported would
+    otherwise run a different suite than CI does, against their own real session file.
+
+    Deliberately here and not in a ``cli/tests/conftest.py``: a conftest in this directory
+    is imported under the bare module name ``conftest``, which is the name
+    ``mcp-server/tests`` reaches for (``from conftest import json_response``). Adding one
+    breaks ``pytest cli/tests mcp-server/tests`` — a combination that works today, and one
+    CI does not run only because it runs the two suites as separate commands. Measured, not
+    assumed: with a conftest here that invocation dies with "cannot import name
+    'json_response' from 'conftest'".
+    """
+    monkeypatch.delenv(SESSION_FILE_ENV, raising=False)
+    set_session_file(None)
+    yield
+    set_session_file(None)
+
+
+@pytest.fixture
+def runner(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("ARCHIMEDES_EMAIL", "unused@example.com")
+    monkeypatch.setenv("ARCHIMEDES_PASSWORD", "unused")
+    monkeypatch.delenv("ARCHIMEDES_API_URL", raising=False)
+    monkeypatch.delenv("ARCHIMEDES_API_KEY", raising=False)
+    return CliRunner()
+
+
+# ── where the file lives ─────────────────────────────────────────────
+
+
+class TestResolvingTheSessionPath:
+    def test_the_default_is_still_under_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert session_path() == tmp_path / ".config" / "archimedes" / "session.json"
+
+    def test_the_env_var_moves_it(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(SESSION_FILE_ENV, str(tmp_path / "lane-a.json"))
+        assert session_path() == tmp_path / "lane-a.json"
+
+    def test_the_env_var_expands_a_tilde(self, tmp_path, monkeypatch):
+        """A quoted argument or an ``execve`` with no shell in between hands the CLI a
+        literal ``~``; treating it as a directory name would silently write the session
+        into a folder called ``~`` in the cwd."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(SESSION_FILE_ENV, "~/lane-b.json")
+        assert session_path() == tmp_path / "lane-b.json"
+
+    def test_adversarial_a_blank_env_var_is_treated_as_unset(self, tmp_path, monkeypatch):
+        """The input that should NOT be honoured: an exported-but-empty variable is a
+        shell saying "not configured", and resolving it would put the session at the
+        current directory rather than anywhere deliberate."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(SESSION_FILE_ENV, "   ")
+        assert session_path() == tmp_path / ".config" / "archimedes" / "session.json"
+
+    def test_the_flag_wins_over_the_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(SESSION_FILE_ENV, str(tmp_path / "from-env.json"))
+        set_session_file(tmp_path / "from-flag.json")
+        assert session_path() == tmp_path / "from-flag.json"
+
+    def test_an_absent_flag_falls_back_to_the_env_var(self, tmp_path, monkeypatch):
+        """``set_session_file(None)`` is what an unpassed ``--session-file`` does, and it
+        must not shadow the env var — the commands call it unconditionally."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(SESSION_FILE_ENV, str(tmp_path / "from-env.json"))
+        set_session_file(None)
+        assert session_path() == tmp_path / "from-env.json"
+
+
+# ── two lanes ────────────────────────────────────────────────────────
+
+
+class TestTwoLanesDoNotSeeEachOther:
+    def test_two_files_hold_two_identities(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        lane_a = tmp_path / "a.json"
+        lane_b = tmp_path / "b.json"
+        _seed(lane_a, email="a@example.com", cookie="tok-a")
+        _seed(lane_b, email="b@example.com", cookie="tok-b")
+
+        set_session_file(lane_a)
+        assert load_session()["email"] == "a@example.com"
+        assert load_session()["cookies"] == {SESSION_COOKIE_NAME: "tok-a"}
+
+        set_session_file(lane_b)
+        assert load_session()["email"] == "b@example.com"
+        assert load_session()["cookies"] == {SESSION_COOKIE_NAME: "tok-b"}
+
+        set_session_file(None)
+        assert load_session() is None, "neither lane may leak into the default location"
+
+    def test_a_second_lanes_login_does_not_clobber_the_first(self, runner, tmp_path, monkeypatch):
+        """The incident itself: lane A logs in, lane B logs in, and lane A's identity is
+        still lane A's afterwards."""
+        lane_a = tmp_path / "lane-a.json"
+        lane_b = tmp_path / "lane-b.json"
+
+        _install_transport(monkeypatch, _login_handler(email="a@example.com", cookie="tok-a"))
+        assert runner.invoke(main, ["login", "--json", "--session-file", str(lane_a)]).exit_code == OK
+
+        _install_transport(monkeypatch, _login_handler(email="b@example.com", cookie="tok-b"))
+        assert runner.invoke(main, ["login", "--json", "--session-file", str(lane_b)]).exit_code == OK
+
+        assert json.loads(lane_a.read_text())["email"] == "a@example.com"
+        assert json.loads(lane_a.read_text())["cookies"] == {SESSION_COOKIE_NAME: "tok-a"}
+        assert json.loads(lane_b.read_text())["email"] == "b@example.com"
+        assert not (Path(os.environ["HOME"]) / ".config" / "archimedes" / "session.json").exists()
+
+    def test_adversarial_two_lanes_sharing_one_file_still_clobber(self, runner, tmp_path, monkeypatch):
+        """The control. Without the flag the second login DOES overwrite the first — which
+        is the reported bug, and is what makes the test above a real assertion rather than
+        a tautology about logins never overwriting anything."""
+        shared = tmp_path / "shared.json"
+
+        _install_transport(monkeypatch, _login_handler(email="a@example.com", cookie="tok-a"))
+        assert runner.invoke(main, ["login", "--json", "--session-file", str(shared)]).exit_code == OK
+
+        _install_transport(monkeypatch, _login_handler(email="b@example.com", cookie="tok-b"))
+        assert runner.invoke(main, ["login", "--json", "--session-file", str(shared)]).exit_code == OK
+
+        assert json.loads(shared.read_text())["email"] == "b@example.com"
+
+    def test_adversarial_a_session_file_that_cannot_be_written_exits_2_not_1(self, runner, tmp_path, monkeypatch):
+        """``--session-file`` is user input, so it can name something unwritable — here a
+        directory. The write fails *after* a successful sign-in, and an uncaught OSError
+        would surface as exit 1, which in this CLI means "the gate returned a failing
+        verdict" (README exit-code table). A CI job branching on 1 would read a typo in a
+        path as a research finding."""
+        a_directory = tmp_path / "not-a-file"
+        a_directory.mkdir()
+        _install_transport(monkeypatch, _login_handler(email="a@example.com", cookie="tok-a"))
+
+        result = runner.invoke(main, ["login", "--json", "--session-file", str(a_directory)])
+
+        assert result.exit_code == USAGE
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        assert payload["error"] == "session_file_unwritable"
+        assert str(a_directory) in payload["message"]
+        assert "tok-a" not in result.stdout, "the cookie must not be echoed in the failure"
+
+    def test_an_empty_flag_value_falls_back_rather_than_writing_to_an_empty_path(self, runner, tmp_path, monkeypatch):
+        """``--session-file ''`` is a user saying nothing, not naming a file — it must
+        resolve like an absent flag rather than trying to write to ``.``."""
+        lane = tmp_path / "from-env.json"
+        monkeypatch.setenv(SESSION_FILE_ENV, str(lane))
+        _install_transport(monkeypatch, _login_handler(email="env@example.com", cookie="tok-env"))
+
+        assert runner.invoke(main, ["login", "--json", "--session-file", ""]).exit_code == OK
+
+        assert json.loads(lane.read_text())["email"] == "env@example.com"
+
+    def test_meter_sends_the_cookie_from_its_own_lane(self, runner, tmp_path, monkeypatch):
+        """Reading is isolated too, not just writing: the flag has to reach ``load_session``
+        or a lane would authenticate as whoever wrote the default file."""
+        lane_a = tmp_path / "lane-a.json"
+        lane_b = tmp_path / "lane-b.json"
+        _seed(lane_a, email="a@example.com", cookie="tok-a")
+        _seed(lane_b, email="b@example.com", cookie="tok-b")
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.headers.get("cookie", ""))
+            return httpx.Response(200, json={"date": "2026-09-01", "user_id": "u1", "user": {}, "ip": {}, "quote": {}})
+
+        _install_transport(monkeypatch, handler)
+        assert runner.invoke(main, ["meter", "--json", "--session-file", str(lane_a)]).exit_code == OK
+        assert runner.invoke(main, ["meter", "--json", "--session-file", str(lane_b)]).exit_code == OK
+
+        assert f"{SESSION_COOKIE_NAME}=tok-a" in seen[0]
+        assert "tok-b" not in seen[0]
+        assert f"{SESSION_COOKIE_NAME}=tok-b" in seen[1]
+        assert "tok-a" not in seen[1]
+
+    def test_the_env_var_isolates_a_lane_with_no_flag_at_all(self, runner, tmp_path, monkeypatch):
+        """The fleet-operator path: export the variable once per lane and every command in
+        that lane — including ones with no flag threaded through — follows it."""
+        lane = tmp_path / "lane-env.json"
+        monkeypatch.setenv(SESSION_FILE_ENV, str(lane))
+        _install_transport(monkeypatch, _login_handler(email="env@example.com", cookie="tok-env"))
+
+        assert runner.invoke(main, ["login", "--json"]).exit_code == OK
+
+        assert json.loads(lane.read_text())["email"] == "env@example.com"
+        assert not (Path(os.environ["HOME"]) / ".config" / "archimedes" / "session.json").exists()
+
+
+# ── permissions ──────────────────────────────────────────────────────
+
+
+class TestThePermissionBitSurvivesTheOverride:
+    def test_an_overridden_path_is_still_written_600(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        path = _seed(tmp_path / "lane.json", email="a@example.com", cookie="tok")
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600, f"{path} is {oct(path.stat().st_mode)}"
+
+    def test_a_pre_existing_world_readable_file_is_tightened(self, tmp_path, monkeypatch):
+        """``O_CREAT``'s mode argument applies only when the file is created, so a session
+        file left behind by an older version keeps its own looser mode unless something
+        chmods it. This is the input that would leave a credential world-readable."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        path = tmp_path / "loose.json"
+        path.write_text("{}\n")
+        path.chmod(0o644)
+
+        _seed(path, email="a@example.com", cookie="tok")
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    def test_a_missing_parent_directory_is_created(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        path = _seed(tmp_path / "deep" / "nested" / "lane.json", email="a@example.com", cookie="tok")
+        assert path.exists()
+        assert json.loads(path.read_text())["email"] == "a@example.com"
+
+
+# ── the lock ─────────────────────────────────────────────────────────
+
+
+@requires_flock
+class TestTheAdvisoryLock:
+    """Each of these fails if the corresponding ``fcntl.flock`` call is deleted from
+    ``session.py`` — the operation would then finish while another process holds the
+    lock, which is exactly the interleaving the lock exists to prevent."""
+
+    def test_a_write_waits_for_another_processes_exclusive_lock(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(SESSION_FILE_ENV, str(tmp_path / "session.json"))
+        path = tmp_path / "session.json"
+
+        with _held_by_another_process(path):
+            finished = _in_a_thread(
+                lambda: save_session(api_url="https://x.test", cookies={SESSION_COOKIE_NAME: "t"}, email="a@b.test")
+            )
+            assert not finished.wait(0.5), "save_session wrote while another process held LOCK_EX"
+
+        assert finished.wait(30), "save_session never completed after the lock was released"
+        assert json.loads(path.read_text())["email"] == "a@b.test"
+
+    def test_a_read_waits_for_another_processes_exclusive_lock(self, tmp_path, monkeypatch):
+        """Why the read side needs a lock at all: a writer truncates before it rewrites, so
+        an unlocked reader can land in that window and report "not logged in" for a session
+        that is perfectly good."""
+        path = tmp_path / "session.json"
+        _seed(path, email="a@example.com", cookie="tok-a")
+        monkeypatch.setenv(SESSION_FILE_ENV, str(path))
+        loaded: list[dict | None] = []
+
+        with _held_by_another_process(path):
+            finished = _in_a_thread(lambda: loaded.append(load_session()))
+            assert not finished.wait(0.5), "load_session read while another process held LOCK_EX"
+
+        assert finished.wait(30), "load_session never completed after the lock was released"
+        assert loaded == [
+            {
+                "api_url": "https://archimedes-arc.com",
+                "cookies": {SESSION_COOKIE_NAME: "tok-a"},
+                "email": "a@example.com",
+            }
+        ]
+
+    def test_two_readers_do_not_block_each_other(self, tmp_path, monkeypatch):
+        """The other side of the claim: the read lock is SHARED. If it were exclusive,
+        every concurrent ``meter`` on a runner would serialize behind every other one for
+        no reason."""
+        path = tmp_path / "session.json"
+        _seed(path, email="a@example.com", cookie="tok-a")
+        monkeypatch.setenv(SESSION_FILE_ENV, str(path))
+
+        with _held_by_another_process(path, mode="shared"):
+            finished = _in_a_thread(load_session)
+            assert finished.wait(30), "load_session blocked behind another reader's shared lock"
+
+    def test_the_lock_is_released_when_the_write_finishes(self, tmp_path, monkeypatch):
+        """A lock held past the write would deadlock the next command in the same lane."""
+        path = tmp_path / "session.json"
+        monkeypatch.setenv(SESSION_FILE_ENV, str(path))
+
+        save_session(api_url="https://x.test", cookies={SESSION_COOKIE_NAME: "t1"}, email="a@b.test")
+        save_session(api_url="https://x.test", cookies={SESSION_COOKIE_NAME: "t2"}, email="a@b.test")
+
+        fd = os.open(path, os.O_RDWR)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)  # raises BlockingIOError if still held
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+        assert json.loads(path.read_text())["cookies"] == {SESSION_COOKIE_NAME: "t2"}

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -708,6 +708,12 @@ produces. **Exactly one of the two goes on the wire** — when both exist the ke
 client and no cookie is sent, so the server-side precedence rule can never decide which
 account a call acts as. Neither credential is ever logged, returned, or rendered.
 
+**Running a fleet on one machine?** Add `ARCHIMEDES_SESSION_FILE` to that `env` block —
+one path per agent — and pass `archimedes login --session-file` the same path. One session
+file shared between two agents is one identity shared between two agents: the second
+`login` wins and the first agent keeps working, as somebody else
+([#1752](https://github.com/aprin-labs/archimedes/issues/1752)).
+
 **One honest caveat about the key.** Scoped API keys are owner decision **D3** on the same
 PR and are not on `main` at the time of writing, so against production today a bearer key
 `401`s and the cookie is the working lane. The header is written to the agreed shape now so

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -46,12 +46,18 @@ archimedes-mcp --help 2>/dev/null || true   # it speaks MCP over stdio; a client
 `archimedes login` caches at `~/.config/archimedes/session.json` (mode `600`), loaded
 through `archimedes_cli.session.load_session` — imported, not copied.
 
+`ARCHIMEDES_SESSION_FILE` in the same `env` block moves that file. Running more than one
+agent on a machine? Give each one its own path (`"ARCHIMEDES_SESSION_FILE":
+"/home/agent/.archimedes/lane-a.json"`, and `archimedes login --session-file` that same
+path). One file per agent is what keeps two agents from sharing one identity — the failure
+[#1752](https://github.com/aprin-labs/archimedes/issues/1752) reported.
+
 ## Authentication
 
 | Order | Source | Sent as |
 | --- | --- | --- |
 | 1 | `ARCHIMEDES_API_KEY` | `Authorization: Bearer <key>` |
-| 2 | `~/.config/archimedes/session.json` | the `better-auth.session_token` cookie |
+| 2 | `~/.config/archimedes/session.json`, or `$ARCHIMEDES_SESSION_FILE` | the `better-auth.session_token` cookie |
 
 **Exactly one credential goes on the wire.** When both exist the key wins here and no
 `Cookie` header is sent, so the server-side precedence rule (cookie wins) can never decide

--- a/mcp-server/src/archimedes_mcp/contract.py
+++ b/mcp-server/src/archimedes_mcp/contract.py
@@ -66,7 +66,8 @@ CREDENTIAL_SOURCES = (
     "ARCHIMEDES_API_KEY  ->  Authorization: Bearer <key>",
     "~/.config/archimedes/session.json  ->  the session cookie `archimedes login` cached "
     "(mode 600) -- __Secure-better-auth.session_token in production, "
-    "better-auth.session_token on local HTTP",
+    "better-auth.session_token on local HTTP. ARCHIMEDES_SESSION_FILE moves that file, "
+    "which is how concurrent agents on one machine hold separate identities",
 )
 
 TOOLS: tuple[dict, ...] = (

--- a/mcp-server/src/archimedes_mcp/credentials.py
+++ b/mcp-server/src/archimedes_mcp/credentials.py
@@ -12,11 +12,13 @@ Two ways to authenticate as an account, in this order:
    no change here. Nothing in this file blocks on it: the fallback below carries the
    server until then.
 2. **The CLI session cache** at ``~/.config/archimedes/session.json`` — the cookie
-   ``archimedes login`` writes at mode ``600``. Loaded through
-   ``archimedes_cli.session.load_session``: imported, not reimplemented. Copying that
-   loader would mean two definitions of "is there a usable session", and the copy would be
-   the one that drifts — the exact second-surface failure mode this whole server was
-   scoped to avoid. That cookie is one of *two* names depending on which host issued it —
+   ``archimedes login`` writes at mode ``600``, or wherever ``ARCHIMEDES_SESSION_FILE``
+   points, which is how two agents on one runner keep separate identities (#1752: set it
+   in this server's ``env`` block, one file per agent, and their sessions stop clobbering
+   each other). Loaded through ``archimedes_cli.session.load_session``: imported, not
+   reimplemented. Copying that loader would mean two definitions of "is there a usable
+   session", and the copy would be the one that drifts — the exact second-surface failure
+   mode this whole server was scoped to avoid. That cookie is one of *two* names depending on which host issued it —
    ``__Secure-better-auth.session_token`` in production, the bare
    ``better-auth.session_token`` on local HTTP (``archimedes_cli.session`` picks between
    them; see :func:`~archimedes_cli.session.pick_session_cookie`) — and this module sends

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -8,8 +8,8 @@ Mocking at the boundary — the ``httpx.Client`` construction point, not the too
 credential fallback reads ``~/.config/archimedes/session.json`` through
 ``Path.home()``, so without this a developer who happens to be logged in would run a
 different test than CI does — and the "no credential" tests would silently pass for the
-wrong reason. ``ARCHIMEDES_API_KEY`` / ``ARCHIMEDES_API_URL`` are cleared for the same
-reason.
+wrong reason. ``ARCHIMEDES_SESSION_FILE`` (which overrides that path outright, #1752),
+``ARCHIMEDES_API_KEY`` and ``ARCHIMEDES_API_URL`` are cleared for the same reason.
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from archimedes_cli.session import SESSION_FILE_ENV
 from archimedes_mcp import client
 from archimedes_mcp.credentials import API_KEY_ENV, API_URL_ENV
 
@@ -29,6 +30,7 @@ TEST_API_URL = "https://api.test.invalid"
 @pytest.fixture(autouse=True)
 def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(SESSION_FILE_ENV, raising=False)
     monkeypatch.delenv(API_KEY_ENV, raising=False)
     monkeypatch.setenv(API_URL_ENV, TEST_API_URL)
     return tmp_path

--- a/skills/archimedes-cli/SKILL.md
+++ b/skills/archimedes-cli/SKILL.md
@@ -71,17 +71,43 @@ What actually happens, in order (cli.py:187-253):
    a crash (cli.py:231-235, the `ValueError` branch). No `user.email` in the
    response → fails as `session_not_confirmed` (cli.py:239-246) and, again,
    nothing is cached.
-5. Only then: `save_session(...)` writes
-   `~/.config/archimedes/session.json` — [`session.py`](../../cli/src/archimedes_cli/session.py):59-76,
-   opened via `os.open(..., 0o600)` (never briefly world-readable) and
-   `chmod(0o600)` again afterward in case the path pre-existed with looser
-   permissions (session.py:62-65 comment explains why the second chmod isn't
-   redundant).
+5. Only then: `save_session(...)` writes the session cache — by default
+   `~/.config/archimedes/session.json`, or wherever `--session-file` /
+   `ARCHIMEDES_SESSION_FILE` points (see "One session file per lane" below) —
+   [`session.py`](../../cli/src/archimedes_cli/session.py):218-250, opened via
+   `os.open(..., 0o600)` (never briefly world-readable) and `chmod(0o600)` again
+   under the write lock, in case the path pre-existed with looser permissions
+   (the docstring there explains why the second chmod isn't redundant).
 
 The password is sent once, on that one request, and is never written to disk
 (cli.py docstring, lines 180-182). Linking a crypto wallet is a separate, later,
 optional step for on-chain vault actions — it is not part of `login` and does
 not authenticate you (cli.py:183-185).
+
+### One session file per lane
+
+`login`, `meter`, `verify` and `generate` all take `--session-file PATH`, and all read
+`ARCHIMEDES_SESSION_FILE` when the flag is absent (the flag wins;
+[`session.py`](../../cli/src/archimedes_cli/session.py):129-142 is the whole precedence
+rule — flag, then env var, then `~/.config/archimedes/session.json`).
+
+```bash
+ARCHIMEDES_SESSION_FILE=~/.archimedes/lane-a.json archimedes login   # agent A
+ARCHIMEDES_SESSION_FILE=~/.archimedes/lane-b.json archimedes login   # agent B
+archimedes meter --session-file ~/.archimedes/lane-a.json            # still agent A
+```
+
+**If you are driving more than one agent on one machine, give each one its own file.**
+A shared file is a shared identity: the second `login` overwrites the first, and the
+first lane keeps getting clean `200`s as somebody else. That is
+[#1752](https://github.com/aprin-labs/archimedes/issues/1752), observed live on
+2026-09-01, and before the flag existed the only lever was a fabricated `$HOME`.
+
+The file is mode `600` wherever you point it, and every read and write takes an advisory
+`flock` on it (`session.py`:150-170), so even a shared file never yields a half-written
+read. The MCP server (`mcp-server/`) loads this same cache through
+`archimedes_cli.session`, so `ARCHIMEDES_SESSION_FILE` in an `mcpServers` env block moves
+that agent's credential too.
 
 ### `archimedes meter`
 


### PR DESCRIPTION
Closes #1752.

Do not merge — owner vets first.

## What was wrong

`session_path()` returned `Path.home()/".config"/"archimedes"/"session.json"` with no
override of any kind, so `HOME` was the only lever and two CLI lanes on one runner shared
one file — and therefore one identity. That is the 2026-09-01 dogfood observation in the
issue: a second lane's `login` overwrote the first lane's session between two otherwise
clean `meter` calls, and the first lane went on returning 200s as somebody else. There was
also no lock, so even a deliberate single-file setup could read a session mid-rewrite.

## What this does

**`ARCHIMEDES_SESSION_FILE` (env) and `--session-file PATH` (flag)** — the names the issue
asks for — now decide where the cache lives, on `login`, `meter`, `verify` and `generate`.
Precedence is flag → env var → the old default. A blank env var is treated as unset (same
reading `ARCHIMEDES_API_KEY` gets), and `~` is expanded so a value that never met a shell
still resolves.

The flag is **not** declared with click's `envvar=`. `archimedes_cli.session.session_path()`
reads the variable itself — it has to, because `archimedes_mcp.credentials` calls it with no
click context in the process — and a second reader of the same variable is a second place
for the precedence rule to drift. That also means the MCP server is isolated by the same
variable for free: it imports `session_path`/`load_session` rather than reimplementing them.

**Advisory `flock`**: shared to read, exclusive to write, on the session file itself. For
the case where the override is *not* used and two processes do share a path — without it a
reader can land in the window a concurrent `login` leaves between truncate and rewrite and
report "not logged in" for a perfectly good session. `O_TRUNC` moved out of the open flags
into the locked region, because the kernel would otherwise truncate before the lock could be
taken (which would have made the lock decorative for exactly that race).

**0600 is preserved** on the overridden path, including the pre-existing-loose case that
motivates the second chmod. It is now `os.fchmod` on the open fd, inside the lock — no
unlocked window, no path race.

**One bug found while adversarially testing my own change**: `--session-file` takes user
input, so it can name a directory or a read-only path, and the write happens *after* a
successful sign-in. An uncaught `OSError` exits **1**, which this CLI's exit-code contract
reserves for "the gate ran and returned a failing verdict" — a CI job branching on 1 would
read a mistyped path as a research finding. It now exits 2 with `session_file_unwritable`.

## Every guard shown RED before pushing

Each mutation was applied to the source, the suite run, the output captured, then reverted
by editing the file back.

**1. `_locked` made a pass-through (no `flock` at all):**

```
FAILED tests/test_session_isolation.py::TestTheAdvisoryLock::test_a_write_waits_for_another_processes_exclusive_lock - AssertionError: save_session wrote while another process held LOCK_EX
FAILED tests/test_session_isolation.py::TestTheAdvisoryLock::test_a_read_waits_for_another_processes_exclusive_lock - AssertionError: load_session read while another process held LOCK_EX
2 failed, 16 passed in 0.27s
```

**2. `session_path()` made to ignore both overrides (the pre-fix behaviour):** 13 of 18
failed, including the incident test itself —

```
FAILED tests/test_session_isolation.py::TestTwoLanesDoNotSeeEachOther::test_two_files_hold_two_identities - AssertionError: assert 'b@example.com' == 'a@example.com'
FAILED tests/test_session_isolation.py::TestTwoLanesDoNotSeeEachOther::test_meter_sends_the_cookie_from_its_own_lane - AssertionError: assert 'better-auth.session_token=tok-a' in 'better-auth.se...
13 failed, 5 passed in 0.19s
```

**3. The `chmod` under the lock removed:**

```
FAILED tests/test_session_isolation.py::TestThePermissionBitSurvivesTheOverride::test_a_pre_existing_world_readable_file_is_tightened - AssertionError: assert 420 == 384
1 failed, 119 passed in 2.22s
```

(420 = `0o644`, 384 = `0o600`.)

**4. The unwritable-path guard** was written test-first — before it existed:

```
E   AssertionError: assert 1 == 2
E    +  where 1 = <Result IsADirectoryError(21, 'Is a directory')>.exit_code
```

### And the race the lock exists to stop, measured

The committed lock tests prove the lock is *taken*. This one-off (deliberately **not**
committed — it is timing-dependent and would be flake bait in CI) measures what it buys:
one process calling `save_session` in a loop while another calls `load_session` in a loop,
4,000 iterations each, against one shared file.

```
run 1   unlocked: 1253 of 4000 reads saw no usable session
        locked:      0 of 4000 reads saw no usable session
run 2   unlocked:  735 of 4000 reads saw no usable session
        locked:      0 of 4000 reads saw no usable session
```

Between a fifth and a third of reads in the unlocked runs reported "not logged in" for a
session that was perfectly good — they landed in the writer's truncate/rewrite window. The
unlocked count varies run to run, as a race does. The locked count did not: zero, twice.

<details><summary>the script (run from the repo root with <code>./cli</code> installed)</summary>

```python
# race.py MODE PATH ROLE N   —  MODE is "locked" or "unlocked"
import contextlib, os, sys
from archimedes_cli import session as S
MODE, PATH, ROLE, N = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
if MODE == "unlocked":
    @contextlib.contextmanager
    def _nolock(fd, operation):
        yield
    S._locked = _nolock                      # the mutation, applied at runtime only
os.environ["ARCHIMEDES_SESSION_FILE"] = PATH
if ROLE == "writer":
    for i in range(N):
        S.save_session(api_url="https://x.test", cookies={S.SESSION_COOKIE_NAME: f"tok{i}"}, email="a@b.test")
else:
    misses = sum(1 for _ in range(N) if S.load_session() is None)
    print(f"{MODE}: {misses} of {N} reads saw no usable session")
```

```bash
for MODE in unlocked locked; do
  P=/tmp/session-$MODE.json; rm -f $P
  python race.py $MODE $P writer 1 >/dev/null      # seed
  python race.py $MODE $P writer 4000 & W=$!
  python race.py $MODE $P reader 4000
  wait $W
done
```

</details>

The lock is proven by a **separate process** holding `flock(LOCK_EX)` and handshaking over
a pipe (no sleeps in the synchronisation), so it is a real inter-process lock rather than
something this process could satisfy from its own bookkeeping.
`test_two_readers_do_not_block_each_other` pins the other side: the read lock must be
*shared*, or every concurrent `meter` on a runner serialises. And
`test_adversarial_two_lanes_sharing_one_file_still_clobber` is the control — it drives the
*same* file twice and asserts the clobber still happens, so the isolation tests cannot be passing for the vacuous reason that a second
login never overwrites anything.

## Tests

- `cli/tests/test_session_isolation.py` — 20 new tests (resolution + precedence, two lanes
  through the real `login`/`meter` commands, the lock, 0600, the exit code). Run 18 times
  in a row on a loaded machine while checking for flakiness in the timing-sensitive lock
  tests: 18 green.
- An autouse fixture in that module clears `ARCHIMEDES_SESSION_FILE` and the process-wide
  override around every test — `CliRunner` runs in-process, so a `--session-file` test
  would otherwise leak its override into whatever ran next. The three existing `runner`
  fixtures (`test_cli.py`, `test_generate.py`, `test_api_url_resolution.py`) clear the
  variable too, for the same reason they redirect `HOME`: it overrides `HOME` outright, so
  a developer with it exported would run a different suite than CI does.
- **This is deliberately not a `cli/tests/conftest.py`**, which is where it belongs on
  looks. A conftest in that directory is imported as the bare module `conftest`, and
  `mcp-server/tests` reaches for that exact name (`from conftest import json_response`).
  I wrote it as a conftest first and `pytest cli/tests mcp-server/tests` — which passes on
  `main` — died with `cannot import name 'json_response' from 'conftest'`. Measured, not
  assumed; reverted; the reason is written down in the fixture's docstring so the next
  person does not re-introduce it. CI is unaffected either way (it runs the two suites as
  separate commands), and after the change that combined invocation passes 335.
- `mcp-server/tests/conftest.py` — clears the variable too, same reason as its existing
  `HOME` redirect.

```
cli/tests          122 passed          (was 102 — 20 new)
mcp-server/tests   213 passed
backend (CI cmd)   1 failed, 5790 passed, 4 skipped, 2 deselected in 32:33
ruff format --check .                clean
ruff check . --select E9,F63,F7,F40  clean   (the blocking gate's rule set)
make docs-check    links 1810 scanned / 0 broken · index 180/180 · staleness informational
```

**The one backend failure is a load artifact, not this diff.**
`test_security_hardening.py::test_startup_fails_without_encryption_key_in_production`
shells out to a subprocess that imports `archimedes.main` with a **30-second** timeout;
this laptop was running ~10 concurrent pytest suites from other worktrees at the time and
the import did not finish inside it (`subprocess.TimeoutExpired ... timed out after 30
seconds`). Re-run afterwards it passes on both trees:

```
this branch, whole file:              18 passed in 81.46s
clean origin/main export, that test:   1 passed in 12.28s
```

This PR touches no backend code — `pytest.ini` lists `cli` and `mcp-server` under
`norecursedirs`, so the backend suite does not even import what changed here, apart from
`mcp-server/src/archimedes_mcp/contract.py`, which `test_mcp_contract_drift.py` guards and
which passes (15 passed), alongside 85 passed across every backend test that reads a
`cli/` or `docs/` surface, re-run against the final tree.

The full (informational, non-blocking) `ruff check` reports the same 6 findings on this
branch as on `origin/main` — byte-identical lists, all in `cli/tests/` files this PR does
not touch. Nothing new was added.

No UI files are touched, so `ui` was not run.

## Not in this PR

- **`ARCHIMEDES_SESSION_PATH` / `--session-path` as aliases.** The issue names
  `ARCHIMEDES_SESSION_FILE` and `--session-file`; those are what shipped. Two names for one
  setting is a precedence rule waiting to drift.
- **A Windows lock.** `fcntl` is POSIX-only. Rather than an import error that would make
  the whole CLI unusable there, `_locked` degrades to no lock on a platform without it, and
  says so in its docstring; the lock tests skip rather than lie. CI, prod and dev are POSIX.
- **`docs/specs/agent-native-onboarding-spec.md`**, which mentions the file in a dated audit
  row. Its claim ("the CLI's answer is a 0600 file at `~/.config/archimedes/session.json`")
  is still true — that is the default — and rewriting a dated finding is worse than leaving
  it.
- **No `updated:` bump on `docs/agent-quickstart.md`.** `docs/CONVENTIONS.md` defines that
  date as "the date the *content* was last checked against reality" — the whole page. I
  added one verified paragraph; I did not re-verify the other eleven steps, so bumping it
  would be a claim I did not earn. (The staleness check is informational and green either
  way.)
- **No version bump.** `archimedes-cli` is not on PyPI yet, so 0.2.0 has not shipped
  anywhere for this to be a change to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx
