### PR TITLE
hotfix(migrations): single alembic head — re-point #1845's c8a4d1f70b93 onto #1844's a4d7e1b93c2f

### DIFF
--- a/.github/scripts/migration_chain_guard.py
+++ b/.github/scripts/migration_chain_guard.py
@@ -92,10 +92,28 @@ def main() -> int:
     if main_chain:
         heads = [r for r in main_chain if r not in main_chain.values()]
         if len(heads) != 1:
+            # main is already forked (two PRs merged whose CI each saw a single
+            # head — 2026-09-04, #1844 + #1845). The one PR that must still be
+            # able to merge is the repair: it re-points an existing migration
+            # so the chain has one head again, and adds nothing. Anything else
+            # (a third head, a repair that also grafts a new migration, a
+            # "repair" that drops a revision) keeps failing — the guard cannot
+            # tell which head a NEW migration should extend until main is fixed.
+            pr_chain = _chain_at(repo, "HEAD")
+            pr_heads = [r for r in pr_chain if r not in pr_chain.values()]
+            adds_nothing = set(pr_chain) == set(main_chain)
+            if len(pr_heads) == 1 and adds_nothing:
+                print(
+                    f"migration_chain_guard: OK — {args.base_ref} has {len(heads)} heads "
+                    f"({heads}); this PR re-serialises them into one chain (head {pr_heads[0]}) "
+                    "and adds no new migration. Repair accepted."
+                )
+                return 0
             print(
                 f"FAIL: {args.base_ref}'s migration chain doesn't have exactly one head "
                 f"(found {heads}) — this guard can't tell which one your migration should "
-                "extend. Fix main's chain before this guard can validate new migrations."
+                "extend. Fix main's chain before this guard can validate new migrations "
+                "(a repair PR that only re-points existing migrations onto one head passes)."
             )
             return 1
         main_head = heads[0]

--- a/backend/migrations/versions/c8a4d1f70b93_assoc_v1_passport_projection_columns.py
+++ b/backend/migrations/versions/c8a4d1f70b93_assoc_v1_passport_projection_columns.py
@@ -72,7 +72,7 @@ never moves), and #1792's stored rigor verdict keys off ``id`` too — so this
 is the pre-existing per-writer split-brain moved, not widened. PR-2 closes it.
 
 Revision ID: c8a4d1f70b93
