### PR TITLE
[security] Secret scanning ignores the brief-screen PII fixtures (synthetic credentials by design)

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,11 @@
+# GitHub secret scanning: paths whose contents are DELIBERATELY key-shaped.
+#
+# backend/tests/fixtures/brief_screen/red.jsonl holds synthetic credentials
+# (an AWS example key, a patterned Google-API-key lookalike, ghp_/xoxb_/sk-
+# lookalikes, a PEM header) so backend/archimedes/services/brief_screen.py can
+# prove it REFUSES them before any prompt is built (#1801, PR #1835). GitHub's
+# scanner matches the same shapes and paged the owner on 2026-09-03 (alert #1,
+# "Google API Key", validity unknown — it is not a real key). Nothing under
+# this directory is a live secret; real secrets live in SSM /archimedes/prod/.
+paths-ignore:
+  - "backend/tests/fixtures/brief_screen/**"


### PR DESCRIPTION
Part of #1801.

GitHub secret-scanning alert #1 ("Google API Key", 2026-09-03) fired on `backend/tests/fixtures/brief_screen/red.jsonl` from PR #1835. Every credential in that file is synthetic (`AKIAIOSFODNN7EXAMPLE` is AWS's documented example key; the Google-shaped value is a patterned lookalike found nowhere else in any branch) and exists so `brief_screen.py` can prove it refuses key-shaped input before any prompt is built. GitHub's scanner matches the same shapes.

This adds `.github/secret_scanning.yml` with `paths-ignore` for that fixture directory so future rows do not page the owner. Real secrets live in SSM under `/archimedes/prod/`; nothing under the fixture path is live.

Do not merge — owner vets first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx