### PR TITLE
Correct the ELB-5xx rationale against the account, pin alarm periods (#1818 P5 review round)

### DIFF
--- a/backend/tests/test_outage_alarms_1818.py
+++ b/backend/tests/test_outage_alarms_1818.py
@@ -19,7 +19,8 @@ the site. So P5 is three gaps, of which Terraform owns two:
    The alarms guarded below close that; ``aurora_connections_wedge`` fires at
    ~03:48 and is the only reason this set is worth applying.
 2. **Detection latency.** 9m46s is the 5-of-5-minute window plus lag. The
-   unhealthy-hosts retune to 2-of-2 buys back ~6 minutes.
+   unhealthy-hosts retune to 2-of-2 drops three of the five one-minute
+   datapoints, so it buys back ~3 minutes; the 2m46s evaluation lag stays.
 3. **The page did not reach the owner.** Nothing in Terraform fixes that. What
    the code can do is refuse to leave the destination unchosen —
    ``var.owner_alert_email`` has no default — and refuse to let that choice be
@@ -102,6 +103,7 @@ ALARM_SPECS: dict[str, dict[str, object]] = {
         "statistic": "Maximum",
         "comparison_operator": "GreaterThanOrEqualToThreshold",
         "threshold": 1,
+        "period": 60,
         "window_s": 120,
     },
     # "HTTPCode_ELB_5XX_Count >= 5 in 5 minutes"
@@ -111,6 +113,7 @@ ALARM_SPECS: dict[str, dict[str, object]] = {
         "statistic": "Sum",
         "comparison_operator": "GreaterThanOrEqualToThreshold",
         "threshold": 5,
+        "period": 300,
         "window_s": 300,
     },
     # "ECS service MemoryUtilization max > 85% for 5 minutes"
@@ -120,6 +123,7 @@ ALARM_SPECS: dict[str, dict[str, object]] = {
         "statistic": "Maximum",
         "comparison_operator": "GreaterThanThreshold",
         "threshold": 85,
+        "period": 60,
         "window_s": 300,
     },
     # "ECS CPUUtilization > 90% for 10 minutes"
@@ -129,6 +133,7 @@ ALARM_SPECS: dict[str, dict[str, object]] = {
         "statistic": "Average",
         "comparison_operator": "GreaterThanThreshold",
         "threshold": 90,
+        "period": 60,
         "window_s": 600,
     },
     # "RDS DatabaseConnections > 30 for 15 minutes (today's wedge sat at 33)"
@@ -138,6 +143,7 @@ ALARM_SPECS: dict[str, dict[str, object]] = {
         "statistic": "Average",
         "comparison_operator": "GreaterThanThreshold",
         "threshold": 30,
+        "period": 300,
         "window_s": 900,
     },
 }
@@ -311,8 +317,8 @@ class TestThePagingDestinationIsChosenDeliberately:
         """``alerts_email`` is live, confirmed, and delivering — do not touch it.
 
         Its ``count`` gate is a real landmine (a bare apply without
-        ``TF_VAR_alarm_email`` unsubscribes the only destination the topic has
-        subscription this topic has), but that landmine predates #1818 P5 and closing it
+        ``TF_VAR_alarm_email`` unsubscribes the only subscription this topic
+        has), but that landmine predates #1818 P5 and closing it
         means capturing the applied address in ``terraform.tfvars`` — the
         owner's to do. What this PR must not do is *widen* it: adding another
         term to the condition would make a plain apply destroy the working
@@ -342,14 +348,31 @@ class TestOutageAlarmShapes:
 
     @pytest.mark.parametrize("name", ALARM_NAMES)
     def test_the_window_is_the_duration_the_issue_asks_for(self, name: str) -> None:
-        """``period × datapoints_to_alarm``, checked as a product.
+        """Both ``period`` and the ``period × datapoints_to_alarm`` product.
 
-        Pinning the two fields separately lets them drift apart while each
-        still reads plausibly on its own line — the shape that turned the
-        unhealthy-hosts alarm into a 5-minute window in the first place.
+        The product alone is NOT sufficient, and assuming it was is a real hole
+        this file shipped with. A ``Sum`` alarm applies its threshold *per
+        period*, so reshuffling ``alb_elb_5xx_count`` from 300 × 1 to 60 × 5
+        holds the product at 300s and keeps ``datapoints_to_alarm ==
+        evaluation_periods`` — passing both this test and the consecutive-
+        datapoints test — while silently changing the alarm from ">= 5 errors
+        in five minutes" to ">= 5 errors in each of five consecutive minutes",
+        i.e. >= 25. That is a 5x weakening with no failing test.
+
+        So ``period`` is pinned directly. The product is kept as well, because
+        it is what catches the two fields drifting apart while each still reads
+        plausibly on its own line — the shape that turned the unhealthy-hosts
+        alarm into a 5-minute window in the first place.
         """
         body = _alarm(name)
