### PR TITLE
[frontend] Auth copy: generate settles real testnet USDC

### DIFF
--- a/ui/src/components/AuthPage.jsx
+++ b/ui/src/components/AuthPage.jsx
@@ -38,9 +38,11 @@ const VERIFICATION_RESENT_MESSAGE = 'Verification email sent — check your inbo
 //      linked-wallets.js linkConnectedWallet always signs the server's SIWE
 //      challenge, and wallet_routes.verify_wallet_challenge 401s with
 //      "Invalid wallet signature" when the recovered signer does not match.
-//   3. Arc public testnet uses no real funds.
-//      chain-config.js DEFAULT_CHAIN_ID 5042002 / DEFAULT_RPC_URL
-//      https://rpc.testnet.arc.network — Arc's public testnet.
+//   3. Generation settles real testnet USDC on Arc public testnet.
+//      GET /api/generate/quote on prod answers dry_run: false,
+//      price "$2.000000" USDC, chain arcTestnet — generate is paid,
+//      not free. chain-config.js DEFAULT_CHAIN_ID 5042002 is Arc's
+//      public testnet (https://rpc.testnet.arc.network).
 // The sentence that used to sit above them was removed rather than reworded:
 // it scoped a linked wallet to chain activity alone, which the code does not
 // bear out — user_routes._extract_linked_wallet gates PII profile reads on
@@ -51,7 +53,7 @@ const VERIFICATION_RESENT_MESSAGE = 'Verification email sent — check your inbo
 const ACCOUNT_BOUNDARY_PROOFS = [
   'Email and password work without a wallet.',
   'Wallet linking requires signature proof.',
-  'Arc public testnet uses no real funds.',
+  'Generation settles real testnet USDC on Arc public testnet.',
 ]
 
 /* Google's four-colour "G", reproduced unmodified per Google's brand

--- a/ui/test/auth-page-copy.test.js
+++ b/ui/test/auth-page-copy.test.js
@@ -51,7 +51,7 @@ test("the account-boundary header is kept", () => {
 const TRUE_STATEMENTS = [
 	"Email and password work without a wallet.",
 	"Wallet linking requires signature proof.",
-	"Arc public testnet uses no real funds.",
+	"Generation settles real testnet USDC on Arc public testnet.",
 ];
 
 // Slice the RENDERED const's array literal — a match in a code comment must not
@@ -98,6 +98,17 @@ test("removed-claim patterns match their own canonical examples (guard is not va
 			`pattern ${pattern} no longer matches its own canonical example — it is guarding nothing`,
 		);
 	}
+});
+
+test("the false no-real-funds claim never returns", () => {
+	// Vacuity: the pattern still matches the overclaim it is meant to reject.
+	const overclaim = "Arc public testnet uses no real funds.";
+	assert.match(overclaim, /no real funds/i);
+	assert.doesNotMatch(
+		authPage,
+		/no real funds/i,
+		'AuthPage.jsx overclaims: generate is paid (GET /api/generate/quote, prod dry_run: false, $2 USDC on arcTestnet). Testnet USDC is not "no real funds."',
+	);
 });
 
 test("the false wallet-boundary claim never returns", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replace the sign-in/sign-up overclaim that “Arc public testnet uses no real funds.” The Account-before-wallet proof now says generation settles real testnet USDC on Arc public testnet — paid generate, not free.

## Why

Product Intel re-spot 7 Sep: generate is paid. `GET /api/generate/quote` on prod answers `dry_run: false` / `$2` USDC on `arcTestnet`. Calling that “no real funds” is false. Landing and DESIGN.md already say the honest version; auth lagged.

Copy/honesty only. No execution, flags, terraform, PAPER_ADVANCE, deploy.yml, or infra changes. Does not re-enable PAPER_ADVANCE. Does not touch GitHub About, repo settings, or aprin.ai / company-site.

## Issues

No closing keyword — copy-only honesty fix, not tied to a numbered issue.

## Verification

From `ui/`:

```
node --test test/auth-page-copy.test.js
```

13 tests, 13 pass (0 fail). Nearby AuthPage readers (`signin-claims`, `a11y`, `auth-errors`, `app-visuals`, `password-rules`) also green: 86 pass.

Guard is not vacuous: the new test matches its own canonical overclaim (`"Arc public testnet uses no real funds."`) and `doesNotMatch`s `/no real funds/i` against `AuthPage.jsx`. The rendered `ACCOUNT_BOUNDARY_PROOFS` pin is the honest sentence.

## What a reviewer should push back on

Scope is the auth page plus the test that already pinned this bullet. Other “no real funds” strings (paper-trading track-record copy) were left alone on purpose — those name the paper ledger, not the paid generate path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb36a158-f15d-47f3-b3a1-1a67ed20ba52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb36a158-f15d-47f3-b3a1-1a67ed20ba52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