-Revises: e6b2a19c4d70
+Revises: a4d7e1b93c2f
 Create Date: 2026-09-03 12:00:00.000000
 """
 

--- a/backend/migrations/versions/c8a4d1f70b93_assoc_v1_passport_projection_columns.py
+++ b/backend/migrations/versions/c8a4d1f70b93_assoc_v1_passport_projection_columns.py
@@ -84,7 +84,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "c8a4d1f70b93"
-down_revision: str | Sequence[str] | None = "e6b2a19c4d70"
+down_revision: str | Sequence[str] | None = "a4d7e1b93c2f"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/tests/test_migration_chain_guard_repair.py
+++ b/backend/tests/test_migration_chain_guard_repair.py
@@ -24,9 +24,7 @@ VERSIONS = "backend/migrations/versions"
 
 
 def _git(repo: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
-    ).stdout
+    return subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True).stdout
 
 
 def _migration(rev: str, down: str | None) -> str:

--- a/backend/tests/test_migration_chain_guard_repair.py
+++ b/backend/tests/test_migration_chain_guard_repair.py
@@ -1,0 +1,126 @@
+"""The migration chain guard must let the repair of a forked main through.
+
+2026-09-04: #1844 and #1845 each added a migration on ``e6b2a19c4d70``; each
+PR's CI saw one head, main ended with two, and the deploy of main failed in
+boot validation. The repair PR (#1847) re-points one migration onto the other
+— and the guard, seeing two heads on main, refused to validate it: the fix for
+a forked main was unmergeable under the guard whose job is to prevent forks.
+
+These tests build real git repositories in ``tmp_path`` and run the guard the
+way CI runs it (subprocess, ``--base-ref``). Hermetic: no network, no alembic.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / ".github" / "scripts" / "migration_chain_guard.py"
+VERSIONS = "backend/migrations/versions"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _migration(rev: str, down: str | None) -> str:
+    down_s = "None" if down is None else f'"{down}"'
+    return f'"""m {rev}"""\nrevision = "{rev}"\ndown_revision = {down_s}\n'
+
+
+def _write(repo: Path, rev: str, down: str | None) -> None:
+    d = repo / VERSIONS
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{rev}_m.py").write_text(_migration(rev, down), encoding="utf-8")
+
+
+def _commit(repo: Path, msg: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", msg)
+
+
+@pytest.fixture
+def forked_main(tmp_path: Path) -> Path:
+    """A repo whose ``main`` carries two heads: aaa1 and bbb1 both on base0."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _write(repo, "base0", None)
+    _write(repo, "aaa1", "base0")
+    _write(repo, "bbb1", "base0")
+    _commit(repo, "main with two heads")
+    _git(repo, "checkout", "-q", "-b", "pr")
+    return repo
+
+
+def _run_guard(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GUARD), "--base-ref", "main"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_the_fixture_main_really_has_two_heads(forked_main: Path):
+    _write(forked_main, "ccc1", "aaa1")
+    _commit(forked_main, "touch so the guard looks")
+    out = _run_guard(forked_main)
+    assert out.returncode == 1
+    assert "doesn't have exactly one head" in out.stdout
+
+
+def test_a_repair_that_re_points_onto_one_head_passes(forked_main: Path):
+    _write(forked_main, "bbb1", "aaa1")  # the #1847 shape
+    _commit(forked_main, "repair")
+    out = _run_guard(forked_main)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "Repair accepted" in out.stdout
+
+
+def test_a_repair_that_also_adds_a_migration_still_fails(forked_main: Path):
+    _write(forked_main, "bbb1", "aaa1")
+    _write(forked_main, "ccc1", "bbb1")
+    _commit(forked_main, "repair plus a new migration")
+    out = _run_guard(forked_main)
+    assert out.returncode == 1
+    assert "Repair accepted" not in out.stdout
+
+
+def test_a_third_head_on_a_forked_main_still_fails(forked_main: Path):
+    _write(forked_main, "ccc1", "base0")
+    _commit(forked_main, "third head")
+    out = _run_guard(forked_main)
+    assert out.returncode == 1
+
+
+def test_a_repair_that_drops_a_revision_still_fails(forked_main: Path):
+    (forked_main / VERSIONS / "bbb1_m.py").unlink()
+    # A deletion alone is filtered out of the guard's diff (ACMR); make the
+    # surviving head's file actually change so the guard looks at the chain.
+    f = forked_main / VERSIONS / "aaa1_m.py"
+    f.write_text(f.read_text(encoding="utf-8").replace('"""m aaa1"""', '"""m aaa1 (touched)"""'), encoding="utf-8")
+    _commit(forked_main, "drop a head instead of re-pointing it")
+    out = _run_guard(forked_main)
+    assert out.returncode == 1
+
+
+def test_a_single_head_main_is_unaffected(tmp_path: Path):
+    repo = tmp_path / "clean"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _write(repo, "base0", None)
+    _write(repo, "aaa1", "base0")
+    _commit(repo, "clean main")
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _write(repo, "bbb1", "aaa1")
+    _commit(repo, "extends the head")
+    out = _run_guard(repo)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "cleanly" in out.stdout


### PR DESCRIPTION
## Why

Deploy of main `f0e6b3f9` (#1844 + #1845) **failed** in *Validate backend image boots* — run [33876405202](https://github.com/aprin-labs/archimedes/actions/runs/33876405202). Production is still on the previous revision (task def 250).

`alembic heads` on main:

```
a4d7e1b93c2f (head)   ← #1844 passport_display_metrics_source
c8a4d1f70b93 (head)   ← #1845 assoc_v1_passport_projection_columns
```

Both were written against `e6b2a19c4d70` (#1837). Each PR's CI ran on its own merge ref and saw one head; the merged result has two, and `alembic upgrade head` refuses.

## Fix

One line: `c8a4d1f70b93.down_revision = "a4d7e1b93c2f"`. Neither migration has run in production (the migrate task never launched), so no data path changes.

## Evidence

- `alembic heads` → `c8a4d1f70b93 (head)` only.
- `backend/tests/test_alembic_migrations.py`: **33 failed** on main `f0e6b3f9` (the existing single-head guard at line 61 plus every upgrade-to-head test) → **39 passed** here.

## Guard change (second commit)

The **Migrations — chain fork guard** went red on this PR by design: with two heads on main it refuses every PR, including the repair. `migration_chain_guard.py` now passes a PR when main has more than one head AND the PR's own chain has exactly one head AND the PR adds no revision (a pure re-point). A third head, a repair that also grafts a new migration, or a repair that drops a revision still fail. `backend/tests/test_migration_chain_guard_repair.py` builds real git repos and holds all five shapes (6 passed). On this branch the guard prints `Repair accepted`.

## Process note

The existing guard is correct; it ran against a stale merge ref. Rule going forward for me: run `alembic heads` on the union before each merge of a PR that carries a migration (same class as the 2026-08-31 #1403+#1562 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4PwqGhQB27adUMyaweQx