-        window_s = _int_attr(body, "period") * _int_attr(body, "datapoints_to_alarm")
+        period = _int_attr(body, "period")
+        assert period == ALARM_SPECS[name]["period"], (
+            f"{name} uses period {period}s but issue #1818 P5 specifies "
+            f"{ALARM_SPECS[name]['period']}s. For a Sum statistic the threshold applies "
+            f"PER PERIOD, so a shorter period with proportionally more datapoints is a "
+            f"threshold increase, not the same alarm."
+        )
+        window_s = period * _int_attr(body, "datapoints_to_alarm")
         assert window_s == ALARM_SPECS[name]["window_s"], (
             f"{name} breaches after {window_s}s but issue #1818 P5 specifies {ALARM_SPECS[name]['window_s']}s"
         )
@@ -401,13 +424,26 @@ class TestThresholdsAreTiedToTheIncident:
         )
 
     def test_the_elb_5xx_alarm_watches_the_balancer_not_the_target(self) -> None:
-        """The distinction the outage turned on.
+        """Two different metrics, and the alarm must stay on the ELB-side one.
 
         ``alb_5xx_high`` counts ``HTTPCode_Target_5XX_Count`` — 5xx the backend
-        produced. On 2026-09-03 the backend produced none; it produced nothing
-        at all, and the ALB synthesised 504s. Only the ELB-side metric sees
-        that, and it has no ``TargetGroup`` dimension — adding one selects
-        nothing and parks the alarm in INSUFFICIENT_DATA.
+        produced and the ALB relayed. This alarm counts
+        ``HTTPCode_ELB_5XX_Count`` — 5xx the balancer generated itself.
+
+        On 2026-09-03 the *ELB-side* metric published no datapoints at all (all
+        of ``HTTPCode_ELB_5XX/500/502/503/504_Count`` return zero datapoints for
+        the day, while ``RequestCount`` returns them over the same minutes), so
+        this alarm would not have fired. The only 5xx were four target-side
+        responses at 13:31–13:33Z, which is what put ``alb_5xx_rate_high``
+        (#418) into ALARM at 13:39:16Z. The alarm is therefore general ELB-side
+        cover for a metric nothing watched — 1,254 errors on UTC day
+        2026-08-20 — not an #1818 detector.
+
+        What this test pins is the split: ``HTTPCode_ELB_5XX_Count`` has no
+        ``TargetGroup`` dimension, so adding one selects nothing and parks the
+        alarm in INSUFFICIENT_DATA; and if ``alb_5xx_high`` ever moves off the
+        target-side metric, this alarm becomes a duplicate rather than a
+        complement.
         """
         body = _alarm("alb_elb_5xx_count")
         dimensions = _dimensions(body)

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -66,7 +66,8 @@ resource "aws_sns_topic_subscription" "alerts_email" {
 #       ramping). Those alarms are added below, and the connections one is the
 #       single highest-value line in this file: it fires at ~03:48.
 #   (b) DETECTION LATENCY. 9m46s is the 5-of-5-minute window plus evaluation
-#       lag. The retune to 2-of-2 below buys back ~6 minutes of that.
+#       lag. The retune to 2-of-2 below drops three of the five one-minute
+#       datapoints, so it buys back about three minutes of that.
 #   (c) THE PAGE DID NOT REACH THE OWNER. Six delivered emails, zero failures,
 #       and it still had to be discovered by hand. NOTHING IN TERRAFORM FIXES
 #       THAT. It is an address/channel decision — a mailbox that is actually
@@ -145,18 +146,25 @@ resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_hosts" {
   # fast tripwire.
   #
   # RE-TUNED AGAIN 2026-09-03 (issue #1818 P5, owner call): back to 2 minutes.
-  # MEASURED, not inferred: this alarm went OK -> ALARM at 13:38:46Z on an
-  # outage that began at 13:29 (CloudWatch alarm history, read 2026-09-03).
-  # 9m46s is the 5-of-5-minute window plus evaluation lag; 2-of-2 buys back
-  # about six of those minutes. Modest, and worth being clear-eyed about: six
-  # minutes was not what made this a 94-minute outage.
+  # MEASURED, not inferred (CloudWatch, read 2026-09-03): the incident began at
+  # 13:29Z; UnHealthyHostCount on this target group read 0 through 13:30Z and
+  # first read 2 at 13:31Z; this alarm went OK -> ALARM at 13:38:46Z. So the
+  # 9m46s decomposes as ~2 min before the ALB itself saw anything, 5 min of
+  # 5-of-5 window, and ~2m46s of evaluation/publication lag.
+  #
+  # 2-of-2 removes three of the five one-minute datapoints, so it fires about
+  # THREE minutes earlier — not the six an earlier draft of this comment
+  # claimed, which had quietly assumed the retuned alarm evaluates with no lag
+  # while the 5-of-5 alarm demonstrably lagged its own window by 2m46s.
+  # Modest, and worth being clear-eyed about: three minutes was not what made
+  # this a 94-minute outage.
   #
   # KNOWN COST, stated rather than discovered: the 2026-08-21 flapping was real
   # and this brings some of it back. `deployment_minimum_healthy_percent = 100`
   # (ecs.tf) means every rollout registers new targets — `initial` state counts
   # as unhealthy — while old ones drain, so expect transient fires on deploys,
   # and they go to a mailbox that already has an attention problem. If the
-  # noise proves worse than the six minutes, revert `datapoints_to_alarm` here
+  # noise proves worse than the three minutes, revert `datapoints_to_alarm` here
   # — that trade is the owner's, and the numbers on both sides are now known.
   alarm_name          = "${var.project_name}-alb-unhealthy-hosts"
   alarm_description   = "One or more backend targets are unhealthy for 2 min (#1818 P5)."
@@ -276,8 +284,10 @@ resource "aws_cloudwatch_metric_alarm" "aurora_connections_high" {
 #   ────────────────────────────────────    ────────────────────    ───────────
 #   Aurora connections 16 → 33, flat 11.5h  fires above 80          blind   → aurora_connections_wedge
 #   ECS MemoryUtilization 39% → 100%/90min  no ECS alarm at all     blind   → ecs_service_memory_high
-#   ALB 504s (ELB-generated, not target)    counts TARGET 5xx only  blind   → alb_elb_5xx_count
-#   UnHealthyHostCount = 2 from 13:29       fired at 13:38:46       slow    → retuned above to 2 min
+#   Target 5xx: four, 13:31-13:33Z          alb_5xx_rate_high       FIRED 13:39:16Z
+#     (the same four)                       alb_5xx_high (Sum > 10) stayed OK — four is not > 10
+#   ELB-generated 5xx: none at all, all day nothing watched it      unwatched → alb_elb_5xx_count
+#   UnHealthyHostCount = 2 from 13:31Z      fired at 13:38:46Z      slow    → retuned above to 2 min
 #   Aurora CPU ~4%, ECS CPU ~3%             cpu alarms              correctly quiet — never saturation
 #
 # HONESTY NOTE, because "we added alarms" is the kind of claim that rots.
@@ -290,16 +300,22 @@ resource "aws_cloudwatch_metric_alarm" "aurora_connections_high" {
 #                                      HOURS before the first alarm that
 #                                      actually fired on the day (13:38:46),
 #                                      while the fleet is still serving.
-#   ~13:32  alb_unhealthy_hosts        2-of-2 instead of 5-of-5: measured
-#                                      against the real 13:38:46 transition,
-#                                      worth about six minutes. Useful, small.
+#   ~13:36  alb_unhealthy_hosts        2-of-2 instead of 5-of-5 drops three of
+#                                      the five one-minute datapoints, so it
+#                                      fires ~3 min earlier. Measured:
+#                                      UnHealthyHostCount first breached 13:31Z
+#                                      and the 5-of-5 alarm transitioned at
+#                                      13:38:46Z. Useful, small.
 #   ~14:39  ecs_service_memory_high    the 39% → 100% ramp runs 13:31–15:01, so
 #                                      85% is crossed ~68 min in — a real
 #                                      detector, but 70 min into a 94-minute
 #                                      outage. Do not sell it as early warning.
-#   never   alb_elb_5xx_count          the ALB logged 2/1/1 504s per minute,
-#                                      four in the window, under a >= 5
-#                                      threshold at this traffic level.
+#   never   alb_elb_5xx_count          the ELB-side metric had NO datapoints at
+#                                      all on 2026-09-03 — the balancer
+#                                      generated no 5xx of its own. The alarm
+#                                      sits OK via treat_missing_data =
+#                                      notBreaching. It is general ELB-side
+#                                      cover, NOT an #1818 detector.
 #   never   ecs_service_cpu_high       CPU was 3% throughout.
 #
 # The last two are general saturation cover — they catch the ordinary shapes
@@ -312,13 +328,38 @@ resource "aws_cloudwatch_metric_alarm" "aurora_connections_high" {
 
 # The ALB's OWN 5xx, which is a different question from `alb_5xx_high` above.
 # That alarm counts HTTPCode_Target_5XX_Count — 5xx the backend produced and
-# the ALB relayed. On 2026-09-03 the backend produced no 5xx; it produced
-# nothing at all, and the ALB synthesised 504s because no target was healthy
-# and the one it tried timed out. Only HTTPCode_ELB_5XX_Count sees that.
+# the ALB relayed. This one counts HTTPCode_ELB_5XX_Count — 5xx the balancer
+# generated itself (typically 504: no healthy target, or the one it tried
+# timed out). Nothing in this account watched the ELB-side metric before.
+#
+# WHAT 2026-09-03 ACTUALLY SHOWS. An earlier revision of this comment had this
+# backwards, so it is written out with the query that settles it. Re-derived
+# from CloudWatch, account 037613907429 / us-east-1,
+# LoadBalancer = app/archimedes-alb/955aeff03e643d11:
+#
+#   * The balancer generated NO 5xx that day. HTTPCode_ELB_5XX_Count and the
+#     _500_/_502_/_503_/_504_ breakdowns each return ZERO datapoints for the
+#     whole of 2026-09-03, while RequestCount returns datapoints over the same
+#     minutes — so the metric was queried correctly and simply never published.
+#   * The only 5xx were four TARGET-side responses:
+#     HTTPCode_Target_5XX_Count = 2 / 1 / 1 at 13:31 / 13:32 / 13:33Z.
+#   * The target side was therefore NOT blind. `alb_5xx_rate_high` below
+#     (issue #418, metric math 100 * target_5xx / requests) went OK -> ALARM at
+#     13:39:16Z on exactly those four. `alb_5xx_high` stayed OK only because
+#     its threshold is 10 and four is not more than ten — not for want of a
+#     signal.
+#
+# So this alarm would NOT have fired on 2026-09-03 and it is NOT an #1818
+# detector. It is added as general ELB-side cover for a real recurring signal
+# that nothing watched: the same metric carried 1,254 errors on UTC day
+# 2026-08-20 (387 of them in the 04:00Z hour alone) and 306 on 2026-09-01.
 #
 # Dimensioned on LoadBalancer alone: HTTPCode_ELB_5XX_Count has no TargetGroup
-# dimension (AWS/ApplicationELB publishes it per LB and per AZ). Adding one
-# would silently select nothing and the alarm would sit in INSUFFICIENT_DATA.
+# dimension (list-metrics returns LoadBalancer and LoadBalancer+AvailabilityZone
+# only). Adding one would silently select nothing and the alarm would sit in
+# INSUFFICIENT_DATA. treat_missing_data = "notBreaching" for the reason the
+# 2026-09-03 numbers make concrete: the metric is ABSENT, not zero, on a day
+# with no ELB-side errors.
 #
 # Window caveat, stated because it bounds the claim: CloudWatch evaluates fixed
 # 5-minute windows, so four errors in one window plus three in the next never

--- a/infra/runbooks/disaster-recovery.md
+++ b/infra/runbooks/disaster-recovery.md
@@ -68,7 +68,11 @@ aws cloudwatch get-metric-statistics --namespace AWS/SNS \
    ten hours earlier — Aurora connections flat at 33 from 03:33, ECS memory
    ramping. Fixed below: the new connections alarm fires at ~03:48.
 2. **Detection latency.** 9m46s is the 5-of-5-minute window plus evaluation
-   lag. `-alb-unhealthy-hosts` is retuned to 2-of-2, worth about six minutes.
+   lag. `-alb-unhealthy-hosts` is retuned to 2-of-2, which drops three of the
+   five one-minute datapoints and so fires about **three** minutes earlier.
+   (Measured: `UnHealthyHostCount` read 0 through 13:30Z, first read 2 at
+   13:31Z, and the 5-of-5 alarm transitioned at 13:38:46Z — a 2m46s evaluation
+   lag on top of the window, which the retune does not remove.)
 3. **The page did not reach the owner.** Six delivered emails and it still had
    to be found by hand. **No Terraform change fixes this.** What the code can
    do is refuse to let the question go unanswered: `var.owner_alert_email` has
@@ -83,6 +87,15 @@ address.** SNS keys a subscription by (topic, protocol, endpoint), so both
 resources would hold one `SubscriptionArn`, and any later apply that dropped
 either would `Unsubscribe` the one the other still claims — zero subscribers,
 with state saying there is one. The precondition blocks it.
+
+> **Before your next incident, populate `infra/terraform.tfvars`.**
+> `owner_alert_email` is deliberately defaultless, so **every** Terraform
+> invocation in `infra/` — including the emergency `-target`ed recreates in
+> §1 (host loss) and §4 (NAT down) below — now fails with
+> `Error: No value for required variable` until it has a value. `-target` does
+> **not** exempt root-module variables. The error text says nothing about why
+> an unrelated recreate is blocked, so set this now rather than discovering it
+> at 03:00 with the site down.
 
 **Check the subscription is confirmed** after any change (an unconfirmed one
 looks identical to a working one from Terraform's side):
@@ -99,8 +112,8 @@ A `SubscriptionArn` of `PendingConfirmation` means no page will be delivered.
 
 | Alarm | Fires when | Why this number |
 |---|---|---|
-| `archimedes-alb-unhealthy-hosts` | `UnHealthyHostCount >= 1` for **2 min** | Retuned from 5 min. Measured: it fired at 13:38:46 on an outage that began at 13:29. 2-of-2 buys back ~6 min. Costs some deploy-time flapping — revert `datapoints_to_alarm` if that trade goes the other way. |
-| `archimedes-alb-elb-5xx-high` | `HTTPCode_ELB_5XX_Count >= 5` in 5 min | The **balancer's own** 5xx (504 = no healthy target). `-alb-target-5xx-high` counts 5xx the backend produced, and it never fired on 2026-09-03 — the backend produced nothing at all. |
+| `archimedes-alb-unhealthy-hosts` | `UnHealthyHostCount >= 1` for **2 min** | Retuned from 5 min. Measured: the ALB first saw an unhealthy target at 13:31Z and this alarm fired at 13:38:46Z. Dropping three of five one-minute datapoints buys back ~3 min (not the ~6 an earlier draft claimed — the 2m46s evaluation lag stays). Costs some deploy-time flapping — revert `datapoints_to_alarm` if that trade goes the other way. |
+| `archimedes-alb-elb-5xx-high` | `HTTPCode_ELB_5XX_Count >= 5` in 5 min | The **balancer's own** 5xx (504 = no healthy target), which nothing watched before. **Not a 2026-09-03 detector** — the ELB-side metric published *no datapoints at all* that day. General cover for a real recurring signal: 1,254 ELB-side 5xx on UTC day 2026-08-20, 306 on 2026-09-01. |
 | `archimedes-ecs-backend-memory-high` | `MemoryUtilization` **max** > 85% for 5 min | The wedged tasks ramped 39% → 100% over 90 min. `max`, not average — fresh replacement tasks sat near idle and would have averaged it away. |
 | `archimedes-ecs-backend-cpu-high` | `CPUUtilization` avg > 90% for 10 min | General saturation cover: average, because the autoscaling policy tracks average against a 60% target, so it means "the autoscaler is out of room". **Would not have fired on 2026-09-03** — CPU was 3%. |
 | `archimedes-aurora-connections-elevated` | `DatabaseConnections` > 30 for 15 min | Connections went 16 → 33 and sat **flat** at 33 for 11.5 h at 4% CPU — sessions parked on a lock, not load. 30 sits just under the observed wedge; the `>80` alarm is a pool-pressure alarm, and it never fired. |
@@ -108,11 +121,14 @@ A `SubscriptionArn` of `PendingConfirmation` means no page will be delivered.
 Replayed against the timeline, three of the five would have fired and two would
 not: `-aurora-connections-elevated` at **~03:48** — nearly ten hours before the
 first alarm that actually fired that day, and the single reason this set is
-worth applying — `-alb-unhealthy-hosts` at ~13:32, and
+worth applying — `-alb-unhealthy-hosts` at ~13:36, and
 `-ecs-backend-memory-high` at ~14:39 (70 minutes into a 94-minute outage; a
-real detector, not early warning). `-alb-elb-5xx-high` saw four 504s against a
-threshold of five and `-ecs-backend-cpu-high` never left single digits. Do not
-read "five alarms" as five nets under this failure.
+real detector, not early warning). `-alb-elb-5xx-high` would **not** have
+fired: the ELB-side metric had no datapoints at all on 2026-09-03 (the only
+5xx that day were four *target*-side responses at 13:31–13:33Z, which is what
+put `-alb-5xx-rate-high` into ALARM at 13:39:16Z). `-ecs-backend-cpu-high`
+never left single digits. Do not read "five alarms" as five nets under this
+failure.
 
 #### Applying them
 
@@ -167,6 +183,16 @@ alarm (see `infra/cloudwatch.tf`), or `https://archimedes-arc.com/` 502/503.
    cd infra && terraform plan -target=aws_instance.archimedes
    terraform apply -target=aws_instance.archimedes
    ```
+   > **Two caveats, both verified 2026-09-03.** (a) `aws_instance.archimedes`
+   > **no longer exists in the configuration** — commit `652225b8` removed it
+   > with the EC2 decommission, and the web tier is Fargate now, so this recipe
+   > and the `archimedes-ec2-status-check-failed` alarm named above are both
+   > stale. Rewriting §1 for the ECS topology is out of scope here (#1818 P5 is
+   > observability); it is flagged so nobody follows it mid-incident.
+   > (b) Whatever replaces it will need `owner_alert_email` set in
+   > `terraform.tfvars` — `-target` does **not** exempt root-module variables.
+   > See § Paging.
+
    `user-data.sh` re-bootstraps Docker + pulls the stack on first boot. The ALB
    target group re-attaches via `aws_lb_target_group_attachment.backend`.
 
@@ -232,6 +258,9 @@ outage (ECS/ALB keep routing to the healthy AZ's tasks).
    cd infra && terraform plan -target='aws_instance.nat[0]'   # or [1] for the other AZ
    terraform apply -target='aws_instance.nat[0]'
    ```
+   (Needs `owner_alert_email` in `terraform.tfvars` — `-target` does not
+   exempt root-module variables. See § Paging.)
+
    `aws_route.private_nat` (`vpc.tf`) points at
    `aws_instance.nat[*].primary_network_interface_id` — a NEW instance gets a
    NEW ENI, so this targeted apply also updates the affected private route


### PR DESCRIPTION
Part of #1818 (P5).

Do not merge — owner vets first.

Follow-up to #1826, which **merged at 2026-09-04T00:53:31Z while this review round was in flight**. The alarms it added are not applied yet (`describe-alarms` returns none of `-alb-elb-5xx-high`, `-ecs-backend-memory-high`, `-ecs-backend-cpu-high`, `-aurora-connections-elevated`, and `-alb-unhealthy-hosts` is still at the old `> 0`, 5-of-5), so these corrections land before the apply rather than after it.

**No alarm changes.** Every resource, metric, threshold, dimension and window from #1826 is byte-identical. This PR corrects claims, adds one guard, and fixes a doc landmine.

## 1. Blocker — the ELB-5xx rationale was backwards

#1826 justified `alb_elb_5xx_count` with *"on 2026-09-03 the backend produced no 5xx; it produced nothing at all, and the ALB synthesised 504s"*, and tabulated the target-5xx alarm as `blind`. Re-derived from the same account (`037613907429` / `us-east-1`, `LoadBalancer = app/archimedes-alb/955aeff03e643d11`), the account says the opposite:

| claim in #1826 | what the account returns |
|---|---|
| the ALB synthesised 504s | `HTTPCode_ELB_5XX_Count` and the `_500_`/`_502_`/`_503_`/`_504_` breakdowns each return **zero datapoints** for all of 2026-09-03. `RequestCount` returns datapoints over the same minutes, so the query is sound. |
| "the ALB logged 2/1/1 504s per minute, four in the window" | Those are `HTTPCode_Target_5XX_Count` = 2/1/1 at 13:31/13:32/13:33Z — **target-side**. |
| target 5xx was `blind` | `archimedes-alb-5xx-rate-high` (#418, metric math `IF(reqs >= 50, 100 * m5xx / reqs, 0)` over target 5xx ÷ requests) went **OK → ALARM at 13:39:16Z** on exactly those four. |
| `-alb-target-5xx-high` "never fired — the backend produced nothing" | It never fired because its threshold is **10** and four is not more than ten. `describe-alarm-history` shows it had **no state change at all** that day. |

```bash
# zero datapoints, all day, every ELB-generated 5xx metric
aws cloudwatch get-metric-statistics --namespace AWS/ApplicationELB \
  --metric-name HTTPCode_ELB_5XX_Count \
  --dimensions Name=LoadBalancer,Value=app/archimedes-alb/955aeff03e643d11 \
  --start-time 2026-09-03T00:00:00Z --end-time 2026-09-04T00:00:00Z \
  --period 86400 --statistics Sum
```

The **alarm is still right** — correct metric, `LoadBalancer`-only dimension (`list-metrics` confirms this metric publishes at `LoadBalancer` and `LoadBalancer+AvailabilityZone` only, never `TargetGroup`), and `treat_missing_data = "notBreaching"` is exactly right for a metric that is *absent*, not zero, on a clean day. The conclusion "would not have fired" was also right. Only the stated reason was false.

So it is re-justified as what it actually is: **general ELB-side cover for a live metric nothing watched** — 1,254 errors on UTC day 2026-08-20 (387 in the 04:00Z hour alone) and 306 on 2026-09-01 — explicitly **not** an #1818 detector.

Corrected on all five tracked surfaces (`cloudwatch.tf` verdict table, its honesty note, the alarm's comment block, the DR runbook table + replay paragraph, the test docstring), plus #1826's body and issue comment 5532557453, both edited.

> Note on the numbers: an earlier draft of this correction used "293/hour on 2026-08-19". CloudWatch prints bucket timestamps in **local** time (`-05:00`), and that figure is really the 03:00**Z** hour of UTC day **2026-08-20**. Every figure above is stated in UTC after explicit conversion.

## 2. The unhealthy-hosts retune is worth ~3 minutes, not ~6

Measured: `UnHealthyHostCount` read 0 through 13:30Z and first read 2 at **13:31Z**; the 5-of-5 alarm transitioned at **13:38:46Z**. The 9m46s decomposes as ~2 min before the ALB saw anything + 5 min of window + **2m46s of evaluation lag**.

2-of-2 removes three of the five one-minute datapoints, so it fires ~3 min earlier. The lag does not go away. The old "~6 minutes" had quietly assumed the retuned alarm evaluates with zero lag while the 5-of-5 alarm demonstrably did not. Also reconciles `9m47s` (PR body + issue comment) against `9m46s` (code, runbook, tests) — **9m46s** everywhere now.

## 3. New guard — the window test missed a 5× weakening of a `Sum` alarm

`test_the_window_is_the_duration_the_issue_asks_for` asserted only `period × datapoints_to_alarm`. For a `Sum` statistic the threshold applies **per period**, so reshuffling `alb_elb_5xx_count` from `300 × 1 × 1` to `60 × 5 × 5` holds the product at 300s, keeps `datapoints_to_alarm == evaluation_periods`, passes the consecutive-datapoints test too — and silently changes the alarm from ">= 5 errors in five minutes" to ">= 5 in *each of* five consecutive minutes", i.e. **>= 25**.

`period` is now pinned per alarm in `ALARM_SPECS` and asserted directly.

**Shown red on exactly that reshuffle**, which was green before:

```
E   AssertionError: alb_elb_5xx_count uses period 60s but issue #1818 P5 specifies 300s.
    For a Sum statistic the threshold applies PER PERIOD, so a shorter period with
    proportionally more datapoints is a threshold increase, not the same alarm.
    assert 60 == 300
FAILED backend/tests/test_outage_alarms_1818.py::TestOutageAlarmShapes::
       test_the_window_is_the_duration_the_issue_asks_for[alb_elb_5xx_count]
=================== 1 failed, 92 passed in 1.52s ====================
```

Before this PR the same mutation gave `93 passed`. Reverted by editing; `diff` against the pre-mutation copy is byte-identical. The pre-existing 5-of-5 proof still holds (`alb_unhealthy_hosts breaches after 300s but issue #1818 P5 specifies 120s`, 1 failed / 40 passed).

## 4. `owner_alert_email` blocks every emergency `terraform` recipe

It is deliberately defaultless (that is the spec), but the consequence was not documented: **`-target` does not exempt root-module variables**, so the runbook's own incident recipes now fail with an error that says nothing about why an unrelated recreate is blocked. Verified:

```
$ terraform plan -input=false -target='aws_instance.nat[0]'
│ Error: No value for required variable
│  276: variable "owner_alert_email" {
```

Warned in the new Paging section and at both recipes (§1 host loss, §4 NAT down).

**Found while annotating §1:** `aws_instance.archimedes` **no longer exists in the configuration** — commit `652225b8` removed it with the EC2 decommission, and the web tier is Fargate. That recipe and the `archimedes-ec2-status-check-failed` alarm it cites are both dead. Flagged in place so nobody follows it mid-incident; rewriting §1 for the ECS topology is out of scope here (see *Left out*).

## 5. Minor

- Repaired a sentence mangled by `8976626f` in `test_the_working_subscription_is_left_alone`'s docstring ("the only destination the topic has subscription this topic has" → "the only subscription this topic has").
- #1826's body published the full prod platform-admin wallet while every tracked file truncates it to `0x2a29…5105`. Truncated in the body to match. (Public on-chain address, not a secret, but it names which wallet holds the publish bypass.)

## Tests

- `python -m pytest -m "not integration" --tb=short -q -p no:cacheprovider` (repo root): **6209 passed, 4 skipped, 2 deselected, 0 failed** (18m56s), run on the frozen tree at `f7ee2fd2` with `git status --porcelain` empty. No pre-existing failures to attribute.
- CI on `f7ee2fd2`: **19 checks pass, 1 skipping, 0 failures** — Backend unit tests (15m4s), Frontend + Better Auth, Analytics engine, Ruff, all three `Infra — terraform fmt + validate` roots.
- `backend/tests/test_outage_alarms_1818.py` + `test_cloudwatch_alarms.py`: **93 passed**
- `cd ui && npm ci --silent && npm test`: **1040 passed, 0 failed** (no `ui/` files touched; count rose from main)
- `terraform fmt -check -recursive .` clean; `terraform init -backend=false && terraform validate` → *Success! The configuration is valid.*
- `ruff format --check .` → *745 files already formatted*; `ruff check --select E9,F63,F7,F40,F82 .` → *All checks passed!*
- **No `terraform plan` diff to report:** the only `.tf` edits are comments. #1826's plan (`Plan: 5 to add, 1 to change, 0 to destroy`, no destroys/replaces) stands unchanged and is still the apply to run.

## Left out, and why

- **Rewriting DR §1 for Fargate.** The host-loss recipe is stale and now says so. Replacing it needs the current ECS recovery procedure, which is an architecture question, not an observability one — worth its own issue.
- **Everything #1826 listed as left out** (gap 3's channel decision, P1–P4, the alarm drill, `alarm_email`'s tfvars value, the `PAPER_ADVANCE_ENABLED` drift — still `"true"` on main, the memory-ramp cause, Slack/PagerDuty). Unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx
