### PR TITLE
#1818 P2 follow-up: savepoint outside the try, and a cycle guard that sees module-level get_session

### DIFF
--- a/backend/archimedes/services/paper_trace.py
+++ b/backend/archimedes/services/paper_trace.py
@@ -437,8 +437,11 @@ def resolve_paper_hashes(session, arxiv_ids: list[str]) -> list[str]:
     ``except Exception`` would catch a ``PendingRollbackError`` for every
     remaining deployment and the final ``session.commit()`` would raise, i.e.
     the fail-soft return below would be a lie about a whole wedged cycle.
-    ``session.begin_nested()`` scopes the damage to this query, so the caller's
-    work before it survives and its work after it still commits. A
+    ``session.begin_nested()`` scopes the CORPUS QUERY's damage, so the
+    caller's work after it still commits. What the savepoint does NOT scope is
+    the caller's work BEFORE it: ``begin_nested()`` flushes any pending ORM
+    state first, outside the savepoint it is about to open — see the comment at
+    the call, which is why that call sits outside the ``try``. A
     connection-level failure is not recoverable either way — but then the
     cycle's own writes were never going to commit, so nothing is being
     laundered.
@@ -467,8 +470,26 @@ def resolve_paper_hashes(session, arxiv_ids: list[str]) -> list[str]:
 
     from archimedes.models.corpus_store import PaperRecord
 
+    # The savepoint is opened OUTSIDE the ``try``, deliberately.
+    # ``begin_nested()`` FLUSHES before it emits any SAVEPOINT:
+    # ``SessionTransaction.__init__`` calls ``_take_snapshot``, which runs
+    # ``self.session.flush()`` for a BEGIN_NESTED origin (sqlalchemy 2.0,
+    # ``orm/session.py``), and ``SessionLocal`` is ``autoflush=False`` — so the
+    # caller's pending ORM rows are written by this function's own savepoint,
+    # before that savepoint exists and outside its protection.
+    #
+    # With this call inside the ``try``, an ``IntegrityError`` from THAT flush
+    # — a ``DBAPIError`` like any other — was caught by the corpus handler
+    # below. Two lies at once: the trace was stored and HASHED with
+    # ``consulted_paper_hashes=[]`` while the corpus was perfectly healthy, and
+    # on PostgreSQL the caller's transaction was already aborted with no
+    # savepoint to roll back to — exactly the wedge the savepoint exists to
+    # prevent, manufactured by the savepoint's own flush. Out here that failure
+    # reaches the caller as the honest per-deployment failure it is, and the
+    # catch covers the corpus query and nothing else.
+    nested = session.begin_nested()
     try:
-        with session.begin_nested():
+        with nested:
             rows = session.query(PaperRecord).filter(PaperRecord.arxiv_id.in_(sorted(set(wanted)))).all()
     except DBAPIError:
         logger.warning("paper trace: corpus content-hash lookup failed — recording no consulted hashes", exc_info=True)

--- a/backend/tests/services/test_paper_trace.py
+++ b/backend/tests/services/test_paper_trace.py
@@ -556,9 +556,14 @@ class TestResolvePaperHashesAgainstTheCorpus:
                     status="active",
                 )
             )
-            # Deliberately NOT flushed: pending ORM state is the harder case —
-            # a savepoint that opened before the caller's own work would roll
-            # it back along with the failed query.
+            # Deliberately NOT flushed. Note what actually happens to it:
+            # ``begin_nested()`` flushes pending ORM state BEFORE it opens the
+            # savepoint, so this row is written by the lookup's own flush and
+            # is never inside the savepoint at all — which is why the failed
+            # corpus query below cannot take it with it. (The flush being
+            # outside the savepoint is also why that call sits outside
+            # ``resolve_paper_hashes``' ``try``; see
+            # ``test_a_caller_write_that_fails_is_not_laundered_into_a_corpus_outage``.)
             savepoints.clear()  # the caller's own work is not what is being measured
 
             with caplog.at_level("WARNING"):
@@ -583,11 +588,97 @@ class TestResolvePaperHashesAgainstTheCorpus:
 
         with get_session() as session:
             assert session.get(PaperDeployment, "dep-1818-p2") is not None, (
-                "the savepoint rolled back the caller's earlier work, not just the corpus query"
+                "the caller's earlier work did not survive the corpus outage — the savepoint's flush "
+                "wrote it before the savepoint opened, so only the corpus query should have rolled back"
             )
             assert session.get(PaperDeployment, "dep-1818-p2-after") is not None, (
                 "the caller could not write after the corpus outage — the transaction was aborted"
             )
+
+    def test_a_caller_write_that_fails_is_not_laundered_into_a_corpus_outage(self, caplog):
+        """The savepoint's own FLUSH must not be swallowed as an outage.
+
+        ``session.begin_nested()`` is not free of the caller's state.
+        ``SessionTransaction.__init__`` calls ``_take_snapshot``, which runs
+        ``self.session.flush()`` for a BEGIN_NESTED origin BEFORE the savepoint
+        is installed (sqlalchemy 2.0 ``orm/session.py``), and ``SessionLocal``
+        is ``autoflush=False`` — so the caller's pending ORM rows are written
+        to the database by this function's own savepoint, outside it.
+
+        With ``begin_nested()`` inside the ``try``, an ``IntegrityError`` from
+        THAT flush — a ``DBAPIError`` like any other — was caught by the
+        corpus-outage handler. Two lies at once: the trace was stored and
+        HASHED with ``consulted_paper_hashes=[]`` while the corpus was
+        perfectly healthy, and on PostgreSQL the caller's transaction was
+        already aborted with no savepoint to roll back to — precisely the
+        wedge (``PendingRollbackError`` for every remaining deployment, a
+        raising ``commit()``) the savepoint exists to prevent.
+
+        Reachable in the cycle: ``_publish_decision_traces`` does
+        ``session.add(PaperDecisionTrace(...))`` in its loop and can then raise
+        ``PaperTraceCoverageError``; ``advance_all`` catches it per deployment
+        and moves on WITHOUT a rollback, so the next deployment's
+        ``resolve_paper_hashes`` is the thing that flushes the previous one's
+        pending rows.
+
+        The corpus here is HEALTHY. Only the caller's own row is bad, so the
+        error must reach the caller — never a WARNING that blames the corpus.
+        """
+        from archimedes.db import get_session
+        from archimedes.models.paper_store import PaperDailyReturn, PaperDeployment
+        from sqlalchemy.exc import IntegrityError
+
+        self._seed(arxiv_id="0706.1497", title="Faber", content_hash="c" * 64)
+        with get_session() as session:
+            session.add(
+                PaperDeployment(
+                    id="dep-flush",
+                    strategy_id="aa11bb22cc33dd44",
+                    spec_json="{}",
+                    deployed_at=date(2026, 9, 3),
+                    status="active",
+                )
+            )
+            session.flush()
+            session.add(PaperDailyReturn(deployment_id="dep-flush", date=date(2026, 1, 2), daily_return=0.01))
+            session.commit()
+
+        with get_session() as session:
+            # The caller's pending row duplicates (deployment_id, date) — it
+            # cannot flush. Nothing is wrong with the corpus.
+            session.add(PaperDailyReturn(deployment_id="dep-flush", date=date(2026, 1, 2), daily_return=0.02))
+
+            with caplog.at_level("WARNING"), pytest.raises(IntegrityError):
+                resolve_paper_hashes(session, ["0706.1497"])
+
+            assert not [r for r in caplog.records if "content-hash lookup failed" in r.getMessage()], (
+                "a CALLER-side write failure was reported as a corpus outage — the trace would be hashed "
+                "with consulted_paper_hashes=[] while the corpus was healthy, and on PostgreSQL the "
+                "caller's transaction is aborted with no savepoint to roll back to (#1818 P2)"
+            )
+
+    def test_a_healthy_corpus_still_resolves_with_a_pending_caller_row(self):
+        """The same shape with a row that flushes CLEANLY still resolves.
+
+        Guards the fix from over-correcting into "any pending state breaks the
+        lookup": the flush is the caller's, so when it succeeds the corpus
+        query must run normally on top of it.
+        """
+        from archimedes.db import get_session
+        from archimedes.models.paper_store import PaperDeployment
+
+        self._seed(arxiv_id="0706.1497", title="Faber", content_hash="c" * 64)
+        with get_session() as session:
+            session.add(
+                PaperDeployment(
+                    id="dep-flush-ok",
+                    strategy_id="aa11bb22cc33dd44",
+                    spec_json="{}",
+                    deployed_at=date(2026, 9, 3),
+                    status="active",
+                )
+            )
+            assert resolve_paper_hashes(session, ["0706.1497"]) == ["0706.1497:" + "c" * 64]
 
     def test_the_savepoint_is_released_not_leaked_on_the_healthy_path(self):
         """The other side of the same mechanism: a lookup that SUCCEEDS must

--- a/backend/tests/test_paper_trace_pipeline.py
+++ b/backend/tests/test_paper_trace_pipeline.py
@@ -970,9 +970,20 @@ async def test_the_advance_cycle_opens_no_second_session(monkeypatch):
 
     So the guard is not about ``papers`` or about DDL, both of which P1 already
     moved off the cycle path: it is that the cycle is ONE connection, whatever
-    anyone later adds to it. ``archimedes.db.get_session`` is instrumented for
-    the whole advance; exactly one call is allowed, the cycle's own, and the
-    failure message names the file and line of every extra opener.
+    anyone later adds to it. Exactly one session may be opened for the whole
+    advance, the cycle's own, and the failure message names the file and line
+    of every extra opener.
+
+    ``archimedes.db.SessionLocal`` is what is instrumented, NOT ``get_session``.
+    Patching ``get_session`` only intercepts callers that resolve the name at
+    call time; this repo's dominant idiom is a module-level ``from archimedes.db
+    import get_session`` (``api/user_routes.py``, ``api/wallet_routes.py``,
+    ``marketplace/service.py``, ``services/corpus_service.py``,
+    ``scripts/run_backtests.py``, …), and those bindings are invisible to that
+    patch — a second session opened through one of them left this guard GREEN.
+    ``get_session()`` is ``return SessionLocal()``, resolving the module global
+    at call time, so instrumenting the factory counts every route to a session
+    including those bindings.
 
     The corpus row is seeded so the lookup genuinely resolves — a guard that
     passed because ``resolve_paper_hashes`` returned early on an empty corpus
@@ -995,14 +1006,20 @@ async def test_the_advance_cycle_opens_no_second_session(monkeypatch):
     monkeypatch.setattr(paper_trading, "replay_spec_with_decisions", one_decision)
 
     opens: list[str] = []
-    real_get_session = db_module.get_session
+    real_session_local = db_module.SessionLocal
+    db_file = db_module.__file__
 
-    def _recording_get_session():
-        caller = traceback.extract_stack()[-2]
+    def _recording_session_local(*args, **kwargs):
+        # Name the REAL opener: drop this wrapper, then any ``archimedes/db.py``
+        # frame, since ``get_session`` is only ``return SessionLocal()``. A
+        # future direct ``SessionLocal()`` caller is attributed just as
+        # precisely, which a fixed stack index would not manage.
+        stack = traceback.extract_stack()[:-1]
+        caller = next((f for f in reversed(stack) if f.filename != db_file), stack[-1])
         opens.append(f"{caller.filename}:{caller.lineno} in {caller.name}()")
-        return real_get_session()
+        return real_session_local(*args, **kwargs)
 
-    monkeypatch.setattr(db_module, "get_session", _recording_get_session)
+    monkeypatch.setattr(db_module, "SessionLocal", _recording_session_local)
 
     store = _Store()
     with _store(store):

--- a/docs/incidents/2026-09-03-paper-advance-ddl-wedge.md
+++ b/docs/incidents/2026-09-03-paper-advance-ddl-wedge.md
@@ -149,19 +149,47 @@ anything takes an exclusive lock on `papers` (a migration, a `VACUUM FULL`, a ha
    `papers` table would stop costing this lookup and start costing the cycle — every remaining
    deployment failing on `PendingRollbackError` and `session.commit()` raising. That would make
    the function's documented fail-soft return a lie about a wedged cycle.
-   `session.begin_nested()` scopes the failure to the query, so the caller's earlier work
-   survives and its later work still commits. A connection-level failure is still fatal, as it
-   must be — the cycle's writes were never going to commit either way.
+   `session.begin_nested()` scopes the failure to the query, so the caller's later work still
+   commits. A connection-level failure is still fatal, as it must be — the cycle's writes were
+   never going to commit either way.
+
+   **The savepoint does not cover the caller's work BEFORE it, and the call is deliberately
+   outside the `try`.** `session.begin_nested()` FLUSHES first: `SessionTransaction.__init__`
+   calls `_take_snapshot`, which runs `session.flush()` for a BEGIN_NESTED origin before the
+   savepoint is installed (SQLAlchemy 2.0 `orm/session.py`), and `SessionLocal` is
+   `autoflush=False` — so the caller's pending ORM rows are written by this lookup's own
+   savepoint, outside it. With `begin_nested()` inside the `try` (as first shipped), an
+   `IntegrityError` from that flush — a `DBAPIError` like any other — was caught by the corpus
+   handler: the trace was stored and HASHED with `consulted_paper_hashes = []` against a
+   perfectly healthy corpus, and on PostgreSQL the caller's transaction was already aborted with
+   no savepoint to roll back to — the exact wedge this savepoint exists to prevent, manufactured
+   by the savepoint. Reachable in the cycle: `_publish_decision_traces` adds `PaperDecisionTrace`
+   rows in its loop and can then raise `PaperTraceCoverageError`, which `advance_all` catches per
+   deployment WITHOUT rolling back, so the next deployment's `resolve_paper_hashes` is what
+   flushes the previous one's pending rows. Taking the savepoint outside the `try` sends that
+   failure to the caller as the honest per-deployment failure it is.
 
 Guards (all hermetic, tmp-file SQLite):
 
 - `backend/tests/test_paper_trace_pipeline.py::test_the_advance_cycle_opens_no_second_session`
-  instruments `archimedes.db.get_session` for the whole of `advance_all` and allows exactly one
+  instruments `archimedes.db.SessionLocal` for the whole of `advance_all` and allows exactly one
   call — the cycle's own — naming the file and line of any extra opener. Shown red by
   reinstating the old `with get_session() as session:` inside `resolve_paper_hashes`: *"the
-  advance cycle opened 2 sessions, not 1 … Openers: ['…/paper_trace.py:472 in
+  advance cycle opened 2 sessions, not 1 … Openers: ['…/paper_trace.py:494 in
   resolve_paper_hashes()']"*. The guard is about the CYCLE being one connection, not about
   `papers` or about DDL, so it also catches whatever is added to the cycle path next.
+
+  It instruments the FACTORY, not `get_session`, and that distinction is the whole of the claim
+  above. Patching `get_session` only intercepts callers that resolve the name at call time; this
+  repo's dominant idiom is a module-level `from archimedes.db import get_session`
+  (`api/user_routes.py`, `api/wallet_routes.py`, `marketplace/service.py`,
+  `services/corpus_service.py`, `scripts/run_backtests.py`, …), and those bindings are invisible
+  to it — as first shipped, a second session opened through one left the guard GREEN, so "catches
+  whatever is added next" was not true for the way most of this repo opens sessions.
+  `get_session()` is only `return SessionLocal()`, resolving the module global at call time, so
+  instrumenting `SessionLocal` counts every route to a session. Shown red on all three idioms in
+  `_publish_decision_traces`: a module-level-bound `get_session`, a direct `db.SessionLocal()`,
+  and the original in-function `get_session()`.
 - `test_the_outage_is_contained_by_a_savepoint_not_by_luck` drops the `papers` table for real
   and asserts the savepoint/rollback through SQLAlchemy's own connection events. The events are
   the guard rather than "the caller could still write afterwards", because SQLite does not abort
@@ -172,6 +200,12 @@ Guards (all hermetic, tmp-file SQLite):
 - `test_it_reads_on_the_session_it_was_given_and_opens_none` arms `get_session` to RAISE at unit
   scale, and `test_the_signature_requires_a_session_it_can_never_open_one` pins the absence of
   the `= None` default.
+- `test_a_caller_write_that_fails_is_not_laundered_into_a_corpus_outage` holds the savepoint's own
+  flush honest: a pending caller row that cannot flush, against a HEALTHY corpus, must reach the
+  caller as an `IntegrityError` and must NOT log the corpus-outage warning. Shown red with
+  `begin_nested()` back inside the `try`: *"Failed: DID NOT RAISE <class
+  'sqlalchemy.exc.IntegrityError'>"*. `test_a_healthy_corpus_still_resolves_with_a_pending_caller_row`
+  is the other side, so the fix cannot over-correct into "any pending state breaks the lookup".
 
 Note the cycle still holds a second connection deliberately: `paper_advance_loop` keeps the
 fleet-lock session open for the whole cycle, on its own connection, which is what the advisory


### PR DESCRIPTION
Part of #1818 (P2). Post-merge review round on **#1831**, which is already merged (`42cc1294`), so the corrections land here rather than on that PR — the same shape as #1838 for #1826.

Two majors and one minor, all in the part of P2 that is supposed to be the permanent barrier against the 2026-09-03 wedge.

Do not merge — owner vets first.

## 1 (major) — the SAVEPOINT was not emitted in the one case the docstring promised, and the `try` swallowed the CALLER's errors

`session.begin_nested()` was called **inside** the `try`.

`SessionTransaction.__init__` calls `_take_snapshot`, which runs `self.session.flush()` for a `BEGIN_NESTED` origin **before** the transaction is installed and before any `SAVEPOINT` SQL is emitted (sqlalchemy 2.0.51, `orm/session.py:962` → `:1090`), and `SessionLocal` is `autoflush=False`. So the caller's pending ORM rows were flushed right there, outside the savepoint. `IntegrityError` **is** a `DBAPIError`, so that flush failure was caught by the corpus handler.

Probed on the merged head (`PYTHONPATH=backend`, tmp sqlite, real models), one pending `PaperDailyReturn` violating `uq_paper_daily_returns_dep_date`, against a **healthy** corpus:

```
PENDING BEFORE: 1
LOG WARNING archimedes.services.paper_trace: paper trace: corpus content-hash lookup failed — recording no consulted hashes
RESULT: []
STATEMENTS: ['INSERT INTO paper_daily_returns (deployment_id, date, daily_']
SAVEPOINT EVENTS: []
```

One statement, **zero savepoint events**, and the corpus query never ran. Two lies at once:

- the trace is stored and **hashed** with `consulted_paper_hashes=[]` while the corpus is fine, and
- on PostgreSQL that failed INSERT has already aborted the caller's transaction with **no savepoint to roll back to** — precisely the "`PendingRollbackError` for every remaining deployment and a raising `session.commit()`" outcome that #1831's body §2, the docstring and the incident doc all said `begin_nested()` prevents.

Reachable in the cycle: `_publish_decision_traces` does `session.add(PaperDecisionTrace(...))` in its loop (`paper_trading.py:725`) and can then raise `PaperTraceCoverageError` (`:751`), and `_decision_parts` can raise `PaperReplayError` mid-loop; `advance_all` (`:922-940`) catches both, **never rolls back**, and moves to the next deployment — whose `resolve_paper_hashes` then flushes the previous one's pending rows.

**Fix** — hoist the savepoint out of the swallow: `nested = session.begin_nested()` on the line before `try:`, then `with nested:` inside it. The flush failure reaches the caller as the honest per-deployment failure it is; the `DBAPIError` catch again covers the corpus query and nothing else.

Same probe, before vs after (identical script, `PYTHONPATH` pointed at each tree):

| | merged P2 (`8e8ca678`) | this branch |
|---|---|---|
| call 1 | `RESULT []` + corpus-outage WARNING | `RAISED IntegrityError`, no warning |
| call 2 | `RAISED PendingRollbackError` | `RAISED PendingRollbackError` |
| after `session.rollback()` | resolves normally | resolves normally |

Downstream is unchanged — what changes is that deployment N no longer publishes a falsely-empty provenance trace. **Residual, disclosed:** `advance_all` still does not roll back between deployments, so one unflushable pending row fails the rest of that cycle (it did before too). Surfacing it loudly is strictly better than laundering it; whether `advance_all` should roll back per deployment is a design call for the owner and is **not** in this PR.

Corrected in all three places that stated the savepoint covers the caller's earlier work: the `paper_trace.py` docstring, the sibling test's comment + assertion message, and the incident doc's "What the P2 PR changes" item 2. (#1831's body cannot be edited without rewriting a merged record; the correction is posted as a comment there instead.)

## 2 (major) — the cycle guard had a blind spot, and the claim made about it was false

`test_the_advance_cycle_opens_no_second_session` patched `archimedes.db.get_session`, which only intercepts callers that resolve the name **at call time**. This repo's dominant idiom is a module-level `from archimedes.db import get_session` — `api/user_routes.py:29`, `api/wallet_routes.py:18`, `marketplace/service.py:26`, `services/corpus_service.py:23`, `scripts/run_backtests.py:19`, … — and those bindings are invisible to that patch.

Mutation on the merged head: a module-level `from archimedes.db import get_session as _mgs` in `paper_trading.py` plus a genuinely second session opened with it inside `_publish_decision_traces` (executing `SELECT 1`):

```
tests/test_paper_trace_pipeline.py .                                     [100%]
1 passed, 1 warning in 3.53s
```

**GREEN.** So "it also catches whatever is added to the cycle path next" (#1831 body, the test docstring, and the incident doc) was not true for the way most of this repo opens sessions — and this guard is the permanent regression barrier for a P0.

**Fix** — instrument `archimedes.db.SessionLocal` instead. `get_session()` is only `return SessionLocal()`, resolving the module global at call time, so every route to a session is counted. The opener is named by walking past `archimedes/db.py` frames rather than a fixed stack index, so a future direct `SessionLocal()` caller is attributed just as precisely. Patching `db.SessionLocal` is already the house idiom (`test_gate_equivalence.py:239`, `test_cost_parity.py:514`, `test_strategy_ownership.py:52`, `tests/db_isolation.redirect_to_tmp_sqlite`).

**Shown RED on all three second-session idioms**, in `_publish_decision_traces` (mutation → run → revert by editing):

```
E   AssertionError: the advance cycle opened 2 sessions, not 1 — a second connection inside the cycle
    transaction is the 2026-09-03 wedge shape (#1818 P2).
    Openers: ['.../backend/archimedes/services/paper_trading.py:620 in _publish_decision_traces()']
```

- module-level-bound `get_session` (the one that was GREEN before) → RED
- direct `db.SessionLocal()` → RED
- the original in-function `with get_session() as session:` in `resolve_paper_hashes` → RED, `Openers: ['.../paper_trace.py:494 in resolve_paper_hashes()']` — no coverage regression

GREEN on clean code, message unchanged.

## 3 (minor) — stale ruff figure in #1831's body

#1831 reports `ruff format --check .` → "742 files already formatted"; on its own pushed head the figure was 750 (the body carried a pre-merge run). Carried into the comment on #1831 rather than editing a merged body. On this branch it is **764**.

## New guards

- `test_a_caller_write_that_fails_is_not_laundered_into_a_corpus_outage` — a pending caller row that cannot flush, against a **healthy** corpus, must reach the caller as `IntegrityError` and must **not** log the corpus-outage warning. **Shown RED** before the fix: `Failed: DID NOT RAISE <class 'sqlalchemy.exc.IntegrityError'>`.
- `test_a_healthy_corpus_still_resolves_with_a_pending_caller_row` — the other side, so the fix cannot over-correct into "any pending state breaks the lookup".

## Tests

- Full CI backend command from the repo root — `python -m pytest -m "not integration" --tb=short -q -p no:cacheprovider`: **6211 passed, 4 skipped, 2 deselected, 337 warnings in 1200.84s**, EXIT=0
- Clean `origin/main` (`bf76999c`) baseline worktree, same command: **6209 passed, 4 skipped, 2 deselected, 337 warnings in 1208.66s**, EXIT=0 — the +2 is exactly the two new guards. No pre-existing failures on either side
- Targeted paper suites (`test_paper_trace.py`, `test_paper_trading.py`, `test_paper_advance_isolation.py`, `test_paper_advance_kill_switch.py`, `test_paper_marks.py`, `test_paper_trace_pipeline.py`, `test_paper_marks_routes.py`, `test_paper_routes_auth.py`, `test_leaderboard_live_paper.py`, `test_ecs_paper_advance_deploy_pin.py`): **197 passed, 1 skipped in 42.02s**.
- `ruff format --check .` → **764 files already formatted**; `ruff check --select E9,F63,F7,F40,F82 .` → All checks passed; `ruff check` on the changed files → All checks passed. The informational full `ruff check` is **46 on this branch and 46 on clean `origin/main`** — pre-existing, unchanged.
- **ui:** no `ui/` files in the diff — nothing to run. **terraform:** none in the diff — no fmt/validate/plan.

## Diff

4 files: `backend/archimedes/services/paper_trace.py` (savepoint out of the `try` + docstring), `backend/tests/services/test_paper_trace.py` (2 new guards + the sibling test's corrected premise), `backend/tests/test_paper_trace_pipeline.py` (instrument `SessionLocal`), `docs/incidents/2026-09-03-paper-advance-ddl-wedge.md`.

No production behaviour changes beyond `paper_trace.py`'s two lines. The serving path (`POST /api/paper/deployments` → `create_deployment` flushes at `paper_trading.py:543-544` before `advance_deployment`) has no pending ORM state at the lookup, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx
